### PR TITLE
Update build scripts for cross-platform compatibility

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -74,7 +74,13 @@ jobs:
           GITHUB_REF: ${{ github.ref }}
 
       - name: Build
-        run: bun run build
+        run: |
+          if [ "$RUNNER_OS" == "Windows" ]; then
+            bun run build:win
+          else
+            bun run build
+          fi
+        shell: bash
 
       - name: Rename artifact
         shell: bash

--- a/package.json
+++ b/package.json
@@ -9,7 +9,8 @@
   "scripts": {
     "dev": "bun run src/cli/index.ts",
     "prebuild": "bun run scripts/generate-version.ts",
-    "build": "bun build src/cli/index.ts --compile --windows-icon=./logo.ico --outfile dist/capa --icon logo.ico",
+    "build": "bun build src/cli/index.ts --compile --outfile dist/capa --icon logo.ico",
+    "build:win": "bun build src/cli/index.ts --compile --windows-icon=./logo.ico --outfile dist/capa --icon logo.ico",
     "server": "bun run src/server/index.ts",
     "test": "bun test",
     "test:coverage": "bun test --coverage"


### PR DESCRIPTION
- Added a new build script for Windows (`build:win`) to handle platform-specific requirements.
- Modified the main build command to streamline the build process for non-Windows environments.
- Updated the GitHub Actions workflow to conditionally run the appropriate build command based on the operating system.