### PR TITLE
Fixed OAuth2 code flow detection for server with authorization header

### DIFF
--- a/src/server/mcp-proxy.ts
+++ b/src/server/mcp-proxy.ts
@@ -352,11 +352,16 @@ class HttpMCPTransport implements Transport {
         }
       }
 
+      const tlsOptions = this.serverDefinition.tlsSkipVerify
+        ? ({ tls: { rejectUnauthorized: false } } as object)
+        : {};
+
       const response = await fetch(this.url, {
         method: 'POST',
         headers,
         body: JSON.stringify(message),
-      });
+        ...tlsOptions,
+      } as RequestInit);
 
       // Handle 401 Unauthorized - token might be expired
       if (response.status === 401 && this.serverDefinition.oauth2) {
@@ -382,7 +387,8 @@ class HttpMCPTransport implements Transport {
               method: 'POST',
               headers,
               body: JSON.stringify(message),
-            });
+              ...tlsOptions,
+            } as RequestInit);
 
             if (retryResponse.ok) {
               // Extract session ID from retry response

--- a/src/types/capabilities.ts
+++ b/src/types/capabilities.ts
@@ -99,6 +99,8 @@ export interface MCPServerDefinition {
   // For remote MCP servers
   url?: string;
   headers?: Record<string, string>;
+  /** Skip TLS certificate verification (e.g. for self-signed certs on internal servers) */
+  tlsSkipVerify?: boolean;
   // For local MCP servers (subprocess)
   cmd?: string;
   args?: string[];


### PR DESCRIPTION
If a connection to an mcp server was made via an authorization header it would be pointless to try and detect whether it requires OAuth2 code flow.