### PR TITLE
feat: support default values for command tool arguments

### DIFF
--- a/skills/capabilities-manager/SKILL.md
+++ b/skills/capabilities-manager/SKILL.md
@@ -505,6 +505,35 @@ tools:
             required: true
 ```
 
+#### Default Argument Values (`default`)
+
+Command tool arguments support an optional `default` field. When the caller omits an argument that has a default, the default value is used for placeholder substitution instead of raising a missing-argument error. Arguments with defaults are exposed as **optional** in the MCP schema (removed from `required` and annotated with the default value), so the AI only needs to supply them when overriding.
+
+```yaml
+tools:
+  - id: list_items
+    type: command
+    description: List items from the API
+    def:
+      run:
+        cmd: "curl -s 'https://api.example.com/items?limit={limit}&offset={offset}'"
+        args:
+          - name: limit
+            type: number
+            description: Page size
+            default: 25
+          - name: offset
+            type: number
+            description: Starting offset
+            default: 0
+```
+
+In this example, both `limit` and `offset` will default to `25` and `0` respectively when not provided. The agent can still override them by passing explicit values.
+
+This is useful when:
+- A parameter has a sensible default that rarely changes (e.g. page sizes, output formats)
+- You want to expose a tool to the agent without requiring it to pass every argument
+
 **Optional Init**: Add `init` block to run setup commands before first use:
 
 ```yaml

--- a/src/cli/commands/__tests__/sh.test.ts
+++ b/src/cli/commands/__tests__/sh.test.ts
@@ -1,0 +1,250 @@
+import { describe, it, expect } from 'bun:test';
+import { slugify, parseInlineArgs, resolveArgs } from '../sh';
+import type { ShellCommand } from '../sh';
+
+function makeCommand(overrides: Partial<ShellCommand> = {}): ShellCommand {
+  return {
+    id: 'test-tool',
+    slug: 'test-tool',
+    type: 'command',
+    description: '',
+    inputSchema: {
+      type: 'object',
+      properties: {},
+      required: [],
+    },
+    argSlugs: new Map(),
+    ...overrides,
+  };
+}
+
+describe('parseInlineArgs', () => {
+  it('should parse key-value pairs', () => {
+    const result = parseInlineArgs(['--name', 'Alice', '--age', '30']);
+    expect(result).toEqual({ name: 'Alice', age: '30' });
+  });
+
+  it('should treat flags without values as boolean true', () => {
+    const result = parseInlineArgs(['--verbose']);
+    expect(result).toEqual({ verbose: 'true' });
+  });
+
+  it('should handle mixed flags and key-value pairs', () => {
+    const result = parseInlineArgs(['--name', 'Alice', '--verbose', '--count', '5']);
+    expect(result).toEqual({ name: 'Alice', verbose: 'true', count: '5' });
+  });
+
+  it('should return empty object for no args', () => {
+    const result = parseInlineArgs([]);
+    expect(result).toEqual({});
+  });
+
+  it('should ignore tokens not starting with --', () => {
+    const result = parseInlineArgs(['ignored', '--name', 'Alice']);
+    expect(result).toEqual({ name: 'Alice' });
+  });
+});
+
+describe('resolveArgs', () => {
+  it('should resolve slugified names to original names', () => {
+    const cmd = makeCommand({
+      argSlugs: new Map([['page-size', 'pageSize']]),
+      inputSchema: {
+        type: 'object',
+        properties: { pageSize: { type: 'number' } },
+        required: ['pageSize'],
+      },
+    });
+
+    const result = resolveArgs(cmd, { 'page-size': '25' });
+    expect(result).toEqual({ pageSize: 25 });
+  });
+
+  it('should convert number types', () => {
+    const cmd = makeCommand({
+      argSlugs: new Map([['limit', 'limit']]),
+      inputSchema: {
+        type: 'object',
+        properties: { limit: { type: 'number' } },
+      },
+    });
+
+    const result = resolveArgs(cmd, { limit: '50' });
+    expect(result).toEqual({ limit: 50 });
+  });
+
+  it('should convert boolean types', () => {
+    const cmd = makeCommand({
+      argSlugs: new Map([['verbose', 'verbose']]),
+      inputSchema: {
+        type: 'object',
+        properties: { verbose: { type: 'boolean' } },
+      },
+    });
+
+    expect(resolveArgs(cmd, { verbose: 'true' })).toEqual({ verbose: true });
+    expect(resolveArgs(cmd, { verbose: 'false' })).toEqual({ verbose: false });
+    expect(resolveArgs(cmd, { verbose: '0' })).toEqual({ verbose: false });
+  });
+
+  it('should keep string types as-is', () => {
+    const cmd = makeCommand({
+      argSlugs: new Map([['name', 'name']]),
+      inputSchema: {
+        type: 'object',
+        properties: { name: { type: 'string' } },
+      },
+    });
+
+    const result = resolveArgs(cmd, { name: 'Alice' });
+    expect(result).toEqual({ name: 'Alice' });
+  });
+
+  it('should pass through args not in slugs map', () => {
+    const cmd = makeCommand();
+    const result = resolveArgs(cmd, { unknown: 'value' });
+    expect(result).toEqual({ unknown: 'value' });
+  });
+});
+
+describe('slugify', () => {
+  it('should convert camelCase to kebab-case', () => {
+    expect(slugify('pageSize')).toBe('page-size');
+    expect(slugify('myLongVariableName')).toBe('my-long-variable-name');
+  });
+
+  it('should convert underscores to hyphens', () => {
+    expect(slugify('page_size')).toBe('page-size');
+  });
+
+  it('should handle already kebab-case names', () => {
+    expect(slugify('page-size')).toBe('page-size');
+  });
+
+  it('should handle PascalCase', () => {
+    expect(slugify('PageSize')).toBe('page-size');
+  });
+
+  it('should collapse multiple hyphens', () => {
+    expect(slugify('a--b')).toBe('a-b');
+  });
+
+  it('should strip leading/trailing hyphens', () => {
+    expect(slugify('-name-')).toBe('name');
+  });
+});
+
+describe('default argument merging in CLI context', () => {
+  it('should use defaults when args are not provided', () => {
+    const cmd = makeCommand({
+      argSlugs: new Map([['limit', 'limit'], ['offset', 'offset']]),
+      inputSchema: {
+        type: 'object',
+        properties: {
+          limit: { type: 'number', default: 25 },
+          offset: { type: 'number', default: 0 },
+        },
+        required: [],
+      },
+      defaults: { limit: 25, offset: 0 },
+    });
+
+    const rawArgs = parseInlineArgs([]);
+    const resolved = resolveArgs(cmd, rawArgs);
+
+    if (cmd.defaults) {
+      for (const [key, value] of Object.entries(cmd.defaults)) {
+        if (!(key in resolved)) {
+          resolved[key] = value;
+        }
+      }
+    }
+
+    expect(resolved).toEqual({ limit: 25, offset: 0 });
+  });
+
+  it('should let user-provided args override defaults', () => {
+    const cmd = makeCommand({
+      argSlugs: new Map([['limit', 'limit'], ['offset', 'offset']]),
+      inputSchema: {
+        type: 'object',
+        properties: {
+          limit: { type: 'number', default: 25 },
+          offset: { type: 'number', default: 0 },
+        },
+        required: [],
+      },
+      defaults: { limit: 25, offset: 0 },
+    });
+
+    const rawArgs = parseInlineArgs(['--limit', '100']);
+    const resolved = resolveArgs(cmd, rawArgs);
+
+    if (cmd.defaults) {
+      for (const [key, value] of Object.entries(cmd.defaults)) {
+        if (!(key in resolved)) {
+          resolved[key] = value;
+        }
+      }
+    }
+
+    expect(resolved).toEqual({ limit: 100, offset: 0 });
+  });
+
+  it('should work with no defaults defined', () => {
+    const cmd = makeCommand({
+      argSlugs: new Map([['name', 'name']]),
+      inputSchema: {
+        type: 'object',
+        properties: { name: { type: 'string' } },
+        required: ['name'],
+      },
+    });
+
+    const rawArgs = parseInlineArgs(['--name', 'test']);
+    const resolved = resolveArgs(cmd, rawArgs);
+
+    if (cmd.defaults) {
+      for (const [key, value] of Object.entries(cmd.defaults)) {
+        if (!(key in resolved)) {
+          resolved[key] = value;
+        }
+      }
+    }
+
+    expect(resolved).toEqual({ name: 'test' });
+  });
+
+  it('should not count defaulted args as missing required', () => {
+    const cmd = makeCommand({
+      argSlugs: new Map([['limit', 'limit']]),
+      inputSchema: {
+        type: 'object',
+        properties: {
+          limit: { type: 'number', default: 25 },
+        },
+        required: [],
+      },
+      defaults: { limit: 25 },
+    });
+
+    const rawArgs = parseInlineArgs([]);
+    const resolved = resolveArgs(cmd, rawArgs);
+
+    if (cmd.defaults) {
+      for (const [key, value] of Object.entries(cmd.defaults)) {
+        if (!(key in resolved)) {
+          resolved[key] = value;
+        }
+      }
+    }
+
+    const required: string[] = cmd.inputSchema?.required || [];
+    const missingRequired = required.filter(
+      (r: string) => !(slugify(r) in rawArgs) && !(r in rawArgs) && !(r in (cmd.defaults || {}))
+    );
+
+    expect(missingRequired).toEqual([]);
+    expect(resolved.limit).toBe(25);
+  });
+});

--- a/src/cli/commands/sh.ts
+++ b/src/cli/commands/sh.ts
@@ -23,7 +23,7 @@ interface ShellCommand {
   inputSchema: any;
   /** Maps slugified arg name → original arg name */
   argSlugs: Map<string, string>;
-  /** Default argument values (MCP tools only) */
+  /** Default argument values */
   defaults?: Record<string, any>;
 }
 
@@ -370,8 +370,16 @@ async function execCommand(
   const rawArgs = parseInlineArgs(rawArgTokens);
   const resolved = resolveArgs(cmd, rawArgs);
 
+  if (cmd.defaults) {
+    for (const [key, value] of Object.entries(cmd.defaults)) {
+      if (!(key in resolved)) {
+        resolved[key] = value;
+      }
+    }
+  }
+
   const required: string[] = cmd.inputSchema?.required || [];
-  const missingRequired = required.filter((r) => !(slugify(r) in rawArgs) && !(r in rawArgs));
+  const missingRequired = required.filter((r) => !(slugify(r) in rawArgs) && !(r in rawArgs) && !(r in (cmd.defaults || {})));
   if (missingRequired.length > 0) {
     const props = cmd.inputSchema?.properties || {};
     console.error(`Missing required parameter(s):\n`);

--- a/src/cli/commands/sh.ts
+++ b/src/cli/commands/sh.ts
@@ -15,7 +15,7 @@ interface ShellToolInfo {
   defaults?: Record<string, any>;
 }
 
-interface ShellCommand {
+export interface ShellCommand {
   id: string;
   slug: string;
   type: 'command' | 'mcp';
@@ -153,7 +153,7 @@ export function slugify(name: string): string {
     .replace(/^-|-$/g, '');
 }
 
-function parseInlineArgs(tokens: string[]): Record<string, string> {
+export function parseInlineArgs(tokens: string[]): Record<string, string> {
   const result: Record<string, string> = {};
   let i = 0;
   while (i < tokens.length) {
@@ -175,7 +175,7 @@ function parseInlineArgs(tokens: string[]): Record<string, string> {
 }
 
 /** Resolve slugified arg names in the user's input to original names expected by the tool. */
-function resolveArgs(cmd: ShellCommand, rawArgs: Record<string, string>): Record<string, any> {
+export function resolveArgs(cmd: ShellCommand, rawArgs: Record<string, string>): Record<string, any> {
   const resolved: Record<string, any> = {};
   for (const [slug, value] of Object.entries(rawArgs)) {
     const originalName = cmd.argSlugs.get(slug) ?? slug;

--- a/src/server/__tests__/mcp-handler.test.ts
+++ b/src/server/__tests__/mcp-handler.test.ts
@@ -18,7 +18,7 @@ describe('applyDefaultsToSchema', () => {
   });
 
   it('should annotate properties with default values', () => {
-    const schema = {
+    const schema: any = {
       type: 'object',
       properties: {
         limit: { type: 'number' },

--- a/src/server/__tests__/mcp-handler.test.ts
+++ b/src/server/__tests__/mcp-handler.test.ts
@@ -1,0 +1,148 @@
+import { describe, it, expect } from 'bun:test';
+import { applyDefaultsToSchema, mergeDefaults } from '../mcp-handler';
+
+describe('applyDefaultsToSchema', () => {
+  it('should remove defaulted keys from required array', () => {
+    const schema = {
+      type: 'object',
+      properties: {
+        name: { type: 'string' },
+        limit: { type: 'number' },
+      },
+      required: ['name', 'limit'],
+    };
+
+    applyDefaultsToSchema(schema, { limit: 25 });
+
+    expect(schema.required).toEqual(['name']);
+  });
+
+  it('should annotate properties with default values', () => {
+    const schema = {
+      type: 'object',
+      properties: {
+        limit: { type: 'number' },
+        offset: { type: 'number' },
+      },
+      required: ['limit', 'offset'],
+    };
+
+    applyDefaultsToSchema(schema, { limit: 25, offset: 0 });
+
+    expect(schema.properties.limit.default).toBe(25);
+    expect(schema.properties.offset.default).toBe(0);
+  });
+
+  it('should handle empty defaults', () => {
+    const schema = {
+      type: 'object',
+      properties: {
+        name: { type: 'string' },
+      },
+      required: ['name'],
+    };
+
+    applyDefaultsToSchema(schema, {});
+
+    expect(schema.required).toEqual(['name']);
+    expect((schema.properties.name as any).default).toBeUndefined();
+  });
+
+  it('should handle schema without required array', () => {
+    const schema = {
+      type: 'object',
+      properties: {
+        limit: { type: 'number' },
+      },
+    };
+
+    applyDefaultsToSchema(schema, { limit: 10 });
+
+    expect((schema.properties.limit as any).default).toBe(10);
+  });
+
+  it('should ignore defaults for non-existent properties', () => {
+    const schema = {
+      type: 'object',
+      properties: {
+        name: { type: 'string' },
+      },
+      required: ['name'],
+    };
+
+    applyDefaultsToSchema(schema, { nonExistent: 'value' });
+
+    expect(schema.required).toEqual(['name']);
+    expect((schema.properties as any).nonExistent).toBeUndefined();
+  });
+
+  it('should handle string default values', () => {
+    const schema = {
+      type: 'object',
+      properties: {
+        format: { type: 'string' },
+      },
+      required: ['format'],
+    };
+
+    applyDefaultsToSchema(schema, { format: 'json' });
+
+    expect(schema.required).toEqual([]);
+    expect((schema.properties.format as any).default).toBe('json');
+  });
+
+  it('should handle boolean default values', () => {
+    const schema = {
+      type: 'object',
+      properties: {
+        verbose: { type: 'boolean' },
+      },
+      required: ['verbose'],
+    };
+
+    applyDefaultsToSchema(schema, { verbose: false });
+
+    expect(schema.required).toEqual([]);
+    expect((schema.properties.verbose as any).default).toBe(false);
+  });
+});
+
+describe('mergeDefaults', () => {
+  it('should return args when no defaults', () => {
+    const args = { name: 'test' };
+    const result = mergeDefaults(undefined, args);
+
+    expect(result).toEqual({ name: 'test' });
+  });
+
+  it('should merge defaults with args', () => {
+    const defaults = { limit: 25, offset: 0 };
+    const args = { name: 'test' };
+    const result = mergeDefaults(defaults, args);
+
+    expect(result).toEqual({ name: 'test', limit: 25, offset: 0 });
+  });
+
+  it('should let caller args override defaults', () => {
+    const defaults = { limit: 25 };
+    const args = { limit: 50 };
+    const result = mergeDefaults(defaults, args);
+
+    expect(result).toEqual({ limit: 50 });
+  });
+
+  it('should handle empty args with defaults', () => {
+    const defaults = { limit: 25, offset: 0 };
+    const result = mergeDefaults(defaults, {});
+
+    expect(result).toEqual({ limit: 25, offset: 0 });
+  });
+
+  it('should handle empty defaults', () => {
+    const defaults = {};
+    const args = { name: 'test' };
+    const result = mergeDefaults(defaults, args);
+
+    expect(result).toEqual({ name: 'test' });
+  });
+});

--- a/src/server/__tests__/tool-executor.test.ts
+++ b/src/server/__tests__/tool-executor.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, beforeEach, afterEach } from 'bun:test';
+import { describe, it, expect, beforeAll, afterAll } from 'bun:test';
 import { CommandToolExecutor } from '../tool-executor';
 import { CapaDatabase } from '../../db/database';
 import { mkdtempSync, rmSync } from 'fs';
@@ -12,7 +12,7 @@ describe('CommandToolExecutor', () => {
   let executor: CommandToolExecutor;
   const projectId = 'test-project';
 
-  beforeEach(() => {
+  beforeAll(() => {
     tempDir = mkdtempSync(join(tmpdir(), 'capa-executor-test-'));
     const dbPath = join(tempDir, 'test.db');
     db = new CapaDatabase(dbPath);
@@ -20,7 +20,7 @@ describe('CommandToolExecutor', () => {
     executor = new CommandToolExecutor(db, projectId, tempDir);
   });
 
-  afterEach(() => {
+  afterAll(() => {
     db.close();
     rmSync(tempDir, { recursive: true, force: true });
   });

--- a/src/server/__tests__/tool-executor.test.ts
+++ b/src/server/__tests__/tool-executor.test.ts
@@ -1,0 +1,185 @@
+import { describe, it, expect, beforeEach, afterEach } from 'bun:test';
+import { CommandToolExecutor } from '../tool-executor';
+import { CapaDatabase } from '../../db/database';
+import { mkdtempSync, rmSync } from 'fs';
+import { join } from 'path';
+import { tmpdir } from 'os';
+import type { ToolCommandDefinition } from '../../types/capabilities';
+
+describe('CommandToolExecutor', () => {
+  let db: CapaDatabase;
+  let tempDir: string;
+  let executor: CommandToolExecutor;
+  const projectId = 'test-project';
+
+  beforeEach(() => {
+    tempDir = mkdtempSync(join(tmpdir(), 'capa-executor-test-'));
+    const dbPath = join(tempDir, 'test.db');
+    db = new CapaDatabase(dbPath);
+    db.upsertProject({ id: projectId, path: tempDir });
+    executor = new CommandToolExecutor(db, projectId, tempDir);
+  });
+
+  afterEach(() => {
+    db.close();
+    rmSync(tempDir, { recursive: true, force: true });
+  });
+
+  describe('default argument values', () => {
+    it('should use default when argument is not provided', async () => {
+      const def: ToolCommandDefinition = {
+        run: {
+          cmd: 'echo {greeting}',
+          args: [
+            { name: 'greeting', type: 'string', default: 'hello' },
+          ],
+        },
+      };
+
+      const result = await executor.execute('test-tool', def, {});
+      expect(result.success).toBe(true);
+      expect(result.result?.trim()).toBe('hello');
+    });
+
+    it('should allow caller to override the default', async () => {
+      const def: ToolCommandDefinition = {
+        run: {
+          cmd: 'echo {greeting}',
+          args: [
+            { name: 'greeting', type: 'string', default: 'hello' },
+          ],
+        },
+      };
+
+      const result = await executor.execute('test-tool', def, { greeting: 'bonjour' });
+      expect(result.success).toBe(true);
+      expect(result.result?.trim()).toBe('bonjour');
+    });
+
+    it('should use defaults for some args and caller values for others', async () => {
+      const def: ToolCommandDefinition = {
+        run: {
+          cmd: 'echo {name} {count}',
+          args: [
+            { name: 'name', type: 'string', required: true },
+            { name: 'count', type: 'number', default: 10 },
+          ],
+        },
+      };
+
+      const result = await executor.execute('test-tool', def, { name: 'items' });
+      expect(result.success).toBe(true);
+      expect(result.result?.trim()).toBe('items 10');
+    });
+
+    it('should fail when required arg without default is missing', async () => {
+      const def: ToolCommandDefinition = {
+        run: {
+          cmd: 'echo {name} {count}',
+          args: [
+            { name: 'name', type: 'string', required: true },
+            { name: 'count', type: 'number', default: 10 },
+          ],
+        },
+      };
+
+      const result = await executor.execute('test-tool', def, {});
+      expect(result.success).toBe(false);
+      expect(result.error).toContain('Missing required argument: name');
+    });
+
+    it('should treat arg with default as optional even if required is not set', async () => {
+      const def: ToolCommandDefinition = {
+        run: {
+          cmd: 'echo {limit}',
+          args: [
+            { name: 'limit', type: 'number', default: 25 },
+          ],
+        },
+      };
+
+      const result = await executor.execute('test-tool', def, {});
+      expect(result.success).toBe(true);
+      expect(result.result?.trim()).toBe('25');
+    });
+
+    it('should handle multiple args all with defaults', async () => {
+      const def: ToolCommandDefinition = {
+        run: {
+          cmd: 'echo {a} {b} {c}',
+          args: [
+            { name: 'a', type: 'string', default: 'x' },
+            { name: 'b', type: 'string', default: 'y' },
+            { name: 'c', type: 'string', default: 'z' },
+          ],
+        },
+      };
+
+      const result = await executor.execute('test-tool', def, { b: 'B' });
+      expect(result.success).toBe(true);
+      expect(result.result?.trim()).toBe('x B z');
+    });
+
+    it('should handle boolean default', async () => {
+      const def: ToolCommandDefinition = {
+        run: {
+          cmd: 'echo {verbose}',
+          args: [
+            { name: 'verbose', type: 'boolean', default: false },
+          ],
+        },
+      };
+
+      const result = await executor.execute('test-tool', def, {});
+      expect(result.success).toBe(true);
+      expect(result.result?.trim()).toBe('false');
+    });
+  });
+
+  describe('argument handling (no defaults)', () => {
+    it('should substitute required args normally', async () => {
+      const def: ToolCommandDefinition = {
+        run: {
+          cmd: 'echo {message}',
+          args: [
+            { name: 'message', type: 'string', required: true },
+          ],
+        },
+      };
+
+      const result = await executor.execute('test-tool', def, { message: 'hi' });
+      expect(result.success).toBe(true);
+      expect(result.result?.trim()).toBe('hi');
+    });
+
+    it('should fail when required arg is missing and no default', async () => {
+      const def: ToolCommandDefinition = {
+        run: {
+          cmd: 'echo {message}',
+          args: [
+            { name: 'message', type: 'string', required: true },
+          ],
+        },
+      };
+
+      const result = await executor.execute('test-tool', def, {});
+      expect(result.success).toBe(false);
+      expect(result.error).toContain('Missing required argument: message');
+    });
+
+    it('should allow optional arg to be omitted', async () => {
+      const def: ToolCommandDefinition = {
+        run: {
+          cmd: 'echo done',
+          args: [
+            { name: 'verbose', type: 'boolean', required: false },
+          ],
+        },
+      };
+
+      const result = await executor.execute('test-tool', def, {});
+      expect(result.success).toBe(true);
+      expect(result.result?.trim()).toBe('done');
+    });
+  });
+});

--- a/src/server/mcp-handler.ts
+++ b/src/server/mcp-handler.ts
@@ -510,6 +510,18 @@ export class CapaMCPServer {
         if (tool.group) {
           info.group = tool.group;
         }
+        const def = tool.def as ToolCommandDefinition;
+        if (def.run.args) {
+          const cmdDefaults: Record<string, any> = {};
+          for (const arg of def.run.args) {
+            if (arg.default !== undefined) {
+              cmdDefaults[arg.name] = arg.default;
+            }
+          }
+          if (Object.keys(cmdDefaults).length > 0) {
+            info.defaults = cmdDefaults;
+          }
+        }
       }
       result.push(info);
     }
@@ -626,11 +638,15 @@ export class CapaMCPServer {
 
       if (def.run.args) {
         for (const arg of def.run.args) {
-          properties[arg.name] = {
+          const prop: any = {
             type: arg.type,
             description: arg.description,
           };
-          if (arg.required !== false) {
+          if (arg.default !== undefined) {
+            prop.default = arg.default;
+          }
+          properties[arg.name] = prop;
+          if (arg.required !== false && arg.default === undefined) {
             required.push(arg.name);
           }
         }

--- a/src/server/mcp-handler.ts
+++ b/src/server/mcp-handler.ts
@@ -46,7 +46,7 @@ export interface ToolValidationResult {
  * Remove defaulted parameters from the schema's `required` array and annotate
  * each property with a `default` value so MCP clients see them as optional.
  */
-function applyDefaultsToSchema(schema: any, defaults: Record<string, any>): void {
+export function applyDefaultsToSchema(schema: any, defaults: Record<string, any>): void {
   const defaultKeys = Object.keys(defaults);
   if (defaultKeys.length === 0) return;
   if (Array.isArray(schema.required)) {
@@ -62,7 +62,7 @@ function applyDefaultsToSchema(schema: any, defaults: Record<string, any>): void
 }
 
 /** Merge tool-level default args with caller-supplied args (caller wins). */
-function mergeDefaults(
+export function mergeDefaults(
   defaults: Record<string, any> | undefined,
   args: Record<string, any>
 ): Record<string, any> {

--- a/src/server/tool-executor.ts
+++ b/src/server/tool-executor.ts
@@ -86,7 +86,10 @@ export class CommandToolExecutor {
     // Replace argument placeholders
     if (spec.args) {
       for (const argDef of spec.args) {
-        const value = args[argDef.name];
+        let value = args[argDef.name];
+        if (value === undefined && argDef.default !== undefined) {
+          value = argDef.default;
+        }
         if (value === undefined && argDef.required !== false) {
           return {
             success: false,
@@ -94,7 +97,6 @@ export class CommandToolExecutor {
           };
         }
         
-        // Simple placeholder replacement - in production would need more sophisticated handling
         const placeholder = `{${argDef.name}}`;
         if (cmd.includes(placeholder)) {
           cmd = cmd.replace(placeholder, String(value));

--- a/src/types/capabilities.ts
+++ b/src/types/capabilities.ts
@@ -259,6 +259,7 @@ export interface ArgumentDefinition {
   type: 'string' | 'number' | 'boolean' | 'object' | 'array';
   description?: string;
   required?: boolean;
+  default?: any;
 }
 
 /**


### PR DESCRIPTION
## Summary

- Adds a default field to ArgumentDefinition so command tool arguments can specify fallback values.
- When a caller omits an argument that has a default, the executor uses the default for placeholder substitution instead of failing with a missing-argument error.
- Arguments with defaults are excluded from the MCP equired array and annotated with default in the JSON Schema, so agents see them as optional.
- The capa sh CLI merges defaults into resolved args before the required-check, keeping the shell experience consistent.

## Test plan

- [ ] Define a command tool with default on one or more args in capabilities.yaml and verify:
  - Calling the tool **without** the argument succeeds using the default.
  - Calling the tool **with** the argument overrides the default.
- [ ] Run capa sh <tool> --help and confirm the default value is displayed.
- [ ] Verify that args with defaults are **not** listed as required in the MCP schema (	ools/list).
- [ ] Ensure existing tools without defaults are unaffected.

Made with [Cursor](https://cursor.com)