### PR TITLE
fix: recursively copy entire skill directory during install

### DIFF
--- a/src/cli/commands/install.ts
+++ b/src/cli/commands/install.ts
@@ -361,19 +361,25 @@ function readSkillFromDirectory(skillMdPath: string): {
   const skillDir = dirname(skillMdPath);
   const additionalFiles = new Map<string, string>();
   
-  // Read all files in the skill directory (except SKILL.md itself)
-  try {
-    const entries = readdirSync(skillDir, { withFileTypes: true });
-    for (const entry of entries) {
-      if (entry.isFile() && entry.name !== 'SKILL.md') {
-        const filePath = join(skillDir, entry.name);
-        const content = readFileSync(filePath, 'utf-8');
-        additionalFiles.set(entry.name, content);
+  function collectFiles(dir: string, relativeBase: string): void {
+    try {
+      const entries = readdirSync(dir, { withFileTypes: true });
+      for (const entry of entries) {
+        const relativePath = relativeBase ? join(relativeBase, entry.name) : entry.name;
+        if (entry.isDirectory()) {
+          collectFiles(join(dir, entry.name), relativePath);
+        } else if (entry.isFile()) {
+          if (relativeBase === '' && entry.name === 'SKILL.md') continue;
+          const content = readFileSync(join(dir, entry.name), 'utf-8');
+          additionalFiles.set(relativePath, content);
+        }
       }
+    } catch (error) {
+      // Can't read directory, skip
     }
-  } catch (error) {
-    // No additional files or can't read directory
   }
+
+  collectFiles(skillDir, '');
   
   return { markdown, additionalFiles };
 }


### PR DESCRIPTION
## Summary

- **Bug:** When installing a skill (local, GitHub, or GitLab), only \SKILL.md\ and top-level files were copied. Subdirectories and their contents were silently skipped.
- **Fix:** Made \
eadSkillFromDirectory\ recursively traverse subdirectories, collecting all files with their relative paths. The existing write logic already supports nested paths via \mkdirSync({ recursive: true })\, so no changes were needed on the install side.
- Security checks (blocked phrases, character sanitization) continue to apply to all collected files.

## Test plan

- [x] Install a skill that has files in subdirectories (e.g. \
eferences/\ folder) from a local path and verify the entire directory tree is copied
- [x] Install a skill from a GitHub repo with nested reference files and verify all files are present
- [x] Install a skill with only \SKILL.md\ (no subdirectories) and verify it still works as before
- [x] Verify security checks (blocked phrases) still apply to files in subdirectories

Made with [Cursor](https://cursor.com)