### PR TITLE
ci(infragate-capa): add HOL skill-publish validate workflow

### DIFF
--- a/.github/workflows/hol-skill-validate.yml
+++ b/.github/workflows/hol-skill-validate.yml
@@ -1,0 +1,30 @@
+name: HOL Skill Validate
+
+on:
+  push:
+    branches:
+      - main
+      - master
+  pull_request:
+    branches:
+      - main
+      - master
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  validate:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
+
+      - name: Validate Skill
+        uses: hashgraph-online/skill-publish@47895cf40f6214511c713628dbbafd0c3316f4dd
+        with:
+          mode: validate
+          skill-dir: skills/capabilities-manager
+          annotate: "false"
+          preview-upload: "false"


### PR DESCRIPTION
This repo already has enough skill metadata to validate in CI.

A couple of repo-specific details I checked first:
- ⚡ Dynamic on-demand tool loading
- Use the brave.search tool to find current information online
- CAPA installs your skills, starts the capability server, and automatically registers with your MCP client (Cursor, Claude Desktop)

- Detected skill package: `.`

This adds one workflow for `.` and leaves the runtime code alone.
It only runs the schema and trust checks for the skill metadata in validate mode.

If you would rather place the workflow under a different filename or point it at a different skill directory, I can adjust the branch.