### PR TITLE
fix(web-ui): truncate long labels

### DIFF
--- a/web-ui/src/components/common/ServerBadge.tsx
+++ b/web-ui/src/components/common/ServerBadge.tsx
@@ -22,6 +22,7 @@ export function SourceBadge({ name, kind = 'server', search }: SourceBadgeProps)
     <span
       className="server-badge inline-flex items-center gap-1 rounded-full px-2 py-0.5 text-[11px] font-medium leading-none"
       style={style}
+      title={name}
     >
       <Icon size={10} className="shrink-0" />
       {search ? (

--- a/web-ui/src/components/layout/TopBar.tsx
+++ b/web-ui/src/components/layout/TopBar.tsx
@@ -46,7 +46,7 @@ export function TopBar({ title, showBack }: TopBarProps) {
           {title && (
             <>
               <span className="text-text-tertiary">&rsaquo;</span>
-              <span className="truncate">{title}</span>
+              <span className="truncate" title={title}>{title}</span>
             </>
           )}
           {isHome && !title && <span>{t('projects:title')}</span>}

--- a/web-ui/src/features/projects/components/ProjectsTable.tsx
+++ b/web-ui/src/features/projects/components/ProjectsTable.tsx
@@ -38,7 +38,7 @@ function ProjectRow({ project }: { project: ProjectSummary }) {
     >
       <div>
         <div className="mb-1 text-sm font-medium">{name}</div>
-        <div className="truncate font-mono text-xs text-text-tertiary">{project.path}</div>
+        <div className="truncate font-mono text-xs text-text-tertiary" title={project.path}>{project.path}</div>
       </div>
       <div className="text-center text-sm text-text-secondary max-md:hidden">
         {project.skills_count}

--- a/web-ui/src/features/projects/components/RulesList.tsx
+++ b/web-ui/src/features/projects/components/RulesList.tsx
@@ -62,9 +62,10 @@ function RuleItem({ rule, search }: { rule: Rule; search: string }) {
           className={`mt-0.5 shrink-0 text-text-tertiary transition-transform duration-150 ${expanded ? 'rotate-90' : ''}`}
         />
         <div className="min-w-0 flex-1">
-          <div className="flex items-center gap-2">
+          <div className="flex items-center gap-2 min-w-0">
             <span
-              className="font-mono text-xs font-medium text-text-primary"
+              className="truncate font-mono text-xs font-medium text-text-primary"
+              title={rule.id}
               dangerouslySetInnerHTML={{ __html: highlightText(rule.id, search) }}
             />
             <span
@@ -74,7 +75,7 @@ function RuleItem({ rule, search }: { rule: Rule; search: string }) {
             </span>
           </div>
           {!expanded && rule.description && (
-            <div className="mt-0.5 truncate text-[11px] text-text-tertiary">
+            <div className="mt-0.5 truncate text-[11px] text-text-tertiary" title={rule.description}>
               {rule.description}
             </div>
           )}

--- a/web-ui/src/features/projects/components/ServersList.tsx
+++ b/web-ui/src/features/projects/components/ServersList.tsx
@@ -126,6 +126,7 @@ function ServerItem({
             <span className="shrink-0 text-text-tertiary">&bull;</span>
             <span
               className={`font-mono text-[11px] ${expanded ? 'break-all' : 'truncate'}`}
+              title={connectionText}
               dangerouslySetInnerHTML={{ __html: highlightText(connectionText, search) }}
             />
           </>

--- a/web-ui/src/features/projects/components/ServersList.tsx
+++ b/web-ui/src/features/projects/components/ServersList.tsx
@@ -117,15 +117,15 @@ function ServerItem({
           </span>
         )}
       </div>
-      <div className="mb-1 flex items-center gap-2 text-xs text-text-secondary">
-        <span className="rounded-sm bg-bg-secondary px-1.5 py-0.5 text-[11px] font-medium uppercase">
+      <div className="mb-1 flex items-center gap-2 text-xs text-text-secondary min-w-0">
+        <span className="shrink-0 rounded-sm bg-bg-secondary px-1.5 py-0.5 text-[11px] font-medium uppercase">
           {server.type}
         </span>
         {connectionText && (
           <>
-            <span className="text-text-tertiary">&bull;</span>
+            <span className="shrink-0 text-text-tertiary">&bull;</span>
             <span
-              className="font-mono text-[11px]"
+              className={`font-mono text-[11px] ${expanded ? 'break-all' : 'truncate'}`}
               dangerouslySetInnerHTML={{ __html: highlightText(connectionText, search) }}
             />
           </>

--- a/web-ui/src/features/projects/components/SkillsList.tsx
+++ b/web-ui/src/features/projects/components/SkillsList.tsx
@@ -33,13 +33,14 @@ export function SkillsList({ skills, search }: SkillsListProps) {
         <div className="space-y-1">
           {visible.map((skill) => (
             <div key={skill.id} className="rounded-sm border border-border-tertiary bg-bg-tertiary p-3">
-              <div
-                className="mb-1 font-mono text-[13px] font-medium text-text-primary"
-                dangerouslySetInnerHTML={{ __html: highlightText(skill.id, search) }}
-              />
-              <div className="mb-1 flex items-center gap-2 text-xs text-text-secondary">
+              <div className="mb-1 flex items-center gap-2 min-w-0">
                 <span
-                  className={`rounded-sm px-1.5 py-0.5 text-[11px] font-medium uppercase ${sourceTypeBadgeClasses(skill.type)}`}
+                  className="truncate font-mono text-[13px] font-medium text-text-primary"
+                  title={skill.id}
+                  dangerouslySetInnerHTML={{ __html: highlightText(skill.id, search) }}
+                />
+                <span
+                  className={`shrink-0 rounded-sm px-1.5 py-0.5 text-[10px] font-medium uppercase ${sourceTypeBadgeClasses(skill.type)}`}
                 >
                   {skill.type}
                 </span>

--- a/web-ui/src/features/projects/components/SubagentsList.tsx
+++ b/web-ui/src/features/projects/components/SubagentsList.tsx
@@ -68,11 +68,12 @@ function SubagentItem({ agent, search }: { agent: SubAgent; search: string }) {
         />
         <div className="min-w-0 flex-1">
           <span
-            className="font-mono text-xs font-medium text-text-primary"
+            className="truncate font-mono text-xs font-medium text-text-primary"
+            title={agent.id}
             dangerouslySetInnerHTML={{ __html: highlightText(agent.id, search) }}
           />
           {!expanded && (
-            <div className="mt-0.5 truncate text-[11px] text-text-tertiary">
+            <div className="mt-0.5 truncate text-[11px] text-text-tertiary" title={desc || undefined}>
               {descPreview || t('subagents.noDescription')}
             </div>
           )}

--- a/web-ui/src/features/projects/components/ToolsList.tsx
+++ b/web-ui/src/features/projects/components/ToolsList.tsx
@@ -125,9 +125,10 @@ function ToolItem({
           className={`mt-0.5 shrink-0 text-text-tertiary transition-transform duration-150 ${expanded ? 'rotate-90' : ''}`}
         />
         <div className="min-w-0 flex-1">
-          <div className="flex items-center gap-2">
+          <div className="flex items-center gap-2 min-w-0">
             <span
-              className="font-mono text-xs font-medium text-text-primary"
+              className="truncate font-mono text-xs font-medium text-text-primary"
+              title={tool.id}
               dangerouslySetInnerHTML={{ __html: highlightText(tool.id, search) }}
             />
             <span className="shrink-0 rounded-sm bg-bg-secondary px-1.5 py-0.5 text-[10px] font-medium uppercase text-text-tertiary">
@@ -140,7 +141,7 @@ function ToolItem({
             )}
           </div>
           {!expanded && descPreview && (
-            <div className="mt-0.5 truncate text-[11px] text-text-tertiary">
+            <div className="mt-0.5 truncate text-[11px] text-text-tertiary" title={desc}>
               {descPreview}
             </div>
           )}


### PR DESCRIPTION
## Summary
- Fix long MCP server URLs overflowing their container in the web UI
- When collapsed: URL is truncated with ellipsis (`...`)
- When expanded (tool list visible): full URL is shown with word wrapping

## Test plan
- [x] Open the web UI with an MCP server that has a long URL
- [x] Verify the URL is truncated with ellipsis when the tool list is collapsed
- [x] Expand the tool list and verify the full URL is visible and wraps correctly