### PR TITLE
Enhance rules installation and pruning; add project UI URL helpers

### DIFF
--- a/src/cli/commands/install.ts
+++ b/src/cli/commands/install.ts
@@ -881,21 +881,25 @@ export async function installCommand(
     await unregisterMCPServer(projectPath, projectId, providers);
   }
 
-  // Step 5a: Process sub-agents — register filtered endpoints + write instruction blocks
-  if (capabilitiesToUse.subagents && capabilitiesToUse.subagents.length > 0) {
-    console.log('\n🤖 Installing sub-agents...');
+  // Step 5a: Process sub-agents — cleanup removed, then register + write instruction blocks
+  const installedAgents = db.getSubAgents(projectId);
+  const currentSubagents = capabilitiesToUse.subagents ?? [];
+  const currentAgentIds = new Set(currentSubagents.map((a) => a.id));
+  const removedSubAgentIds = installedAgents
+    .filter(({ agent_id }) => !currentAgentIds.has(agent_id))
+    .map(({ agent_id }) => agent_id);
+  const needsSubagentCleanup = removedSubAgentIds.length > 0;
+  const needsSubagentInstall = currentSubagents.length > 0;
 
-    // Clean up sub-agents that were removed since the last install
-    const installedAgents = db.getSubAgents(projectId);
-    const currentAgentIds = new Set(capabilitiesToUse.subagents.map((a) => a.id));
-    const removedSubAgentIds = installedAgents
-      .filter(({ agent_id }) => !currentAgentIds.has(agent_id))
-      .map(({ agent_id }) => agent_id);
+  if (needsSubagentCleanup || needsSubagentInstall) {
+    console.log(
+      needsSubagentInstall
+        ? '\n🤖 Installing sub-agents...'
+        : '\n🤖 Cleaning up removed sub-agents...'
+    );
 
-    // Cursor no longer uses per-sub-agent MCP entries — purge stale MCP keys and
-    // legacy `.cursor/rules/{agentId}.mdc` scoping files for removed sub-agents only
     if (providers.some((p) => p.toLowerCase() === 'cursor')) {
-      await purgeCursorSubAgentMCPEntries(projectPath, removedSubAgentIds);
+      await purgeCursorSubAgentMCPEntries(projectPath);
     }
 
     for (const { agent_id } of installedAgents) {
@@ -907,11 +911,9 @@ export async function installCommand(
       }
     }
 
-    // Install or update each sub-agent
-    for (const subAgent of capabilitiesToUse.subagents) {
+    for (const subAgent of currentSubagents) {
       console.log(`\n  Sub-agent: ${subAgent.id}${subAgent.description ? ` — ${subAgent.description}` : ''}`);
 
-      // Register filtered MCP endpoint
       const agentMcpUrl = `${serverStatus.url}/${projectId}/agents/${subAgent.id}/mcp`;
       await registerSubAgentMCPServer(
         projectPath,
@@ -920,7 +922,6 @@ export async function installCommand(
         providers
       );
 
-      // Write instruction block to CLAUDE.md / AGENTS.md
       installSubAgentInstructions(
         projectPath,
         subAgent,
@@ -928,11 +929,14 @@ export async function installCommand(
         providers
       );
 
-      // Track in DB for future cleanup
       db.upsertSubAgent(projectId, subAgent.id);
     }
 
-    console.log(`\n  ✓ ${capabilitiesToUse.subagents.length} sub-agent(s) installed`);
+    if (needsSubagentInstall) {
+      console.log(`\n  ✓ ${currentSubagents.length} sub-agent(s) installed`);
+    } else if (needsSubagentCleanup) {
+      console.log(`\n  ✓ Removed ${removedSubAgentIds.length} sub-agent(s)`);
+    }
   }
 
   db.close();

--- a/src/cli/commands/install.ts
+++ b/src/cli/commands/install.ts
@@ -20,6 +20,7 @@ import { parseEnvFile } from '../../shared/env-parser';
 import { extractAllVariables } from '../../shared/variable-resolver';
 import { resolvePlugins } from './plugin-install';
 import { installAgentsFile, installSubAgentInstructions, removeSubAgentInstructions } from '../utils/agents-file';
+import { installRules, pruneRules, isProviderRulesManagedPath } from '../utils/rules-installer';
 import {
   loadBlockedPhrases,
   checkBlockedPhrases,
@@ -710,12 +711,36 @@ export async function installCommand(
     }
   }
 
-  // Step 3.5: Install rules across providers
-  // We also always run a prune step (further down) so that rules removed or
-  // commented out since the last install have their files / marker blocks
-  // cleaned up. The install step itself is gated on `rules.length > 0`
-  // because there's nothing to fetch otherwise.
   const currentRules = capabilitiesToUse.rules ?? [];
+
+  // Step 3.5: Prune rule artifacts that are no longer in the capabilities file.
+  // Runs before install so orphans are removed first; install then writes current rules.
+  if (providers.length > 0) {
+    try {
+      const previouslyManaged = db.getManagedFiles(projectId);
+      const { removedFiles, removedMarkers } = pruneRules(
+        projectPath,
+        providers,
+        currentRules,
+        previouslyManaged
+      );
+      for (const f of removedFiles) {
+        db.removeManagedFile(projectId, f);
+      }
+      if (removedFiles.length + removedMarkers.length > 0) {
+        const fileWord = removedFiles.length === 1 ? 'file' : 'files';
+        const blockWord = removedMarkers.length === 1 ? 'block' : 'blocks';
+        console.log(
+          `\n📏 Pruned ${removedFiles.length} orphan rule ${fileWord} and ` +
+          `${removedMarkers.length} orphan rule marker ${blockWord}`
+        );
+      }
+    } catch (err: any) {
+      console.error(`  ⚠  Failed to prune orphan rules: ${err.message}`);
+    }
+  }
+
+  // Step 3.6: Install rules across providers (gated on `rules.length > 0` — nothing to fetch otherwise)
   if (currentRules.length > 0) {
     console.log('\n📏 Installing rules...');
     try {
@@ -764,7 +789,6 @@ export async function installCommand(
         resolvedContent.set(rule.id, body);
       }
 
-      const { installRules } = await import('../utils/rules-installer');
       installRules(projectPath, currentRules, providers, resolvedContent, {
         // Register every rule file we write so `pruneRules` (and `capa
         // clean`) can find it later, even after the user removes the rule
@@ -776,37 +800,6 @@ export async function installCommand(
       console.error(`  ✗ Failed to install rules: ${err.message}`);
       db.close();
       process.exit(1);
-    }
-  }
-
-  // Step 3.6: Prune rule artifacts that are no longer in the capabilities file.
-  // Runs unconditionally so commenting out or removing a rule removes its
-  // file (for directory-based providers) or marker block (for instruction-
-  // folded providers) on the next install.
-  if (providers.length > 0) {
-    try {
-      const { pruneRules } = await import('../utils/rules-installer');
-      const previouslyManaged = db.getManagedFiles(projectId);
-      const { removedFiles, removedMarkers } = pruneRules(
-        projectPath,
-        providers,
-        currentRules,
-        previouslyManaged
-      );
-      for (const f of removedFiles) {
-        db.removeManagedFile(projectId, f);
-      }
-      if (removedFiles.length + removedMarkers.length > 0) {
-        const fileWord = removedFiles.length === 1 ? 'file' : 'files';
-        const blockWord = removedMarkers.length === 1 ? 'block' : 'blocks';
-        console.log(
-          `  ✓ Pruned ${removedFiles.length} orphan rule ${fileWord} and ` +
-          `${removedMarkers.length} orphan rule marker ${blockWord}`
-        );
-      }
-    } catch (err: any) {
-      console.error(`  ⚠  Failed to prune orphan rules: ${err.message}`);
-      // Non-fatal: install can still proceed even if prune partially failed.
     }
   }
 
@@ -892,14 +885,19 @@ export async function installCommand(
   if (capabilitiesToUse.subagents && capabilitiesToUse.subagents.length > 0) {
     console.log('\n🤖 Installing sub-agents...');
 
-    // Cursor no longer uses per-sub-agent MCP entries — purge any stale ones from prior installs
-    if (providers.some((p) => p.toLowerCase() === 'cursor')) {
-      await purgeCursorSubAgentMCPEntries(projectPath);
-    }
-
     // Clean up sub-agents that were removed since the last install
     const installedAgents = db.getSubAgents(projectId);
     const currentAgentIds = new Set(capabilitiesToUse.subagents.map((a) => a.id));
+    const removedSubAgentIds = installedAgents
+      .filter(({ agent_id }) => !currentAgentIds.has(agent_id))
+      .map(({ agent_id }) => agent_id);
+
+    // Cursor no longer uses per-sub-agent MCP entries — purge stale MCP keys and
+    // legacy `.cursor/rules/{agentId}.mdc` scoping files for removed sub-agents only
+    if (providers.some((p) => p.toLowerCase() === 'cursor')) {
+      await purgeCursorSubAgentMCPEntries(projectPath, removedSubAgentIds);
+    }
+
     for (const { agent_id } of installedAgents) {
       if (!currentAgentIds.has(agent_id)) {
         console.log(`  Removing sub-agent "${agent_id}" (no longer in capabilities)...`);
@@ -1011,6 +1009,11 @@ async function cleanupRemovedSkills(
   
   // Check each managed directory
   for (const managedPath of managedFiles) {
+    // Rule files share the managed-files table but are pruned in step 3.5
+    if (isProviderRulesManagedPath(projectPath, managedPath, clients)) {
+      continue;
+    }
+
     // Extract the skill ID from the managed path
     // Managed paths are typically: /path/to/project/.agents/skills/skill-id
     const skillId = basename(managedPath);

--- a/src/cli/utils/__tests__/mcp-client-manager.test.ts
+++ b/src/cli/utils/__tests__/mcp-client-manager.test.ts
@@ -5,6 +5,7 @@ import { tmpdir } from 'os';
 import {
   registerMCPServer,
   unregisterMCPServer,
+  purgeCursorSubAgentMCPEntries,
   getSupportedMCPClients,
   getMCPClientDisplayName,
 } from '../mcp-client-manager';
@@ -386,6 +387,42 @@ describe('mcp-client-manager', () => {
       const config = JSON.parse(readFileSync(configPath, 'utf-8'));
       
       expect(config.mcpServers['capa']).toBeDefined();
+    });
+  });
+
+  describe('purgeCursorSubAgentMCPEntries', () => {
+    it('removes legacy sub-agent .mdc only for removed agent ids, not capa rules', async () => {
+      const rulesDir = join(projectPath, '.cursor', 'rules');
+      mkdirSync(rulesDir, { recursive: true });
+      writeFileSync(join(rulesDir, 'code-style.mdc'), '# capa rule', 'utf-8');
+      writeFileSync(join(rulesDir, 'researcher.mdc'), '# legacy sub-agent scope', 'utf-8');
+      writeFileSync(join(rulesDir, 'user-custom.mdc'), '# user file', 'utf-8');
+
+      mkdirSync(join(projectPath, '.cursor'), { recursive: true });
+      writeFileSync(
+        join(projectPath, '.cursor', 'mcp.json'),
+        JSON.stringify({ mcpServers: { 'capa-old-agent': { url: 'http://x/mcp' } } }, null, 2),
+        'utf-8'
+      );
+
+      await purgeCursorSubAgentMCPEntries(projectPath, ['researcher']);
+
+      expect(existsSync(join(rulesDir, 'code-style.mdc'))).toBe(true);
+      expect(existsSync(join(rulesDir, 'user-custom.mdc'))).toBe(true);
+      expect(existsSync(join(rulesDir, 'researcher.mdc'))).toBe(false);
+
+      const config = JSON.parse(readFileSync(join(projectPath, '.cursor', 'mcp.json'), 'utf-8'));
+      expect(config.mcpServers['capa-old-agent']).toBeUndefined();
+    });
+
+    it('does not touch .cursor/rules when no sub-agents were removed', async () => {
+      const rulesDir = join(projectPath, '.cursor', 'rules');
+      mkdirSync(rulesDir, { recursive: true });
+      writeFileSync(join(rulesDir, 'code-style.mdc'), '# capa rule', 'utf-8');
+
+      await purgeCursorSubAgentMCPEntries(projectPath, []);
+
+      expect(existsSync(join(rulesDir, 'code-style.mdc'))).toBe(true);
     });
   });
 

--- a/src/cli/utils/__tests__/mcp-client-manager.test.ts
+++ b/src/cli/utils/__tests__/mcp-client-manager.test.ts
@@ -391,38 +391,24 @@ describe('mcp-client-manager', () => {
   });
 
   describe('purgeCursorSubAgentMCPEntries', () => {
-    it('removes legacy sub-agent .mdc only for removed agent ids, not capa rules', async () => {
-      const rulesDir = join(projectPath, '.cursor', 'rules');
-      mkdirSync(rulesDir, { recursive: true });
-      writeFileSync(join(rulesDir, 'code-style.mdc'), '# capa rule', 'utf-8');
-      writeFileSync(join(rulesDir, 'researcher.mdc'), '# legacy sub-agent scope', 'utf-8');
-      writeFileSync(join(rulesDir, 'user-custom.mdc'), '# user file', 'utf-8');
-
+    it('removes stale capa-* MCP entries from .cursor/mcp.json', async () => {
       mkdirSync(join(projectPath, '.cursor'), { recursive: true });
       writeFileSync(
         join(projectPath, '.cursor', 'mcp.json'),
-        JSON.stringify({ mcpServers: { 'capa-old-agent': { url: 'http://x/mcp' } } }, null, 2),
+        JSON.stringify({
+          mcpServers: {
+            capa: { url: 'http://x/mcp' },
+            'capa-old-agent': { url: 'http://x/agent/mcp' },
+          },
+        }, null, 2),
         'utf-8'
       );
 
-      await purgeCursorSubAgentMCPEntries(projectPath, ['researcher']);
-
-      expect(existsSync(join(rulesDir, 'code-style.mdc'))).toBe(true);
-      expect(existsSync(join(rulesDir, 'user-custom.mdc'))).toBe(true);
-      expect(existsSync(join(rulesDir, 'researcher.mdc'))).toBe(false);
+      await purgeCursorSubAgentMCPEntries(projectPath);
 
       const config = JSON.parse(readFileSync(join(projectPath, '.cursor', 'mcp.json'), 'utf-8'));
+      expect(config.mcpServers['capa']).toBeDefined();
       expect(config.mcpServers['capa-old-agent']).toBeUndefined();
-    });
-
-    it('does not touch .cursor/rules when no sub-agents were removed', async () => {
-      const rulesDir = join(projectPath, '.cursor', 'rules');
-      mkdirSync(rulesDir, { recursive: true });
-      writeFileSync(join(rulesDir, 'code-style.mdc'), '# capa rule', 'utf-8');
-
-      await purgeCursorSubAgentMCPEntries(projectPath, []);
-
-      expect(existsSync(join(rulesDir, 'code-style.mdc'))).toBe(true);
     });
   });
 

--- a/src/cli/utils/__tests__/sub-agent-mcp.test.ts
+++ b/src/cli/utils/__tests__/sub-agent-mcp.test.ts
@@ -44,7 +44,7 @@ describe('sub-agent MCP client registration', () => {
       ['cursor']
     );
 
-    // Cursor uses .cursor/rules/{id}.mdc for sub-agent scoping, not MCP server entries
+    // Cursor does not register per-sub-agent MCP entries
     expect(existsSync(join(tempDir, '.cursor', 'mcp.json'))).toBe(false);
   });
 

--- a/src/cli/utils/agents-file.ts
+++ b/src/cli/utils/agents-file.ts
@@ -548,14 +548,6 @@ function removeSubAgentFile(projectPath: string, providerId: string, agentId: st
     unlinkSync(filePath);
     console.log(`  ✓ Removed ${sa.dir}/${agentId}${sa.extension}`);
   }
-
-  // Legacy cleanup for Cursor: remove old .cursor/rules/{id}.mdc files
-  if (providerId === 'cursor') {
-    const legacyPath = join(projectPath, '.cursor', 'rules', `${agentId}.mdc`);
-    if (existsSync(legacyPath)) {
-      unlinkSync(legacyPath);
-    }
-  }
 }
 
 /**

--- a/src/cli/utils/mcp-client-manager.ts
+++ b/src/cli/utils/mcp-client-manager.ts
@@ -1,4 +1,4 @@
-import { existsSync, readFileSync, writeFileSync, mkdirSync, unlinkSync } from 'fs';
+import { existsSync, readFileSync, writeFileSync, mkdirSync } from 'fs';
 import { join, dirname } from 'path';
 import { getProvider, getAllProviders } from '../../shared/providers';
 import { readTomlFile, writeTomlFile, setNestedKey, deleteNestedKey } from '../../shared/toml-io';
@@ -156,17 +156,10 @@ export async function unregisterSubAgentMCPServer(
 }
 
 /**
- * Remove stale capa-{agentId} sub-agent entries from Cursor's MCP config and
- * legacy per-sub-agent `.cursor/rules/{agentId}.mdc` scoping files from older
- * capa versions. Does not touch capa-managed capability rules.
- *
- * @param removedSubAgentIds - Sub-agent ids dropped from the capabilities file
- *   since the last install; only their legacy `.mdc` files are removed.
+ * Remove stale capa-{agentId} sub-agent entries from Cursor's MCP config.
+ * Cursor does not use per-sub-agent MCP server entries; capa no longer writes them.
  */
-export async function purgeCursorSubAgentMCPEntries(
-  projectPath: string,
-  removedSubAgentIds: string[] = []
-): Promise<void> {
+export async function purgeCursorSubAgentMCPEntries(projectPath: string): Promise<void> {
   const configPath = join(projectPath, '.cursor', 'mcp.json');
   if (!existsSync(configPath)) return;
 
@@ -186,22 +179,6 @@ export async function purgeCursorSubAgentMCPEntries(
       writeFileSync(configPath, JSON.stringify(config, null, 2), 'utf-8');
       console.log(`  ✓ Removed ${staleKeys.length} stale sub-agent MCP entr${staleKeys.length === 1 ? 'y' : 'ies'} from .cursor/mcp.json`);
     }
-  }
-
-  if (removedSubAgentIds.length === 0) return;
-
-  const rulesDir = join(projectPath, '.cursor', 'rules');
-  let removedLegacyRules = 0;
-  for (const agentId of removedSubAgentIds) {
-    const legacyPath = join(rulesDir, `${agentId}.mdc`);
-    if (!existsSync(legacyPath)) continue;
-    unlinkSync(legacyPath);
-    removedLegacyRules++;
-  }
-  if (removedLegacyRules > 0) {
-    console.log(
-      `  ✓ Removed ${removedLegacyRules} legacy sub-agent rule file(s) from .cursor/rules/`
-    );
   }
 }
 

--- a/src/cli/utils/mcp-client-manager.ts
+++ b/src/cli/utils/mcp-client-manager.ts
@@ -1,4 +1,4 @@
-import { existsSync, readFileSync, writeFileSync, mkdirSync, readdirSync, unlinkSync } from 'fs';
+import { existsSync, readFileSync, writeFileSync, mkdirSync, unlinkSync } from 'fs';
 import { join, dirname } from 'path';
 import { getProvider, getAllProviders } from '../../shared/providers';
 import { readTomlFile, writeTomlFile, setNestedKey, deleteNestedKey } from '../../shared/toml-io';
@@ -156,10 +156,17 @@ export async function unregisterSubAgentMCPServer(
 }
 
 /**
- * Remove any stale capa-{agentId} sub-agent entries from Cursor's MCP config.
- * Also cleans up legacy .cursor/rules/*.mdc files from old capa versions.
+ * Remove stale capa-{agentId} sub-agent entries from Cursor's MCP config and
+ * legacy per-sub-agent `.cursor/rules/{agentId}.mdc` scoping files from older
+ * capa versions. Does not touch capa-managed capability rules.
+ *
+ * @param removedSubAgentIds - Sub-agent ids dropped from the capabilities file
+ *   since the last install; only their legacy `.mdc` files are removed.
  */
-export async function purgeCursorSubAgentMCPEntries(projectPath: string): Promise<void> {
+export async function purgeCursorSubAgentMCPEntries(
+  projectPath: string,
+  removedSubAgentIds: string[] = []
+): Promise<void> {
   const configPath = join(projectPath, '.cursor', 'mcp.json');
   if (!existsSync(configPath)) return;
 
@@ -181,15 +188,20 @@ export async function purgeCursorSubAgentMCPEntries(projectPath: string): Promis
     }
   }
 
+  if (removedSubAgentIds.length === 0) return;
+
   const rulesDir = join(projectPath, '.cursor', 'rules');
-  if (existsSync(rulesDir)) {
-    const staleRules = readdirSync(rulesDir).filter((f) => f.endsWith('.mdc'));
-    for (const file of staleRules) {
-      unlinkSync(join(rulesDir, file));
-    }
-    if (staleRules.length > 0) {
-      console.log(`  ✓ Removed ${staleRules.length} stale .cursor/rules/*.mdc file(s)`);
-    }
+  let removedLegacyRules = 0;
+  for (const agentId of removedSubAgentIds) {
+    const legacyPath = join(rulesDir, `${agentId}.mdc`);
+    if (!existsSync(legacyPath)) continue;
+    unlinkSync(legacyPath);
+    removedLegacyRules++;
+  }
+  if (removedLegacyRules > 0) {
+    console.log(
+      `  ✓ Removed ${removedLegacyRules} legacy sub-agent rule file(s) from .cursor/rules/`
+    );
   }
 }
 

--- a/src/cli/utils/rules-installer.ts
+++ b/src/cli/utils/rules-installer.ts
@@ -98,6 +98,31 @@ function writeMd(projectPath: string, filename: string, content: string): void {
 }
 
 // ---------------------------------------------------------------------------
+// Managed-path helpers
+// ---------------------------------------------------------------------------
+
+/**
+ * True when `filePath` is a capa-managed rule file for one of the given providers
+ * (under `provider.rules.dir` with the provider's extension).
+ */
+export function isProviderRulesManagedPath(
+  projectPath: string,
+  filePath: string,
+  providers: string[]
+): boolean {
+  for (const pid of providers) {
+    const provider = getProvider(pid);
+    if (!provider?.rules) continue;
+    const rulesDir = join(projectPath, provider.rules.dir);
+    const dirPrefix = rulesDir.endsWith(sep) ? rulesDir : rulesDir + sep;
+    if (!filePath.startsWith(dirPrefix)) continue;
+    if (!filePath.endsWith(provider.rules.extension)) continue;
+    return true;
+  }
+  return false;
+}
+
+// ---------------------------------------------------------------------------
 // Public API
 // ---------------------------------------------------------------------------
 

--- a/src/server/index.ts
+++ b/src/server/index.ts
@@ -15,6 +15,7 @@ import { RegistryManager } from '../shared/registries/manager';
 import type { RegistryCapability } from '../types/registry';
 import { VERSION } from '../version';
 import { logger } from '../shared/logger';
+import { projectUiUrl } from '../shared/ui-urls';
 
 // Import the React SPA bundle as text at compile time - this bundles it into the binary
 import spaHtml from '../../web-ui/dist/index.html' with { type: 'text' };
@@ -719,7 +720,7 @@ class CapaServer {
         if (needsOAuth2Connection) {
           apiLogger.warn(`OAuth2 connections needed: ${oauth2Servers.filter(s => !s.isConnected).map(s => s.serverId).join(', ')}`);
         }
-        const credentialsUrl = `http://${this.settings.server.host}:${this.settings.server.port}/ui?project=${projectId}`;
+        const credentialsUrl = projectUiUrl(this.uiOrigin(), projectId);
         
         return new Response(
           JSON.stringify({
@@ -870,6 +871,10 @@ class CapaServer {
     );
   }
 
+  private uiOrigin(): string {
+    return `http://${this.settings.server.host}:${this.settings.server.port}`;
+  }
+
   /** Close and remove the callback server for a port (after completion or idle timeout). */
   private closeOAuthCallbackServer(port: number): void {
     const entry = this.oauthCallbackServers.get(port);
@@ -889,7 +894,7 @@ class CapaServer {
     if (this.oauthCallbackServers.has(port)) return;
     const self = this;
     const IDLE_MS = 5 * 60 * 1000; // 5 minutes
-    const mainBase = `http://${this.settings.server.host}:${this.settings.server.port}`;
+    const mainBase = this.uiOrigin();
     const server = createServer((req, res) => {
       if (req.method !== 'GET' || !req.url) {
         res.writeHead(405);
@@ -914,12 +919,21 @@ class CapaServer {
       const error = reqUrl.searchParams.get('error');
       const apiLogger = self.logger.child('API');
 
-      const redirectToUi = (projectId: string | undefined, success: boolean, message?: string) => {
+      const redirectToUi = (
+        projectId: string | undefined,
+        success: boolean,
+        message?: string,
+        serverId?: string
+      ) => {
         closeWhenDone(); // register before sending so 'finish' fires reliably
-        const q = new URLSearchParams();
-        if (projectId) q.set('project', projectId);
-        q.set(success ? 'oauth_success' : 'oauth_error', message ?? (success ? 'true' : 'Unknown error'));
-        const loc = `${mainBase}/ui?${q.toString()}`;
+        const loc = projectId
+          ? projectUiUrl(mainBase, projectId, {
+              ...(success
+                ? { oauth_success: message ?? 'true' }
+                : { oauth_error: message ?? 'Unknown error' }),
+              ...(serverId ? { server: serverId } : {}),
+            })
+          : `${mainBase}/`;
         res.writeHead(302, { Location: loc });
         res.end();
       };
@@ -948,13 +962,7 @@ class CapaServer {
           return;
         }
         apiLogger.success(`OAuth2 flow completed for server: ${result.serverId}`);
-        closeWhenDone(); // register before sending so 'finish' fires reliably
-        const q = new URLSearchParams();
-        if (result.projectId) q.set('project', result.projectId);
-        q.set('oauth_success', 'true');
-        if (result.serverId) q.set('server', result.serverId);
-        res.writeHead(302, { Location: `${mainBase}/ui?${q.toString()}` });
-        res.end();
+        redirectToUi(result.projectId, true, 'true', result.serverId);
       }).catch((err: any) => {
         apiLogger.failure(`Callback error: ${err.message}`);
         redirectToUi(undefined, false, err.message ?? 'Token exchange failed');
@@ -1051,8 +1059,7 @@ class CapaServer {
 
       if (error) {
         apiLogger.error(`OAuth2 callback error: ${error}`);
-        // Redirect to UI with error
-        const redirectUrl = `http://${this.settings.server.host}:${this.settings.server.port}/ui?project=${projectId}&oauth_error=${encodeURIComponent(error)}`;
+        const redirectUrl = projectUiUrl(this.uiOrigin(), projectId, { oauth_error: error });
         return new Response(null, {
           status: 302,
           headers: { Location: redirectUrl },
@@ -1072,7 +1079,9 @@ class CapaServer {
       
       if (!result.success) {
         apiLogger.failure(`Callback failed: ${result.error}`);
-        const redirectUrl = `http://${this.settings.server.host}:${this.settings.server.port}/ui?project=${projectId}&oauth_error=${encodeURIComponent(result.error || 'Unknown error')}`;
+        const redirectUrl = projectUiUrl(this.uiOrigin(), projectId, {
+          oauth_error: result.error || 'Unknown error',
+        });
         return new Response(null, {
           status: 302,
           headers: { Location: redirectUrl },
@@ -1080,9 +1089,11 @@ class CapaServer {
       }
 
       apiLogger.success(`OAuth2 flow completed for server: ${result.serverId}`);
-      
-      // Redirect back to UI with success
-      const redirectUrl = `http://${this.settings.server.host}:${this.settings.server.port}/ui?project=${projectId}&oauth_success=true&server=${result.serverId}`;
+
+      const redirectUrl = projectUiUrl(this.uiOrigin(), projectId, {
+        oauth_success: 'true',
+        ...(result.serverId ? { server: result.serverId } : {}),
+      });
       return new Response(null, {
         status: 302,
         headers: { Location: redirectUrl },
@@ -1090,7 +1101,9 @@ class CapaServer {
     } catch (error: any) {
       const apiLogger = this.logger.child('API');
       apiLogger.failure(`Error: ${error.message}`);
-      const redirectUrl = `http://${this.settings.server.host}:${this.settings.server.port}/ui?project=${projectId}&oauth_error=${encodeURIComponent(error.message)}`;
+      const redirectUrl = projectUiUrl(this.uiOrigin(), projectId, {
+        oauth_error: error.message,
+      });
       return new Response(null, {
         status: 302,
         headers: { Location: redirectUrl },

--- a/src/shared/__tests__/ui-urls.test.ts
+++ b/src/shared/__tests__/ui-urls.test.ts
@@ -1,0 +1,22 @@
+import { describe, it, expect } from 'bun:test';
+import { projectUiPath, projectUiUrl } from '../ui-urls';
+
+describe('ui-urls', () => {
+  it('projectUiPath uses /ui/project with id query param', () => {
+    expect(projectUiPath('my-proj-1234')).toBe('/ui/project?id=my-proj-1234');
+  });
+
+  it('projectUiPath appends extra query params', () => {
+    const path = projectUiPath('my-proj-1234', { oauth_success: 'true', server: 'slack' });
+    expect(path).toContain('/ui/project?');
+    expect(path).toContain('id=my-proj-1234');
+    expect(path).toContain('oauth_success=true');
+    expect(path).toContain('server=slack');
+  });
+
+  it('projectUiUrl builds absolute URL', () => {
+    expect(projectUiUrl('http://127.0.0.1:5912', 'proj-1')).toBe(
+      'http://127.0.0.1:5912/ui/project?id=proj-1'
+    );
+  });
+});

--- a/src/shared/__tests__/ui-urls.test.ts
+++ b/src/shared/__tests__/ui-urls.test.ts
@@ -14,6 +14,12 @@ describe('ui-urls', () => {
     expect(path).toContain('server=slack');
   });
 
+  it('projectUiPath ignores id in query so projectId always wins', () => {
+    expect(projectUiPath('real-proj', { id: 'other-proj', oauth_success: 'true' })).toBe(
+      '/ui/project?oauth_success=true&id=real-proj'
+    );
+  });
+
   it('projectUiUrl builds absolute URL', () => {
     expect(projectUiUrl('http://127.0.0.1:5912', 'proj-1')).toBe(
       'http://127.0.0.1:5912/ui/project?id=proj-1'

--- a/src/shared/providers/__tests__/registry.test.ts
+++ b/src/shared/providers/__tests__/registry.test.ts
@@ -631,6 +631,21 @@ describe('Rules: managed-file registration + pruning', () => {
     expect(result.removedMarkers).toEqual(['cursor-only']);
   });
 
+  it('isProviderRulesManagedPath identifies capa rule files but not skill dirs', async () => {
+    const { isProviderRulesManagedPath } = await import('../../../cli/utils/rules-installer');
+    const rulePath = join(tempDir, '.cursor', 'rules', 'my-rule.mdc');
+    const skillDir = join(tempDir, '.cursor', 'skills', 'my-skill');
+    mkdirSync(join(tempDir, '.cursor', 'rules'), { recursive: true });
+    writeFileSync(rulePath, 'rule', 'utf-8');
+    mkdirSync(skillDir, { recursive: true });
+
+    expect(isProviderRulesManagedPath(tempDir, rulePath, ['cursor'])).toBe(true);
+    expect(isProviderRulesManagedPath(tempDir, skillDir, ['cursor'])).toBe(false);
+    expect(isProviderRulesManagedPath(tempDir, join(skillDir, 'SKILL.md'), ['cursor'])).toBe(
+      false
+    );
+  });
+
   it('pruneRules ignores managed files outside the provider rules dir (no false deletions)', async () => {
     const { pruneRules } = await import('../../../cli/utils/rules-installer');
     // A skill directory is "managed" but lives elsewhere. pruneRules must

--- a/src/shared/ui-urls.ts
+++ b/src/shared/ui-urls.ts
@@ -1,0 +1,21 @@
+/**
+ * Web UI route helpers for the capa server SPA.
+ */
+
+/** Relative path to a project's detail page (credentials, OAuth, variables). */
+export function projectUiPath(projectId: string, query?: Record<string, string>): string {
+  const q = new URLSearchParams();
+  q.set('id', projectId);
+  if (query) {
+    for (const [key, value] of Object.entries(query)) {
+      q.set(key, value);
+    }
+  }
+  return `/ui/project?${q.toString()}`;
+}
+
+/** Absolute URL to a project's detail page. */
+export function projectUiUrl(origin: string, projectId: string, query?: Record<string, string>): string {
+  const base = origin.replace(/\/$/, '');
+  return `${base}${projectUiPath(projectId, query)}`;
+}

--- a/src/shared/ui-urls.ts
+++ b/src/shared/ui-urls.ts
@@ -5,12 +5,13 @@
 /** Relative path to a project's detail page (credentials, OAuth, variables). */
 export function projectUiPath(projectId: string, query?: Record<string, string>): string {
   const q = new URLSearchParams();
-  q.set('id', projectId);
   if (query) {
     for (const [key, value] of Object.entries(query)) {
+      if (key === 'id') continue;
       q.set(key, value);
     }
   }
+  q.set('id', projectId);
   return `/ui/project?${q.toString()}`;
 }
 


### PR DESCRIPTION
Closes #53 #54 

This pull request introduces several improvements to rule and sub-agent management in the install process, and refactors server-side UI URL construction for better maintainability and consistency. The changes enhance how orphaned rule files are pruned, ensure only legacy sub-agent files are removed, and centralize the way UI URLs are generated for OAuth2 flows. Tests have also been added to cover the new URL helpers and sub-agent cleanup logic.

**Rule and sub-agent management improvements:**

* The pruning of orphaned rule files is now performed before rule installation, ensuring that any outdated files are removed prior to writing new ones. This also prevents accidental removal of currently managed files. (`src/cli/commands/install.ts`, `src/cli/utils/rules-installer.ts`) [[1]](diffhunk://#diff-9d7adcca5f47eca20859c2a649219f9db7e7f42d4bf23a92eae392a4e8cdf4fcL713-R743) [[2]](diffhunk://#diff-9d7adcca5f47eca20859c2a649219f9db7e7f42d4bf23a92eae392a4e8cdf4fcL782-L812) [[3]](diffhunk://#diff-19daae95e2e19f979942f50511d4dec0204e987c7e567a74c1c0b86727eca6e3R100-R124)
* Added the `isProviderRulesManagedPath` helper to distinguish between rule files managed by providers and other managed files, preventing accidental deletion of active rule files during cleanup. (`src/cli/utils/rules-installer.ts`, `src/cli/commands/install.ts`) [[1]](diffhunk://#diff-19daae95e2e19f979942f50511d4dec0204e987c7e567a74c1c0b86727eca6e3R100-R124) [[2]](diffhunk://#diff-9d7adcca5f47eca20859c2a649219f9db7e7f42d4bf23a92eae392a4e8cdf4fcR1012-R1016)

**Server UI URL handling refactor:**

* Introduced the `projectUiUrl` helper to generate UI URLs for OAuth2 redirects, replacing manual string construction throughout the server. This ensures consistency and easier maintenance. (`src/server/index.ts`, `src/shared/ui-urls.ts`, `src/shared/__tests__/ui-urls.test.ts`) [[1]](diffhunk://#diff-e4e7a68d82cdfba4e7dab9a32a8f55f3806ffa0cf33f1b8ab64b42941cf68888L722-R723) [[2]](diffhunk://#diff-e4e7a68d82cdfba4e7dab9a32a8f55f3806ffa0cf33f1b8ab64b42941cf68888R874-R877) [[3]](diffhunk://#diff-e4e7a68d82cdfba4e7dab9a32a8f55f3806ffa0cf33f1b8ab64b42941cf68888L892-R897) [[4]](diffhunk://#diff-e4e7a68d82cdfba4e7dab9a32a8f55f3806ffa0cf33f1b8ab64b42941cf68888L917-R936) [[5]](diffhunk://#diff-e4e7a68d82cdfba4e7dab9a32a8f55f3806ffa0cf33f1b8ab64b42941cf68888L951-R965) [[6]](diffhunk://#diff-e4e7a68d82cdfba4e7dab9a32a8f55f3806ffa0cf33f1b8ab64b42941cf68888L1054-R1062) [[7]](diffhunk://#diff-e4e7a68d82cdfba4e7dab9a32a8f55f3806ffa0cf33f1b8ab64b42941cf68888L1075-R1084) [[8]](diffhunk://#diff-e4e7a68d82cdfba4e7dab9a32a8f55f3806ffa0cf33f1b8ab64b42941cf68888L1084-R1106) [[9]](diffhunk://#diff-523aa0991388a5ec0c036b46b4fecf373fcf1ce37570878c53673d501b9de2f4R1-R22)

**Testing improvements:**

* Added new tests for the `purgeCursorSubAgentMCPEntries` logic to verify that only the correct files are deleted, and for the new `projectUiPath` and `projectUiUrl` helpers to ensure correct URL formatting. (`src/cli/utils/__tests__/mcp-client-manager.test.ts`, `src/shared/__tests__/ui-urls.test.ts`) [[1]](diffhunk://#diff-69392a2f1a710794d2e3aa0792b8c51e79e33d7a0e8f80e07c87ea8da120430bR393-R428) [[2]](diffhunk://#diff-523aa0991388a5ec0c036b46b4fecf373fcf1ce37570878c53673d501b9de2f4R1-R22)