### PR TITLE
ci: add CodeQL + Dependency Review security scanning

### DIFF
--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -1,0 +1,57 @@
+name: Security
+
+on:
+  push:
+    branches: [main, develop]
+  pull_request:
+    branches: [main, develop]
+  schedule:
+    # Weekly re-scan catches new advisories against unchanged code.
+    - cron: '23 5 * * 1'
+
+permissions:
+  contents: read
+
+jobs:
+  codeql:
+    name: CodeQL (${{ matrix.language }})
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      security-events: write
+      actions: read
+    strategy:
+      fail-fast: false
+      matrix:
+        language: [javascript-typescript]
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+
+      - name: Initialize CodeQL
+        uses: github/codeql-action/init@v3
+        with:
+          languages: ${{ matrix.language }}
+          queries: security-extended
+
+      - name: Perform CodeQL Analysis
+        uses: github/codeql-action/analyze@v3
+        with:
+          category: /language:${{ matrix.language }}
+
+  dependency-review:
+    name: Dependency Review
+    runs-on: ubuntu-latest
+    if: github.event_name == 'pull_request'
+    permissions:
+      contents: read
+      pull-requests: write
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+
+      - name: Review PR-introduced dependencies
+        uses: actions/dependency-review-action@v4
+        with:
+          fail-on-severity: high
+          comment-summary-in-pr: on-failure


### PR DESCRIPTION
## Summary

Adds a free, GitHub-native vulnerability scanning workflow at \`.github/workflows/security.yml\` covering two angles:

- **CodeQL** (SAST) — runs the \`security-extended\` query suite for \`javascript-typescript\` on every push to \`main\`/\`develop\`, on every PR, and weekly via cron so newly-published advisories surface against code that hasn't changed.
- **Dependency Review** — runs only on PRs; fails the PR when it would introduce a dependency carrying a known **high**-or-higher severity advisory (per the GitHub Advisory Database). Posts a summary comment when it fails.

Both are free for public repositories and require no third-party accounts or tokens.

## Why these two

- CodeQL covers code-level issues (unsafe \`eval\`, prototype pollution, path traversal, command injection, etc.) — relevant for capa's CLI surfaces and the local HTTP server.
- Dependency Review covers the most likely ingress for new CVEs: a PR adding/upgrading an npm or GitHub Action.

Existing **Dependabot** (\`.github/dependabot.yml\`) already opens PRs for outdated/vulnerable deps weekly — this PR is complementary, not duplicative.

## Triggers

| Job              | push (main/develop) | pull_request | schedule (weekly) |
|------------------|---------------------|--------------|-------------------|
| CodeQL           | ✓                   | ✓            | ✓                 |
| Dependency Review| —                   | ✓            | —                 |

## Cost / runtime

- CodeQL adds ~3-5 min on top of the existing Test matrix per push/PR.
- Dependency Review is a few seconds.
- Free minutes on public repos.

## Test plan

- Watch this PR's own \`Security\` workflow run go green.
- Inspect the \`Security\` tab in the repo after the run completes — CodeQL findings (if any) will appear under **Code scanning**.

## Follow-up (not in this PR, repo-settings only)

Worth enabling in Settings → Code security:
- **Secret scanning** + **Push protection** (free for public repos, blocks pushes that contain detected secrets — can't be configured from a workflow file).

Made with [Cursor](https://cursor.com)