### PR TITLE
fix(release): drop unstable Windows ARM64 build, fall back to x64

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -50,15 +50,13 @@ jobs:
             artifact_name: capa.exe
             asset_name: capa-x86_64-pc-windows-msvc.exe
 
-          # Windows aarch64 (ARM64)
-          - os: windows-latest
-            target: aarch64-pc-windows-msvc
-            bun_target: bun-windows-arm64
-            artifact_name: capa.exe
-            asset_name: capa-aarch64-pc-windows-msvc.exe
-
-          # install.ps1 also maps x86 -> i686-pc-windows-msvc, but bun build --compile
-          # has no bun-windows-i686 target; 32-bit Windows installs remain unsupported.
+          # Windows ARM64 falls back to the x64 binary via install.ps1
+          # (`bun build --compile --target=bun-windows-arm64` is unstable as of
+          # Bun 1.3.x — runtime download fails to extract). Windows on ARM64
+          # runs x64 binaries fine under Prism emulation.
+          #
+          # Windows x86 (32-bit) is also unsupported because there is no
+          # `bun-windows-i686` build target.
 
     steps:
       - name: Checkout code

--- a/install.ps1
+++ b/install.ps1
@@ -166,7 +166,10 @@ function Get-Architecture {
     
     switch ($arch) {
         "AMD64" { return "x86_64-pc-windows-msvc" }
-        "ARM64" { return "aarch64-pc-windows-msvc" }
+        # ARM64: no native binary is shipped (bun-windows-arm64 compile target
+        # is unstable). Fall back to the x64 build, which Windows on ARM runs
+        # transparently via Prism emulation.
+        "ARM64" { return "x86_64-pc-windows-msvc" }
         "x86" { return "i686-pc-windows-msvc" }
         default {
             Write-Error-Custom "Unsupported architecture: $arch"


### PR DESCRIPTION
## Summary

Unblocks the v1.9.0 release. The `aarch64-pc-windows-msvc` matrix entry in \`release.yml\` fails on every run with:

\`\`\`
Failed to extract executable for 'bun-windows-aarch64-v1.3.14'. The download may be incomplete.
\`\`\`

The bun-windows-arm64 runtime is still flagged experimental upstream and the download pipeline isn't reliable in CI. Two changes:

- **\`.github/workflows/release.yml\`** — drop the \`aarch64-pc-windows-msvc\` matrix entry so the release job is no longer skipped.
- **\`install.ps1\`** — map ARM64 hosts to the \`x86_64-pc-windows-msvc\` binary. Windows on ARM runs x64 executables transparently via Prism emulation, so ARM64 users still get a working install rather than an "Unsupported architecture" error.

The doc comment above the Windows section now mentions both the ARM64 and the x86 gaps in one place.

## Follow-up

Re-enable the matrix entry once Bun ships a stable Windows ARM64 compile target.

## Test plan

- Land this PR on \`main\`.
- Re-tag \`v1.9.0\` at the new main HEAD.
- Confirm all 5 build targets (linux x64/arm64, macos x64/arm64, windows x64) succeed and the release row is created with all six artifacts (5 binaries + SHA256SUMS.txt).

Made with [Cursor](https://cursor.com)