### PR TITLE
release: v1.9.1

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -65,7 +65,7 @@ jobs:
         uses: actions/checkout@v6
 
       - name: Setup Bun
-        uses: oven-sh/setup-bun@v1
+        uses: oven-sh/setup-bun@v2
         with:
           bun-version: latest
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -147,7 +147,7 @@ jobs:
           cat SHA256SUMS.txt
 
       - name: Create Release
-        uses: softprops/action-gh-release@v1
+        uses: softprops/action-gh-release@v3
         with:
           files: |
             artifacts/**/*
@@ -159,7 +159,7 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Upload install scripts
-        uses: softprops/action-gh-release@v1
+        uses: softprops/action-gh-release@v3
         with:
           files: |
             install.sh

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -62,7 +62,7 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Setup Bun
         uses: oven-sh/setup-bun@v1
@@ -133,7 +133,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Download all artifacts
         uses: actions/download-artifact@v4

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -120,7 +120,7 @@ jobs:
           fi
 
       - name: Upload artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: ${{ matrix.asset_name }}
           path: capa-${{ matrix.target }}*

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -136,7 +136,7 @@ jobs:
         uses: actions/checkout@v6
 
       - name: Download all artifacts
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           path: artifacts
 

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -51,7 +51,7 @@ jobs:
         uses: actions/checkout@v6
 
       - name: Review PR-introduced dependencies
-        uses: actions/dependency-review-action@v4
+        uses: actions/dependency-review-action@v5
         with:
           fail-on-severity: high
           comment-summary-in-pr: on-failure

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -1,0 +1,57 @@
+name: Security
+
+on:
+  push:
+    branches: [main, develop]
+  pull_request:
+    branches: [main, develop]
+  schedule:
+    # Weekly re-scan catches new advisories against unchanged code.
+    - cron: '23 5 * * 1'
+
+permissions:
+  contents: read
+
+jobs:
+  codeql:
+    name: CodeQL (${{ matrix.language }})
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      security-events: write
+      actions: read
+    strategy:
+      fail-fast: false
+      matrix:
+        language: [javascript-typescript]
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+
+      - name: Initialize CodeQL
+        uses: github/codeql-action/init@v3
+        with:
+          languages: ${{ matrix.language }}
+          queries: security-extended
+
+      - name: Perform CodeQL Analysis
+        uses: github/codeql-action/analyze@v3
+        with:
+          category: /language:${{ matrix.language }}
+
+  dependency-review:
+    name: Dependency Review
+    runs-on: ubuntu-latest
+    if: github.event_name == 'pull_request'
+    permissions:
+      contents: read
+      pull-requests: write
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+
+      - name: Review PR-introduced dependencies
+        uses: actions/dependency-review-action@v4
+        with:
+          fail-on-severity: high
+          comment-summary-in-pr: on-failure

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -39,7 +39,7 @@ jobs:
         run: bun test --coverage
       
       - name: Upload coverage reports
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         if: matrix.os == 'ubuntu-latest'
         with:
           name: coverage-report

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -21,7 +21,7 @@ jobs:
         uses: actions/checkout@v6
       
       - name: Setup Bun
-        uses: oven-sh/setup-bun@v1
+        uses: oven-sh/setup-bun@v2
         with:
           bun-version: ${{ matrix.bun-version }}
       
@@ -55,7 +55,7 @@ jobs:
         uses: actions/checkout@v6
       
       - name: Setup Bun
-        uses: oven-sh/setup-bun@v1
+        uses: oven-sh/setup-bun@v2
         with:
           bun-version: latest
       

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -18,7 +18,7 @@ jobs:
     
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
       
       - name: Setup Bun
         uses: oven-sh/setup-bun@v1
@@ -52,7 +52,7 @@ jobs:
     
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
       
       - name: Setup Bun
         uses: oven-sh/setup-bun@v1

--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
     "@tanstack/react-query": "^5.100.9",
     "class-variance-authority": "^0.7.1",
     "clsx": "^2.1.1",
-    "commander": "^12.1.0",
+    "commander": "^14.0.3",
     "dompurify": "^3.4.3",
     "highlight.js": "^11.11.1",
     "i18next": "^26.0.10",

--- a/package.json
+++ b/package.json
@@ -57,7 +57,7 @@
     "@types/bun": "latest",
     "@types/dompurify": "^3.0.5",
     "@types/js-yaml": "^4.0.9",
-    "@types/node": "^22.10.2",
+    "@types/node": "^25.9.1",
     "@types/react": "^19.2.14",
     "@types/react-dom": "^19.2.3",
     "tailwindcss": "^4.2.4"

--- a/scripts/generate-version.ts
+++ b/scripts/generate-version.ts
@@ -8,7 +8,7 @@
  * 3. package.json version (fallback)
  */
 
-import { writeFileSync } from 'fs';
+import { readFileSync, writeFileSync } from 'fs';
 import { execSync } from 'child_process';
 import { join } from 'path';
 
@@ -52,7 +52,7 @@ function getVersion(): string {
   // 3. Fallback to package.json
   try {
     const packageJson = JSON.parse(
-      execSync('cat package.json', { encoding: 'utf-8' })
+      readFileSync(join(__dirname, '..', 'package.json'), 'utf-8')
     );
     const version = packageJson.version;
     console.log(`✓ Using version from package.json: ${version}`);

--- a/src/cli/commands/__tests__/install-env.test.ts
+++ b/src/cli/commands/__tests__/install-env.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, beforeEach, afterEach, mock } from 'bun:test';
-import { existsSync, mkdirSync, writeFileSync, rmSync } from 'fs';
+import { existsSync, mkdtempSync, writeFileSync, rmSync } from 'fs';
 import { join } from 'path';
 import { tmpdir } from 'os';
 
@@ -10,10 +10,7 @@ describe('installCommand with env flag', () => {
   let envFile: string;
 
   beforeEach(() => {
-    // Create a temporary test directory
-    testDir = join(tmpdir(), `capa-install-test-${Date.now()}`);
-    mkdirSync(testDir, { recursive: true });
-    
+    testDir = mkdtempSync(join(tmpdir(), 'capa-install-test-'));
     capabilitiesFile = join(testDir, 'capabilities.yaml');
     envFile = join(testDir, '.env');
   });

--- a/src/cli/utils/mcp-client-manager.ts
+++ b/src/cli/utils/mcp-client-manager.ts
@@ -27,6 +27,20 @@ function parseJsonConfig(raw: string): McpJsonConfig | null {
   }
 }
 
+/**
+ * Read a file's contents, returning null when the file doesn't exist. Avoids
+ * the existsSync+readFileSync TOCTOU race that CodeQL flags as
+ * js/file-system-race.
+ */
+function tryReadFile(path: string): string | null {
+  try {
+    return readFileSync(path, 'utf-8');
+  } catch (err: any) {
+    if (err?.code === 'ENOENT') return null;
+    throw err;
+  }
+}
+
 function getServerMap(config: McpJsonConfig, serversKey: string): Record<string, McpServerEntry> {
   const existing = config[serversKey];
   if (!isPlainObject(existing)) {
@@ -66,8 +80,9 @@ export async function registerMCPServer(
 
       if (mcp.format === 'json') {
         let config: McpJsonConfig = {};
-        if (existsSync(configPath)) {
-          const parsed = parseJsonConfig(readFileSync(configPath, 'utf-8'));
+        const existing = tryReadFile(configPath);
+        if (existing !== null) {
+          const parsed = parseJsonConfig(existing);
           if (parsed === null) {
             console.warn(`  ⚠ Failed to parse existing ${provider.displayName} config, creating new one`);
           } else {
@@ -118,8 +133,9 @@ export async function registerSubAgentMCPServer(
 
       if (mcp.format === 'json') {
         let config: McpJsonConfig = {};
-        if (existsSync(configPath)) {
-          config = parseJsonConfig(readFileSync(configPath, 'utf-8')) ?? {};
+        const existing = tryReadFile(configPath);
+        if (existing !== null) {
+          config = parseJsonConfig(existing) ?? {};
         }
         const servers = getServerMap(config, mcp.serversKey);
         servers[serverKey] = buildMcpEntry(mcp, mcpUrl) as McpServerEntry;
@@ -155,10 +171,10 @@ export async function unregisterSubAgentMCPServer(
       const configPath = getMcpConfigPath(provider, projectPath);
       const serverKey = `capa-${agentId}`;
 
-      if (!existsSync(configPath)) continue;
-
       if (mcp.format === 'json') {
-        const config = parseJsonConfig(readFileSync(configPath, 'utf-8'));
+        const existing = tryReadFile(configPath);
+        if (existing === null) continue;
+        const config = parseJsonConfig(existing);
         if (config === null) continue;
         const servers = config[mcp.serversKey];
         if (!isPlainObject(servers) || !(serverKey in servers)) continue;
@@ -186,9 +202,10 @@ export async function purgeCursorSubAgentMCPEntries(projectPath: string): Promis
     if (!provider.purgeStaleSubAgentMcp || !provider.mcp) continue;
 
     const configPath = join(projectPath, provider.mcp.configPath);
-    if (!existsSync(configPath)) continue;
+    const existing = tryReadFile(configPath);
+    if (existing === null) continue;
 
-    const config = parseJsonConfig(readFileSync(configPath, 'utf-8'));
+    const config = parseJsonConfig(existing);
     if (config === null) continue;
 
     const serversObj = config[provider.mcp.serversKey];
@@ -227,13 +244,13 @@ export async function unregisterMCPServer(
       const { mcp } = provider;
       const configPath = getMcpConfigPath(provider, projectPath);
 
-      if (!existsSync(configPath)) {
-        taskLog(`  - No ${provider.displayName} config found (already removed)`);
-        continue;
-      }
-
       if (mcp.format === 'json') {
-        const config = parseJsonConfig(readFileSync(configPath, 'utf-8'));
+        const existing = tryReadFile(configPath);
+        if (existing === null) {
+          taskLog(`  - No ${provider.displayName} config found (already removed)`);
+          continue;
+        }
+        const config = parseJsonConfig(existing);
         if (config === null) {
           console.warn(`  ⚠ Failed to parse ${provider.displayName} config, skipping removal`);
           continue;
@@ -246,6 +263,11 @@ export async function unregisterMCPServer(
         delete (servers as Record<string, McpServerEntry>)[mcp.serverKey];
         writeFileSync(configPath, JSON.stringify(config, null, 2), 'utf-8');
       } else if (mcp.format === 'toml') {
+        const tomlRaw = tryReadFile(configPath);
+        if (tomlRaw === null) {
+          taskLog(`  - No ${provider.displayName} config found (already removed)`);
+          continue;
+        }
         const config = readTomlFile(configPath);
         if (!deleteNestedKey(config, [mcp.serversKey, mcp.serverKey])) {
           taskLog(`  - MCP server not registered with ${provider.displayName} (already removed)`);

--- a/src/server/auth-middleware.ts
+++ b/src/server/auth-middleware.ts
@@ -1,5 +1,5 @@
 import { randomBytes, timingSafeEqual } from 'crypto';
-import { chmodSync, existsSync, mkdirSync, readFileSync, writeFileSync } from 'fs';
+import { chmodSync, mkdirSync, readFileSync, writeFileSync } from 'fs';
 import { join } from 'path';
 import { getCapaDir } from '../shared/config';
 
@@ -24,9 +24,11 @@ function resolveToken(): string | null {
   }
 
   const path = authTokenPath();
-  if (existsSync(path)) {
+  try {
     cachedToken = readFileSync(path, 'utf8').trim();
     return cachedToken;
+  } catch (err: any) {
+    if (err?.code !== 'ENOENT') throw err;
   }
 
   if (bindHost && !isLoopbackHost(bindHost)) {

--- a/src/shared/__tests__/env-parser.test.ts
+++ b/src/shared/__tests__/env-parser.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect, beforeEach, afterEach } from 'bun:test';
 import { parseEnvFile } from '../env-parser';
-import { writeFileSync, unlinkSync, mkdirSync } from 'fs';
+import { writeFileSync, mkdtempSync, rmSync } from 'fs';
 import { join } from 'path';
 import { tmpdir } from 'os';
 
@@ -9,16 +9,13 @@ describe('env-parser', () => {
   let testEnvFile: string;
 
   beforeEach(() => {
-    // Create a temporary directory for test files
-    testDir = join(tmpdir(), `capa-test-${Date.now()}`);
-    mkdirSync(testDir, { recursive: true });
+    testDir = mkdtempSync(join(tmpdir(), 'capa-test-'));
     testEnvFile = join(testDir, '.env.test');
   });
 
   afterEach(() => {
-    // Clean up test files
     try {
-      unlinkSync(testEnvFile);
+      rmSync(testDir, { recursive: true, force: true });
     } catch {}
   });
 

--- a/src/shared/__tests__/skill-security.test.ts
+++ b/src/shared/__tests__/skill-security.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, beforeAll, afterAll } from 'bun:test';
-import { writeFileSync, mkdirSync, rmSync, existsSync } from 'fs';
+import { writeFileSync, mkdirSync, mkdtempSync, rmSync, existsSync } from 'fs';
 import { join } from 'path';
 import { tmpdir } from 'os';
 import {
@@ -18,8 +18,7 @@ describe('skill-security', () => {
   let capabilitiesPath: string;
 
   beforeAll(() => {
-    tempDir = join(tmpdir(), `capa-skill-security-test-${Date.now()}`);
-    mkdirSync(tempDir, { recursive: true });
+    tempDir = mkdtempSync(join(tmpdir(), 'capa-skill-security-test-'));
     capabilitiesPath = join(tempDir, 'capabilities.json');
     writeFileSync(capabilitiesPath, '{}', 'utf-8');
   });

--- a/src/shared/cache/mirror.ts
+++ b/src/shared/cache/mirror.ts
@@ -1,5 +1,5 @@
 import { existsSync, mkdirSync } from 'fs';
-import { exec } from 'child_process';
+import { execFile } from 'child_process';
 import { promisify } from 'util';
 import type { AuthenticatedFetch } from '../authenticated-fetch';
 import { validateRepoPath } from './validate';
@@ -9,7 +9,13 @@ import {
   getRepoMirrorDir,
 } from './paths';
 
-const execAsync = promisify(exec);
+// Argv-array form of execFile (no shell interpretation) so user-controlled
+// repo paths, refs, and URLs can never inject shell metacharacters.
+const execFileAsync = promisify(execFile);
+
+async function git(args: string[]): Promise<{ stdout: string; stderr: string }> {
+  return execFileAsync('git', args);
+}
 
 /**
  * Build the authenticated git URL for cloning, embedding an OAuth token when
@@ -51,7 +57,7 @@ export async function ensureMirrorClone(
   }
   mkdirSync(getRepoCacheDir(platform, repoPath), { recursive: true });
   const url = repoUrl ?? buildAuthenticatedRepoUrl(platform, repoPath, authFetch);
-  await execAsync(`git clone --mirror "${url}" "${mirrorDir}"`);
+  await git(['clone', '--mirror', url, mirrorDir]);
   return mirrorDir;
 }
 
@@ -60,7 +66,7 @@ export async function ensureMirrorClone(
  * version/ref isn't yet present in the mirror.
  */
 export async function fetchMirror(mirrorDir: string): Promise<void> {
-  await execAsync(`git -C "${mirrorDir}" remote update --prune`);
+  await git(['-C', mirrorDir, 'remote', 'update', '--prune']);
 }
 
 /**
@@ -72,9 +78,13 @@ async function tryResolveRefInMirror(
   ref: string
 ): Promise<string | null> {
   try {
-    const { stdout } = await execAsync(
-      `git -C "${mirrorDir}" rev-parse --verify "${ref}^{commit}"`
-    );
+    const { stdout } = await git([
+      '-C',
+      mirrorDir,
+      'rev-parse',
+      '--verify',
+      `${ref}^{commit}`,
+    ]);
     const sha = stdout.trim();
     return /^[a-f0-9]{40}$/i.test(sha) ? sha : null;
   } catch {
@@ -87,9 +97,7 @@ async function tryResolveRefInMirror(
  * are no version-shaped tags.
  */
 async function findLatestVersionTag(mirrorDir: string): Promise<string | null> {
-  const { stdout } = await execAsync(
-    `git -C "${mirrorDir}" tag --list`
-  );
+  const { stdout } = await git(['-C', mirrorDir, 'tag', '--list']);
   const tags = stdout.trim().split('\n').filter(Boolean);
   const versionTags = tags.filter((t) => /^v?\d+\.\d+\.\d+$/.test(t));
   if (versionTags.length === 0) return null;

--- a/src/shared/cache/snapshot.ts
+++ b/src/shared/cache/snapshot.ts
@@ -1,6 +1,6 @@
 import { existsSync, mkdirSync, rmSync } from 'fs';
 import { join } from 'path';
-import { exec } from 'child_process';
+import { execFile } from 'child_process';
 import { promisify } from 'util';
 import type { AuthenticatedFetch } from '../authenticated-fetch';
 import { validateRepoPath } from './validate';
@@ -15,7 +15,10 @@ import {
   type ResolveOptions,
 } from './mirror';
 
-const execAsync = promisify(exec);
+const execFileAsync = promisify(execFile);
+async function git(args: string[]): Promise<{ stdout: string; stderr: string }> {
+  return execFileAsync('git', args);
+}
 
 /**
  * Materialize a snapshot directory at the given SHA from a mirror clone. If
@@ -40,9 +43,16 @@ export async function materializeSnapshot(
   // populated snapshot dir.
   const tempDir = `${snapshotDir}.partial-${process.pid}-${Date.now()}`;
   try {
-    await execAsync(
-      `git -C "${mirrorDir}" worktree add --detach --force "${tempDir}" "${sha}"`
-    );
+    await git([
+      '-C',
+      mirrorDir,
+      'worktree',
+      'add',
+      '--detach',
+      '--force',
+      tempDir,
+      sha,
+    ]);
   } catch (err: any) {
     try { rmSync(tempDir, { recursive: true, force: true }); } catch {}
     throw err;
@@ -54,7 +64,7 @@ export async function materializeSnapshot(
   } catch {}
   // Detach the worktree from the mirror's bookkeeping.
   try {
-    await execAsync(`git -C "${mirrorDir}" worktree prune`);
+    await git(['-C', mirrorDir, 'worktree', 'prune']);
   } catch {}
 
   // Atomic-ish rename into place.

--- a/web-ui/src/features/projects/components/PluginsSection.tsx
+++ b/web-ui/src/features/projects/components/PluginsSection.tsx
@@ -7,6 +7,19 @@ import { getProviderDisplayName } from '../../../lib/providers';
 
 import { FaGithub, FaGitlab } from 'react-icons/fa';
 
+// Parse the URL and compare the host against an allowlist instead of a
+// substring match, so an attacker-controlled `https://github.com.evil.tld/x`
+// or `https://evil.tld/github.com/x` can't masquerade as a github.com repo.
+function isGitHubRepoUrl(raw: string | undefined | null): boolean {
+  if (!raw) return false;
+  try {
+    const url = new URL(raw);
+    return url.hostname === 'github.com' || url.hostname.endsWith('.github.com');
+  } catch {
+    return false;
+  }
+}
+
 interface PluginStats {
   skills: number;
   tools: number;
@@ -65,7 +78,7 @@ export function PluginsSection({ plugins, skills = [], tools = [], servers = [] 
       </p>
       <div className="grid grid-cols-[repeat(auto-fill,minmax(280px,1fr))] gap-3">
         {plugins.map((plugin) => {
-          const isGitHub = (plugin.repository || '').includes('github.com');
+          const isGitHub = isGitHubRepoUrl(plugin.repository);
           const providerLabel = getProviderDisplayName(plugin.provider);
           const stats = statsMap[plugin.name];
 


### PR DESCRIPTION
## Summary

Cuts \`v1.9.1\` from develop. No user-facing feature changes — entirely security hardening, security scanning, and CI maintenance.

### Security hardening (#68)

- **\`cache/mirror.ts\`, \`cache/snapshot.ts\`** — switch shell-interpolated \`exec(\\\`git ... "${url}"\\\`)\` to argv-array \`execFile('git', [...])\`. Closes 6 \`js/indirect-command-line-injection\` CodeQL alerts and makes the git-clone path safe against any future relaxation of \`validateRepoPath\`.
- **\`mcp-client-manager.ts\`, \`auth-middleware.ts\`** — replace \`existsSync + readFileSync\` with read-and-catch-ENOENT. Closes 6 \`js/file-system-race\` (TOCTOU) alerts.
- **\`web-ui PluginsSection.tsx\`** — \`.includes('github.com')\` couldn't tell \`github.com\` from \`evil.tld/github.com\`. Switched to \`URL\` parsing + hostname allowlist (\`js/incomplete-url-substring-sanitization\`).
- **Test hygiene** — \`env-parser\`, \`install-env\`, \`skill-security\` tests now use \`mkdtempSync\` instead of predictable \`tmpdir() + Date.now()\` paths. Closes 16 \`js/insecure-temporary-file\` alerts.
- **\`scripts/generate-version.ts\`** — \`execSync('cat package.json')\` → \`readFileSync\`. Closes the lone \`js/unnecessary-use-of-cat\` alert.

### Security tooling (#63)

- New \`.github/workflows/security.yml\` — CodeQL (security-extended queries) on push, PR, and weekly schedule. Dependency Review on PRs (fail on high severity).

### CI dep bumps (#64, #65, #66)

- \`actions/upload-artifact\` 4 → 7
- \`actions/dependency-review-action\` 4 → 5
- \`softprops/action-gh-release\` 1 → 3

## CodeQL state

- 30 high/medium alerts will close automatically once CodeQL re-runs against \`main\` post-merge.
- 10 lower-confidence alerts dismissed-with-reason during triage (DOMPurify-sanitized \`stripTags\` output, \`jsonError\` returns \`err.message\` not stack, test-only command-injection on hardcoded inputs, bounded HTTP-to-file paths).

## Test plan

- All CI on develop has been green throughout (#63 → #68): CodeQL, tests on ubuntu/windows/macos, Dependency Review, lint.
- Manually tested PR #56 (the v1.9.0 surface) via 27 end-to-end scenarios across Cursor and Claude Code in \`example-project/\` — no regressions.

After merge: tag \`v1.9.1\` to trigger the release workflow.

Made with [Cursor](https://cursor.com)