### PR TITLE
fix(auth): keep git OAuth tokens on transient refresh failures

### DIFF
--- a/src/server/__tests__/refresh-token.test.ts
+++ b/src/server/__tests__/refresh-token.test.ts
@@ -84,6 +84,66 @@ describe('git token refresh security', () => {
       expect(body.provider).toBe('github.com');
       expect(body.refresh_token).toBe('old-refresh');
     });
+
+    it('preserves the stored token when the cloud proxy returns a transient 5xx', async () => {
+      globalThis.fetch = (async (_input: RequestInfo | URL, _init?: RequestInit) => {
+        return new Response('upstream temporarily unavailable', {
+          status: 502,
+          headers: { 'Content-Type': 'text/plain' },
+        });
+      }) as typeof fetch;
+
+      const ok = await manager.refreshAccessToken('github');
+      expect(ok).toBe(false);
+
+      const stored = db.getGitIntegration('github');
+      expect(stored).not.toBeNull();
+      expect(stored?.access_token).toBe('old-access');
+      expect(stored?.refresh_token).toBe('old-refresh');
+    });
+
+    it('preserves the stored token when the refresh request hits a network error', async () => {
+      globalThis.fetch = (async (_input: RequestInfo | URL, _init?: RequestInit) => {
+        throw new Error('ECONNRESET');
+      }) as unknown as typeof fetch;
+
+      const ok = await manager.refreshAccessToken('github');
+      expect(ok).toBe(false);
+
+      const stored = db.getGitIntegration('github');
+      expect(stored).not.toBeNull();
+      expect(stored?.access_token).toBe('old-access');
+    });
+
+    it('preserves the stored token when the proxy returns 401 without an invalid_grant marker', async () => {
+      globalThis.fetch = (async (_input: RequestInfo | URL, _init?: RequestInit) => {
+        return new Response('rate limited', {
+          status: 401,
+          headers: { 'Content-Type': 'text/plain' },
+        });
+      }) as typeof fetch;
+
+      const ok = await manager.refreshAccessToken('github');
+      expect(ok).toBe(false);
+
+      const stored = db.getGitIntegration('github');
+      expect(stored).not.toBeNull();
+    });
+
+    it('deletes the stored token when the cloud proxy reports invalid_grant', async () => {
+      globalThis.fetch = (async (_input: RequestInfo | URL, _init?: RequestInit) => {
+        return new Response(JSON.stringify({ error: 'invalid_grant' }), {
+          status: 400,
+          headers: { 'Content-Type': 'application/json' },
+        });
+      }) as typeof fetch;
+
+      const ok = await manager.refreshAccessToken('github');
+      expect(ok).toBe(false);
+
+      const stored = db.getGitIntegration('github');
+      expect(stored).toBeNull();
+    });
   });
 
   describe('/api/integrations/:platform/refresh', () => {

--- a/src/server/git-integration-manager.ts
+++ b/src/server/git-integration-manager.ts
@@ -6,6 +6,7 @@ import type { GitPlatform, GitPATConfig } from '../types/git-integration';
 import { logger } from '../shared/logger';
 import { CAPA_CLOUD_OAUTH_URL } from '../shared/ui-urls';
 import { getGitProvider, getAllGitProviders } from '../shared/git-providers/registry';
+import { isPermanentRefreshFailure } from '../shared/oauth-refresh';
 
 export class GitIntegrationManager {
   private db: CapaDatabase;
@@ -293,18 +294,26 @@ export class GitIntegrationManager {
           refresh_token: integration.refresh_token,
         }),
       });
-      
+
       if (!response.ok) {
         const errorText = await response.text();
         this.logger.failure(`Token refresh failed: ${response.status} ${errorText}`);
-        
-        // If refresh failed, delete the invalid token
-        this.db.deleteGitIntegration(platform, host || null);
+
+        // Only delete the stored token when the refresh_token itself is known to be
+        // unusable (invalid_grant / invalid_token / expired). Transient failures like
+        // proxy 5xx, rate limits, or network blips keep the token so the next
+        // scheduler tick (or user retry) can succeed.
+        if (isPermanentRefreshFailure(undefined, response, errorText)) {
+          this.db.deleteGitIntegration(platform, host || null);
+          this.logger.info(`Deleted invalid token for ${platform}`);
+        } else {
+          this.logger.warn(`Transient refresh failure for ${platform}, keeping token`);
+        }
         return false;
       }
 
       const tokenData = await response.json();
-      
+
       if (!tokenData.access_token) {
         this.logger.failure('No access token in refresh response');
         return false;

--- a/src/server/oauth-manager.ts
+++ b/src/server/oauth-manager.ts
@@ -12,24 +12,10 @@ import type {
 import { generateCodeVerifier, generateCodeChallenge, generateState } from '../utils/pkce';
 import { logger } from '../shared/logger';
 import { shouldSkipTlsVerify } from '../shared/tls-skip-verify';
+import { isPermanentRefreshFailure } from '../shared/oauth-refresh';
 
-const PERMANENT_REFRESH_FAILURE_MARKERS = ['invalid_grant', 'invalid_token', 'expired'];
-
-export function isPermanentRefreshFailure(
-  error?: unknown,
-  response?: Response,
-  responseBody?: string,
-): boolean {
-  if (response) {
-    const status = response.status;
-    if (status === 400 || status === 401 || status === 403) {
-      const body = (responseBody ?? '').toLowerCase();
-      return PERMANENT_REFRESH_FAILURE_MARKERS.some((marker) => body.includes(marker));
-    }
-    return false;
-  }
-  return false;
-}
+// Re-exported for backwards compatibility with existing import sites.
+export { isPermanentRefreshFailure };
 
 export class OAuth2Manager {
   private db: CapaDatabase;

--- a/src/shared/__tests__/authenticated-fetch.test.ts
+++ b/src/shared/__tests__/authenticated-fetch.test.ts
@@ -30,6 +30,32 @@ function makeDb(integration: GitIntegration | null): CapaDatabase {
   } as unknown as CapaDatabase;
 }
 
+function makeDbWithSpies(integration: GitIntegration | null) {
+  const deletes: Array<{ platform: string; host: string | null }> = [];
+  const sets: Array<{ platform: string; tokenData: Record<string, unknown> }> = [];
+  let current: GitIntegration | null = integration;
+  const db = {
+    getGitIntegration: () => current,
+    getAllGitIntegrations: () => (current ? [current] : []),
+    setGitIntegration: (platform: string, tokenData: Record<string, unknown>) => {
+      sets.push({ platform, tokenData });
+      if (current) {
+        current = {
+          ...current,
+          access_token: String(tokenData.access_token ?? current.access_token),
+          refresh_token: (tokenData.refresh_token as string | null | undefined) ?? current.refresh_token,
+          expires_at: (tokenData.expires_at as number | null | undefined) ?? current.expires_at,
+        };
+      }
+    },
+    deleteGitIntegration: (platform: string, host: string | null) => {
+      deletes.push({ platform, host });
+      current = null;
+    },
+  } as unknown as CapaDatabase;
+  return { db, deletes, sets, get current() { return current; } };
+}
+
 describe('AuthenticatedFetch', () => {
   const originalFetch = globalThis.fetch;
   let fetchCalls: Array<{ url: string; init?: RequestInit }>;
@@ -114,5 +140,81 @@ describe('AuthenticatedFetch', () => {
     expect(response.status).toBe(404);
     expect(fetchCalls).toHaveLength(1);
     expect(AuthenticatedFetch.isPrivateRepoError(response)).toBe(false);
+  });
+
+  describe('refresh failure classification', () => {
+    it('keeps the stored token when the cloud refresh endpoint returns a transient 5xx', async () => {
+      globalThis.fetch = (async (input: RequestInfo | URL) => {
+        const url = typeof input === 'string' ? input : input.toString();
+        if (url.includes('/auth/refresh')) {
+          return new Response('bad gateway', { status: 502 });
+        }
+        return new Response('ok', { status: 200 });
+      }) as typeof fetch;
+
+      const harness = makeDbWithSpies(
+        makeIntegration({
+          expires_at: Date.now() - 60_000,
+          refresh_token: 'still-valid-refresh',
+        })
+      );
+      const authFetch = new AuthenticatedFetch(harness.db);
+
+      await expect(authFetch.fetch(GITHUB_RAW_URL)).rejects.toThrow(/expired/i);
+
+      expect(harness.deletes).toHaveLength(0);
+      expect(harness.current).not.toBeNull();
+      expect(harness.current?.refresh_token).toBe('still-valid-refresh');
+    });
+
+    it('keeps the stored token when the refresh request throws a network error', async () => {
+      globalThis.fetch = (async (input: RequestInfo | URL) => {
+        const url = typeof input === 'string' ? input : input.toString();
+        if (url.includes('/auth/refresh')) {
+          throw new Error('ENOTFOUND capa.infragate.ai');
+        }
+        return new Response('ok', { status: 200 });
+      }) as typeof fetch;
+
+      const harness = makeDbWithSpies(
+        makeIntegration({
+          expires_at: Date.now() - 60_000,
+          refresh_token: 'still-valid-refresh',
+        })
+      );
+      const authFetch = new AuthenticatedFetch(harness.db);
+
+      await expect(authFetch.fetch(GITHUB_RAW_URL)).rejects.toThrow(/expired/i);
+
+      expect(harness.deletes).toHaveLength(0);
+      expect(harness.current).not.toBeNull();
+    });
+
+    it('deletes the stored token when the refresh_token is rejected as invalid_grant', async () => {
+      globalThis.fetch = (async (input: RequestInfo | URL) => {
+        const url = typeof input === 'string' ? input : input.toString();
+        if (url.includes('/auth/refresh')) {
+          return new Response(JSON.stringify({ error: 'invalid_grant' }), {
+            status: 400,
+            headers: { 'Content-Type': 'application/json' },
+          });
+        }
+        return new Response('ok', { status: 200 });
+      }) as typeof fetch;
+
+      const harness = makeDbWithSpies(
+        makeIntegration({
+          expires_at: Date.now() - 60_000,
+          refresh_token: 'truly-revoked',
+        })
+      );
+      const authFetch = new AuthenticatedFetch(harness.db);
+
+      await expect(authFetch.fetch(GITHUB_RAW_URL)).rejects.toThrow(/expired/i);
+
+      expect(harness.deletes).toHaveLength(1);
+      expect(harness.deletes[0]).toEqual({ platform: 'github', host: null });
+      expect(harness.current).toBeNull();
+    });
   });
 });

--- a/src/shared/authenticated-fetch.ts
+++ b/src/shared/authenticated-fetch.ts
@@ -9,6 +9,7 @@ import type { CapaDatabase } from '../db/database';
 import type { GitIntegration } from '../types/database';
 import type { GitPlatform } from '../types/git-integration';
 import { getGitProvider, getGitProviderByHost } from './git-providers/registry';
+import { isPermanentRefreshFailure } from './oauth-refresh';
 
 const CLOUD_OAUTH_ENDPOINT = 'https://capa.infragate.ai/auth';
 
@@ -92,7 +93,13 @@ export class AuthenticatedFetch {
         }),
       });
       if (!response.ok) {
-        this.db.deleteGitIntegration(platform, host ?? null);
+        // Only drop the stored token when the refresh_token is provably bad. Transient
+        // 5xx / rate-limit / network failures leave the token in place so the next
+        // request (or the scheduler) can retry.
+        const body = await response.text().catch(() => '');
+        if (isPermanentRefreshFailure(undefined, response, body)) {
+          this.db.deleteGitIntegration(platform, host ?? null);
+        }
         return false;
       }
 

--- a/src/shared/oauth-refresh.ts
+++ b/src/shared/oauth-refresh.ts
@@ -1,0 +1,33 @@
+/**
+ * Shared OAuth refresh-failure classifier.
+ *
+ * A refresh call can fail for many reasons. Most of them are transient
+ * (network blip, proxy 5xx, rate limit, DNS hiccup, laptop sleep/resume)
+ * and the stored refresh_token is still good — retrying later will succeed.
+ *
+ * Only a small set of failures indicate the refresh_token itself is no
+ * longer usable and the user must re-authenticate:
+ *   - HTTP 400 / 401 / 403, AND
+ *   - The response body mentions `invalid_grant`, `invalid_token`, or
+ *     `expired` (per RFC 6749 §5.2 + common provider conventions).
+ *
+ * Anything else (5xx, timeouts, thrown errors) is treated as transient so
+ * we don't delete a perfectly valid stored token on a temporary outage.
+ */
+const PERMANENT_REFRESH_FAILURE_MARKERS = ['invalid_grant', 'invalid_token', 'expired'];
+
+export function isPermanentRefreshFailure(
+  error?: unknown,
+  response?: Response,
+  responseBody?: string,
+): boolean {
+  if (response) {
+    const status = response.status;
+    if (status === 400 || status === 401 || status === 403) {
+      const body = (responseBody ?? '').toLowerCase();
+      return PERMANENT_REFRESH_FAILURE_MARKERS.some((marker) => body.includes(marker));
+    }
+    return false;
+  }
+  return false;
+}


### PR DESCRIPTION
## Summary

Git OAuth integrations (GitHub / GitLab) were being silently dropped after first use. Users reported logging in successfully and then noticing they had been "logged out" some time later. Root cause is a follow-through miss from the May tech-debt sweep:

- Commit `4957a4b` ("phase 2C debt fixes") added `isPermanentRefreshFailure()` in `src/server/oauth-manager.ts` and wired it into `OAuth2Manager.refreshAccessToken`. The commit message explicitly says *"OAuth refresh: only delete stored tokens on permanent failures (invalid_grant / invalid_token / expired), not on transient network/5xx errors"*.
- That fix was applied to the **MCP** OAuth path only. The two **git** OAuth refresh paths kept the old "delete on any non-OK response" behaviour:
  - `src/server/git-integration-manager.ts` — called from `TokenRefreshScheduler` (default 60s tick, 10-min refresh-ahead threshold).
  - `src/shared/authenticated-fetch.ts` — called when fetching private `github.com` / `gitlab.com` repo files.

So the user-visible failure mode was: ~50 minutes after a successful `capa auth`, the scheduler tried to proactively refresh the token, got back a single 502 / 503 / rate-limit / network blip from `https://capa.infragate.ai/auth/refresh`, and deleted the stored integration. No warning, no recovery — the user had to re-run `capa auth`.

## Changes

- Promote `isPermanentRefreshFailure` into a small shared module `src/shared/oauth-refresh.ts` so the classifier can be reused from both `server/` (MCP refresh) and `shared/` (private-repo fetch refresh) without crossing the `shared → server` layering boundary.
- `OAuth2Manager` re-exports `isPermanentRefreshFailure` to keep the existing `oauth-manager.test.ts` import path working.
- `GitIntegrationManager.refreshAccessToken`: only delete the stored integration when the cloud proxy returns 400/401/403 with one of the permanent markers (`invalid_grant`, `invalid_token`, `expired`). Transient failures log a warning and leave the token in place so the next scheduler tick can recover.
- `AuthenticatedFetch.refreshAccessToken`: same treatment, applied at the per-request fetch layer so a transient outage during a private-repo fetch no longer wipes the token.

## Test plan

- [x] Run the full bun test suite (`bun test`): **939 pass / 0 fail**.
- [x] Run `bunx tsc --noEmit`: clean.
- [x] Added four new cases in `src/server/__tests__/refresh-token.test.ts` covering the failure classifier on `GitIntegrationManager`:
  - transient 502 → token preserved
  - thrown network error → token preserved
  - 401 without `invalid_grant` body → token preserved (treated as rate-limit/transient)
  - 400 + `{"error":"invalid_grant"}` → token deleted
- [x] Added three new cases in `src/shared/__tests__/authenticated-fetch.test.ts` covering the same classifier on `AuthenticatedFetch` (with a stub DB that records every `setGitIntegration` / `deleteGitIntegration` call so each assertion pins which side of the classifier fired).
- [x] Existing `OAuth2Manager > isPermanentRefreshFailure > …` tests still pass against the re-exported helper, so the behaviour for MCP token refresh is unchanged.

## Risk

Low. Per-request behaviour is unchanged on success; on failure we either keep a token we would previously have deleted (recoverable) or take the exact same delete-and-warn path as before (when the refresh_token is genuinely revoked).

Made with [Cursor](https://cursor.com)