### PR TITLE
fix(agents): only write provider-declared instructions files and clean them fully

### DIFF
--- a/docs/providers/README.md
+++ b/docs/providers/README.md
@@ -126,11 +126,17 @@ documentation.
 
 ### Cross-cutting notes
 
-- **`AGENTS.md` is universal.** Every install run touches `AGENTS.md`
-  if any provider is active — `getTargetFilenames` adds it
-  unconditionally (`agents-file.ts`). Providers with their own
-  `instructions.filename` get the same marker blocks duplicated into
-  that file.
+- **Instructions filename follows the provider.** `getTargetFilenames`
+  (`agents-file.ts`) returns the union of `instructions.filename` across
+  the active providers — `AGENTS.md` for most universal-spec providers,
+  `CLAUDE.md` for Claude Code, `.github/copilot-instructions.md` for
+  Copilot, `replit.md` for Replit, etc. Capa does **not** write a file
+  no configured provider will read; running `capa install --provider
+  claude-code` only produces `CLAUDE.md`. When two providers declare
+  different filenames (e.g. `claude-code` + `codex`) the same marker
+  blocks are written into both. `AGENTS.md` is also used as a
+  last-resort fallback if no active provider declares an instructions
+  filename.
 - **Sub-agent MCP entries** are only written for providers whose
   `mcp.supportsSubAgentEntries === true`. Cursor and GitHub Copilot opt
   out (Cursor additionally has `purgeStaleSubAgentMcp` to clean up

--- a/docs/providers/claude-code.md
+++ b/docs/providers/claude-code.md
@@ -12,7 +12,7 @@ Source-of-truth definition: [`src/shared/providers/registry.ts → claude-code`]
 | --- | --- | --- |
 | Skills | `.claude/skills/<id>/` | Standard SKILL.md tree. |
 | MCP | `.mcp.json` → `mcpServers.capa.url` | JSON map; per-sub-agent entries (`mcpServers.capa-<agentId>`) supported. |
-| Instructions | `CLAUDE.md` | Universal marker blocks; `AGENTS.md` also written if any other provider is active. |
+| Instructions | `CLAUDE.md` | Universal marker blocks. `AGENTS.md` is **only** written if another active provider declares it (e.g. `codex`, `cursor`); a claude-code-only install never produces an `AGENTS.md`. |
 | Rules | `.claude/rules/<id>.md` | YAML frontmatter — capa's `appliesTo` maps to `paths`. A file with no `paths` is loaded unconditionally. |
 | Sub-agents | `.claude/agents/<id>.md` | Markdown + frontmatter (`name`, `description`, `model: inherit`). Also folds a `sub-agent:<id>` snippet into `CLAUDE.md`. |
 | Hooks | `.claude/settings.json` → `hooks` | JSON map keyed by event (`PreToolUse`, `PostToolUse`, `UserPromptSubmit`, `SessionStart`, `SessionEnd`, `Stop`, `SubagentStop`, `PreCompact`, `Notification`). Capa upserts `[{ matcher, hooks: [{ name: "capa:<id>", type, command, timeout }] }]` and only touches the entries it tagged. |

--- a/src/cli/commands/__tests__/clean.test.ts
+++ b/src/cli/commands/__tests__/clean.test.ts
@@ -116,11 +116,16 @@ tools: []
 
   it('removes capa-managed snippets from CLAUDE.md / AGENTS.md even when capabilities.yaml has no `agents:` block', async () => {
     // Sub-agent integrations (e.g. Claude's foldSubAgentsIntoInstructions)
-    // can write capa snippets into CLAUDE.md / AGENTS.md without a top-level
-    // `agents:` block, so `capa clean` must always run the agents-file cleanup.
+    // can write capa snippets into the provider's instructions file without
+    // a top-level `agents:` block, so `capa clean` must always run the
+    // agents-file cleanup for each active provider.
+    //
+    // With the `getTargetFilenames` fix, claude-code only manages `CLAUDE.md`
+    // (no stray `AGENTS.md`), so this test enables both `claude-code` and
+    // `codex` to exercise the multi-file cleanup path.
     writeFileSync(
       join(projectDir, 'capabilities.yaml'),
-      `providers: [claude-code]
+      `providers: [claude-code, codex]
 options:
   toolExposure: on-demand
 skills: []
@@ -153,6 +158,40 @@ researcher block
     // Both files were entirely capa-managed, so they should now be gone.
     expect(existsSync(join(projectDir, 'CLAUDE.md'))).toBe(false);
     expect(existsSync(join(projectDir, 'AGENTS.md'))).toBe(false);
+  });
+
+  it('leaves a pre-existing AGENTS.md alone when claude-code is the only provider', async () => {
+    // Regression: capa used to seed AGENTS.md unconditionally into the target
+    // file list, so a claude-code-only `capa clean` would scan AGENTS.md even
+    // though no claude-code install ever writes one. With the fix,
+    // `getTargetFilenames(['claude-code'])` returns just `CLAUDE.md` and a
+    // hand-authored AGENTS.md (e.g. for another tool the user is also using)
+    // must not be touched.
+    writeFileSync(
+      join(projectDir, 'capabilities.yaml'),
+      `providers: [claude-code]
+options:
+  toolExposure: on-demand
+skills: []
+servers: []
+tools: []
+`,
+      'utf-8'
+    );
+    writeFileSync(
+      join(projectDir, 'AGENTS.md'),
+      `# My project
+
+Hand-authored AGENTS.md unrelated to claude-code.
+`,
+      'utf-8'
+    );
+
+    await captureOutput(() => cleanCommand());
+
+    expect(existsSync(join(projectDir, 'AGENTS.md'))).toBe(true);
+    const remaining = readFileSync(join(projectDir, 'AGENTS.md'), 'utf-8');
+    expect(remaining).toContain('Hand-authored AGENTS.md unrelated to claude-code.');
   });
 
   it('preserves non-capa content in CLAUDE.md while removing capa snippets', async () => {

--- a/src/cli/utils/__tests__/agents-file.test.ts
+++ b/src/cli/utils/__tests__/agents-file.test.ts
@@ -1,5 +1,13 @@
-import { describe, it, expect } from 'bun:test';
-import { detectRepoCoordsFromRawUrl } from '../agents-file';
+import { describe, it, expect, beforeEach, afterEach } from 'bun:test';
+import { existsSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from 'fs';
+import { join } from 'path';
+import { tmpdir } from 'os';
+import {
+  cleanAgentsFile,
+  detectRepoCoordsFromRawUrl,
+  getTargetFilenames,
+  installAgentsFile,
+} from '../agents-file';
 import { parseRepoString } from '../../../shared/repo-string';
 
 describe('detectRepoCoordsFromRawUrl', () => {
@@ -205,5 +213,213 @@ describe('detectRepoCoordsFromRawUrl', () => {
       platform: 'github',
       repoString: 'owner/repo::foo/AGENTS.md:feature',
     });
+  });
+});
+
+describe('getTargetFilenames', () => {
+  // The registry-driven target file list is the contract that drives both
+  // `installAgentsFile` (where to write) and `cleanAgentsFile` (where to
+  // clean). Provider-only installs must not bleed marker blocks into files
+  // the provider will never read — most importantly: `claude-code` must
+  // only produce `CLAUDE.md`, never a stray `AGENTS.md`.
+
+  it('returns only CLAUDE.md when claude-code is the only provider', () => {
+    const files = getTargetFilenames(['claude-code']);
+    expect(files).toEqual(['CLAUDE.md']);
+    expect(files).not.toContain('AGENTS.md');
+  });
+
+  it('returns only AGENTS.md for universal-spec providers like codex', () => {
+    expect(getTargetFilenames(['codex'])).toEqual(['AGENTS.md']);
+  });
+
+  it('returns the union when claude-code and an AGENTS.md provider are both active', () => {
+    const files = getTargetFilenames(['claude-code', 'codex']);
+    expect(new Set(files)).toEqual(new Set(['CLAUDE.md', 'AGENTS.md']));
+  });
+
+  it('returns the provider-declared filename for non-universal providers', () => {
+    expect(getTargetFilenames(['github-copilot'])).toEqual(['.github/copilot-instructions.md']);
+    expect(getTargetFilenames(['replit'])).toEqual(['replit.md']);
+  });
+
+  it('deduplicates filenames when multiple providers share one', () => {
+    // Both `codex` and `cursor` write to AGENTS.md — exactly one entry expected.
+    const files = getTargetFilenames(['codex', 'cursor']);
+    expect(files).toEqual(['AGENTS.md']);
+  });
+
+  it('falls back to AGENTS.md when no providers are passed', () => {
+    // Empty providers means "consider all registered providers" — and since
+    // most declare AGENTS.md, that's the natural baseline. The fallback also
+    // guarantees `cleanAgentsFile` has something to scan when invoked
+    // without provider context.
+    expect(getTargetFilenames([])).toContain('AGENTS.md');
+  });
+
+  it('falls back to AGENTS.md when every passed provider id is unknown', () => {
+    // Defensive: bad ids in the capabilities file shouldn't make capa drop
+    // cleanup behavior on the floor.
+    expect(getTargetFilenames(['definitely-not-a-real-provider'])).toEqual(['AGENTS.md']);
+  });
+});
+
+describe('installAgentsFile + cleanAgentsFile end-to-end', () => {
+  // These tests pin down the two regressions that motivated the fix:
+  //   1. claude-code-only installs must not write AGENTS.md.
+  //   2. `agents.base` content must round-trip through clean — i.e. the file
+  //      must be entirely deleted on `capa clean`, not left behind with
+  //      orphan base content because the base was written raw.
+  let projectDir: string;
+
+  beforeEach(() => {
+    projectDir = mkdtempSync(join(tmpdir(), 'capa-agents-file-'));
+  });
+
+  afterEach(() => {
+    rmSync(projectDir, { recursive: true, force: true });
+  });
+
+  it('writes only CLAUDE.md (not AGENTS.md) for a claude-code-only install with inline snippets', async () => {
+    await installAgentsFile(
+      projectDir,
+      {
+        additional: [
+          { id: 'team-notes', type: 'inline', content: '## Team notes\n\nHello.' },
+        ],
+      },
+      ['claude-code'],
+    );
+
+    expect(existsSync(join(projectDir, 'CLAUDE.md'))).toBe(true);
+    expect(existsSync(join(projectDir, 'AGENTS.md'))).toBe(false);
+
+    const claude = readFileSync(join(projectDir, 'CLAUDE.md'), 'utf8');
+    expect(claude).toContain('<!-- capa:start:team-notes -->');
+    expect(claude).toContain('Hello.');
+  });
+
+  it('writes both CLAUDE.md and AGENTS.md when claude-code and an AGENTS-using provider are both active', async () => {
+    await installAgentsFile(
+      projectDir,
+      {
+        additional: [
+          { id: 'shared', type: 'inline', content: 'Shared instructions.' },
+        ],
+      },
+      ['claude-code', 'codex'],
+    );
+
+    expect(existsSync(join(projectDir, 'CLAUDE.md'))).toBe(true);
+    expect(existsSync(join(projectDir, 'AGENTS.md'))).toBe(true);
+
+    const claude = readFileSync(join(projectDir, 'CLAUDE.md'), 'utf8');
+    const agents = readFileSync(join(projectDir, 'AGENTS.md'), 'utf8');
+    expect(claude).toContain('Shared instructions.');
+    expect(agents).toContain('Shared instructions.');
+  });
+
+  it('wraps agents.base content in a __base__ marker block so clean can remove it', async () => {
+    // Local base file — keeps the test offline-friendly while still exercising
+    // the same write/clean path as remote/github/gitlab bases.
+    const basePath = join(projectDir, 'base.md');
+    writeFileSync(basePath, '# Base instructions\n\nFrom the base file.\n', 'utf8');
+
+    const capabilitiesPath = join(projectDir, 'capabilities.yaml');
+    writeFileSync(capabilitiesPath, '# placeholder so dirname() works\n', 'utf8');
+
+    await installAgentsFile(
+      projectDir,
+      {
+        base: { type: 'local', path: './base.md' },
+        additional: [
+          { id: 'team', type: 'inline', content: '## Team additions' },
+        ],
+      },
+      ['codex'],
+      undefined,
+      capabilitiesPath,
+    );
+
+    const agentsPath = join(projectDir, 'AGENTS.md');
+    expect(existsSync(agentsPath)).toBe(true);
+    const written = readFileSync(agentsPath, 'utf8');
+    expect(written).toContain('<!-- capa:start:__base__ -->');
+    expect(written).toContain('<!-- capa:end:__base__ -->');
+    expect(written).toContain('From the base file.');
+    expect(written).toContain('<!-- capa:start:team -->');
+
+    cleanAgentsFile(projectDir, ['codex']);
+
+    // The whole file was capa-managed, so it must be gone — not left with
+    // an orphan copy of the base content (the bug this test guards against).
+    expect(existsSync(agentsPath)).toBe(false);
+  });
+
+  it('preserves user content outside markers while still removing the __base__ block on clean', async () => {
+    const basePath = join(projectDir, 'base.md');
+    writeFileSync(basePath, 'Base content.\n', 'utf8');
+
+    const capabilitiesPath = join(projectDir, 'capabilities.yaml');
+    writeFileSync(capabilitiesPath, '# placeholder\n', 'utf8');
+
+    // Simulate a user who hand-edited their AGENTS.md before configuring
+    // `agents.base`. The pre-existing content must survive install and clean.
+    const agentsPath = join(projectDir, 'AGENTS.md');
+    writeFileSync(agentsPath, '# My project\n\nHand-written notes.\n', 'utf8');
+
+    await installAgentsFile(
+      projectDir,
+      { base: { type: 'local', path: './base.md' } },
+      ['codex'],
+      undefined,
+      capabilitiesPath,
+    );
+
+    const afterInstall = readFileSync(agentsPath, 'utf8');
+    expect(afterInstall).toContain('Hand-written notes.');
+    expect(afterInstall).toContain('<!-- capa:start:__base__ -->');
+    expect(afterInstall).toContain('Base content.');
+
+    cleanAgentsFile(projectDir, ['codex']);
+
+    expect(existsSync(agentsPath)).toBe(true);
+    const afterClean = readFileSync(agentsPath, 'utf8');
+    expect(afterClean).toContain('Hand-written notes.');
+    expect(afterClean).not.toContain('Base content.');
+    expect(afterClean).not.toContain('capa:start');
+  });
+
+  it('re-running install with a different base replaces the base block in place', async () => {
+    const basePath = join(projectDir, 'base.md');
+    writeFileSync(basePath, 'First version.\n', 'utf8');
+
+    const capabilitiesPath = join(projectDir, 'capabilities.yaml');
+    writeFileSync(capabilitiesPath, '# placeholder\n', 'utf8');
+
+    await installAgentsFile(
+      projectDir,
+      { base: { type: 'local', path: './base.md' } },
+      ['codex'],
+      undefined,
+      capabilitiesPath,
+    );
+
+    writeFileSync(basePath, 'Second version.\n', 'utf8');
+
+    await installAgentsFile(
+      projectDir,
+      { base: { type: 'local', path: './base.md' } },
+      ['codex'],
+      undefined,
+      capabilitiesPath,
+    );
+
+    const written = readFileSync(join(projectDir, 'AGENTS.md'), 'utf8');
+    expect(written).toContain('Second version.');
+    expect(written).not.toContain('First version.');
+    // Exactly one __base__ block — the upsert must not duplicate it.
+    const starts = written.match(/<!-- capa:start:__base__ -->/g) ?? [];
+    expect(starts).toHaveLength(1);
   });
 });

--- a/src/cli/utils/agents-file.ts
+++ b/src/cli/utils/agents-file.ts
@@ -20,6 +20,13 @@ import { taskLog } from '../ui';
 
 const UNIVERSAL_AGENTS_FILENAME = 'AGENTS.md';
 
+/**
+ * Reserved marker id for the optional base content seeded by `agents.base`.
+ * Wrapping the base in a marker block makes the whole file capa-managed so
+ * `cleanAgentsFile` can remove it instead of leaving orphan content behind.
+ */
+const BASE_BLOCK_ID = '__base__';
+
 const MARKER_START = (id: string) => `<!-- capa:start:${id} -->`;
 const MARKER_END = (id: string) => `<!-- capa:end:${id} -->`;
 
@@ -43,16 +50,27 @@ function buildBlock(id: string, body: string): string {
 
 /**
  * Determine which agent instruction filenames to manage based on the active providers.
- * Uses the provider registry to collect unique instruction filenames.
- * AGENTS.md is always included as the universal baseline.
+ * Each provider declares the instructions filename it reads (e.g. `AGENTS.md` for
+ * most universal-spec providers, `CLAUDE.md` for Claude Code, `replit.md` for Replit).
+ *
+ * Only filenames declared by an active provider are returned — capa never writes a
+ * file that no configured provider will read. When no providers are passed (e.g. a
+ * fresh `capa clean` with no record of a previous install), we fall back to the
+ * union across the entire registry so legacy artefacts can still be cleaned up.
  */
 export function getTargetFilenames(providers: string[]): string[] {
-  const filenames = new Set<string>([UNIVERSAL_AGENTS_FILENAME]);
+  const filenames = new Set<string>();
   const list = providers.length > 0 ? providers.map(getProvider).filter(Boolean) : getAllProviders();
   for (const p of list) {
     if (p?.instructions) {
       filenames.add(p.instructions.filename);
     }
+  }
+  // Safety net: if the provider list resolves to nothing with an instructions
+  // file (unrecognised id, or a provider whose integration omits instructions),
+  // keep the universal AGENTS.md as a fallback target.
+  if (filenames.size === 0) {
+    filenames.add(UNIVERSAL_AGENTS_FILENAME);
   }
   return [...filenames];
 }
@@ -173,28 +191,38 @@ function applyConfigToFile(
   hasBase: boolean,
   snippetBodies: Map<string, string>
 ): void {
-  let content: string;
+  // The base block is upserted as a marker-wrapped snippet (id `__base__`)
+  // rather than written raw, so:
+  //   1. `cleanAgentsFile` / `removeAllCapaSnippets` can detect it and remove
+  //      the file entirely when nothing user-authored remains (otherwise the
+  //      raw base content would linger forever after `capa clean`).
+  //   2. Re-running install refreshes the base in place without clobbering
+  //      content the user added outside capa markers — this matches the
+  //      contract documented on `AgentFileConfig.base`.
+  let content = readMdFile(projectPath, filename);
 
-  const snippetEntries = [...snippetBodies.entries()].filter(([id]) => id !== '__base__');
+  const snippetEntries = [...snippetBodies.entries()].filter(([id]) => id !== BASE_BLOCK_ID);
+  const currentIds = new Set<string>(snippetEntries.map(([id]) => id));
 
   if (hasBase) {
-    content = snippetBodies.get('__base__')!.trimEnd();
-    for (const [id, body] of snippetEntries) {
-      content = upsertSnippet(content, id, body);
+    const baseBody = snippetBodies.get(BASE_BLOCK_ID);
+    if (baseBody === undefined) {
+      throw new Error(
+        `Internal error: hasBase=true but no '${BASE_BLOCK_ID}' entry in snippetBodies.`
+      );
     }
-  } else {
-    content = readMdFile(projectPath, filename);
+    content = upsertSnippet(content, BASE_BLOCK_ID, baseBody);
+    currentIds.add(BASE_BLOCK_ID);
+  }
 
-    const currentIds = new Set(snippetEntries.map(([id]) => id));
-    for (const [id, body] of snippetEntries) {
-      content = upsertSnippet(content, id, body);
-    }
+  for (const [id, body] of snippetEntries) {
+    content = upsertSnippet(content, id, body);
+  }
 
-    for (const id of listCapaSnippetIds(content)) {
-      if (!currentIds.has(id)) {
-        taskLog(`  Removing stale agent snippet "${id}" from ${filename}`);
-        content = removeSnippet(content, id);
-      }
+  for (const id of listCapaSnippetIds(content)) {
+    if (!currentIds.has(id)) {
+      taskLog(`  Removing stale agent snippet "${id}" from ${filename}`);
+      content = removeSnippet(content, id);
     }
   }
 
@@ -310,7 +338,7 @@ export async function installAgentsFile(
       );
     }
 
-    snippetBodies.set('__base__', applySecurityChecks(baseContent, 'agents:base'));
+    snippetBodies.set(BASE_BLOCK_ID, applySecurityChecks(baseContent, 'agents:base'));
   }
 
   for (const snippet of config.additional ?? []) {


### PR DESCRIPTION
## Summary

Fixes two related bugs in how capa manages `AGENTS.md` / `CLAUDE.md`:

### Bug 1 — `AGENTS.md` written even when no provider reads it

`getTargetFilenames` seeded `AGENTS.md` into the target set unconditionally as a "universal baseline", then unioned provider-specific filenames on top. So a claude-code-only install produced **both** `CLAUDE.md` (which Claude reads) **and** a stray `AGENTS.md` (which Claude does not read, polluting the repo).

This contradicts what the docs already promised. `docs/providers/claude-code.md` says:

> Instructions | `CLAUDE.md` | Universal marker blocks; `AGENTS.md` also written **if any other provider is active**.

The fix drops the unconditional seed and computes the file set purely from the active providers' `instructions.filename`. `AGENTS.md` is kept only as a last-resort fallback when no active provider declares an instructions file (so `capa clean` still has something to scan when no provider context is known).

Practical effect:

| Providers                       | Before                          | After                              |
| ------------------------------- | ------------------------------- | ---------------------------------- |
| `claude-code`                   | `CLAUDE.md`, `AGENTS.md`        | `CLAUDE.md`                        |
| `codex`                         | `AGENTS.md`                     | `AGENTS.md` (unchanged)            |
| `claude-code` + `codex`         | `CLAUDE.md`, `AGENTS.md`        | `CLAUDE.md`, `AGENTS.md` (unchanged) |
| `github-copilot`                | `.github/copilot-instructions.md`, `AGENTS.md` | `.github/copilot-instructions.md` |
| `replit`                        | `replit.md`, `AGENTS.md`        | `replit.md`                        |

### Bug 2 — `agents.base` content survives `capa clean`

When `agents.base` was configured, `applyConfigToFile` wrote the base body **raw** (with no capa markers wrapping it) and then appended snippet marker blocks. `cleanAgentsFile` uses `removeAllCapaSnippets`, which only strips marker blocks — so any file installed with a base was never fully removed by `capa clean`; the raw base content lingered forever and the file persisted.

The fix wraps the base in a reserved `__base__` marker block. The id was already documented on `AgentFileConfig.base` for exactly this purpose:

```ts
/**
 * Optional base file downloaded and written as the starting content of AGENTS.md.
 * Capa tracks this block under the reserved id `__base__` so re-running install
 * refreshes it without overwriting user-added content outside capa markers.
 */
base?: AgentFileBase;
```

…but the implementation didn't actually do that. With the fix, the documented behavior is also now the actual behavior:

- `capa clean` removes the `__base__` block along with every other capa marker, so a purely capa-managed file is deleted entirely.
- Re-running `capa install` refreshes the base in place via the existing `upsertSnippet`, preserving any content the user added outside capa markers (previously the entire file was overwritten).

`applyConfigToFile` is also collapsed from two divergent branches (hasBase / !hasBase) into a single upsert-then-prune pass.

## Migration note

Users who already ran `capa install` on an older capa version with an `agents.base` config will have a file containing **raw base content with no `__base__` marker**. For those files, `capa clean` will still leave the raw content behind (it has no way to tell it apart from hand-written content). The recommended one-time fix is:

1. Re-run `capa install` — this adds the `__base__` marker block around the new base (any pre-existing raw content stays).
2. Manually delete the residual raw content (or just delete the file and re-install).

After that, future install→clean cycles are fully idempotent.

## Test plan

- [x] `bun test src/cli/utils/__tests__/agents-file.test.ts src/cli/commands/__tests__/clean.test.ts` — all green, including new cases.
- [x] Full suite (`bun test`) — 993 pass, 0 fail.
- [x] New tests cover:
  - `getTargetFilenames` for `claude-code`, `codex`, `github-copilot`, `replit`, the `claude-code` + `codex` union, unknown ids, and the empty fallback.
  - `installAgentsFile` does **not** write `AGENTS.md` for a `claude-code`-only install.
  - `installAgentsFile` writes both files when `claude-code` and `codex` are both active.
  - `agents.base` content gets wrapped in a `__base__` marker block.
  - `cleanAgentsFile` removes a purely capa-managed file with `agents.base` (the bug-2 regression test).
  - User content outside markers survives both install and clean when `agents.base` is configured.
  - Re-installing with a different base replaces the `__base__` block in place (exactly one marker remains).
- [x] Updated `clean.test.ts` regression test to use `[claude-code, codex]` so it still exercises the multi-file cleanup path under the new behavior, plus a new case verifying a pre-existing `AGENTS.md` is left untouched when only `claude-code` is configured.
- [x] Docs updated: `docs/providers/README.md` (cross-cutting note) and `docs/providers/claude-code.md` (instructions row) now match the actual behavior.


Made with [Cursor](https://cursor.com)