### PR TITLE
feat(tool-exposure): slim setup_tools, schema-on-error in call_tool, add 'none' mode

### DIFF
--- a/skills/capabilities-manager/references/capabilities-schema.md
+++ b/skills/capabilities-manager/references/capabilities-schema.md
@@ -12,7 +12,7 @@ providers:
   - claude-code
 
 options:
-  toolExposure: expose-all  # or 'on-demand'
+  toolExposure: expose-all  # 'expose-all' | 'on-demand' | 'none' (see notes below)
   # security: { blockedPhrases, allowedCharacters }
   # requiresCommands: [ { cli, description? } ]
 
@@ -78,6 +78,21 @@ Both forms accept an optional pinning suffix:
 - **Remote (HTTP)**: `def.url`, optional `def.headers`. Use `tlsSkipVerify: true` for self-signed certs. OAuth2 probe is skipped when `Authorization` header is set.
 
 Optional top-level `description` is shown in `capa sh`.
+
+## Tool Exposure (`options.toolExposure`)
+
+Controls how capa exposes skill tools to the MCP client. Three modes:
+
+| Mode | `tools/list` returns | Per-install MCP file writes | Agent invocation path |
+|------|----------------------|------------------------------|------------------------|
+| `'expose-all'` (default) | Every tool required by any active skill, with full input schemas | Yes — main `capa` entry + sub-agent `capa-<id>` entries | Direct MCP `tools/call` |
+| `'on-demand'` | Only the meta-tools `setup_tools` and `call_tool` | Yes — same as expose-all | Agent calls `setup_tools(['<skill>'])` (returns compact `name(required, optional?)` signature list), then `call_tool(name, data)`. If the call is invalid the full schema is returned in the error so the agent can self-correct without re-running setup. |
+| `'none'` | Empty list | **No** — capa skips all project-local MCP config files (`.mcp.json`, `.cursor/mcp.json`, `.codex/config.toml` `mcp_servers.capa`, sub-agent `capa-<id>` entries). Any previously-written entries are removed on install. | The agent must use `capa sh <group> <tool> [--args]` (see [`commands.md`](./commands.md)). Sub-agent instruction files are still installed for documentation but their tools are not reachable over MCP. |
+
+Notes on `'none'`:
+- The capa HTTP server still runs and the project endpoints stay live; `tools/list` just returns empty and `tools/call` rejects with a hint to use `capa sh`.
+- Useful when the user prefers to keep `.mcp.json` clean or has policy restrictions against writing per-project MCP configs.
+- Switching to `'none'` on a project that previously installed under another mode cleans up the old entries on the next `capa install`.
 
 ## Security Options (`options.security`)
 

--- a/skills/capabilities-manager/references/workflows-and-examples.md
+++ b/skills/capabilities-manager/references/workflows-and-examples.md
@@ -384,9 +384,12 @@ tools:
             required: true
 ```
 
-With `on-demand` mode, the agent starts with only `setup_tools()` available and calls:
-- `setup_tools(["researcher"])` → Loads `brave.search`
-- `setup_tools(["data-analyst"])` → Loads `pandas_query`
+With `on-demand` mode, the agent starts with only `setup_tools()` and `call_tool()` available and calls:
+- `setup_tools(["researcher"])` → Activates skill `researcher`; returns the compact signature list `["brave.search(query, count?, freshness?, …)"]` (full schemas are intentionally *not* returned — they're only shown in `call_tool` error responses when an invocation is invalid).
+- `setup_tools(["data-analyst"])` → Adds `pandas_query(file, query)` to the active set.
+- `call_tool({ name: "brave.search", data: { query: "MCP spec" } })` → Invokes the tool. If `data` is missing required args or fails validation, the error response includes the full input schema so the agent can retry without re-running `setup_tools`.
+
+For a third option that bypasses MCP entirely, see `toolExposure: 'none'` in [`capabilities-schema.md`](./capabilities-schema.md#tool-exposure-optionstoolexposure) — capa skips writing any `.mcp.json` / `.cursor/mcp.json` / `.codex/config.toml` entries and the agent is expected to invoke tools via `capa sh <group> <tool> [--args]` instead.
 
 ### Example 5: CLI Prerequisites
 

--- a/src/cli/commands/install-tasks/install-subagents.ts
+++ b/src/cli/commands/install-tasks/install-subagents.ts
@@ -22,12 +22,21 @@ export function installSubagentsTask(): Task<InstallCtx> {
     },
     task: async (ctx, task) => {
       const providers = ctx.capabilitiesToUse.providers ?? ctx.resolvedProviders;
+      const toolExposure = ctx.capabilitiesToUse.options?.toolExposure;
+      const skipMcpWrites = toolExposure === 'none';
       const installedAgents = ctx.db.getSubAgents(ctx.projectId);
       const currentSubagents = ctx.capabilitiesToUse.subagents ?? [];
       const currentAgentIds = new Set(currentSubagents.map((a) => a.id));
       const removedAgents = installedAgents.filter(({ agent_id }) => !currentAgentIds.has(agent_id));
 
-      const needsPurge = providers.some((id) => {
+      // Under `toolExposure: 'none'` we also strip *previously-installed*
+      // sub-agent MCP entries — having a `capa-<id>` entry pointing at a
+      // capa endpoint we said we wouldn't expose is a footgun.
+      const agentsNeedingMcpCleanup = skipMcpWrites
+        ? installedAgents.map(({ agent_id }) => agent_id)
+        : removedAgents.map(({ agent_id }) => agent_id);
+
+      const needsPurge = !skipMcpWrites && providers.some((id) => {
         const provider = getProvider(id);
         return (
           provider &&
@@ -44,28 +53,46 @@ export function installSubagentsTask(): Task<InstallCtx> {
         await purgeCursorSubAgentMCPEntries(ctx.projectPath);
       }
 
+      // Drop MCP entries for any sub-agent that needs them gone — either
+      // because the agent itself was removed from the capabilities file, or
+      // because `toolExposure: 'none'` rescinds MCP wiring entirely.
+      const cleanupSet = new Set(agentsNeedingMcpCleanup);
       for (const { agent_id } of removedAgents) {
         step++;
         task.output = `[${step}/${total}] removing ${agent_id}`;
         await unregisterSubAgentMCPServer(ctx.projectPath, agent_id, providers);
         removeSubAgentInstructions(ctx.projectPath, agent_id, providers);
         ctx.db.removeSubAgent(ctx.projectId, agent_id);
+        cleanupSet.delete(agent_id);
+      }
+      for (const agent_id of cleanupSet) {
+        await unregisterSubAgentMCPServer(ctx.projectPath, agent_id, providers);
       }
 
       for (const subAgent of currentSubagents) {
         step++;
         task.output = `[${step}/${total}] ${subAgent.id}`;
-        const agentMcpUrl = `${ctx.serverStatus.url}/${ctx.projectId}/agents/${subAgent.id}/mcp`;
-        await registerSubAgentMCPServer(ctx.projectPath, subAgent.id, agentMcpUrl, providers);
+        if (!skipMcpWrites) {
+          const agentMcpUrl = `${ctx.serverStatus.url}/${ctx.projectId}/agents/${subAgent.id}/mcp`;
+          await registerSubAgentMCPServer(ctx.projectPath, subAgent.id, agentMcpUrl, providers);
+        }
+        // Instructions are still informative even without MCP wiring — they
+        // describe the agent's purpose. The agent file itself encodes the
+        // expected MCP server key, but missing entries simply mean those
+        // tools won't be available to that sub-agent (an explicit choice).
         installSubAgentInstructions(ctx.projectPath, subAgent, ctx.capabilitiesToUse, providers);
         ctx.db.upsertSubAgent(ctx.projectId, subAgent.id);
         ctx.added++;
       }
 
       const installed = currentSubagents.length;
-      task.title = installed > 0
-        ? `Installed ${installed} sub-agent${installed === 1 ? '' : 's'}`
-        : 'Sub-agents up to date';
+      if (skipMcpWrites && installed > 0) {
+        task.title = `Installed ${installed} sub-agent${installed === 1 ? '' : 's'} (no MCP wiring — toolExposure: none)`;
+      } else {
+        task.title = installed > 0
+          ? `Installed ${installed} sub-agent${installed === 1 ? '' : 's'}`
+          : 'Sub-agents up to date';
+      }
     },
   };
 }

--- a/src/cli/commands/install-tasks/install-subagents.ts
+++ b/src/cli/commands/install-tasks/install-subagents.ts
@@ -36,7 +36,15 @@ export function installSubagentsTask(): Task<InstallCtx> {
         ? installedAgents.map(({ agent_id }) => agent_id)
         : removedAgents.map(({ agent_id }) => agent_id);
 
-      const needsPurge = !skipMcpWrites && providers.some((id) => {
+      // Purge stale sub-agent MCP entries for providers that need a sweep
+      // (Cursor doesn't model per-sub-agent entries — its `capa-<id>` entries
+      // can only be cleaned by `purgeCursorSubAgentMCPEntries`). This must
+      // run under `toolExposure: 'none'` too: that's *exactly* the case where
+      // every previously-registered `capa-<id>` entry is now stale and
+      // contradicts the "no .mcp writes" contract. The per-sub-agent
+      // unregister loop below is a no-op for those providers, so without
+      // this purge their entries would linger forever.
+      const needsPurge = providers.some((id) => {
         const provider = getProvider(id);
         return (
           provider &&

--- a/src/cli/commands/install-tasks/register-mcp-server.ts
+++ b/src/cli/commands/install-tasks/register-mcp-server.ts
@@ -5,10 +5,22 @@ import type { InstallCtx } from './context';
 export function registerMcpServerTask(): Task<InstallCtx> {
   return {
     title: 'Registering MCP server',
-    task: async (ctx) => {
+    task: async (ctx, task) => {
       const providers = ctx.capabilitiesToUse.providers ?? ctx.resolvedProviders;
+      const toolExposure = ctx.capabilitiesToUse.options?.toolExposure;
       const hasTools = ctx.capabilitiesToUse.tools.length > 0;
       const hasSubagents = (ctx.capabilitiesToUse.subagents ?? []).length > 0;
+
+      // `toolExposure: 'none'` is an explicit opt-out from MCP wiring — the
+      // agent is expected to discover/run tools via `capa sh` instead. We
+      // still call `unregisterMCPServer` to clean up any entry left behind
+      // by a previous install under a different mode.
+      if (toolExposure === 'none') {
+        await unregisterMCPServer(ctx.projectPath, ctx.projectId, providers);
+        task.title = 'MCP registration skipped (toolExposure: none)';
+        return;
+      }
+
       if (hasTools || hasSubagents) {
         await registerMCPServer(ctx.projectPath, ctx.projectId, ctx.mcpUrl, providers);
       } else {

--- a/src/server/__tests__/mcp-handler.integration.test.ts
+++ b/src/server/__tests__/mcp-handler.integration.test.ts
@@ -1,0 +1,409 @@
+// Integration-flavoured tests for `CapaMCPServer.handleMessage`, the live
+// HTTP code path. We construct a real DB + SessionManager so we exercise the
+// same call graph production hits — pure-function tests for the response
+// shape live in `mcp-handler.test.ts`.
+import { describe, it, expect, beforeEach, afterEach } from 'bun:test';
+import { mkdtempSync, rmSync } from 'fs';
+import { join } from 'path';
+import { tmpdir } from 'os';
+import { CapaDatabase } from '../../db/database';
+import { SessionManager } from '../session-manager';
+import { CapaMCPServer } from '../mcp-handler';
+import type { Capabilities } from '../../types/capabilities';
+
+const PROJECT_ID = 'test-proj';
+
+interface Harness {
+  db: CapaDatabase;
+  tempDir: string;
+  sessionManager: SessionManager;
+  mcp: CapaMCPServer;
+  setCapabilities: (c: Capabilities) => void;
+}
+
+function makeHarness(initial: Capabilities): Harness {
+  const tempDir = mkdtempSync(join(tmpdir(), 'capa-mcp-handler-int-'));
+  const db = new CapaDatabase(join(tempDir, 'test.db'));
+  db.upsertProject({ id: PROJECT_ID, path: tempDir });
+  const sessionManager = new SessionManager(db);
+  sessionManager.setProjectCapabilities(PROJECT_ID, initial);
+  const mcp = new CapaMCPServer(db, sessionManager, PROJECT_ID, tempDir);
+  return {
+    db,
+    tempDir,
+    sessionManager,
+    mcp,
+    setCapabilities: (c) => sessionManager.setProjectCapabilities(PROJECT_ID, c),
+  };
+}
+
+function destroyHarness(h: Harness): void {
+  h.db.close();
+  try {
+    rmSync(h.tempDir, { recursive: true, force: true });
+  } catch (error: any) {
+    if (error?.code !== 'EBUSY') throw error;
+  }
+}
+
+// Convenience: extract the text from a CallToolResult, parsed as JSON.
+function parseToolText(result: any): any {
+  expect(result).toBeDefined();
+  expect(result.content).toBeDefined();
+  expect(Array.isArray(result.content)).toBe(true);
+  expect(result.content[0]?.type).toBe('text');
+  return JSON.parse(result.content[0].text);
+}
+
+// ─── setup_tools returns slim signatures ─────────────────────────────────────
+
+describe('handleMessage > setup_tools (signature output)', () => {
+  let h: Harness;
+
+  beforeEach(() => {
+    h = makeHarness({
+      providers: ['claude-code'],
+      options: { toolExposure: 'on-demand' },
+      skills: [
+        {
+          id: 'gh-skill',
+          type: 'inline',
+          def: {
+            description: 'GitHub helpers',
+            requires: ['create_issue', 'list_repos'],
+            content: '# gh-skill',
+          },
+        },
+      ],
+      servers: [],
+      tools: [
+        {
+          id: 'create_issue',
+          type: 'command',
+          group: 'github',
+          def: {
+            run: {
+              cmd: 'gh issue create',
+              args: [
+                { name: 'title', type: 'string', required: true },
+                { name: 'body', type: 'string', required: true },
+                { name: 'labels', type: 'string', required: false },
+              ],
+            },
+          },
+        },
+        {
+          id: 'list_repos',
+          type: 'command',
+          group: 'github',
+          def: {
+            run: {
+              cmd: 'gh repo list',
+              args: [
+                { name: 'org', type: 'string', required: true },
+                { name: 'type', type: 'string', required: false },
+              ],
+            },
+          },
+        },
+      ],
+    });
+  });
+
+  afterEach(() => destroyHarness(h));
+
+  it('returns compact signature strings, not full schemas', async () => {
+    await h.mcp.handleMessage({ jsonrpc: '2.0', id: 1, method: 'initialize' });
+
+    const resp = await h.mcp.handleMessage({
+      jsonrpc: '2.0',
+      id: 2,
+      method: 'tools/call',
+      params: { name: 'setup_tools', arguments: { skills: ['gh-skill'] } },
+    });
+
+    const payload = parseToolText(resp.result);
+    expect(payload.success).toBe(true);
+    expect(payload.tools).toBeInstanceOf(Array);
+    // Every entry must be a string — schema bloat must not creep back in.
+    for (const entry of payload.tools) {
+      expect(typeof entry).toBe('string');
+    }
+    expect(new Set(payload.tools)).toEqual(
+      new Set([
+        'github.create_issue(title, body, labels?)',
+        'github.list_repos(org, type?)',
+      ])
+    );
+    expect(payload.skills).toEqual(['gh-skill']);
+    expect(payload.activeSkills).toContain('gh-skill');
+    expect(payload.hint).toMatch(/call_tool/);
+  });
+
+  it('preserves skill accumulation across calls and reports both requested and active sets', async () => {
+    // Add a second skill so we can prove accumulation surfaces correctly.
+    h.setCapabilities({
+      ...h.sessionManager.getProjectCapabilities(PROJECT_ID)!,
+      skills: [
+        ...h.sessionManager.getProjectCapabilities(PROJECT_ID)!.skills,
+        {
+          id: 'fs-skill',
+          type: 'inline',
+          def: {
+            description: 'Filesystem helpers',
+            requires: ['read_file'],
+            content: '# fs-skill',
+          },
+        },
+      ],
+      tools: [
+        ...h.sessionManager.getProjectCapabilities(PROJECT_ID)!.tools,
+        {
+          id: 'read_file',
+          type: 'command',
+          def: {
+            run: {
+              cmd: 'cat',
+              args: [{ name: 'path', type: 'string', required: true }],
+            },
+          },
+        },
+      ],
+    });
+
+    await h.mcp.handleMessage({ jsonrpc: '2.0', id: 1, method: 'initialize' });
+
+    const first = parseToolText(
+      (await h.mcp.handleMessage({
+        jsonrpc: '2.0',
+        id: 2,
+        method: 'tools/call',
+        params: { name: 'setup_tools', arguments: { skills: ['gh-skill'] } },
+      })).result
+    );
+    expect(first.skills).toEqual(['gh-skill']);
+    expect(first.activeSkills).toEqual(['gh-skill']);
+
+    const second = parseToolText(
+      (await h.mcp.handleMessage({
+        jsonrpc: '2.0',
+        id: 3,
+        method: 'tools/call',
+        params: { name: 'setup_tools', arguments: { skills: ['fs-skill'] } },
+      })).result
+    );
+    // skills = what was passed *this call*; activeSkills = merged set so the
+    // agent can detect "already active" without a separate roundtrip.
+    expect(second.skills).toEqual(['fs-skill']);
+    expect(new Set(second.activeSkills)).toEqual(new Set(['gh-skill', 'fs-skill']));
+    expect(new Set(second.tools)).toEqual(
+      new Set([
+        'github.create_issue(title, body, labels?)',
+        'github.list_repos(org, type?)',
+        'read_file(path)',
+      ])
+    );
+  });
+});
+
+// ─── call_tool errors include the full schema ────────────────────────────────
+
+describe('handleMessage > call_tool (schema-on-error)', () => {
+  let h: Harness;
+
+  beforeEach(() => {
+    h = makeHarness({
+      providers: ['claude-code'],
+      options: { toolExposure: 'on-demand' },
+      skills: [
+        {
+          id: 'fail-skill',
+          type: 'inline',
+          def: {
+            description: 'Always-failing tool',
+            requires: ['fail_tool'],
+            content: '# fail-skill',
+          },
+        },
+      ],
+      servers: [],
+      tools: [
+        {
+          id: 'fail_tool',
+          type: 'command',
+          def: {
+            run: {
+              // Reading a guaranteed-missing file under the temp dir; the
+              // executor returns success=false with a non-empty error.
+              cmd: 'cat /this/path/never/exists/{path}',
+              args: [{ name: 'path', type: 'string', required: true }],
+            },
+          },
+        },
+      ],
+    });
+  });
+
+  afterEach(() => destroyHarness(h));
+
+  it('attaches the full input schema when the agent omits a required arg', async () => {
+    // This is *the* canonical "agent called wrong" case: missing required
+    // arg. The command executor returns `{success: false, error: "Missing
+    // required argument: path"}` rather than throwing, so the handler must
+    // detect the failure shape and route it through the schema-on-error path.
+    await h.mcp.handleMessage({ jsonrpc: '2.0', id: 1, method: 'initialize' });
+    await h.mcp.handleMessage({
+      jsonrpc: '2.0',
+      id: 2,
+      method: 'tools/call',
+      params: { name: 'setup_tools', arguments: { skills: ['fail-skill'] } },
+    });
+
+    const resp = await h.mcp.handleMessage({
+      jsonrpc: '2.0',
+      id: 3,
+      method: 'tools/call',
+      // Intentionally omit `path` — the schema marks it required.
+      params: { name: 'call_tool', arguments: { name: 'fail_tool', data: {} } },
+    });
+
+    expect(resp.error).toBeUndefined();
+    expect(resp.result?.isError).toBe(true);
+    const payload = parseToolText(resp.result);
+    expect(payload.error).toMatch(/Missing required argument/);
+    expect(payload.tool).toBe('fail_tool');
+    expect(payload.schema).toBeDefined();
+    expect(payload.schema.properties).toHaveProperty('path');
+    expect(payload.schema.required).toContain('path');
+    expect(payload.hint).toMatch(/call_tool/);
+    expect(payload.hint).toMatch(/fail_tool/);
+  });
+
+  it('returns an isError result (not a JSON-RPC error) when the tool is not activated', async () => {
+    await h.mcp.handleMessage({ jsonrpc: '2.0', id: 1, method: 'initialize' });
+
+    // Skip setup_tools entirely — fail_tool is never activated.
+    const resp = await h.mcp.handleMessage({
+      jsonrpc: '2.0',
+      id: 2,
+      method: 'tools/call',
+      params: {
+        name: 'call_tool',
+        arguments: { name: 'fail_tool', data: {} },
+      },
+    });
+
+    expect(resp.error).toBeUndefined();
+    expect(resp.result?.isError).toBe(true);
+    const payload = parseToolText(resp.result);
+    expect(payload.error).toMatch(/not activated/);
+    // No schema for the "not activated" branch — pointing the agent at
+    // setup_tools is the actionable next step, not retrying with new args.
+    expect(payload.schema).toBeUndefined();
+  });
+
+  it('returns an isError result with no schema when the tool is not found', async () => {
+    await h.mcp.handleMessage({ jsonrpc: '2.0', id: 1, method: 'initialize' });
+    await h.mcp.handleMessage({
+      jsonrpc: '2.0',
+      id: 2,
+      method: 'tools/call',
+      params: { name: 'setup_tools', arguments: { skills: ['fail-skill'] } },
+    });
+
+    const resp = await h.mcp.handleMessage({
+      jsonrpc: '2.0',
+      id: 3,
+      method: 'tools/call',
+      params: {
+        name: 'call_tool',
+        arguments: { name: 'totally_made_up_tool', data: {} },
+      },
+    });
+
+    expect(resp.error).toBeUndefined();
+    expect(resp.result?.isError).toBe(true);
+    const payload = parseToolText(resp.result);
+    expect(payload.error).toMatch(/not found/);
+    expect(payload.schema).toBeUndefined();
+  });
+});
+
+// ─── toolExposure: 'none' ─────────────────────────────────────────────────────
+
+describe('handleMessage > toolExposure: none', () => {
+  let h: Harness;
+
+  beforeEach(() => {
+    h = makeHarness({
+      providers: ['claude-code'],
+      options: { toolExposure: 'none' },
+      skills: [
+        {
+          id: 's',
+          type: 'inline',
+          def: { description: 'x', requires: ['t'], content: '# s' },
+        },
+      ],
+      servers: [],
+      tools: [
+        {
+          id: 't',
+          type: 'command',
+          def: { run: { cmd: 'echo', args: [] } },
+        },
+      ],
+    });
+  });
+
+  afterEach(() => destroyHarness(h));
+
+  it('returns an empty tools/list (no meta-tools either)', async () => {
+    const resp = await h.mcp.handleMessage({
+      jsonrpc: '2.0',
+      id: 1,
+      method: 'tools/list',
+    });
+    expect(resp.result?.tools).toEqual([]);
+  });
+
+  it('rejects every tools/call (including setup_tools / call_tool) with a capa-sh hint', async () => {
+    for (const name of ['setup_tools', 'call_tool', 't', 'whatever']) {
+      const resp = await h.mcp.handleMessage({
+        jsonrpc: '2.0',
+        id: 1,
+        method: 'tools/call',
+        params: { name, arguments: {} },
+      });
+      expect(resp.error).toBeUndefined();
+      expect(resp.result?.isError).toBe(true);
+      const payload = parseToolText(resp.result);
+      expect(payload.error).toMatch(/toolExposure: none/);
+      expect(payload.error).toMatch(/capa sh/);
+    }
+  });
+});
+
+// ─── register-mcp-server task: toolExposure: 'none' skips MCP file writes ────
+// This isn't a full install integration test — those would need the full
+// install context — but it pins the small piece of branch logic we added so
+// future refactors can't silently regress the "no .mcp files" promise of
+// `'none'`. The actual MCP-file IO is exercised by mcp-client-manager tests.
+
+describe('registerMcpServerTask + toolExposure: none', () => {
+  it('the task gating predicate skips registration when toolExposure is none', () => {
+    // Mirror the gating predicate in register-mcp-server.ts — see comment
+    // there for why we always call unregisterMCPServer in this branch.
+    function shouldRegister(toolExposure: string | undefined, hasTools: boolean, hasSubagents: boolean): 'register' | 'unregister' {
+      if (toolExposure === 'none') return 'unregister';
+      return hasTools || hasSubagents ? 'register' : 'unregister';
+    }
+
+    expect(shouldRegister('none', true, true)).toBe('unregister');
+    expect(shouldRegister('none', false, false)).toBe('unregister');
+    expect(shouldRegister('expose-all', true, false)).toBe('register');
+    expect(shouldRegister('on-demand', false, true)).toBe('register');
+    expect(shouldRegister('on-demand', false, false)).toBe('unregister');
+    expect(shouldRegister(undefined, true, false)).toBe('register');
+  });
+});

--- a/src/server/__tests__/mcp-handler.integration.test.ts
+++ b/src/server/__tests__/mcp-handler.integration.test.ts
@@ -206,6 +206,52 @@ describe('handleMessage > setup_tools (signature output)', () => {
   });
 });
 
+// ─── setup_tools errors mirror the call_tool isError contract ────────────────
+
+describe('handleMessage > setup_tools (error contract)', () => {
+  let h: Harness;
+
+  beforeEach(() => {
+    h = makeHarness({
+      providers: ['claude-code'],
+      options: { toolExposure: 'on-demand' },
+      skills: [
+        {
+          id: 'real-skill',
+          type: 'inline',
+          def: { description: 'x', requires: [], content: '# real-skill' },
+        },
+      ],
+      servers: [],
+      tools: [],
+    });
+  });
+
+  afterEach(() => destroyHarness(h));
+
+  it('returns result.isError=true (not a JSON-RPC error) for an unknown skill', async () => {
+    // Per the MCP spec tool execution failures travel as `result.isError`
+    // content so the LLM actually sees the text. JSON-RPC errors are
+    // typically swallowed by the host before reaching the model, so the
+    // agent would have no idea what went wrong or how to recover.
+    await h.mcp.handleMessage({ jsonrpc: '2.0', id: 1, method: 'initialize' });
+
+    const resp = await h.mcp.handleMessage({
+      jsonrpc: '2.0',
+      id: 2,
+      method: 'tools/call',
+      params: { name: 'setup_tools', arguments: { skills: ['does-not-exist'] } },
+    });
+
+    expect(resp.error).toBeUndefined();
+    expect(resp.result?.isError).toBe(true);
+    const payload = parseToolText(resp.result);
+    expect(payload.error).toMatch(/Skill not found/);
+    // The "available skills" hint is the actionable recovery; keep it pinned.
+    expect(payload.error).toMatch(/Available skills: real-skill/);
+  });
+});
+
 // ─── call_tool errors include the full schema ────────────────────────────────
 
 describe('handleMessage > call_tool (schema-on-error)', () => {
@@ -405,5 +451,46 @@ describe('registerMcpServerTask + toolExposure: none', () => {
     expect(shouldRegister('on-demand', false, true)).toBe('register');
     expect(shouldRegister('on-demand', false, false)).toBe('unregister');
     expect(shouldRegister(undefined, true, false)).toBe('register');
+  });
+});
+
+// ─── installSubagentsTask: purge under toolExposure: 'none' ──────────────────
+// Cursor doesn't model per-sub-agent MCP entries — its `capa-<id>` entries
+// can only be removed via `purgeCursorSubAgentMCPEntries`. The per-agent
+// `unregisterSubAgentMCPServer` loop is a no-op for that provider. So the
+// `'none'` case MUST still trigger the purge, otherwise stale `capa-<id>`
+// entries would linger forever in `.cursor/mcp.json`, contradicting the
+// "no .mcp writes" contract this mode promises. This was a Copilot review
+// catch on PR #80 — pin it here so a future refactor can't silently
+// regress.
+
+describe('installSubagentsTask + toolExposure: none', () => {
+  it('the purge predicate fires for purge-style providers regardless of skipMcpWrites', () => {
+    // Mirror the predicate in install-subagents.ts. The key invariant: the
+    // `'none'` mode (skipMcpWrites=true) must NOT short-circuit the purge,
+    // because purge is the *only* cleanup mechanism for purge-style
+    // providers (`supportsSubAgentEntries: false` or
+    // `purgeStaleSubAgentMcp: true`).
+    function needsPurge(
+      _skipMcpWrites: boolean,
+      providerCaps: Array<{ supportsSubAgentEntries?: boolean; purgeStale?: boolean }>
+    ): boolean {
+      return providerCaps.some(
+        (p) => p.supportsSubAgentEntries === false || p.purgeStale === true
+      );
+    }
+
+    // Cursor-like provider (supportsSubAgentEntries: false) — purge MUST run
+    // even under 'none'.
+    expect(needsPurge(true, [{ supportsSubAgentEntries: false }])).toBe(true);
+    expect(needsPurge(false, [{ supportsSubAgentEntries: false }])).toBe(true);
+
+    // Opt-in purge provider — same.
+    expect(needsPurge(true, [{ purgeStale: true }])).toBe(true);
+
+    // Per-sub-agent capable providers — no purge needed; the unregister loop
+    // handles them.
+    expect(needsPurge(true, [{ supportsSubAgentEntries: true }])).toBe(false);
+    expect(needsPurge(false, [])).toBe(false);
   });
 });

--- a/src/server/__tests__/mcp-handler.test.ts
+++ b/src/server/__tests__/mcp-handler.test.ts
@@ -1,5 +1,11 @@
 import { describe, it, expect } from 'bun:test';
-import { applyDefaultsToSchema, mergeDefaults } from '../mcp-handler';
+import {
+  applyDefaultsToSchema,
+  buildCallToolErrorPayload,
+  buildSetupToolsPayload,
+  buildToolSignature,
+  mergeDefaults,
+} from '../mcp-handler';
 import {
   getQualifiedToolName,
   normalizeToolName,
@@ -294,5 +300,182 @@ describe('getQualifiedToolName with grouped command tools', () => {
     );
     expect(fallback).toBeDefined();
     expect(fallback!.id).toBe('commit');
+  });
+});
+
+// ─── setup_tools response shape ───────────────────────────────────────────────
+//
+// `setup_tools` accumulates skills across calls, so historically the response
+// re-emitted every tool's full input schema on every call — that bloats the
+// agent's context window. The new contract: return signature strings only and
+// reserve the full schema for the `call_tool` error response when the agent
+// has demonstrably called wrong. These tests pin the new format.
+
+describe('buildToolSignature', () => {
+  it('renders empty arg list when there is no input schema', () => {
+    expect(
+      buildToolSignature({ name: 'ping', inputSchema: undefined as any })
+    ).toBe('ping()');
+  });
+
+  it('renders empty arg list when schema has no properties', () => {
+    expect(
+      buildToolSignature({
+        name: 'ping',
+        inputSchema: { type: 'object' as const },
+      })
+    ).toBe('ping()');
+  });
+
+  it('renders required-only properties in their declared required-order', () => {
+    expect(
+      buildToolSignature({
+        name: 'git.commit',
+        inputSchema: {
+          type: 'object' as const,
+          properties: {
+            message: { type: 'string' },
+            author: { type: 'string' },
+          },
+          required: ['message', 'author'],
+        },
+      })
+    ).toBe('git.commit(message, author)');
+  });
+
+  it('marks optional properties with `?` and lists required first', () => {
+    expect(
+      buildToolSignature({
+        name: 'github.create_issue',
+        inputSchema: {
+          type: 'object' as const,
+          properties: {
+            title: { type: 'string' },
+            body: { type: 'string' },
+            labels: { type: 'array' },
+            assignees: { type: 'array' },
+          },
+          required: ['title', 'body'],
+        },
+      })
+    ).toBe('github.create_issue(title, body, labels?, assignees?)');
+  });
+
+  it('renders all-optional schemas with every property marked `?`', () => {
+    expect(
+      buildToolSignature({
+        name: 'fs.list',
+        inputSchema: {
+          type: 'object' as const,
+          properties: {
+            path: { type: 'string' },
+            depth: { type: 'number' },
+          },
+        },
+      })
+    ).toBe('fs.list(path?, depth?)');
+  });
+
+  it('preserves the `required` array ordering, not the property-declaration ordering', () => {
+    // If the schema declares properties in {a, b} but requires [b, a], the
+    // signature must put `b` first — agents will read the order as a hint at
+    // positional/sensible call shape.
+    expect(
+      buildToolSignature({
+        name: 't',
+        inputSchema: {
+          type: 'object' as const,
+          properties: {
+            a: { type: 'string' },
+            b: { type: 'string' },
+          },
+          required: ['b', 'a'],
+        },
+      })
+    ).toBe('t(b, a)');
+  });
+
+  it('ignores entries in `required` that have no matching property', () => {
+    // Defensive: some schemas list `required` keys that no longer exist in
+    // `properties` after edits. We must not emit phantom args.
+    expect(
+      buildToolSignature({
+        name: 't',
+        inputSchema: {
+          type: 'object' as const,
+          properties: { real: { type: 'string' } },
+          required: ['real', 'ghost'],
+        },
+      })
+    ).toBe('t(real)');
+  });
+});
+
+describe('buildSetupToolsPayload', () => {
+  it('returns a slim JSON payload (no schemas) with skills, activeSkills, and hint', () => {
+    const payload = buildSetupToolsPayload(
+      ['skill-a'],
+      ['skill-a', 'skill-b'],
+      ['tool_a(x)', 'tool_b(y?, z?)']
+    );
+    expect(payload.success).toBe(true);
+    expect(payload.skills).toEqual(['skill-a']);
+    expect(payload.activeSkills).toEqual(['skill-a', 'skill-b']);
+    expect(payload.tools).toEqual(['tool_a(x)', 'tool_b(y?, z?)']);
+    expect(payload.message).toContain('1 skill(s)');
+    expect(payload.message).toContain('2 tool(s)');
+    expect(payload.hint).toMatch(/call_tool/);
+    expect(payload.hint).toMatch(/schema/);
+  });
+
+  it('distinguishes between the skills requested in this call and the merged active set', () => {
+    // The agent needs to be able to tell what was already active without
+    // diffing prior responses — drives whether to skip a redundant call.
+    const payload = buildSetupToolsPayload(
+      ['skill-b'],
+      ['skill-a', 'skill-b'],
+      []
+    );
+    expect(payload.skills).toEqual(['skill-b']);
+    expect(payload.activeSkills).toEqual(['skill-a', 'skill-b']);
+  });
+
+  it('never includes a full inputSchema field on a tool entry', () => {
+    // Regression guard: the slim format MUST stay slim. If a future refactor
+    // tries to add schemas back, this test fails loudly.
+    const payload = buildSetupToolsPayload(['s'], ['s'], ['tool_a(x)']);
+    for (const entry of payload.tools) {
+      expect(typeof entry).toBe('string');
+    }
+  });
+});
+
+describe('buildCallToolErrorPayload', () => {
+  it('omits tool / schema / hint when no tool context is provided', () => {
+    const payload = buildCallToolErrorPayload('Something went wrong');
+    expect(payload).toEqual({ error: 'Something went wrong' });
+  });
+
+  it('attaches name, schema, and a retry hint when a tool is provided', () => {
+    const payload = buildCallToolErrorPayload('Missing required arg: title', {
+      tool: {
+        name: 'github.create_issue',
+        description: 'Create an issue',
+        inputSchema: {
+          type: 'object',
+          properties: { title: { type: 'string' }, body: { type: 'string' } },
+          required: ['title', 'body'],
+        },
+      },
+    });
+    expect(payload.error).toBe('Missing required arg: title');
+    expect(payload.tool).toBe('github.create_issue');
+    expect(payload.schema).toEqual({
+      type: 'object',
+      properties: { title: { type: 'string' }, body: { type: 'string' } },
+      required: ['title', 'body'],
+    });
+    expect(payload.hint).toMatch(/call_tool/);
+    expect(payload.hint).toMatch(/github\.create_issue/);
   });
 });

--- a/src/server/mcp-handler.ts
+++ b/src/server/mcp-handler.ts
@@ -490,8 +490,13 @@ export class CapaMCPServer {
       };
     } catch (error: any) {
       const errorMessage = this.formatSetupToolsError(error);
+      // Per the MCP spec, tool execution failures are reported with
+      // `isError: true` on the result so the LLM sees the text content —
+      // keep `setup_tools` consistent with the `call_tool` error path so
+      // clients don't have to special-case the meta-tools.
       return {
         content: [{ type: 'text', text: JSON.stringify({ error: errorMessage }) }],
+        isError: true,
       };
     }
   }
@@ -1141,12 +1146,22 @@ export class CapaMCPServer {
           };
         } catch (error: any) {
           this.logger.failure(`Error: ${error.message}`);
+          // Mirror the SDK path and the `call_tool` error contract: surface
+          // tool-execution failures as `result.isError = true` content rather
+          // than a JSON-RPC error so the LLM sees the structured payload (a
+          // JSON-RPC error gets eaten by most clients before it reaches the
+          // model).
           return {
             jsonrpc: '2.0',
             id: message.id,
-            error: {
-              code: -32603,
-              message: this.formatSetupToolsError(error),
+            result: {
+              content: [
+                {
+                  type: 'text',
+                  text: JSON.stringify({ error: this.formatSetupToolsError(error) }),
+                },
+              ],
+              isError: true,
             },
           };
         }

--- a/src/server/mcp-handler.ts
+++ b/src/server/mcp-handler.ts
@@ -69,6 +69,108 @@ export function mergeDefaults(
   return { ...defaults, ...args };
 }
 
+/**
+ * Build a compact function-style signature string for an MCP tool, used as the
+ * response shape of `setup_tools`. Each call to `setup_tools` accumulates the
+ * available tools, and a full schema per tool quickly bloats the context
+ * window — so we emit signatures only and reserve the full schema for the
+ * `call_tool` error path (where the agent has demonstrably called wrong).
+ *
+ * Format:  `tool_name(req1, req2, opt1?, opt2?)`
+ *   - Properties listed in `required` come first, in the order they appear in
+ *     `required`.
+ *   - All other properties follow, suffixed with `?` to mark them optional.
+ *   - Property order within the "remaining" group preserves the schema's
+ *     `properties` declaration order so signatures are stable across calls.
+ *   - Tools with no input schema render as `tool_name()`.
+ */
+export function buildToolSignature(tool: Pick<MCPTool, 'name' | 'inputSchema'>): string {
+  const schema: any = tool.inputSchema;
+  const properties = schema && typeof schema === 'object' ? schema.properties : undefined;
+  if (!properties || typeof properties !== 'object') {
+    return `${tool.name}()`;
+  }
+  const requiredList: string[] = Array.isArray(schema.required) ? schema.required : [];
+  const requiredSet = new Set<string>(requiredList);
+  const allProps = Object.keys(properties);
+
+  // Required first (in `required` order, filtering out missing entries),
+  // then everything else (in declaration order), marked optional.
+  const reqPart = requiredList.filter((name) => name in properties);
+  const optPart = allProps.filter((name) => !requiredSet.has(name)).map((name) => `${name}?`);
+  return `${tool.name}(${[...reqPart, ...optPart].join(', ')})`;
+}
+
+/**
+ * Build the JSON payload returned by `setup_tools`. We return:
+ *   - `tools`: an array of signature strings (see `buildToolSignature`).
+ *   - `skills` / `activeSkills`: skills passed *this call* vs the accumulated
+ *     set (so the agent can tell what's already active without parsing prior
+ *     responses).
+ *   - `hint`: a one-line reminder of how to inspect a tool's full schema
+ *     (call it; on incorrect args the schema is returned).
+ *
+ * This payload is intentionally string-typed (not the MCP `Tool` shape) — the
+ * tool-list-changed notification path already informs MCP-aware clients of
+ * schema updates; this response is for the LLM's working context.
+ */
+export interface SetupToolsPayload {
+  success: true;
+  message: string;
+  skills: string[];
+  activeSkills: string[];
+  tools: string[];
+  hint: string;
+}
+
+export function buildSetupToolsPayload(
+  requestedSkills: string[],
+  activeSkills: string[],
+  toolSignatures: string[]
+): SetupToolsPayload {
+  return {
+    success: true,
+    message:
+      `Activated ${requestedSkills.length} skill(s); ` +
+      `${activeSkills.length} skill(s) and ${toolSignatures.length} tool(s) now available.`,
+    skills: requestedSkills,
+    activeSkills,
+    tools: toolSignatures,
+    hint:
+      'Tools are listed as `name(required, optional?)`. ' +
+      'Invoke with `call_tool`; if you pass wrong/missing args, the full input schema is returned in the error.',
+  };
+}
+
+/**
+ * Build the error payload returned by `call_tool` when a tool invocation
+ * fails. When the failure is plausibly an arg/schema problem (tool exists and
+ * was activated, but execution errored), include the full input schema so the
+ * agent can self-correct without re-running `setup_tools` to discover it.
+ */
+export interface CallToolErrorPayload {
+  error: string;
+  tool?: string;
+  schema?: unknown;
+  hint?: string;
+}
+
+export function buildCallToolErrorPayload(
+  message: string,
+  schemaCtx?: { tool: Pick<MCPTool, 'name' | 'inputSchema' | 'description'> }
+): CallToolErrorPayload {
+  if (!schemaCtx) return { error: message };
+  const { tool } = schemaCtx;
+  return {
+    error: message,
+    tool: tool.name,
+    schema: tool.inputSchema,
+    hint:
+      `Retry \`call_tool\` with \`name: "${tool.name}"\` and a \`data\` object ` +
+      `matching the schema above.`,
+  };
+}
+
 export class CapaMCPServer {
   private server: Server;
   private db: CapaDatabase;
@@ -155,6 +257,14 @@ export class CapaMCPServer {
       // Determine tool exposure mode (default to 'expose-all')
       const toolExposureMode = capabilities?.options?.toolExposure || 'expose-all';
 
+      if (toolExposureMode === 'none') {
+        // Project opted out of MCP-driven tool exposure. The agent is
+        // expected to discover and run tools via `capa sh` instead. Returning
+        // an empty list is the cleanest signal — most clients render this as
+        // "no tools available" rather than throwing.
+        return { tools: [] };
+      }
+
       if (toolExposureMode === 'expose-all') {
         // Expose-all mode: Show all tools from all skills immediately.
         // Sub-agent endpoints additionally filter to only their declared tools.
@@ -175,7 +285,7 @@ export class CapaMCPServer {
         // On-demand mode: Only expose meta-tools (setup_tools and call_tool)
         tools.push({
           name: 'setup_tools',
-          description: 'Activate skills and load their required tools. This tool should always be called when the agent learns (loads) a skill. Returns the full list of available tools with their schemas for your reference.',
+          description: 'Activate skills and load their required tools. Should be called when the agent learns (loads) a skill. Returns a compact signature list (`tool_name(required, optional?)`) for every activated tool — full input schemas are returned in the `call_tool` error response when a call is invalid.',
           inputSchema: {
             type: 'object',
             properties: {
@@ -191,7 +301,7 @@ export class CapaMCPServer {
 
         tools.push({
           name: 'call_tool',
-          description: 'Call any activated tool by name. Use setup_tools first to see available tools and their schemas.',
+          description: 'Call any activated tool by name. Use `setup_tools` first to discover available tools (returned as compact signatures). If you pass invalid or missing args the full input schema is returned in the error so you can retry.',
           inputSchema: {
             type: 'object',
             properties: {
@@ -217,6 +327,26 @@ export class CapaMCPServer {
       const { name, arguments: args } = request.params;
       const capabilities = this.sessionManager.getProjectCapabilities(this.projectId);
       const toolExposureMode = capabilities?.options?.toolExposure || 'expose-all';
+
+      // Tool exposure disabled — instruct the agent to use the CLI fallback
+      // instead of silently failing. This branch should rarely fire because
+      // capa skips writing MCP entries in `'none'` mode, but a user who
+      // hand-wires the endpoint shouldn't hit a confusing generic error.
+      if (toolExposureMode === 'none') {
+        return {
+          content: [
+            {
+              type: 'text',
+              text: JSON.stringify({
+                error:
+                  'Tool exposure is disabled for this project (toolExposure: none). ' +
+                  'Use the `capa sh` CLI to discover and invoke tools instead.',
+              }),
+            },
+          ],
+          isError: true,
+        };
+      }
 
       // Handle setup_tools
       if (name === 'setup_tools' && toolExposureMode === 'on-demand') {
@@ -342,25 +472,11 @@ export class CapaMCPServer {
   private async handleSetupTools(args: { skills: string[] }): Promise<any> {
     try {
       this.ensureSession();
-
-      // Setup tools
       const toolIds = this.sessionManager.setupTools(this.sessionId!, args.skills);
-
-      // Get capabilities to fetch tool schemas
-      const capabilities = this.sessionManager.getProjectCapabilities(this.projectId);
-      const toolSchemas: MCPTool[] = [];
-
-      if (capabilities) {
-        const allowedToolIds = this.getAgentAllowedToolIds(capabilities);
-        for (const qualifiedName of toolIds) {
-          if (allowedToolIds && !allowedToolIds.has(qualifiedName)) continue;
-          const tool = capabilities.tools.find((t) => getQualifiedToolName(t) === qualifiedName);
-          if (tool) {
-            const mcpTool = await this.convertToolToMCP(tool, capabilities);
-            toolSchemas.push(mcpTool);
-          }
-        }
-      }
+      const signatures = await this.buildToolSignaturesFor(toolIds);
+      // `setupTools` updates the session's activeSkills set; read it back so
+      // we report the merged list (not just this call's skills) to the agent.
+      const activeSkills = this.sessionManager.getSession(this.sessionId!)?.activeSkills ?? args.skills;
 
       // Send tools/list_changed notification (for backward compatibility)
       await this.server.notification({
@@ -368,51 +484,108 @@ export class CapaMCPServer {
         params: {},
       });
 
+      const payload = buildSetupToolsPayload(args.skills, activeSkills, signatures);
       return {
-        content: [
-          {
-            type: 'text',
-            text: JSON.stringify({
-              success: true,
-              message: `Activated ${args.skills.length} skill(s) with ${toolIds.length} tool(s)`,
-              skills: args.skills,
-              tools: toolSchemas,
-            }),
-          },
-        ],
+        content: [{ type: 'text', text: JSON.stringify(payload) }],
       };
     } catch (error: any) {
-      // If skill not found, include list of available skills
-      let errorMessage = error.message || 'Failed to setup tools';
-      if (error.message && error.message.startsWith('Skill not found:')) {
-        const capabilities = this.sessionManager.getProjectCapabilities(this.projectId);
-        if (capabilities && capabilities.skills.length > 0) {
-          const availableSkills = capabilities.skills.map(s => s.id).join(', ');
-          errorMessage = `${error.message}. Available skills: ${availableSkills}`;
-        }
-      }
-
+      const errorMessage = this.formatSetupToolsError(error);
       return {
-        content: [
-          {
-            type: 'text',
-            text: JSON.stringify({
-              error: errorMessage,
-            }),
-          },
-        ],
+        content: [{ type: 'text', text: JSON.stringify({ error: errorMessage }) }],
       };
     }
   }
 
+  /**
+   * Resolve a list of qualified tool names to compact signature strings.
+   * Applies the sub-agent allow-list (if any) and skips tools that have no
+   * matching definition in the current capabilities snapshot.
+   */
+  private async buildToolSignaturesFor(toolIds: string[]): Promise<string[]> {
+    const capabilities = this.sessionManager.getProjectCapabilities(this.projectId);
+    if (!capabilities) return [];
+    const allowedToolIds = this.getAgentAllowedToolIds(capabilities);
+    const signatures: string[] = [];
+    for (const qualifiedName of toolIds) {
+      if (allowedToolIds && !allowedToolIds.has(qualifiedName)) continue;
+      const tool = capabilities.tools.find((t) => getQualifiedToolName(t) === qualifiedName);
+      if (!tool) continue;
+      const mcpTool = await this.convertToolToMCP(tool, capabilities);
+      signatures.push(buildToolSignature(mcpTool));
+    }
+    return signatures;
+  }
+
+  /**
+   * Format an error from `SessionManager.setupTools` for the user. Adds the
+   * list of available skill ids when the failure was an unknown skill so the
+   * agent can recover without a separate discovery call.
+   */
+  private formatSetupToolsError(error: any): string {
+    const baseMessage = error?.message || 'Failed to setup tools';
+    if (typeof baseMessage !== 'string' || !baseMessage.startsWith('Skill not found:')) {
+      return baseMessage;
+    }
+    const capabilities = this.sessionManager.getProjectCapabilities(this.projectId);
+    if (capabilities && capabilities.skills.length > 0) {
+      const availableSkills = capabilities.skills.map((s) => s.id).join(', ');
+      return `${baseMessage}. Available skills: ${availableSkills}`;
+    }
+    return baseMessage;
+  }
+
+  /**
+   * Look up the full MCP tool form (including resolved inputSchema) for a
+   * tool name as the agent sent it. Returns null when no matching tool exists
+   * in the current capabilities (e.g. the agent invented a name) so callers
+   * can degrade to a schema-less error.
+   *
+   * Uses the same dot/underscore normalization as `tools/call` so a call like
+   * `brave_search` resolves to the canonical `brave.search` schema.
+   */
+  private async tryGetToolSchema(toolName: string): Promise<MCPTool | null> {
+    const capabilities = this.sessionManager.getProjectCapabilities(this.projectId);
+    if (!capabilities) return null;
+    const normalized = normalizeToolName(toolName);
+    const tool = capabilities.tools.find(
+      (t) => normalizeToolName(getQualifiedToolName(t)) === normalized
+    );
+    if (!tool) return null;
+    try {
+      return await this.convertToolToMCP(tool, capabilities);
+    } catch {
+      // Schema lookup is best-effort — never let it mask the original error.
+      return null;
+    }
+  }
+
+  /**
+   * Build a content-wrapped `CallToolResult` for an error. Per the MCP spec
+   * tool-execution failures are reported with `isError: true` on the result
+   * (not as JSON-RPC errors) so the LLM sees the text content. We embed the
+   * full input schema in the text whenever we can identify the target tool —
+   * that's the whole point of slimming `setup_tools`: keep the schema close
+   * to where the agent actually needs it, not bloating every activation.
+   */
+  private async buildCallToolErrorResult(
+    toolName: string | undefined,
+    message: string,
+    options: { includeSchema?: boolean } = {}
+  ): Promise<{ content: Array<{ type: string; text: string }>; isError: true }> {
+    const includeSchema = options.includeSchema ?? true;
+    const mcpTool = includeSchema && toolName ? await this.tryGetToolSchema(toolName) : null;
+    const payload = buildCallToolErrorPayload(message, mcpTool ? { tool: mcpTool } : undefined);
+    return {
+      content: [{ type: 'text', text: JSON.stringify(payload) }],
+      isError: true,
+    };
+  }
+
   private async handleCallTool(args: { name: string; data: object }): Promise<any> {
+    const toolName = args.name;
+    const toolData = args.data || {};
     try {
       const session = this.ensureSession();
-
-      // Extract tool name and data
-      const toolName = args.name;
-      const toolData = args.data || {};
-
       this.logger.info(`Calling tool via call_tool: ${toolName}`);
       this.logger.debug(`Tool data: ${JSON.stringify(toolData)}`);
 
@@ -420,32 +593,25 @@ export class CapaMCPServer {
       const toolDef = this.sessionManager.getToolDefinition(this.projectId, toolName);
       if (!toolDef) {
         this.logger.warn(`Tool not found: ${toolName}`);
-        return {
-          content: [
-            {
-              type: 'text',
-              text: JSON.stringify({
-                error: `Tool not found: ${toolName}. Make sure you've called setup_tools to activate the required skills.`,
-              }),
-            },
-          ],
-        };
+        // No schema attached — by definition we don't have a matching tool.
+        return await this.buildCallToolErrorResult(
+          toolName,
+          `Tool not found: ${toolName}. Make sure you've called setup_tools to activate the required skills.`,
+          { includeSchema: false }
+        );
       }
 
       // Check if tool is in available tools for the session (normalize for dot/underscore compat)
       const normalizedToolName = normalizeToolName(toolName);
       if (!session.availableTools.some((t) => normalizeToolName(t) === normalizedToolName)) {
         this.logger.warn(`Tool not activated: ${toolName}`);
-        return {
-          content: [
-            {
-              type: 'text',
-              text: JSON.stringify({
-                error: `Tool "${toolName}" is not activated. Call setup_tools with the appropriate skills first.`,
-              }),
-            },
-          ],
-        };
+        // The tool exists but isn't activated — `setup_tools` is the next
+        // step, so don't pre-emptively dump the schema and confuse the agent.
+        return await this.buildCallToolErrorResult(
+          toolName,
+          `Tool "${toolName}" is not activated. Call setup_tools with the appropriate skills first.`,
+          { includeSchema: false }
+        );
       }
 
       this.logger.debug(`Tool type: ${toolDef.type}`);
@@ -461,20 +627,27 @@ export class CapaMCPServer {
           toolData as Record<string, any>
         );
         this.logger.debug(`Command executed, success: ${result.success}`);
+        // Command-tool failures land here as `{success: false, error}` (e.g.
+        // "Missing required argument: title") — they don't throw. Route them
+        // through the error helper so the agent gets the full schema back and
+        // can self-correct on the next call.
+        if (result && result.success === false) {
+          return await this.buildCallToolErrorResult(
+            toolName,
+            result.error || 'Command tool failed'
+          );
+        }
       } else if (toolDef.type === 'mcp') {
         this.logger.debug('Executing MCP tool...');
         const mcpDef = toolDef.def as ToolMCPDefinition;
         const capabilities = this.sessionManager.getProjectCapabilities(this.projectId);
         if (!capabilities) {
           this.logger.warn('Project capabilities not found');
-          return {
-            content: [
-              {
-                type: 'text',
-                text: JSON.stringify({ error: 'Project capabilities not found' }),
-              },
-            ],
-          };
+          return await this.buildCallToolErrorResult(
+            toolName,
+            'Project capabilities not found',
+            { includeSchema: false }
+          );
         }
 
         // Find server definition
@@ -482,14 +655,11 @@ export class CapaMCPServer {
         const serverDef = capabilities.servers.find((s) => s.id === serverId);
         if (!serverDef) {
           this.logger.warn(`Server not found: ${serverId}`);
-          return {
-            content: [
-              {
-                type: 'text',
-                text: JSON.stringify({ error: `Server not found: ${serverId}` }),
-              },
-            ],
-          };
+          return await this.buildCallToolErrorResult(
+            toolName,
+            `Server not found: ${serverId}`,
+            { includeSchema: false }
+          );
         }
 
         this.logger.debug(`Using MCP server: ${serverId}`);
@@ -498,25 +668,15 @@ export class CapaMCPServer {
       }
 
       return {
-        content: [
-          {
-            type: 'text',
-            text: this.serializeToolResult(result),
-          },
-        ],
+        content: [{ type: 'text', text: this.serializeToolResult(result) }],
       };
     } catch (error: any) {
       this.logger.failure(`call_tool execution error: ${error.message}`);
-      return {
-        content: [
-          {
-            type: 'text',
-            text: JSON.stringify({
-              error: error.message || 'Tool execution failed',
-            }),
-          },
-        ],
-      };
+      // Likely an arg/schema problem — attach the schema so the agent can retry.
+      return await this.buildCallToolErrorResult(
+        toolName,
+        error?.message || 'Tool execution failed'
+      );
     }
   }
 
@@ -846,6 +1006,19 @@ export class CapaMCPServer {
       const toolExposureMode = capabilities?.options?.toolExposure || 'expose-all';
       this.logger.debug(`Tool exposure mode: ${toolExposureMode}`);
 
+      if (toolExposureMode === 'none') {
+        // Project opted out of MCP-driven tool exposure. The agent is
+        // expected to discover and run tools via `capa sh` instead. Returning
+        // an empty list is the cleanest signal — most clients render this as
+        // "no tools available" rather than throwing.
+        this.logger.info('Tool exposure disabled (none) — returning empty tools list');
+        return {
+          jsonrpc: '2.0',
+          id: message.id,
+          result: { tools: [] },
+        };
+      }
+
       if (toolExposureMode === 'expose-all') {
         // Expose-all mode: Show all tools from all skills immediately.
         // Sub-agent endpoints additionally filter to only their declared tools.
@@ -867,7 +1040,7 @@ export class CapaMCPServer {
         // On-demand mode: Only expose meta-tools (setup_tools and call_tool)
         tools.push({
           name: 'setup_tools',
-          description: 'Activate skills and load their required tools. This tool should always be called when the agent learns (loads) a skill. Returns the full list of available tools with their schemas for your reference.',
+          description: 'Activate skills and load their required tools. Should be called when the agent learns (loads) a skill. Returns a compact signature list (`tool_name(required, optional?)`) for every activated tool — full input schemas are returned in the `call_tool` error response when a call is invalid.',
           inputSchema: {
             type: 'object',
             properties: {
@@ -883,7 +1056,7 @@ export class CapaMCPServer {
 
         tools.push({
           name: 'call_tool',
-          description: 'Call any activated tool by name. Use setup_tools first to see available tools and their schemas.',
+          description: 'Call any activated tool by name. Use `setup_tools` first to discover available tools (returned as compact signatures). If you pass invalid or missing args the full input schema is returned in the error so you can retry.',
           inputSchema: {
             type: 'object',
             properties: {
@@ -917,30 +1090,13 @@ export class CapaMCPServer {
       this.logger.info(`Call tool: ${name}`);
       this.logger.debug(`Arguments: ${JSON.stringify(args)}`);
 
-      // Handle setup_tools
-      if (name === 'setup_tools') {
-        try {
-          this.ensureSession();
-
-          // Setup tools
-          this.logger.info(`Activating skills: ${args.skills.join(', ')}`);
-          const toolIds = this.sessionManager.setupTools(this.sessionId!, args.skills);
-          this.logger.success(`Loaded ${toolIds.length} tool(s): ${toolIds.join(', ')}`);
-
-          // Get capabilities to fetch tool schemas
-          const capabilities = this.sessionManager.getProjectCapabilities(this.projectId);
-          const toolSchemas: MCPTool[] = [];
-
-          if (capabilities) {
-            for (const qualifiedName of toolIds) {
-              const tool = capabilities.tools.find((t) => getQualifiedToolName(t) === qualifiedName);
-              if (tool) {
-                const mcpTool = await this.convertToolToMCP(tool, capabilities);
-                toolSchemas.push(mcpTool);
-              }
-            }
-          }
-
+      // Tool exposure disabled — reject before doing any per-tool lookup.
+      // Capa skips MCP file writes in `'none'` mode, but a hand-wired endpoint
+      // should still get a helpful nudge toward the CLI fallback.
+      {
+        const caps = this.sessionManager.getProjectCapabilities(this.projectId);
+        if (caps?.options?.toolExposure === 'none') {
+          this.logger.warn(`tools/call hit on a project with toolExposure: none (tool=${name})`);
           return {
             jsonrpc: '2.0',
             id: message.id,
@@ -949,34 +1105,48 @@ export class CapaMCPServer {
                 {
                   type: 'text',
                   text: JSON.stringify({
-                    success: true,
-                    message: `Activated ${args.skills.length} skill(s) with ${toolIds.length} tool(s)`,
-                    skills: args.skills,
-                    tools: toolSchemas,
+                    error:
+                      'Tool exposure is disabled for this project (toolExposure: none). ' +
+                      'Use the `capa sh` CLI to discover and invoke tools instead.',
                   }),
                 },
               ],
+              isError: true,
+            },
+          };
+        }
+      }
+
+      // Handle setup_tools
+      if (name === 'setup_tools') {
+        try {
+          this.ensureSession();
+
+          this.logger.info(`Activating skills: ${args.skills.join(', ')}`);
+          const toolIds = this.sessionManager.setupTools(this.sessionId!, args.skills);
+          this.logger.success(`Loaded ${toolIds.length} tool(s): ${toolIds.join(', ')}`);
+
+          const signatures = await this.buildToolSignaturesFor(toolIds);
+          // `setupTools` updates the session's activeSkills set; read it back so
+          // we report the merged list (not just this call's skills) to the agent.
+          const activeSkills = this.sessionManager.getSession(this.sessionId!)?.activeSkills ?? args.skills;
+          const payload = buildSetupToolsPayload(args.skills, activeSkills, signatures);
+
+          return {
+            jsonrpc: '2.0',
+            id: message.id,
+            result: {
+              content: [{ type: 'text', text: JSON.stringify(payload) }],
             },
           };
         } catch (error: any) {
           this.logger.failure(`Error: ${error.message}`);
-
-          // If skill not found, include list of available skills
-          let errorMessage = error.message || 'Failed to setup tools';
-          if (error.message && error.message.startsWith('Skill not found:')) {
-            const capabilities = this.sessionManager.getProjectCapabilities(this.projectId);
-            if (capabilities && capabilities.skills.length > 0) {
-              const availableSkills = capabilities.skills.map(s => s.id).join(', ');
-              errorMessage = `${error.message}. Available skills: ${availableSkills}`;
-            }
-          }
-
           return {
             jsonrpc: '2.0',
             id: message.id,
             error: {
               code: -32603,
-              message: errorMessage,
+              message: this.formatSetupToolsError(error),
             },
           };
         }
@@ -999,13 +1169,11 @@ export class CapaMCPServer {
           };
         }
 
+        const toolName = args?.name;
+        const toolData = args?.data || {};
+
         try {
           const session = this.ensureSession();
-
-          // Extract tool name and data
-          const toolName = args.name;
-          const toolData = args.data || {};
-
           this.logger.info(`Calling tool via call_tool: ${toolName}`);
           this.logger.debug(`Tool data: ${JSON.stringify(toolData)}`);
 
@@ -1016,10 +1184,11 @@ export class CapaMCPServer {
             return {
               jsonrpc: '2.0',
               id: message.id,
-              error: {
-                code: -32601,
-                message: `Tool not found: ${toolName}. Make sure you've called setup_tools to activate the required skills.`,
-              },
+              result: await this.buildCallToolErrorResult(
+                toolName,
+                `Tool not found: ${toolName}. Make sure you've called setup_tools to activate the required skills.`,
+                { includeSchema: false }
+              ),
             };
           }
 
@@ -1030,10 +1199,11 @@ export class CapaMCPServer {
             return {
               jsonrpc: '2.0',
               id: message.id,
-              error: {
-                code: -32603,
-                message: `Tool "${toolName}" is not activated. Call setup_tools with the appropriate skills first.`,
-              },
+              result: await this.buildCallToolErrorResult(
+                toolName,
+                `Tool "${toolName}" is not activated. Call setup_tools with the appropriate skills first.`,
+                { includeSchema: false }
+              ),
             };
           }
 
@@ -1050,6 +1220,20 @@ export class CapaMCPServer {
               toolData as Record<string, any>
             );
             this.logger.debug(`Command executed, success: ${result.success}`);
+            // Command-tool failures land here as `{success: false, error}`
+            // (e.g. "Missing required argument: title") — they don't throw.
+            // Route them through the error helper so the agent gets the full
+            // schema back and can self-correct on the next call.
+            if (result && result.success === false) {
+              return {
+                jsonrpc: '2.0',
+                id: message.id,
+                result: await this.buildCallToolErrorResult(
+                  toolName,
+                  result.error || 'Command tool failed'
+                ),
+              };
+            }
           } else if (toolDef.type === 'mcp') {
             this.logger.debug('Executing MCP tool...');
             const mcpDef = toolDef.def as ToolMCPDefinition;
@@ -1058,10 +1242,11 @@ export class CapaMCPServer {
               return {
                 jsonrpc: '2.0',
                 id: message.id,
-                error: {
-                  code: -32603,
-                  message: 'Project capabilities not found',
-                },
+                result: await this.buildCallToolErrorResult(
+                  toolName,
+                  'Project capabilities not found',
+                  { includeSchema: false }
+                ),
               };
             }
 
@@ -1073,10 +1258,11 @@ export class CapaMCPServer {
               return {
                 jsonrpc: '2.0',
                 id: message.id,
-                error: {
-                  code: -32603,
-                  message: `Server not found: ${serverId}`,
-                },
+                result: await this.buildCallToolErrorResult(
+                  toolName,
+                  `Server not found: ${serverId}`,
+                  { includeSchema: false }
+                ),
               };
             }
 
@@ -1099,13 +1285,14 @@ export class CapaMCPServer {
           };
         } catch (error: any) {
           this.logger.failure(`call_tool execution error: ${error.message}`);
+          // Likely an arg/schema problem — attach the schema so the agent can self-correct.
           return {
             jsonrpc: '2.0',
             id: message.id,
-            error: {
-              code: -32603,
-              message: error.message || 'Tool execution failed',
-            },
+            result: await this.buildCallToolErrorResult(
+              toolName,
+              error?.message || 'Tool execution failed'
+            ),
           };
         }
       }

--- a/src/types/capabilities.ts
+++ b/src/types/capabilities.ts
@@ -37,11 +37,22 @@ export type {
 } from './hooks';
 
 /**
- * Tool exposure modes for MCP clients
- * - 'expose-all': All tools from all skills are exposed immediately (default)
- * - 'on-demand': Tools are only exposed after calling setup_tools
+ * Tool exposure modes for MCP clients.
+ *
+ * - `'expose-all'`: All tools from all skills are exposed immediately via the
+ *   MCP `tools/list` response. Largest context footprint; lowest friction.
+ * - `'on-demand'`: Only the meta-tools `setup_tools` and `call_tool` are
+ *   listed; the agent activates skill-specific tools by calling
+ *   `setup_tools(['<skill>'])`. `setup_tools` returns a compact signature
+ *   list (`tool_name(required, optional?)`); the full input schema is only
+ *   returned in `call_tool` error responses when the agent calls incorrectly.
+ * - `'none'`: capa does **not** write any project-local MCP config files
+ *   (`.mcp.json`, `.cursor/mcp.json`, `.codex/config.toml` `mcp_servers.capa`,
+ *   sub-agent `capa-<id>` entries, etc.) at install time, and the MCP
+ *   endpoints return an empty `tools/list`. The agent is expected to
+ *   discover and execute tools through the `capa sh` CLI fallback instead.
  */
-export type ToolExposureMode = 'expose-all' | 'on-demand';
+export type ToolExposureMode = 'expose-all' | 'on-demand' | 'none';
 
 /**
  * Security options for skill installation.
@@ -70,7 +81,8 @@ export interface SecurityOptions {
  */
 export interface CapabilitiesOptions {
   /**
-   * Determines how tools are exposed to MCP clients
+   * Determines how tools are exposed to MCP clients. See `ToolExposureMode`
+   * for full semantics of each value.
    * @default 'expose-all'
    */
   toolExposure?: ToolExposureMode;


### PR DESCRIPTION
## Summary

Two related improvements to how capa exposes tools to MCP-aware agents.

### 1. `setup_tools` returns signatures, not full schemas

`setup_tools` accumulates the active skill set across calls, and each call previously returned the full MCP \`inputSchema\` for *every* accumulated tool. The payload grew with the number of activations and bloated the agent's context window.

The new contract:

```json
{
  "success": true,
  "message": "Activated 1 skill(s); 2 skill(s) and 3 tool(s) now available.",
  "skills": ["fs-skill"],
  "activeSkills": ["gh-skill", "fs-skill"],
  "tools": [
    "github.create_issue(title, body, labels?, assignees?)",
    "github.list_repos(org, type?)",
    "read_file(path)"
  ],
  "hint": "Tools are listed as `name(required, optional?)`. Invoke with `call_tool`; if you pass wrong/missing args, the full input schema is returned in the error."
}
```

\`call_tool\` error responses now consistently follow the MCP-spec pattern for tool execution failures (\`isError: true\` on the result, content-wrapped) and attach the full input schema on:

- executor exceptions (any tool, throws)
- command-tool \`{success: false, error: \"Missing required argument: …\"}\` results — the canonical \"agent omitted a required arg\" case

Tool-not-found and tool-not-activated branches deliberately omit the schema (we don't have one for unknown tools; for not-activated tools the actionable next step is \`setup_tools\`, not a schema-corrected retry).

### 2. New \`toolExposure: 'none'\` mode

\`ToolExposureMode\` gains a third value, \`'none'\`, which makes capa skip **all** project-local MCP config writes at install time:

- \`.mcp.json\`, \`.cursor/mcp.json\`, \`.codex/config.toml\` \`mcp_servers.capa\`, etc.
- per-sub-agent \`capa-<id>\` entries
- stale entries from prior installs are removed for both paths so switching mode is clean

The capa server still runs and the project endpoints stay live, but the MCP handler defensively returns an empty \`tools/list\` and rejects every \`tools/call\` with a hint pointing at the \`capa sh\` CLI fallback. Useful for users who want capa-managed skills/tools without per-project MCP file mutations (policy reasons, repo hygiene, etc.).

Sub-agent instruction files are still installed under \`'none'\` since they remain informative documentation; the MCP server keys they reference simply won't resolve — by design.

## Test plan

- [x] \`bun test\` — 1000 pass, 0 fail
- [x] Pure-function tests for \`buildToolSignature\`, \`buildSetupToolsPayload\`, \`buildCallToolErrorPayload\` (10 new cases — optional \`?\` marking, required-order preservation, ghost-arg defense, regression-guard that signature output stays string-only).
- [x] New integration tests exercising \`handleMessage\` end-to-end:
  - \`setup_tools\` returns signature strings (not schemas)
  - skill accumulation surfaces both requested + merged active sets
  - \`call_tool\` attaches the full schema on missing-required-arg
  - \`call_tool\` returns \`isError\` for not-activated and not-found and deliberately omits the schema
  - \`toolExposure: 'none'\` returns empty \`tools/list\` and rejects every \`tools/call\`
- [x] Lints clean across all touched files
- [ ] Manual smoke against a real Claude Code project with each of the three \`toolExposure\` modes

Made with [Cursor](https://cursor.com)