### PR TITLE
fix(install): suppress 'not exposed to MCP' warning under toolExposure: none

### DIFF
--- a/src/cli/commands/install-tasks/configure-tools.ts
+++ b/src/cli/commands/install-tasks/configure-tools.ts
@@ -109,12 +109,20 @@ export function configureToolsTask(): Task<InstallCtx> {
         }
       }
 
-      const unexposed = getUnexposedToolIds(ctx.capabilitiesToUse);
-      if (unexposed.length > 0) {
-        ctx.warnings.push(
-          `${unexposed.length} tool(s) are not exposed to MCP clients (not required by any skill): ` +
-            `${unexposed.sort().join(', ')}. Add them to a skill's \`requires\` list to expose.`,
-        );
+      // The "tool is not required by any skill" check is meaningless under
+      // `toolExposure: 'none'` — capa never exposes any tools to MCP clients
+      // in that mode by design (the agent invokes them via `capa sh`), so
+      // `requires` lists don't gate anything. Suppress the warning to avoid
+      // noise that would push users to "fix" a non-issue.
+      const toolExposure = ctx.capabilitiesToUse.options?.toolExposure;
+      if (toolExposure !== 'none') {
+        const unexposed = getUnexposedToolIds(ctx.capabilitiesToUse);
+        if (unexposed.length > 0) {
+          ctx.warnings.push(
+            `${unexposed.length} tool(s) are not exposed to MCP clients (not required by any skill): ` +
+              `${unexposed.sort().join(', ')}. Add them to a skill's \`requires\` list to expose.`,
+          );
+        }
       }
     },
   };


### PR DESCRIPTION
## Summary

`capa install` warns when capabilities define tools that no skill's \`requires\` list references:

> 4 tool(s) are not exposed to MCP clients (not required by any skill): foo, bar, baz, qux. Add them to a skill's \`requires\` list to expose.

That heuristic is correct for \`toolExposure: 'expose-all'\` and \`'on-demand'\` (both gate exposure on \`requires\`). It is wrong under \`toolExposure: 'none'\` — that mode deliberately exposes nothing over MCP at all (agents call tools via \`capa sh\`), so \"not exposed\" is the documented contract, not a misconfig. Pushing users toward a \"fix\" the mode explicitly opts out of is misleading noise.

## Change

One-line guard in \`src/cli/commands/install-tasks/configure-tools.ts\`: skip the warning when \`options.toolExposure === 'none'\`. Tool-validation failures, plugin skill warnings, and orphan-server warnings keep firing — those are still meaningful under \`'none'\`.

The \`getUnexposedToolIds\` helper itself is left pure (no mode awareness) since it has only one caller and that semantics shift would be surprising for any future caller.

## Test plan

- [x] \`bun test\` — 1015 pass, 0 fail
- [x] Lints clean
- [x] Manual smoke: \`capa install\` with \`toolExposure: 'none'\` and a tool not referenced by any skill — warning gone; other warnings still appear when triggered.

Targets v1.9.4 patch.

Made with [Cursor](https://cursor.com)