### PR TITLE
fix(server): stop SessionManager cleanup timer on dispose (fixes Windows CI)

### DIFF
--- a/src/server/__tests__/mcp-handler.integration.test.ts
+++ b/src/server/__tests__/mcp-handler.integration.test.ts
@@ -38,6 +38,7 @@ function makeHarness(initial: Capabilities): Harness {
 }
 
 function destroyHarness(h: Harness): void {
+  h.sessionManager.dispose();
   h.db.close();
   try {
     rmSync(h.tempDir, { recursive: true, force: true });

--- a/src/server/__tests__/session-manager.test.ts
+++ b/src/server/__tests__/session-manager.test.ts
@@ -27,6 +27,7 @@ describe('SessionManager', () => {
   });
 
   afterEach(() => {
+    sessionManager.dispose();
     db.close();
     try {
       rmSync(tempDir, { recursive: true, force: true });

--- a/src/server/index.ts
+++ b/src/server/index.ts
@@ -1982,6 +1982,7 @@ class CapaServer {
     this.oauthCallbackServers.clear();
 
     // Close database
+    this.sessionManager.dispose();
     this.db.close();
 
     this.logger.success('CAPA server stopped');

--- a/src/server/session-manager.ts
+++ b/src/server/session-manager.ts
@@ -18,11 +18,30 @@ export class SessionManager {
   private sessions = new Map<string, SessionInfo>();
   private projectCapabilities = new Map<string, Capabilities>();
   private capabilitiesLoadInflight = new Map<string, Promise<Capabilities | null>>();
+  private cleanupTimer: ReturnType<typeof setInterval> | null = null;
+  private disposed = false;
   private logger = logger.child('SessionManager');
 
   constructor(db: CapaDatabase) {
     this.db = db;
     this.startCleanupTimer();
+  }
+
+  /**
+   * Stop background work (cleanup timer) and release references.
+   *
+   * Idempotent. Safe to call multiple times. Must be called by tests and by
+   * the production graceful-shutdown path before closing the underlying
+   * database; otherwise the cleanup interval will keep a strong reference to
+   * `this` (and the closed DB) and fire after teardown.
+   */
+  dispose(): void {
+    if (this.disposed) return;
+    this.disposed = true;
+    if (this.cleanupTimer) {
+      clearInterval(this.cleanupTimer);
+      this.cleanupTimer = null;
+    }
   }
 
   /**
@@ -288,14 +307,27 @@ export class SessionManager {
    * Clean up expired sessions
    */
   private startCleanupTimer(): void {
-    setInterval(() => {
+    const timer = setInterval(() => {
       this.cleanupExpiredSessions();
     }, 60000); // Run every minute
+    // Don't keep the event loop alive solely for this cleanup task. This is a
+    // no-op on platforms/runtimes that don't support `unref` on timers.
+    (timer as { unref?: () => void }).unref?.();
+    this.cleanupTimer = timer;
   }
 
   private cleanupExpiredSessions(): void {
+    if (this.disposed) return;
     const timeout = 60; // 60 minutes
-    this.db.deleteExpiredSessions(timeout);
+    try {
+      this.db.deleteExpiredSessions(timeout);
+    } catch (error) {
+      // The database may have been closed between scheduling and the timer
+      // firing (e.g. during shutdown or in tests). Swallow the error rather
+      // than crash the process with an unhandled rejection.
+      this.logger.debug(`Skipping session cleanup: ${(error as Error).message}`);
+      return;
+    }
 
     // Clean up in-memory sessions
     const cutoff = Date.now() - timeout * 60 * 1000;


### PR DESCRIPTION
## Summary

Windows CI has been failing reliably for some time with a series of `bun:sqlite Database has closed` errors at `deleteExpired` / `cleanupExpiredSessions`, surfacing as **Unhandled error between tests** ([example run](https://github.com/infragate/capa/actions/runs/26670027666/job/78612209563)).

### Root cause

`SessionManager`'s constructor schedules `setInterval(cleanup, 60000)` but **discards the timer handle**, so the interval can never be cleared.

```24:26:src/server/session-manager.ts (before)
constructor(db: CapaDatabase) {
  this.db = db;
  this.startCleanupTimer();
}
```

In tests, every `beforeEach` creates a fresh `SessionManager` (~150 instances across the suite). `afterEach` closes the DB but the leaked intervals keep strong references to the now-closed DB. Once the suite has been running for >60s, the first interval ticks, calls `db.run('DELETE FROM sessions ...')` against a closed handle, and the process aborts with `Database has closed`.

- Linux/macOS finish in ~7s and exit before any timer fires → green.
- Windows runners are slower and reliably cross the 60s threshold → red.

The same leak exists in production: `CapaServer.stop()` never stops the cleanup timer, so graceful shutdown can drag past close.

### Fix

- Store the interval handle and add `SessionManager.dispose()` (idempotent).
- `unref()` the timer so it no longer keeps the event loop alive on its own.
- Guard `cleanupExpiredSessions` against a closed DB / post-dispose ticks so a single late firing can't take the process down.
- Wire `dispose()` into `CapaServer.stop()` and into both test files' teardown (`session-manager.test.ts` and `mcp-handler.integration.test.ts`) so each suite stops leaking timers.

## Test plan

- [x] `bun test` — full suite (1015 pass, 0 fail) locally on macOS.
- [x] `bun test src/server/__tests__/session-manager.test.ts src/server/__tests__/mcp-handler.integration.test.ts` — green.
- [ ] CI green on `windows-latest` (the actual repro environment).

Made with [Cursor](https://cursor.com)