### PR TITLE
fix(mcp-handler): don't gate tools/call on toolExposure: none

### DIFF
--- a/skills/capabilities-manager/references/capabilities-schema.md
+++ b/skills/capabilities-manager/references/capabilities-schema.md
@@ -90,7 +90,7 @@ Controls how capa exposes skill tools to the MCP client. Three modes:
 | `'none'` | Empty list | **No** — capa skips all project-local MCP config files (`.mcp.json`, `.cursor/mcp.json`, `.codex/config.toml` `mcp_servers.capa`, sub-agent `capa-<id>` entries). Any previously-written entries are removed on install. | The agent must use `capa sh <group> <tool> [--args]` (see [`commands.md`](./commands.md)). Sub-agent instruction files are still installed for documentation but their tools are not reachable over MCP. |
 
 Notes on `'none'`:
-- The capa HTTP server still runs and the project endpoints stay live; `tools/list` just returns empty and `tools/call` rejects with a hint to use `capa sh`.
+- The capa HTTP server still runs and the project endpoints stay live; `tools/list` returns empty so MCP-aware agents don't try to discover tools through capa's MCP endpoint. `tools/call` is **not** gated — that's the path `capa sh` uses to execute tools, and gating it would mean rejecting `capa sh` itself.
 - Useful when the user prefers to keep `.mcp.json` clean or has policy restrictions against writing per-project MCP configs.
 - Switching to `'none'` on a project that previously installed under another mode cleans up the old entries on the next `capa install`.
 

--- a/src/server/__tests__/mcp-handler.integration.test.ts
+++ b/src/server/__tests__/mcp-handler.integration.test.ts
@@ -414,20 +414,32 @@ describe('handleMessage > toolExposure: none', () => {
     expect(resp.result?.tools).toEqual([]);
   });
 
-  it('rejects every tools/call (including setup_tools / call_tool) with a capa-sh hint', async () => {
-    for (const name of ['setup_tools', 'call_tool', 't', 'whatever']) {
-      const resp = await h.mcp.handleMessage({
-        jsonrpc: '2.0',
-        id: 1,
-        method: 'tools/call',
-        params: { name, arguments: {} },
-      });
-      expect(resp.error).toBeUndefined();
-      expect(resp.result?.isError).toBe(true);
-      const payload = parseToolText(resp.result);
-      expect(payload.error).toMatch(/toolExposure: none/);
-      expect(payload.error).toMatch(/capa sh/);
-    }
+  // `tools/list` hides tools from MCP-aware agents (so they don't try to
+  // discover them through capa's MCP endpoint), but `tools/call` is *not*
+  // gated on `toolExposure`. The `capa sh` CLI is the documented escape
+  // hatch for this mode and uses this exact endpoint as its execution
+  // channel — gating it here would mean rejecting `capa sh` itself.
+  it('executes a configured tool by qualified name (capa sh fallback path)', async () => {
+    const resp = await h.mcp.handleMessage({
+      jsonrpc: '2.0',
+      id: 1,
+      method: 'tools/call',
+      params: { name: 't', arguments: {} },
+    });
+    expect(resp.error).toBeUndefined();
+    expect(resp.result?.isError).toBeFalsy();
+    expect(resp.result?.content).toBeDefined();
+  });
+
+  it('returns the standard "Tool not found" error for unknown names', async () => {
+    const resp = await h.mcp.handleMessage({
+      jsonrpc: '2.0',
+      id: 1,
+      method: 'tools/call',
+      params: { name: 'totally-made-up', arguments: {} },
+    });
+    expect(resp.error).toBeDefined();
+    expect(resp.error?.message).toMatch(/Tool not found/);
   });
 });
 

--- a/src/server/mcp-handler.ts
+++ b/src/server/mcp-handler.ts
@@ -328,26 +328,6 @@ export class CapaMCPServer {
       const capabilities = this.sessionManager.getProjectCapabilities(this.projectId);
       const toolExposureMode = capabilities?.options?.toolExposure || 'expose-all';
 
-      // Tool exposure disabled — instruct the agent to use the CLI fallback
-      // instead of silently failing. This branch should rarely fire because
-      // capa skips writing MCP entries in `'none'` mode, but a user who
-      // hand-wires the endpoint shouldn't hit a confusing generic error.
-      if (toolExposureMode === 'none') {
-        return {
-          content: [
-            {
-              type: 'text',
-              text: JSON.stringify({
-                error:
-                  'Tool exposure is disabled for this project (toolExposure: none). ' +
-                  'Use the `capa sh` CLI to discover and invoke tools instead.',
-              }),
-            },
-          ],
-          isError: true,
-        };
-      }
-
       // Handle setup_tools
       if (name === 'setup_tools' && toolExposureMode === 'on-demand') {
         return await this.handleSetupTools(args as { skills: string[] });
@@ -1094,33 +1074,6 @@ export class CapaMCPServer {
       const { name, arguments: args } = message.params;
       this.logger.info(`Call tool: ${name}`);
       this.logger.debug(`Arguments: ${JSON.stringify(args)}`);
-
-      // Tool exposure disabled — reject before doing any per-tool lookup.
-      // Capa skips MCP file writes in `'none'` mode, but a hand-wired endpoint
-      // should still get a helpful nudge toward the CLI fallback.
-      {
-        const caps = this.sessionManager.getProjectCapabilities(this.projectId);
-        if (caps?.options?.toolExposure === 'none') {
-          this.logger.warn(`tools/call hit on a project with toolExposure: none (tool=${name})`);
-          return {
-            jsonrpc: '2.0',
-            id: message.id,
-            result: {
-              content: [
-                {
-                  type: 'text',
-                  text: JSON.stringify({
-                    error:
-                      'Tool exposure is disabled for this project (toolExposure: none). ' +
-                      'Use the `capa sh` CLI to discover and invoke tools instead.',
-                  }),
-                },
-              ],
-              isError: true,
-            },
-          };
-        }
-      }
 
       // Handle setup_tools
       if (name === 'setup_tools') {


### PR DESCRIPTION
## Summary

PR #80 added a defensive `toolExposure: 'none'` gate to `tools/call` that rejects every invocation with a hint pointing the user at `capa sh`. The problem: `capa sh` itself executes tools through this exact endpoint — its `executeToolViaMCP` POSTs `tools/call` to `/{projectId}/mcp` — so the gate ironically rejects the very fallback path it advertises. Users running `capa sh <tool>` against a `'none'`-mode project hit:

\`\`\`
{
  \"error\": \"Tool exposure is disabled for this project (toolExposure: none). Use the \`capa sh\` CLI to discover and invoke tools instead.\"
}
\`\`\`

This PR removes the gate and lets `tools/call` fall through to the existing per-tool dispatch.

## Why this is the right asymmetry

- `tools/list` continues to return `[]` under `'none'`. That's the discovery surface — hiding it keeps MCP-aware agents from auto-discovering and invoking tools through capa's endpoint, which is the actual point of `'none'`.
- `tools/call` is execution by qualified name. If a caller already has the name, `capa sh` is how they got it. Gating it only breaks the documented escape hatch; it doesn't add a real boundary (the endpoint is already localhost + origin-checked, and `'none'` is a config preference, not a security wall).

## Changes

- **src/server/mcp-handler.ts**: removes both `tools/call` rejection blocks added by PR #80 — the SDK-style `setRequestHandler(CallToolRequestSchema, ...)` path and the HTTP `handleMessage` path actually hit by `capa sh`. Net **−47 lines**.
- **src/server/__tests__/mcp-handler.integration.test.ts**: replaces the `'rejects every tools/call'` test (which pinned the bad behavior) with two tests pinning the new contract:
    - configured tools execute by qualified name (echo'd command tool runs successfully)
    - unknown names get the standard `Tool not found` JSON-RPC error
- **skills/capabilities-manager/references/capabilities-schema.md**: corrects the doc line that claimed `tools/call rejects with a hint to use capa sh`. Now describes the asymmetry and its rationale.

## What stays from PR #80

Everything else PR #80 introduced is good and untouched:
- Slim `setup_tools` signature output + `call_tool` schema-on-error contract.
- The `toolExposure: 'none'` config option itself.
- All install-task changes that skip `.mcp.json` / `.cursor/mcp.json` / `.codex/config.toml` writes (and clean up stale entries).
- `tools/list` returning `[]` under `'none'`.

## Test plan

- [x] \`bun test\` — 1016 pass, 0 fail across the full suite.
- [x] New `'none'` integration tests prove the `capa sh` execution path now works (\`echo\` actually executes via \`tools/call\` against a \`'none'\`-configured project in the test logs).
- [x] No lint errors on touched files.
- [x] Manually verified \`capa sh\` against a \`toolExposure: 'none'\` project (this is what surfaced the bug).

Made with [Cursor](https://cursor.com)