### PR TITLE
fix: preserve YAML comments/order in capa add (#93) and pointer cursor on buttons (#92)

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -19,7 +19,7 @@
         "@tanstack/react-query": "^5.100.9",
         "class-variance-authority": "^0.7.1",
         "clsx": "^2.1.1",
-        "commander": "^12.1.0",
+        "commander": "^15.0.0",
         "dompurify": "^3.4.3",
         "highlight.js": "^11.11.1",
         "i18next": "^26.0.10",
@@ -36,6 +36,7 @@
         "react-router-dom": "^7.15.0",
         "tailwind-merge": "^3.5.0",
         "xdg-basedir": "^5.1.0",
+        "yaml": "^2.9.0",
         "zod": "^4.4.3",
       },
       "devDependencies": {
@@ -44,7 +45,7 @@
         "@types/bun": "latest",
         "@types/dompurify": "^3.0.5",
         "@types/js-yaml": "^4.0.9",
-        "@types/node": "^22.10.2",
+        "@types/node": "^25.9.1",
         "@types/react": "^19.2.14",
         "@types/react-dom": "^19.2.3",
         "tailwindcss": "^4.2.4",
@@ -234,7 +235,7 @@
 
     "@types/js-yaml": ["@types/js-yaml@4.0.9", "", {}, "sha512-k4MGaQl5TGo/iipqb2UDG2UwjXziSWkh0uysQelTlJpX1qGlpUZYm8PnO4DxG1qBomtJUdYJ6qR6xdIah10JLg=="],
 
-    "@types/node": ["@types/node@22.19.10", "", { "dependencies": { "undici-types": "~6.21.0" } }, "sha512-tF5VOugLS/EuDlTBijk0MqABfP8UxgYazTLo3uIn3b4yJgg26QRbVYJYsDtHrjdDUIRfP70+VfhTTc+CE1yskw=="],
+    "@types/node": ["@types/node@25.9.2", "", { "dependencies": { "undici-types": ">=7.24.0 <7.24.7" } }, "sha512-G05zqtJhcDLb8uslf5EjCxXg9G1KQxiV8OS0R26IC//Eoyitzqe8z37I7cqvnZlrlSfgocQRfSn/AHBZJJFyGw=="],
 
     "@types/react": ["@types/react@19.2.14", "", { "dependencies": { "csstype": "^3.2.2" } }, "sha512-ilcTH/UniCkMdtexkoCN0bI7pMcJDvmQFPvuPvmEaYA/NSfFTAgdUSLAoVjaRJm7+6PvcM+q1zYOwS4wTYMF9w=="],
 
@@ -276,7 +277,7 @@
 
     "clsx": ["clsx@2.1.1", "", {}, "sha512-eYm0QWBtUrBWZWG0d386OGAw16Z995PiOVo2B7bjWSbHedGl5e0ZWaq65kOGgUSNesEIDkB9ISbTg/JK9dhCZA=="],
 
-    "commander": ["commander@12.1.0", "", {}, "sha512-Vw8qHK3bZM9y/P10u3Vib8o/DdkvA2OtPtZvD871QKjy74Wj1WSKFILMPRPSdUSx5RFK1arlJzEtA4PkFgnbuA=="],
+    "commander": ["commander@15.0.0", "", {}, "sha512-z67u4ZhzCL/Tydu1lJARtEZYWbWaN7oYLHbsuzocr6y4N6WZAagG3RQ4FW61V1/0+jImpj293XfrcYnd1qxtPg=="],
 
     "content-disposition": ["content-disposition@1.0.1", "", {}, "sha512-oIXISMynqSqm241k6kcQ5UwttDILMK4BiurCfGEREw6+X9jkkpEe5T9FZaApyLGGOnFuyMWZpdolTXMtvEJ08Q=="],
 
@@ -568,7 +569,7 @@
 
     "type-is": ["type-is@2.0.1", "", { "dependencies": { "content-type": "^1.0.5", "media-typer": "^1.1.0", "mime-types": "^3.0.0" } }, "sha512-OZs6gsjF4vMp32qrCbiVSkrFmXtG/AZhY3t0iAMrMBiAZyV9oALtXO8hsrHbMXF9x6L3grlFuwW2oAz7cav+Gw=="],
 
-    "undici-types": ["undici-types@6.21.0", "", {}, "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ=="],
+    "undici-types": ["undici-types@7.24.6", "", {}, "sha512-WRNW+sJgj5OBN4/0JpHFqtqzhpbnV0GuB+OozA9gCL7a993SmU+1JBZCzLNxYsbMfIeDL+lTsphD5jN5N+n0zg=="],
 
     "unpipe": ["unpipe@1.0.0", "", {}, "sha512-pjy2bYhSsufwWlKwPc+l3cN7+wuJlK6uz0YdJEOlQDbl6jo/YlPi4mb8agUkVC8BF7V8NuzeyPNqRksA3hztKQ=="],
 
@@ -589,6 +590,8 @@
     "wrappy": ["wrappy@1.0.2", "", {}, "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ=="],
 
     "xdg-basedir": ["xdg-basedir@5.1.0", "", {}, "sha512-GCPAHLvrIH13+c0SuacwvRYj2SxJXQ4kaVTT5xgL3kPrz56XxkF21IGhjSE1+W0aw7gpBWRGXLCPnPby6lSpmQ=="],
+
+    "yaml": ["yaml@2.9.0", "", { "bin": { "yaml": "bin.mjs" } }, "sha512-2AvhNX3mb8zd6Zy7INTtSpl1F15HW6Wnqj0srWlkKLcpYl/gMIMJiyuGq2KeI2YFxUPjdlB+3Lc10seMLtL4cA=="],
 
     "zod": ["zod@4.4.3", "", {}, "sha512-ytENFjIJFl2UwYglde2jchW2Hwm4GJFLDiSXWdTrJQBIN9Fcyp7n4DhxJEiWNAJMV1/BqWfW/kkg71UDcHJyTQ=="],
 
@@ -622,11 +625,15 @@
 
     "@tailwindcss/oxide-wasm32-wasi/tslib": ["tslib@2.8.1", "", { "bundled": true }, "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w=="],
 
+    "bun-types/@types/node": ["@types/node@22.19.10", "", { "dependencies": { "undici-types": "~6.21.0" } }, "sha512-tF5VOugLS/EuDlTBijk0MqABfP8UxgYazTLo3uIn3b4yJgg26QRbVYJYsDtHrjdDUIRfP70+VfhTTc+CE1yskw=="],
+
     "log-update/slice-ansi": ["slice-ansi@7.1.2", "", { "dependencies": { "ansi-styles": "^6.2.1", "is-fullwidth-code-point": "^5.0.0" } }, "sha512-iOBWFgUX7caIZiuutICxVgX1SdxwAVFFKwt1EvMYYec/NWO5meOJ6K5uQxhrYBdQJne4KxiqZc+KptFOWFSI9w=="],
 
     "log-update/wrap-ansi": ["wrap-ansi@9.0.2", "", { "dependencies": { "ansi-styles": "^6.2.1", "string-width": "^7.0.0", "strip-ansi": "^7.1.0" } }, "sha512-42AtmgqjV+X1VpdOfyTGOYRi0/zsoLqtXQckTmqTeybT+BDIbM/Guxo7x3pE2vtpr1ok6xRqM9OpBe+Jyoqyww=="],
 
     "react-router/cookie": ["cookie@1.1.1", "", {}, "sha512-ei8Aos7ja0weRpFzJnEA9UHJ/7XQmqglbRwnf2ATjcB9Wq874VKH9kfjjirM6UhU2/E5fFYadylyhFldcqSidQ=="],
+
+    "bun-types/@types/node/undici-types": ["undici-types@6.21.0", "", {}, "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ=="],
 
     "log-update/wrap-ansi/string-width": ["string-width@7.2.0", "", { "dependencies": { "emoji-regex": "^10.3.0", "get-east-asian-width": "^1.0.0", "strip-ansi": "^7.1.0" } }, "sha512-tsaTIkKW9b4N+AEj+SVA+WhJzV7/zMhcSu78mLKWSk7cXMOSHsBKFWUs0fWwq8QyK3MgJBQRX6Gbi4kYbdvGkQ=="],
   }

--- a/package.json
+++ b/package.json
@@ -49,6 +49,7 @@
     "react-router-dom": "^7.15.0",
     "tailwind-merge": "^3.5.0",
     "xdg-basedir": "^5.1.0",
+    "yaml": "^2.9.0",
     "zod": "^4.4.3"
   },
   "devDependencies": {

--- a/src/cli/commands/add.ts
+++ b/src/cli/commands/add.ts
@@ -1,5 +1,5 @@
 import { detectCapabilitiesFile } from '../../shared/paths';
-import { parseCapabilitiesFile, writeCapabilitiesFile } from '../../shared/capabilities';
+import { parseCapabilitiesFile, appendCapabilityEntry } from '../../shared/capabilities';
 import { installCommand } from './install';
 import { RegistryManager } from '../../shared/registries/manager';
 import type { Skill } from '../../types/capabilities';
@@ -457,7 +457,12 @@ export async function addCommand(
           process.exit(1);
         }
         const newSkill: Skill = { ...(snippet as Skill), id: itemName };
-        capabilities.skills.push(newSkill);
+        await appendCapabilityEntry(
+          capabilitiesFile.path,
+          capabilitiesFile.format,
+          'skills',
+          newSkill as unknown as Record<string, unknown>
+        );
       } else if (resolvedCapability === 'plugins') {
         if (!capabilities.plugins) capabilities.plugins = [];
         const newPlugin = snippet as Plugin;
@@ -471,10 +476,13 @@ export async function addCommand(
           console.error(`  Rename or remove the existing entry in ${capabilitiesFile.path} and try again.`);
           process.exit(1);
         }
-        capabilities.plugins.push({ ...newPlugin, id: itemName });
+        await appendCapabilityEntry(
+          capabilitiesFile.path,
+          capabilitiesFile.format,
+          'plugins',
+          { ...newPlugin, id: itemName } as unknown as Record<string, unknown>
+        );
       }
-
-      await writeCapabilitiesFile(capabilitiesFile.path, capabilitiesFile.format, capabilities);
 
       console.log(`\u2713 Added ${resolvedCapability.slice(0, -1)} "${itemName}" from registry "${registryId}" to ${capabilitiesFile.path}`);
       console.log('\n\u{1F4E6} Running installation...\n');
@@ -507,8 +515,12 @@ export async function addCommand(
       process.exit(1);
     }
 
-    capabilities.plugins.push({ id, type: parsed.type, def: parsed.def });
-    await writeCapabilitiesFile(capabilitiesFile.path, capabilitiesFile.format, capabilities);
+    await appendCapabilityEntry(
+      capabilitiesFile.path,
+      capabilitiesFile.format,
+      'plugins',
+      { id, type: parsed.type, def: parsed.def } as unknown as Record<string, unknown>
+    );
 
     console.log(`✓ Added plugin "${id}" to ${capabilitiesFile.path}`);
     console.log(`  Type: ${parsed.type}`);
@@ -543,12 +555,11 @@ export async function addCommand(
     def: skillDef.def
   };
 
-  capabilities.skills.push(newSkill);
-
-  await writeCapabilitiesFile(
+  await appendCapabilityEntry(
     capabilitiesFile.path,
     capabilitiesFile.format,
-    capabilities
+    'skills',
+    newSkill as unknown as Record<string, unknown>
   );
 
   console.log(`✓ Added skill "${skillDef.id}" to ${capabilitiesFile.path}`);

--- a/src/shared/__tests__/capabilities.test.ts
+++ b/src/shared/__tests__/capabilities.test.ts
@@ -4,6 +4,7 @@ import {
   createDefaultCapabilities,
   writeCapabilitiesFile,
   normalizeCapabilities,
+  appendCapabilityEntry,
 } from '../capabilities';
 import { logger } from '../logger';
 import { mkdtempSync, rmSync } from 'fs';
@@ -247,6 +248,75 @@ describe('capabilities', () => {
       
       expect(parsedJson.skills[0].id).toBe('custom-skill');
       expect(parsedJson.tools[0].id).toBe('custom-tool');
+    });
+  });
+
+  describe('appendCapabilityEntry', () => {
+    it('preserves comments and key order when appending to YAML (#93)', async () => {
+      const filePath = join(tempDir, 'capabilities.yaml');
+      const original = [
+        '# Top-level comment that must survive',
+        'options:',
+        '  toolExposure: on-demand # inline comment',
+        'skills:',
+        '  # existing skill below',
+        '  - id: first-skill',
+        '    type: github',
+        '    def:',
+        '      repo: owner/first',
+        'servers: []',
+        '',
+      ].join('\n');
+      await Bun.write(filePath, original);
+
+      await appendCapabilityEntry(filePath, 'yaml', 'skills', {
+        id: 'second-skill',
+        type: 'github',
+        def: { repo: 'owner/second' },
+      });
+
+      const content = await Bun.file(filePath).text();
+
+      // Comments survive
+      expect(content).toContain('# Top-level comment that must survive');
+      expect(content).toContain('# inline comment');
+      expect(content).toContain('# existing skill below');
+
+      // Original ordering is intact: options block precedes skills, which precedes servers
+      expect(content.indexOf('options:')).toBeLessThan(content.indexOf('skills:'));
+      expect(content.indexOf('skills:')).toBeLessThan(content.indexOf('servers:'));
+
+      // The new entry was appended and parses correctly
+      const parsed = await parseCapabilitiesFile(filePath, 'yaml');
+      expect(parsed.skills.map(s => s.id)).toEqual(['first-skill', 'second-skill']);
+    });
+
+    it('creates the section when it is missing (YAML)', async () => {
+      const filePath = join(tempDir, 'capabilities.yaml');
+      await Bun.write(filePath, 'options:\n  toolExposure: on-demand\n');
+
+      await appendCapabilityEntry(filePath, 'yaml', 'plugins', {
+        id: 'p1',
+        type: 'github',
+        def: { repo: 'owner/repo' },
+      });
+
+      const parsed = await parseCapabilitiesFile(filePath, 'yaml');
+      expect(parsed.plugins?.map(p => p.id)).toEqual(['p1']);
+    });
+
+    it('appends to JSON capabilities files', async () => {
+      const filePath = join(tempDir, 'capabilities.json');
+      await writeCapabilitiesFile(filePath, 'json', createDefaultCapabilities());
+
+      await appendCapabilityEntry(filePath, 'json', 'tools', {
+        id: 't1',
+        type: 'mcp',
+        def: { server: '@srv', tool: 'search' },
+      });
+
+      const parsed = await parseCapabilitiesFile(filePath, 'json');
+      expect(parsed.tools.map(t => t.id)).toEqual(['t1']);
     });
   });
 });

--- a/src/shared/capabilities.ts
+++ b/src/shared/capabilities.ts
@@ -1,4 +1,5 @@
 import yaml from 'js-yaml';
+import { parseDocument, isSeq } from 'yaml';
 import { z } from 'zod';
 import type { Capabilities, CapabilitiesFormat } from '../types/capabilities';
 import { logger } from './logger';
@@ -102,4 +103,49 @@ export async function writeCapabilitiesFile(
   }
 
   await Bun.write(path, content);
+}
+
+type ArrayCapabilitySection =
+  | 'skills'
+  | 'servers'
+  | 'tools'
+  | 'plugins'
+  | 'subagents'
+  | 'rules'
+  | 'hooks';
+
+/**
+ * Append a single entry to one of the array-valued capability sections,
+ * preserving the rest of the file verbatim — comments, key ordering, and
+ * formatting all survive. Used by `capa add` so editing the file in place
+ * never rearranges what the user already wrote.
+ *
+ * The entry is added at the end of the target section's list. If the section
+ * is missing it is created.
+ */
+export async function appendCapabilityEntry(
+  path: string,
+  format: CapabilitiesFormat,
+  section: ArrayCapabilitySection,
+  entry: Record<string, unknown>
+): Promise<void> {
+  const content = await Bun.file(path).text();
+
+  if (format === 'json') {
+    const data = JSON.parse(content) as Record<string, unknown>;
+    const list = Array.isArray(data[section]) ? (data[section] as unknown[]) : [];
+    list.push(entry);
+    data[section] = list;
+    await Bun.write(path, JSON.stringify(data, null, 2) + '\n');
+    return;
+  }
+
+  const doc = parseDocument(content);
+  const existing = doc.get(section);
+  if (isSeq(existing)) {
+    existing.add(doc.createNode(entry));
+  } else {
+    doc.set(section, doc.createNode([entry]));
+  }
+  await Bun.write(path, doc.toString());
 }

--- a/web-ui/src/index.css
+++ b/web-ui/src/index.css
@@ -141,6 +141,18 @@
     -webkit-font-smoothing: antialiased;
     -moz-osx-font-smoothing: grayscale;
   }
+
+  button:not(:disabled),
+  [role="button"]:not([aria-disabled="true"]),
+  label[for],
+  summary {
+    cursor: pointer;
+  }
+
+  button:disabled,
+  [role="button"][aria-disabled="true"] {
+    cursor: not-allowed;
+  }
 }
 
 @keyframes spin {


### PR DESCRIPTION
## Summary

Fixes the two most severe open bugs:

- **#93 (data loss):** `capa add` re-serialized the entire `capabilities.yaml` through `js-yaml`'s `dump()`, which **deleted user comments and rearranged keys**. Introduces a comment-preserving `appendCapabilityEntry()` (backed by the round-trip `yaml` parser) and routes every `capa add` write path (registry skill/plugin, `--plugin`, default skill) through it. New entries are appended in place; the rest of the file is left byte-for-byte intact. JSON files keep their existing parse/stringify path.
- **#92 (UX):** Interactive elements in the web UI didn't show a pointer cursor on hover. Adds a global base-layer rule giving `button`/`[role=button]`/`label[for]`/`summary` `cursor: pointer`, and `not-allowed` when disabled — covering all buttons since there's no shared Button component.

## Changes
- `src/shared/capabilities.ts` — new `appendCapabilityEntry()` using `yaml` `parseDocument` for round-trip preservation.
- `src/cli/commands/add.ts` — all write sites now append in place instead of full re-dump.
- `web-ui/src/index.css` — global cursor rules for interactive elements.
- Added `yaml` dependency.

## Test plan
- [x] New unit tests in `capabilities.test.ts` assert comments + key order survive, missing sections are created, and JSON append works.
- [x] Full suite: `bun test` → 1019 pass / 0 fail.
- [x] Typecheck: `bunx tsc --noEmit` clean.
- [x] `bun run build:web` succeeds (CSS compiles).
- [ ] Manual: hover buttons in the local UI to confirm pointer cursor.

🤖 Generated with [Claude Code](https://claude.com/claude-code)