### PR TITLE
fix(plugins): command-based MCP servers from plugins expose no tools (#94)

### DIFF
--- a/src/shared/plugin-manifest/__tests__/mcp-parser.test.ts
+++ b/src/shared/plugin-manifest/__tests__/mcp-parser.test.ts
@@ -1,0 +1,71 @@
+import { describe, it, expect } from 'bun:test';
+import { resolve } from 'path';
+import { resolvePluginServerDef, normalizeMcpServerEntry } from '../mcp-parser';
+
+const PLUGIN_ROOT = '/abs/plugins/aws-dev-toolkit';
+
+describe('resolvePluginServerDef', () => {
+  it('leaves a bare executable command and its flags/specs untouched (#94)', () => {
+    // A typical command-based MCP server: `uvx -y awslabs.some-mcp-server`.
+    const resolved = resolvePluginServerDef(
+      { cmd: 'uvx', args: ['-y', 'awslabs.some-mcp-server'] },
+      PLUGIN_ROOT
+    );
+    expect(resolved.cmd).toBe('uvx');
+    expect(resolved.args).toEqual(['-y', 'awslabs.some-mcp-server']);
+  });
+
+  it('leaves npx package specs untouched', () => {
+    const resolved = resolvePluginServerDef(
+      { cmd: 'npx', args: ['-y', '@modelcontextprotocol/server-filesystem'] },
+      PLUGIN_ROOT
+    );
+    expect(resolved.cmd).toBe('npx');
+    expect(resolved.args).toEqual(['-y', '@modelcontextprotocol/server-filesystem']);
+  });
+
+  it('expands ${CLAUDE_PLUGIN_ROOT} in cmd and args', () => {
+    const resolved = resolvePluginServerDef(
+      {
+        cmd: 'python',
+        args: ['${CLAUDE_PLUGIN_ROOT}/server.py'],
+        env: { DATA_DIR: '${CLAUDE_PLUGIN_ROOT}/data' },
+      },
+      PLUGIN_ROOT
+    );
+    expect(resolved.cmd).toBe('python');
+    expect(resolved.args).toEqual([`${PLUGIN_ROOT}/server.py`]);
+    expect(resolved.env).toEqual({ DATA_DIR: `${PLUGIN_ROOT}/data` });
+  });
+
+  it('resolves explicit relative path commands against the plugin root', () => {
+    const resolved = resolvePluginServerDef(
+      { cmd: './bin/server', args: ['./config.json'] },
+      PLUGIN_ROOT
+    );
+    expect(resolved.cmd).toBe(resolve(PLUGIN_ROOT, './bin/server'));
+    expect(resolved.args).toEqual([resolve(PLUGIN_ROOT, './config.json')]);
+  });
+
+  it('passes remote (url) servers through unchanged', () => {
+    const resolved = resolvePluginServerDef(
+      { url: 'https://mcp.example.com', headers: { 'X-Key': 'v' } },
+      PLUGIN_ROOT
+    );
+    expect(resolved.url).toBe('https://mcp.example.com');
+    expect(resolved.headers).toEqual({ 'X-Key': 'v' });
+    expect(resolved.cmd).toBeUndefined();
+  });
+});
+
+describe('normalizeMcpServerEntry', () => {
+  it('accepts the `command` spelling and maps it to cmd', () => {
+    const normalized = normalizeMcpServerEntry({ command: 'uvx', args: ['x'] });
+    expect(normalized).toEqual({ cmd: 'uvx', args: ['x'], env: undefined });
+  });
+
+  it('accepts the `cmd` spelling', () => {
+    const normalized = normalizeMcpServerEntry({ cmd: 'npx', args: ['-y', 'pkg'] });
+    expect(normalized).toEqual({ cmd: 'npx', args: ['-y', 'pkg'], env: undefined });
+  });
+});

--- a/src/shared/plugin-manifest/mcp-parser.ts
+++ b/src/shared/plugin-manifest/mcp-parser.ts
@@ -202,16 +202,25 @@ export function parseMcpServers(
   return result;
 }
 
-/** Replace ${CLAUDE_PLUGIN_ROOT} and resolve relative paths in a string */
+/**
+ * Replace ${CLAUDE_PLUGIN_ROOT} and resolve explicit plugin-relative paths.
+ *
+ * Only strings that actually reference the plugin directory are rewritten:
+ * the `${CLAUDE_PLUGIN_ROOT}` placeholder, or an explicit relative path
+ * (`./x`, `../x`, `.`). Bare tokens — executable names (`uvx`, `npx`,
+ * `python`), flags (`-y`), and package specs (`@scope/pkg`, `awslabs.foo`) —
+ * are returned untouched so they resolve from PATH or are interpreted by the
+ * launched process. Rewriting them to `<pluginRoot>/<token>` produced
+ * non-existent paths and silently broke command-based MCP servers (#94).
+ */
 function resolvePluginRootInString(value: string, pluginRoot: string): string {
-  const replaced = value.replace(/\$\{CLAUDE_PLUGIN_ROOT\}/g, pluginRoot);
-  if (replaced.startsWith('./') || (replaced.startsWith('.') && !replaced.startsWith('..'))) {
-    return resolve(pluginRoot, replaced);
+  if (value.includes('${CLAUDE_PLUGIN_ROOT}')) {
+    return value.replace(/\$\{CLAUDE_PLUGIN_ROOT\}/g, pluginRoot);
   }
-  if (!isAbsolute(replaced) && !replaced.includes('${')) {
-    return resolve(pluginRoot, replaced);
+  if (value === '.' || value.startsWith('./') || value.startsWith('../')) {
+    return resolve(pluginRoot, value);
   }
-  return replaced;
+  return value;
 }
 
 /**


### PR DESCRIPTION
## Summary

Fixes **#94**: when installing a plugin bundling MCP servers, the **command-based** servers (stdio, e.g. `uvx`/`npx`) exposed **zero tools**, while remote (URL) servers worked.

### Root cause
`resolvePluginRootInString()` in `src/shared/plugin-manifest/mcp-parser.ts` resolved *any* non-absolute string that lacked a `${CLAUDE_PLUGIN_ROOT}` placeholder against the plugin directory. So for a server defined as `uvx -y awslabs.some-mcp-server`:

- `cmd: "uvx"` → `<pluginRoot>/uvx` (does not exist)
- `args: ["-y", "awslabs.some-mcp-server"]` → `<pluginRoot>/-y`, `<pluginRoot>/awslabs.some-mcp-server`

The stdio spawn failed and `listTools()` returned `[]`. Remote `url` servers skip this resolver entirely, which is why only command-based ones broke.

### Fix
Only rewrite strings that actually reference the plugin directory:
- the `${CLAUDE_PLUGIN_ROOT}` placeholder, and
- explicit relative paths (`./x`, `../x`, `.`).

Bare executables, flags, and package specs pass through untouched for PATH resolution.

## Test plan
- [x] New `mcp-parser.test.ts` covers bare commands, npx/uvx specs, `${CLAUDE_PLUGIN_ROOT}` expansion, explicit relative paths, and url passthrough.
- [x] Full suite: `bun test` → 1023 pass / 0 fail.
- [x] `bunx tsc --noEmit` clean.
- [ ] Manual: `capa add claude-plugins:aws-dev-toolkit` and confirm all 3 servers expose tools.

🤖 Generated with [Claude Code](https://claude.com/claude-code)