### PR TITLE
Preserve YAML comments and order, fix button cursor on hover

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -19,7 +19,7 @@
         "@tanstack/react-query": "^5.100.9",
         "class-variance-authority": "^0.7.1",
         "clsx": "^2.1.1",
-        "commander": "^12.1.0",
+        "commander": "^15.0.0",
         "dompurify": "^3.4.3",
         "highlight.js": "^11.11.1",
         "i18next": "^26.0.10",
@@ -36,6 +36,7 @@
         "react-router-dom": "^7.15.0",
         "tailwind-merge": "^3.5.0",
         "xdg-basedir": "^5.1.0",
+        "yaml": "^2.9.0",
         "zod": "^4.4.3",
       },
       "devDependencies": {
@@ -44,7 +45,7 @@
         "@types/bun": "latest",
         "@types/dompurify": "^3.0.5",
         "@types/js-yaml": "^4.0.9",
-        "@types/node": "^22.10.2",
+        "@types/node": "^25.9.1",
         "@types/react": "^19.2.14",
         "@types/react-dom": "^19.2.3",
         "tailwindcss": "^4.2.4",
@@ -234,7 +235,7 @@
 
     "@types/js-yaml": ["@types/js-yaml@4.0.9", "", {}, "sha512-k4MGaQl5TGo/iipqb2UDG2UwjXziSWkh0uysQelTlJpX1qGlpUZYm8PnO4DxG1qBomtJUdYJ6qR6xdIah10JLg=="],
 
-    "@types/node": ["@types/node@22.19.10", "", { "dependencies": { "undici-types": "~6.21.0" } }, "sha512-tF5VOugLS/EuDlTBijk0MqABfP8UxgYazTLo3uIn3b4yJgg26QRbVYJYsDtHrjdDUIRfP70+VfhTTc+CE1yskw=="],
+    "@types/node": ["@types/node@25.9.2", "", { "dependencies": { "undici-types": ">=7.24.0 <7.24.7" } }, "sha512-G05zqtJhcDLb8uslf5EjCxXg9G1KQxiV8OS0R26IC//Eoyitzqe8z37I7cqvnZlrlSfgocQRfSn/AHBZJJFyGw=="],
 
     "@types/react": ["@types/react@19.2.14", "", { "dependencies": { "csstype": "^3.2.2" } }, "sha512-ilcTH/UniCkMdtexkoCN0bI7pMcJDvmQFPvuPvmEaYA/NSfFTAgdUSLAoVjaRJm7+6PvcM+q1zYOwS4wTYMF9w=="],
 
@@ -276,7 +277,7 @@
 
     "clsx": ["clsx@2.1.1", "", {}, "sha512-eYm0QWBtUrBWZWG0d386OGAw16Z995PiOVo2B7bjWSbHedGl5e0ZWaq65kOGgUSNesEIDkB9ISbTg/JK9dhCZA=="],
 
-    "commander": ["commander@12.1.0", "", {}, "sha512-Vw8qHK3bZM9y/P10u3Vib8o/DdkvA2OtPtZvD871QKjy74Wj1WSKFILMPRPSdUSx5RFK1arlJzEtA4PkFgnbuA=="],
+    "commander": ["commander@15.0.0", "", {}, "sha512-z67u4ZhzCL/Tydu1lJARtEZYWbWaN7oYLHbsuzocr6y4N6WZAagG3RQ4FW61V1/0+jImpj293XfrcYnd1qxtPg=="],
 
     "content-disposition": ["content-disposition@1.0.1", "", {}, "sha512-oIXISMynqSqm241k6kcQ5UwttDILMK4BiurCfGEREw6+X9jkkpEe5T9FZaApyLGGOnFuyMWZpdolTXMtvEJ08Q=="],
 
@@ -568,7 +569,7 @@
 
     "type-is": ["type-is@2.0.1", "", { "dependencies": { "content-type": "^1.0.5", "media-typer": "^1.1.0", "mime-types": "^3.0.0" } }, "sha512-OZs6gsjF4vMp32qrCbiVSkrFmXtG/AZhY3t0iAMrMBiAZyV9oALtXO8hsrHbMXF9x6L3grlFuwW2oAz7cav+Gw=="],
 
-    "undici-types": ["undici-types@6.21.0", "", {}, "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ=="],
+    "undici-types": ["undici-types@7.24.6", "", {}, "sha512-WRNW+sJgj5OBN4/0JpHFqtqzhpbnV0GuB+OozA9gCL7a993SmU+1JBZCzLNxYsbMfIeDL+lTsphD5jN5N+n0zg=="],
 
     "unpipe": ["unpipe@1.0.0", "", {}, "sha512-pjy2bYhSsufwWlKwPc+l3cN7+wuJlK6uz0YdJEOlQDbl6jo/YlPi4mb8agUkVC8BF7V8NuzeyPNqRksA3hztKQ=="],
 
@@ -589,6 +590,8 @@
     "wrappy": ["wrappy@1.0.2", "", {}, "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ=="],
 
     "xdg-basedir": ["xdg-basedir@5.1.0", "", {}, "sha512-GCPAHLvrIH13+c0SuacwvRYj2SxJXQ4kaVTT5xgL3kPrz56XxkF21IGhjSE1+W0aw7gpBWRGXLCPnPby6lSpmQ=="],
+
+    "yaml": ["yaml@2.9.0", "", { "bin": { "yaml": "bin.mjs" } }, "sha512-2AvhNX3mb8zd6Zy7INTtSpl1F15HW6Wnqj0srWlkKLcpYl/gMIMJiyuGq2KeI2YFxUPjdlB+3Lc10seMLtL4cA=="],
 
     "zod": ["zod@4.4.3", "", {}, "sha512-ytENFjIJFl2UwYglde2jchW2Hwm4GJFLDiSXWdTrJQBIN9Fcyp7n4DhxJEiWNAJMV1/BqWfW/kkg71UDcHJyTQ=="],
 
@@ -622,11 +625,15 @@
 
     "@tailwindcss/oxide-wasm32-wasi/tslib": ["tslib@2.8.1", "", { "bundled": true }, "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w=="],
 
+    "bun-types/@types/node": ["@types/node@22.19.10", "", { "dependencies": { "undici-types": "~6.21.0" } }, "sha512-tF5VOugLS/EuDlTBijk0MqABfP8UxgYazTLo3uIn3b4yJgg26QRbVYJYsDtHrjdDUIRfP70+VfhTTc+CE1yskw=="],
+
     "log-update/slice-ansi": ["slice-ansi@7.1.2", "", { "dependencies": { "ansi-styles": "^6.2.1", "is-fullwidth-code-point": "^5.0.0" } }, "sha512-iOBWFgUX7caIZiuutICxVgX1SdxwAVFFKwt1EvMYYec/NWO5meOJ6K5uQxhrYBdQJne4KxiqZc+KptFOWFSI9w=="],
 
     "log-update/wrap-ansi": ["wrap-ansi@9.0.2", "", { "dependencies": { "ansi-styles": "^6.2.1", "string-width": "^7.0.0", "strip-ansi": "^7.1.0" } }, "sha512-42AtmgqjV+X1VpdOfyTGOYRi0/zsoLqtXQckTmqTeybT+BDIbM/Guxo7x3pE2vtpr1ok6xRqM9OpBe+Jyoqyww=="],
 
     "react-router/cookie": ["cookie@1.1.1", "", {}, "sha512-ei8Aos7ja0weRpFzJnEA9UHJ/7XQmqglbRwnf2ATjcB9Wq874VKH9kfjjirM6UhU2/E5fFYadylyhFldcqSidQ=="],
+
+    "bun-types/@types/node/undici-types": ["undici-types@6.21.0", "", {}, "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ=="],
 
     "log-update/wrap-ansi/string-width": ["string-width@7.2.0", "", { "dependencies": { "emoji-regex": "^10.3.0", "get-east-asian-width": "^1.0.0", "strip-ansi": "^7.1.0" } }, "sha512-tsaTIkKW9b4N+AEj+SVA+WhJzV7/zMhcSu78mLKWSk7cXMOSHsBKFWUs0fWwq8QyK3MgJBQRX6Gbi4kYbdvGkQ=="],
   }

--- a/install.ps1
+++ b/install.ps1
@@ -314,8 +314,32 @@ function Install-Capa {
     }
     Write-Success "Verified binary integrity"
     
-    # Replace existing binary. When invoked by "capa upgrade", capa exits before we run, so the exe
-    # may still be released briefly by Windows — retry a few times before failing.
+    # Replace existing binary (fixes #19). On Windows a running .exe is locked
+    # and cannot be overwritten, but it *can* be renamed within the same
+    # directory while it runs (the OS keeps the file handle regardless of name).
+    # So move the old binary aside first — that frees $destPath — then drop the
+    # new binary in. This makes the upgrade succeed even if the previous capa
+    # process hasn't fully exited yet, instead of relying on a timing race.
+    $backupPath = "$destPath.old"
+    if (Test-Path $destPath) {
+        # Remove any leftover backup from a prior upgrade (best-effort; harmless
+        # if it's still locked — it'll be cleaned on the next run).
+        if (Test-Path $backupPath) {
+            Remove-Item -LiteralPath $backupPath -Force -ErrorAction SilentlyContinue
+        }
+        try {
+            Move-Item -Path $destPath -Destination $backupPath -Force
+        }
+        catch {
+            # Rename of a locked exe normally succeeds; if it somehow didn't,
+            # fall through and let the retry loop attempt a direct replace.
+            Write-Verbose-Custom "Could not rename existing binary aside: $_"
+        }
+    }
+
+    # Move the new binary into place. If the rename above succeeded, $destPath is
+    # free and this lands on the first try. The retry loop is a fallback for the
+    # rare case the destination is still occupied (e.g. rename failed).
     $replaceOk = $false
     $maxRetries = 5
     $retryDelaySeconds = 2
@@ -332,15 +356,27 @@ function Install-Capa {
             }
             else {
                 Remove-Item -LiteralPath $tempPath -Force -ErrorAction SilentlyContinue
+                # Restore the original binary if we renamed it aside but couldn't
+                # install the new one, so the user isn't left without a capa.exe.
+                if ((-not (Test-Path $destPath)) -and (Test-Path $backupPath)) {
+                    Move-Item -Path $backupPath -Destination $destPath -Force -ErrorAction SilentlyContinue
+                }
                 Write-Error-Custom "Could not replace $destPath. Close any process using it and run the installer again, or run: capa upgrade"
             }
         }
     }
-    
+
     if (-not $replaceOk) {
         exit 1
     }
-    
+
+    # New binary is in place; clean up the old one. This will fail silently if
+    # the previous capa process is still running (the file stays locked) — the
+    # leftover .old is then removed by the next upgrade.
+    if (Test-Path $backupPath) {
+        Remove-Item -LiteralPath $backupPath -Force -ErrorAction SilentlyContinue
+    }
+
     Write-Success "Installed CAPA to $destPath"
     
     # Add to PATH

--- a/package.json
+++ b/package.json
@@ -49,6 +49,7 @@
     "react-router-dom": "^7.15.0",
     "tailwind-merge": "^3.5.0",
     "xdg-basedir": "^5.1.0",
+    "yaml": "^2.9.0",
     "zod": "^4.4.3"
   },
   "devDependencies": {

--- a/src/cli/commands/add.ts
+++ b/src/cli/commands/add.ts
@@ -1,5 +1,5 @@
 import { detectCapabilitiesFile } from '../../shared/paths';
-import { parseCapabilitiesFile, writeCapabilitiesFile } from '../../shared/capabilities';
+import { parseCapabilitiesFile, appendCapabilityEntry } from '../../shared/capabilities';
 import { installCommand } from './install';
 import { RegistryManager } from '../../shared/registries/manager';
 import type { Skill } from '../../types/capabilities';
@@ -457,7 +457,12 @@ export async function addCommand(
           process.exit(1);
         }
         const newSkill: Skill = { ...(snippet as Skill), id: itemName };
-        capabilities.skills.push(newSkill);
+        await appendCapabilityEntry(
+          capabilitiesFile.path,
+          capabilitiesFile.format,
+          'skills',
+          newSkill as unknown as Record<string, unknown>
+        );
       } else if (resolvedCapability === 'plugins') {
         if (!capabilities.plugins) capabilities.plugins = [];
         const newPlugin = snippet as Plugin;
@@ -471,10 +476,13 @@ export async function addCommand(
           console.error(`  Rename or remove the existing entry in ${capabilitiesFile.path} and try again.`);
           process.exit(1);
         }
-        capabilities.plugins.push({ ...newPlugin, id: itemName });
+        await appendCapabilityEntry(
+          capabilitiesFile.path,
+          capabilitiesFile.format,
+          'plugins',
+          { ...newPlugin, id: itemName } as unknown as Record<string, unknown>
+        );
       }
-
-      await writeCapabilitiesFile(capabilitiesFile.path, capabilitiesFile.format, capabilities);
 
       console.log(`\u2713 Added ${resolvedCapability.slice(0, -1)} "${itemName}" from registry "${registryId}" to ${capabilitiesFile.path}`);
       console.log('\n\u{1F4E6} Running installation...\n');
@@ -507,8 +515,12 @@ export async function addCommand(
       process.exit(1);
     }
 
-    capabilities.plugins.push({ id, type: parsed.type, def: parsed.def });
-    await writeCapabilitiesFile(capabilitiesFile.path, capabilitiesFile.format, capabilities);
+    await appendCapabilityEntry(
+      capabilitiesFile.path,
+      capabilitiesFile.format,
+      'plugins',
+      { id, type: parsed.type, def: parsed.def } as unknown as Record<string, unknown>
+    );
 
     console.log(`✓ Added plugin "${id}" to ${capabilitiesFile.path}`);
     console.log(`  Type: ${parsed.type}`);
@@ -543,12 +555,11 @@ export async function addCommand(
     def: skillDef.def
   };
 
-  capabilities.skills.push(newSkill);
-
-  await writeCapabilitiesFile(
+  await appendCapabilityEntry(
     capabilitiesFile.path,
     capabilitiesFile.format,
-    capabilities
+    'skills',
+    newSkill as unknown as Record<string, unknown>
   );
 
   console.log(`✓ Added skill "${skillDef.id}" to ${capabilitiesFile.path}`);

--- a/src/shared/__tests__/capabilities.test.ts
+++ b/src/shared/__tests__/capabilities.test.ts
@@ -4,6 +4,7 @@ import {
   createDefaultCapabilities,
   writeCapabilitiesFile,
   normalizeCapabilities,
+  appendCapabilityEntry,
 } from '../capabilities';
 import { logger } from '../logger';
 import { mkdtempSync, rmSync } from 'fs';
@@ -247,6 +248,75 @@ describe('capabilities', () => {
       
       expect(parsedJson.skills[0].id).toBe('custom-skill');
       expect(parsedJson.tools[0].id).toBe('custom-tool');
+    });
+  });
+
+  describe('appendCapabilityEntry', () => {
+    it('preserves comments and key order when appending to YAML (#93)', async () => {
+      const filePath = join(tempDir, 'capabilities.yaml');
+      const original = [
+        '# Top-level comment that must survive',
+        'options:',
+        '  toolExposure: on-demand # inline comment',
+        'skills:',
+        '  # existing skill below',
+        '  - id: first-skill',
+        '    type: github',
+        '    def:',
+        '      repo: owner/first',
+        'servers: []',
+        '',
+      ].join('\n');
+      await Bun.write(filePath, original);
+
+      await appendCapabilityEntry(filePath, 'yaml', 'skills', {
+        id: 'second-skill',
+        type: 'github',
+        def: { repo: 'owner/second' },
+      });
+
+      const content = await Bun.file(filePath).text();
+
+      // Comments survive
+      expect(content).toContain('# Top-level comment that must survive');
+      expect(content).toContain('# inline comment');
+      expect(content).toContain('# existing skill below');
+
+      // Original ordering is intact: options block precedes skills, which precedes servers
+      expect(content.indexOf('options:')).toBeLessThan(content.indexOf('skills:'));
+      expect(content.indexOf('skills:')).toBeLessThan(content.indexOf('servers:'));
+
+      // The new entry was appended and parses correctly
+      const parsed = await parseCapabilitiesFile(filePath, 'yaml');
+      expect(parsed.skills.map(s => s.id)).toEqual(['first-skill', 'second-skill']);
+    });
+
+    it('creates the section when it is missing (YAML)', async () => {
+      const filePath = join(tempDir, 'capabilities.yaml');
+      await Bun.write(filePath, 'options:\n  toolExposure: on-demand\n');
+
+      await appendCapabilityEntry(filePath, 'yaml', 'plugins', {
+        id: 'p1',
+        type: 'github',
+        def: { repo: 'owner/repo' },
+      });
+
+      const parsed = await parseCapabilitiesFile(filePath, 'yaml');
+      expect(parsed.plugins?.map(p => p.id)).toEqual(['p1']);
+    });
+
+    it('appends to JSON capabilities files', async () => {
+      const filePath = join(tempDir, 'capabilities.json');
+      await writeCapabilitiesFile(filePath, 'json', createDefaultCapabilities());
+
+      await appendCapabilityEntry(filePath, 'json', 'tools', {
+        id: 't1',
+        type: 'mcp',
+        def: { server: '@srv', tool: 'search' },
+      });
+
+      const parsed = await parseCapabilitiesFile(filePath, 'json');
+      expect(parsed.tools.map(t => t.id)).toEqual(['t1']);
     });
   });
 });

--- a/src/shared/capabilities.ts
+++ b/src/shared/capabilities.ts
@@ -1,4 +1,5 @@
 import yaml from 'js-yaml';
+import { parseDocument, isSeq } from 'yaml';
 import { z } from 'zod';
 import type { Capabilities, CapabilitiesFormat } from '../types/capabilities';
 import { logger } from './logger';
@@ -102,4 +103,49 @@ export async function writeCapabilitiesFile(
   }
 
   await Bun.write(path, content);
+}
+
+type ArrayCapabilitySection =
+  | 'skills'
+  | 'servers'
+  | 'tools'
+  | 'plugins'
+  | 'subagents'
+  | 'rules'
+  | 'hooks';
+
+/**
+ * Append a single entry to one of the array-valued capability sections,
+ * preserving the rest of the file verbatim — comments, key ordering, and
+ * formatting all survive. Used by `capa add` so editing the file in place
+ * never rearranges what the user already wrote.
+ *
+ * The entry is added at the end of the target section's list. If the section
+ * is missing it is created.
+ */
+export async function appendCapabilityEntry(
+  path: string,
+  format: CapabilitiesFormat,
+  section: ArrayCapabilitySection,
+  entry: Record<string, unknown>
+): Promise<void> {
+  const content = await Bun.file(path).text();
+
+  if (format === 'json') {
+    const data = JSON.parse(content) as Record<string, unknown>;
+    const list = Array.isArray(data[section]) ? (data[section] as unknown[]) : [];
+    list.push(entry);
+    data[section] = list;
+    await Bun.write(path, JSON.stringify(data, null, 2) + '\n');
+    return;
+  }
+
+  const doc = parseDocument(content);
+  const existing = doc.get(section);
+  if (isSeq(existing)) {
+    existing.add(doc.createNode(entry));
+  } else {
+    doc.set(section, doc.createNode([entry]));
+  }
+  await Bun.write(path, doc.toString());
 }

--- a/src/shared/plugin-manifest/__tests__/mcp-parser.test.ts
+++ b/src/shared/plugin-manifest/__tests__/mcp-parser.test.ts
@@ -1,0 +1,71 @@
+import { describe, it, expect } from 'bun:test';
+import { resolve } from 'path';
+import { resolvePluginServerDef, normalizeMcpServerEntry } from '../mcp-parser';
+
+const PLUGIN_ROOT = '/abs/plugins/aws-dev-toolkit';
+
+describe('resolvePluginServerDef', () => {
+  it('leaves a bare executable command and its flags/specs untouched (#94)', () => {
+    // A typical command-based MCP server: `uvx -y awslabs.some-mcp-server`.
+    const resolved = resolvePluginServerDef(
+      { cmd: 'uvx', args: ['-y', 'awslabs.some-mcp-server'] },
+      PLUGIN_ROOT
+    );
+    expect(resolved.cmd).toBe('uvx');
+    expect(resolved.args).toEqual(['-y', 'awslabs.some-mcp-server']);
+  });
+
+  it('leaves npx package specs untouched', () => {
+    const resolved = resolvePluginServerDef(
+      { cmd: 'npx', args: ['-y', '@modelcontextprotocol/server-filesystem'] },
+      PLUGIN_ROOT
+    );
+    expect(resolved.cmd).toBe('npx');
+    expect(resolved.args).toEqual(['-y', '@modelcontextprotocol/server-filesystem']);
+  });
+
+  it('expands ${CLAUDE_PLUGIN_ROOT} in cmd and args', () => {
+    const resolved = resolvePluginServerDef(
+      {
+        cmd: 'python',
+        args: ['${CLAUDE_PLUGIN_ROOT}/server.py'],
+        env: { DATA_DIR: '${CLAUDE_PLUGIN_ROOT}/data' },
+      },
+      PLUGIN_ROOT
+    );
+    expect(resolved.cmd).toBe('python');
+    expect(resolved.args).toEqual([`${PLUGIN_ROOT}/server.py`]);
+    expect(resolved.env).toEqual({ DATA_DIR: `${PLUGIN_ROOT}/data` });
+  });
+
+  it('resolves explicit relative path commands against the plugin root', () => {
+    const resolved = resolvePluginServerDef(
+      { cmd: './bin/server', args: ['./config.json'] },
+      PLUGIN_ROOT
+    );
+    expect(resolved.cmd).toBe(resolve(PLUGIN_ROOT, './bin/server'));
+    expect(resolved.args).toEqual([resolve(PLUGIN_ROOT, './config.json')]);
+  });
+
+  it('passes remote (url) servers through unchanged', () => {
+    const resolved = resolvePluginServerDef(
+      { url: 'https://mcp.example.com', headers: { 'X-Key': 'v' } },
+      PLUGIN_ROOT
+    );
+    expect(resolved.url).toBe('https://mcp.example.com');
+    expect(resolved.headers).toEqual({ 'X-Key': 'v' });
+    expect(resolved.cmd).toBeUndefined();
+  });
+});
+
+describe('normalizeMcpServerEntry', () => {
+  it('accepts the `command` spelling and maps it to cmd', () => {
+    const normalized = normalizeMcpServerEntry({ command: 'uvx', args: ['x'] });
+    expect(normalized).toEqual({ cmd: 'uvx', args: ['x'], env: undefined });
+  });
+
+  it('accepts the `cmd` spelling', () => {
+    const normalized = normalizeMcpServerEntry({ cmd: 'npx', args: ['-y', 'pkg'] });
+    expect(normalized).toEqual({ cmd: 'npx', args: ['-y', 'pkg'], env: undefined });
+  });
+});

--- a/src/shared/plugin-manifest/mcp-parser.ts
+++ b/src/shared/plugin-manifest/mcp-parser.ts
@@ -202,16 +202,25 @@ export function parseMcpServers(
   return result;
 }
 
-/** Replace ${CLAUDE_PLUGIN_ROOT} and resolve relative paths in a string */
+/**
+ * Replace ${CLAUDE_PLUGIN_ROOT} and resolve explicit plugin-relative paths.
+ *
+ * Only strings that actually reference the plugin directory are rewritten:
+ * the `${CLAUDE_PLUGIN_ROOT}` placeholder, or an explicit relative path
+ * (`./x`, `../x`, `.`). Bare tokens — executable names (`uvx`, `npx`,
+ * `python`), flags (`-y`), and package specs (`@scope/pkg`, `awslabs.foo`) —
+ * are returned untouched so they resolve from PATH or are interpreted by the
+ * launched process. Rewriting them to `<pluginRoot>/<token>` produced
+ * non-existent paths and silently broke command-based MCP servers (#94).
+ */
 function resolvePluginRootInString(value: string, pluginRoot: string): string {
-  const replaced = value.replace(/\$\{CLAUDE_PLUGIN_ROOT\}/g, pluginRoot);
-  if (replaced.startsWith('./') || (replaced.startsWith('.') && !replaced.startsWith('..'))) {
-    return resolve(pluginRoot, replaced);
+  if (value.includes('${CLAUDE_PLUGIN_ROOT}')) {
+    return value.replace(/\$\{CLAUDE_PLUGIN_ROOT\}/g, pluginRoot);
   }
-  if (!isAbsolute(replaced) && !replaced.includes('${')) {
-    return resolve(pluginRoot, replaced);
+  if (value === '.' || value.startsWith('./') || value.startsWith('../')) {
+    return resolve(pluginRoot, value);
   }
-  return replaced;
+  return value;
 }
 
 /**

--- a/web-ui/src/index.css
+++ b/web-ui/src/index.css
@@ -141,6 +141,18 @@
     -webkit-font-smoothing: antialiased;
     -moz-osx-font-smoothing: grayscale;
   }
+
+  button:not(:disabled),
+  [role="button"]:not([aria-disabled="true"]),
+  label[for],
+  summary {
+    cursor: pointer;
+  }
+
+  button:disabled,
+  [role="button"][aria-disabled="true"] {
+    cursor: not-allowed;
+  }
 }
 
 @keyframes spin {


### PR DESCRIPTION
This pull request introduces several improvements and fixes across the CLI, shared utilities, and Windows installer script. The most significant changes include robust handling of YAML/JSON capabilities files to preserve formatting and comments during edits, improved plugin server command resolution to avoid path issues, and enhancements to the Windows installer for safer binary upgrades.

**Capabilities file editing & preservation:**

- Added a new `appendCapabilityEntry` function in `src/shared/capabilities.ts` that appends entries to array sections (like `skills` and `plugins`) in YAML/JSON capabilities files while preserving comments, key ordering, and formatting. This is now used throughout the `add` CLI command instead of rewriting the whole file. Tests verify that comments and order are preserved and that missing sections are created as needed. [[1]](diffhunk://#diff-cdc3db35e38aff18c56202e1b10d1ccd9cbe012d86dfab25b77c5afdce59f975R107-R151) [[2]](diffhunk://#diff-af3148c70ee3d5e4ba56bc4589a50089379f4199a80758cd36ec01261fb20fa4L2-R2) [[3]](diffhunk://#diff-af3148c70ee3d5e4ba56bc4589a50089379f4199a80758cd36ec01261fb20fa4L460-R465) [[4]](diffhunk://#diff-af3148c70ee3d5e4ba56bc4589a50089379f4199a80758cd36ec01261fb20fa4L474-L478) [[5]](diffhunk://#diff-af3148c70ee3d5e4ba56bc4589a50089379f4199a80758cd36ec01261fb20fa4L510-R523) [[6]](diffhunk://#diff-af3148c70ee3d5e4ba56bc4589a50089379f4199a80758cd36ec01261fb20fa4L546-R562) [[7]](diffhunk://#diff-f56358d3f228ec4ae26fd703ea03b758da656567e227b0c462f2af88d117caabR7) [[8]](diffhunk://#diff-f56358d3f228ec4ae26fd703ea03b758da656567e227b0c462f2af88d117caabR253-R321) [[9]](diffhunk://#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519R52)

**Plugin server command resolution fixes:**

- Updated `resolvePluginRootInString` in `src/shared/plugin-manifest/mcp-parser.ts` to only rewrite strings that explicitly reference the plugin root (via `${CLAUDE_PLUGIN_ROOT}` or explicit relative paths). Bare executable names and flags are left untouched, fixing issues where commands were incorrectly rewritten to non-existent paths. New tests cover all cases. [[1]](diffhunk://#diff-46e65424cb47401667b4b1b6bfce96f1e10f8c28cc8f1ea3f3d60d14fd18752eL205-R223) [[2]](diffhunk://#diff-542f909db2bfd8e3ceba2e1606d0661b5bc87800052effe3d79afd278a013c6aR1-R71)

**Windows installer robustness:**

- Improved the Windows installer (`install.ps1`) to safely upgrade binaries even if the old process is still running. The script now renames the old binary before replacing it, restores it if the upgrade fails, and cleans up backups on subsequent runs. This avoids race conditions and ensures users are not left without an executable. [[1]](diffhunk://#diff-50d51a233d8ff4886061fc5cf1a03642de1f64b3625903e4f876e8cd2a3f5806L317-R342) [[2]](diffhunk://#diff-50d51a233d8ff4886061fc5cf1a03642de1f64b3625903e4f876e8cd2a3f5806R359-R363) [[3]](diffhunk://#diff-50d51a233d8ff4886061fc5cf1a03642de1f64b3625903e4f876e8cd2a3f5806R373-R379)

**UI/UX improvements:**

- Updated global CSS to set `cursor: pointer` for clickable elements and `cursor: not-allowed` for disabled buttons, improving accessibility and user feedback.

These changes collectively improve reliability, user experience, and maintainability across the project.
