### PR TITLE
Fix LFS clones, Windows MCP visibility, and OpenCode config

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@
   <a href="https://github.com/infragate/capa/releases/latest"><img src="https://img.shields.io/badge/platform-macOS%20%7C%20Linux%20%7C%20Windows-lightgrey?style=flat-square" alt="Platforms"></a>
 </p>
 
-CAPA is a capabilities manager for AI coding agents. You declare skills, tools, rules, sub-agents, MCP servers, and plugins once in `capabilities.yaml`, run `capa install`, and CAPA writes them into Cursor, Claude Code, Codex, Windsurf, GitHub Copilot, and 30+ other agents.
+CAPA is the package manager for AI coding agents. Declare your skills, tools, rules, sub-agents, MCP servers, and plugins once in `capabilities.yaml`, run `capa install`, and CAPA writes them into Cursor, Claude Code, Codex, Windsurf, GitHub Copilot, and 35+ other agents.
 
 ## Why CAPA?
 
@@ -42,7 +42,7 @@ Scrolling down the same page brings up sub-agents, rules, project options, and c
   <img src="https://github.com/user-attachments/assets/155f861d-cfc9-47a4-a584-c3d88cb9bc39" alt="CAPA project view: sub-agents, rules, options, and credentials" width="900" />
 </p>
 
-The Registries tab pulls skills and plugins from external catalogs. Need a private one? Run `capa registry add owner/repo@my-adapter` (or use the **Manage registries** page) — capa fetches the adapter from GitHub, GitLab, or an HTTPS URL, validates it, and it shows up here too.
+The Registries tab pulls skills and plugins from external catalogs. Need a private one? Run `capa registry add owner/repo@my-adapter` (or use the **Manage registries** page). capa fetches the adapter from GitHub, GitLab, or an HTTPS URL, validates it, and it shows up here too.
 
 <table align="center">
   <tr>
@@ -61,10 +61,10 @@ The Registries tab pulls skills and plugins from external catalogs. Need a priva
 
 - Skills from inline content, raw URLs, GitHub, GitLab, local paths, or a configured registry.
 - 35+ supported agents: Cursor, Claude Code, Codex, Windsurf, GitHub Copilot, Cline, Continue, Goose, Gemini CLI, Roo Code, Qwen Code, and more.
-- One MCP server per agent. Tools load on demand, so the context window stays small.
+- One MCP server per agent. Tools load on demand, so the context window stays small. In our benchmarks that runs 19-40% cheaper than exposing every tool up front, with no drop in quality (150 trials on claude-opus-4-8).
 - Any CLI command can be wrapped as an MCP tool the agent (and `capa sh`) can call.
 - Rules go to each provider's native location: Cursor `.cursor/rules/`, Windsurf `.windsurf/rules/`, Copilot's instructions file, or a managed marker block in `AGENTS.md` / `CLAUDE.md` for providers without a rules directory. Glob scoping works.
-- Lifecycle hooks for providers that support them (Claude Code, Cursor, Codex, Gemini CLI). Declare canonical events like `beforeShell` or `afterFileEdit` once and capa translates them into each provider's hook config — `.claude/settings.json`, `.cursor/hooks.json`, `.codex/config.toml`, `.gemini/settings.json` — using `capa:<id>` tags so user-authored entries are never touched. Providers without hook support emit a warning and skip.
+- Lifecycle hooks for providers that support them (Claude Code, Cursor, Codex, Gemini CLI). Declare canonical events like `beforeShell` or `afterFileEdit` once and capa translates them into each provider's hook config (`.claude/settings.json`, `.cursor/hooks.json`, `.codex/config.toml`, `.gemini/settings.json`), tagging each one with `capa:<id>` so user-authored entries are never touched. Providers without hook support emit a warning and skip.
 - Sub-agents get their own filtered MCP endpoint that exposes only the tools the specialist actually needs.
 - Skills and plugins are browsable from `capa add` and the web UI. Add a registry with `capa registry add owner/repo@my-adapter` (GitHub/GitLab/HTTPS sources, slug auto-derived, adapter validated before install) and it shows up too.
 - `capabilities.lock` records resolved commit SHAs. A SHA-keyed content cache makes repeat installs near instant.

--- a/docs/providers/README.md
+++ b/docs/providers/README.md
@@ -77,7 +77,7 @@ included for completeness but lack any project-local write paths.
 | [Mux (`mux`)](./mux.md) | `.mux/skills/` | — *(bare-command strings, no URL field)* | — | — | — |
 | [Neovate (`neovate`)](./neovate.md) | `.neovate/skills/` | `.neovate/config.json` → `mcpServers.capa.url` | — | — | — |
 | [OpenClaw (`openclaw`)](./openclaw.md) | `skills/` | — *(home-workspace based)* | — | — | — |
-| **[OpenCode (`opencode`)](./opencode.md)** | `.agents/skills/` | `.opencode/opencode.json` → `mcp.capa.url` *(`mcp` key)* | `AGENTS.md` | folded into `AGENTS.md` | `.opencode/agents/*.md` |
+| **[OpenCode (`opencode`)](./opencode.md)** | `.agents/skills/` | `opencode.json` → `mcp.capa.url` *(`mcp` key, `enabled: true`)* | `AGENTS.md` | folded into `AGENTS.md` | `.opencode/agents/*.md` *(mode: subagent)* |
 | [OpenHands (`openhands`)](./openhands.md) | `.openhands/skills/` | — *(global only)* | `AGENTS.md` | — | — |
 | [Pi (`pi`)](./pi.md) | `.pi/skills/` | — *(community extension only)* | `AGENTS.md` | — | — |
 | **[Pochi (`pochi`)](./pochi.md)** | `.pochi/skills/` | `.pochi/config.jsonc` → `mcp.capa.url` *(JSONC; `mcp` key)* | `README.pochi.md` | folded into `README.pochi.md` | `.pochi/agents/*.md` |

--- a/docs/providers/opencode.md
+++ b/docs/providers/opencode.md
@@ -14,8 +14,38 @@ Source-of-truth definition: [`src/shared/providers/registry.ts → opencode`](..
 | MCP | `opencode.json` → `mcp.capa` | Project-root config per [OpenCode config docs](https://opencode.ai/docs/config/). Capa writes `{ type: "remote", url, enabled: true }`. Supports sub-agent entries. |
 | Instructions | `AGENTS.md` | OpenCode also supports an `instructions` array in `opencode.json`; capa uses the shared `AGENTS.md` marker blocks. |
 | Rules | folded into `AGENTS.md` | No project-local rules directory; rules become marker blocks. |
-| Sub-agents | `.opencode/agents/<id>.md` | Markdown + frontmatter; capa sets `mode: subagent`. |
+| Sub-agents | `.opencode/agents/<id>.md` | Markdown + frontmatter; capa sets `mode: subagent` and emits a `permission` allow rule for the agent's own MCP (see scope fence below). |
 | Plugin manifests | — | Not declared. |
+
+## Sub-agent MCP scope fence
+
+OpenCode auto-exposes every entry under the top-level `mcp` key to all primary agents (Build, Plan, …) by default — see [MCP servers › Per agent](https://opencode.ai/docs/mcp-servers/#per-agent). Without scoping, every `capa-<id>` MCP that capa registers for a sub-agent would pollute the main session with sub-agent-only tool blocks.
+
+To prevent that, capa writes a top-level `permission` deny pattern in `opencode.json` and a matching allow pattern in each sub-agent's frontmatter:
+
+```jsonc
+// opencode.json
+{
+  "mcp": {
+    "capa":          { "type": "remote", "url": "…", "enabled": true },
+    "capa-reviewer": { "type": "remote", "url": "…", "enabled": true }
+  },
+  "permission": {
+    "capa-*_*": "deny"   // sub-agent MCPs hidden from primary sessions
+  }
+}
+```
+
+```markdown
+---
+name: reviewer
+mode: subagent
+permission:
+  "capa-reviewer_*": allow
+---
+```
+
+The pattern `capa-*_*` matches sub-agent MCP tool names (`capa-<id>_<tool>`) but intentionally **does not** match the main `capa_*` tools, so the primary session keeps full access to capa's main MCP. Any user-authored permission entries in `opencode.json` are preserved.
 
 ## Sources
 
@@ -23,5 +53,6 @@ Source-of-truth definition: [`src/shared/providers/registry.ts → opencode`](..
 - OpenCode config: <https://opencode.ai/docs/config/>
 - OpenCode skills: <https://opencode.ai/docs/skills/>
 - OpenCode agents: <https://opencode.ai/docs/agents/>
+- OpenCode MCP servers: <https://opencode.ai/docs/mcp-servers/>
 
 Last verified: 2026-06-08

--- a/docs/providers/opencode.md
+++ b/docs/providers/opencode.md
@@ -10,15 +10,49 @@ Source-of-truth definition: [`src/shared/providers/registry.ts → opencode`](..
 
 | Feature | Path | Notes |
 | --- | --- | --- |
-| Skills | `.agents/skills/<id>/` | Universal `.agents/skills/` layout. |
-| MCP | `.opencode/opencode.json` → `mcp.capa.url` | Top-level key is **`mcp`**, not `mcpServers`. Same shape as Crush. Supports sub-agent entries. |
-| Instructions | `AGENTS.md` | — |
+| Skills | `.agents/skills/<id>/` | OpenCode also reads `.opencode/skills/` and `.claude/skills/`; capa uses the universal `.agents/skills/` layout. |
+| MCP | `opencode.json` → `mcp.capa` | Project-root config per [OpenCode config docs](https://opencode.ai/docs/config/). Capa writes `{ type: "remote", url, enabled: true }`. Supports sub-agent entries. |
+| Instructions | `AGENTS.md` | OpenCode also supports an `instructions` array in `opencode.json`; capa uses the shared `AGENTS.md` marker blocks. |
 | Rules | folded into `AGENTS.md` | No project-local rules directory; rules become marker blocks. |
-| Sub-agents | `.opencode/agents/<id>.md` | Markdown + frontmatter. |
+| Sub-agents | `.opencode/agents/<id>.md` | Markdown + frontmatter; capa sets `mode: subagent` and emits a `permission` allow rule for the agent's own MCP (see scope fence below). |
 | Plugin manifests | — | Not declared. |
+
+## Sub-agent MCP scope fence
+
+OpenCode auto-exposes every entry under the top-level `mcp` key to all primary agents (Build, Plan, …) by default — see [MCP servers › Per agent](https://opencode.ai/docs/mcp-servers/#per-agent). Without scoping, every `capa-<id>` MCP that capa registers for a sub-agent would pollute the main session with sub-agent-only tool blocks.
+
+To prevent that, capa writes a top-level `permission` deny pattern in `opencode.json` and a matching allow pattern in each sub-agent's frontmatter:
+
+```jsonc
+// opencode.json
+{
+  "mcp": {
+    "capa":          { "type": "remote", "url": "…", "enabled": true },
+    "capa-reviewer": { "type": "remote", "url": "…", "enabled": true }
+  },
+  "permission": {
+    "capa-*_*": "deny"   // sub-agent MCPs hidden from primary sessions
+  }
+}
+```
+
+```markdown
+---
+name: reviewer
+mode: subagent
+permission:
+  "capa-reviewer_*": allow
+---
+```
+
+The pattern `capa-*_*` matches sub-agent MCP tool names (`capa-<id>_<tool>`) but intentionally **does not** match the main `capa_*` tools, so the primary session keeps full access to capa's main MCP. Any user-authored permission entries in `opencode.json` are preserved.
 
 ## Sources
 
 - OpenCode docs: <https://opencode.ai/docs/>
+- OpenCode config: <https://opencode.ai/docs/config/>
+- OpenCode skills: <https://opencode.ai/docs/skills/>
+- OpenCode agents: <https://opencode.ai/docs/agents/>
+- OpenCode MCP servers: <https://opencode.ai/docs/mcp-servers/>
 
-Last verified: 2026-05-23
+Last verified: 2026-06-08

--- a/docs/providers/opencode.md
+++ b/docs/providers/opencode.md
@@ -10,15 +10,18 @@ Source-of-truth definition: [`src/shared/providers/registry.ts → opencode`](..
 
 | Feature | Path | Notes |
 | --- | --- | --- |
-| Skills | `.agents/skills/<id>/` | Universal `.agents/skills/` layout. |
-| MCP | `.opencode/opencode.json` → `mcp.capa.url` | Top-level key is **`mcp`**, not `mcpServers`. Same shape as Crush. Supports sub-agent entries. |
-| Instructions | `AGENTS.md` | — |
+| Skills | `.agents/skills/<id>/` | OpenCode also reads `.opencode/skills/` and `.claude/skills/`; capa uses the universal `.agents/skills/` layout. |
+| MCP | `opencode.json` → `mcp.capa` | Project-root config per [OpenCode config docs](https://opencode.ai/docs/config/). Capa writes `{ type: "remote", url, enabled: true }`. Supports sub-agent entries. |
+| Instructions | `AGENTS.md` | OpenCode also supports an `instructions` array in `opencode.json`; capa uses the shared `AGENTS.md` marker blocks. |
 | Rules | folded into `AGENTS.md` | No project-local rules directory; rules become marker blocks. |
-| Sub-agents | `.opencode/agents/<id>.md` | Markdown + frontmatter. |
+| Sub-agents | `.opencode/agents/<id>.md` | Markdown + frontmatter; capa sets `mode: subagent`. |
 | Plugin manifests | — | Not declared. |
 
 ## Sources
 
 - OpenCode docs: <https://opencode.ai/docs/>
+- OpenCode config: <https://opencode.ai/docs/config/>
+- OpenCode skills: <https://opencode.ai/docs/skills/>
+- OpenCode agents: <https://opencode.ai/docs/agents/>
 
-Last verified: 2026-05-23
+Last verified: 2026-06-08

--- a/src/cli/utils/__tests__/sub-agent-mcp.test.ts
+++ b/src/cli/utils/__tests__/sub-agent-mcp.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, beforeEach, afterEach } from 'bun:test';
-import { existsSync, mkdtempSync, rmSync, readFileSync } from 'fs';
+import { existsSync, mkdtempSync, rmSync, readFileSync, writeFileSync } from 'fs';
 import { join } from 'path';
 import { tmpdir } from 'os';
 import {
@@ -111,5 +111,64 @@ describe('sub-agent MCP client registration', () => {
     const claudeConfig = readConfig(join(tempDir, '.mcp.json'));
     expect(claudeConfig.mcpServers['capa-infra-agent']).toBeDefined();
     expect(existsSync(join(tempDir, '.cursor', 'mcp.json'))).toBe(false);
+  });
+
+  it('writes the OpenCode sub-agent scope fence so per-sub-agent MCPs are not auto-exposed to primary sessions', async () => {
+    await registerMCPServer(tempDir, 'proj-1', 'http://localhost:5912/proj-1/mcp', ['opencode']);
+    await registerSubAgentMCPServer(
+      tempDir,
+      'reviewer',
+      'http://localhost:5912/proj-1/agents/reviewer/mcp',
+      ['opencode']
+    );
+
+    const config = readConfig(join(tempDir, 'opencode.json'));
+    // Main + sub-agent entries coexist with `enabled: true`.
+    expect(config.mcp.capa).toEqual({
+      type: 'remote',
+      url: 'http://localhost:5912/proj-1/mcp',
+      enabled: true,
+    });
+    expect(config.mcp['capa-reviewer']).toEqual({
+      type: 'remote',
+      url: 'http://localhost:5912/proj-1/agents/reviewer/mcp',
+      enabled: true,
+    });
+    // The fence denies sub-agent MCP tool exposure globally; `permission`
+    // is OpenCode's modern, glob-aware mechanism per their docs.
+    expect(config.permission).toEqual({ 'capa-*_*': 'deny' });
+  });
+
+  it('does not write a scope fence for providers that do not declare one (claude-code)', async () => {
+    await registerSubAgentMCPServer(
+      tempDir,
+      'infra-agent',
+      'http://localhost:5912/proj-1/agents/infra-agent/mcp',
+      ['claude-code']
+    );
+
+    const config = readConfig(join(tempDir, '.mcp.json'));
+    expect(config.permission).toBeUndefined();
+    expect(config.tools).toBeUndefined();
+  });
+
+  it('preserves user-authored permission keys when applying the OpenCode scope fence', async () => {
+    // Pre-existing user config with their own permission entries.
+    writeFileSync(
+      join(tempDir, 'opencode.json'),
+      JSON.stringify({
+        permission: { edit: 'ask', bash: 'allow' },
+      }),
+      'utf-8'
+    );
+
+    await registerMCPServer(tempDir, 'proj-1', 'http://localhost:5912/proj-1/mcp', ['opencode']);
+
+    const config = readConfig(join(tempDir, 'opencode.json'));
+    expect(config.permission).toEqual({
+      edit: 'ask',
+      bash: 'allow',
+      'capa-*_*': 'deny',
+    });
   });
 });

--- a/src/cli/utils/mcp-client-manager.ts
+++ b/src/cli/utils/mcp-client-manager.ts
@@ -3,6 +3,7 @@ import { join, dirname } from 'path';
 import { getProvider, getAllProviders } from '../../shared/providers';
 import { readTomlFile, writeTomlFile, setNestedKey, deleteNestedKey } from '../../shared/toml-io';
 import { getMcpConfigPath, buildMcpEntry } from '../../shared/providers/handlers';
+import type { McpIntegration } from '../../types/providers';
 import { taskLog } from '../ui';
 
 interface McpServerEntry {
@@ -51,6 +52,22 @@ function getServerMap(config: McpJsonConfig, serversKey: string): Record<string,
 }
 
 /**
+ * Apply the provider's optional sub-agent scope-fence at the top level of
+ * the MCP config. For OpenCode this writes
+ *   { permission: { 'capa-*_*': 'deny' } }
+ * so per-sub-agent MCP entries don't leak into the primary session. No-op
+ * for providers without `subAgentScopeFence`. Idempotent.
+ */
+function applySubAgentScopeFence(config: McpJsonConfig, mcp: McpIntegration): void {
+  const fence = mcp.subAgentScopeFence;
+  if (!fence) return;
+  const existing = config[fence.key];
+  const block: Record<string, unknown> = isPlainObject(existing) ? { ...existing } : {};
+  block[fence.pattern] = fence.value;
+  config[fence.key] = block;
+}
+
+/**
  * Register MCP server with client configuration files
  */
 export async function registerMCPServer(
@@ -92,6 +109,7 @@ export async function registerMCPServer(
         }
         const servers = getServerMap(config, mcp.serversKey);
         servers[mcp.serverKey] = buildMcpEntry(mcp, mcpUrl) as McpServerEntry;
+        applySubAgentScopeFence(config, mcp);
         writeFileSync(configPath, JSON.stringify(config, null, 2), 'utf-8');
       } else if (mcp.format === 'toml') {
         const config = readTomlFile(configPath);
@@ -140,6 +158,7 @@ export async function registerSubAgentMCPServer(
         }
         const servers = getServerMap(config, mcp.serversKey);
         servers[serverKey] = buildMcpEntry(mcp, mcpUrl) as McpServerEntry;
+        applySubAgentScopeFence(config, mcp);
         writeFileSync(configPath, JSON.stringify(config, null, 2), 'utf-8');
       } else if (mcp.format === 'toml') {
         const config = readTomlFile(configPath);

--- a/src/server/__tests__/stdio-client-transport.test.ts
+++ b/src/server/__tests__/stdio-client-transport.test.ts
@@ -1,34 +1,27 @@
-import { describe, it, expect, mock, beforeEach } from 'bun:test';
-
-const spawnCalls: Array<{ command: string; args: string[]; options: Record<string, unknown> }> = [];
-
-mock.module('cross-spawn', () => ({
-  default: (command: string, args: string[], options: Record<string, unknown>) => {
-    spawnCalls.push({ command, args, options });
-    const proc = {
-      pid: 12345,
-      stdin: { write: () => true, on: () => {}, once: () => {} },
-      stdout: { on: () => {} },
-      stderr: null,
-      on: (event: string, cb: (...args: unknown[]) => void) => {
-        if (event === 'spawn') {
-          queueMicrotask(() => cb());
-        }
-      },
-      kill: () => {},
-    };
-    return proc;
-  },
-}));
-
-const { HiddenStdioClientTransport } = await import('../stdio-client-transport');
+import { describe, it, expect, beforeEach, spyOn } from 'bun:test';
+import * as childProcess from 'node:child_process';
+import { HiddenStdioClientTransport } from '../stdio-client-transport';
 
 describe('HiddenStdioClientTransport', () => {
   beforeEach(() => {
-    spawnCalls.length = 0;
+    // no-op; spy restored after each test
   });
 
   it('passes windowsHide: true when spawning the MCP server process', async () => {
+    const spawnSpy = spyOn(childProcess, 'spawn').mockImplementation(((
+      command: string,
+      args: readonly string[] | undefined,
+      options: childProcess.SpawnOptions
+    ) => {
+      expect(command).toBe('npx');
+      expect(options.windowsHide).toBe(true);
+      const { EventEmitter } = require('events');
+      const proc = new EventEmitter() as childProcess.ChildProcess;
+      Object.assign(proc, { pid: 12345, stdin: { write: () => true, on: () => {}, once: () => {} }, stdout: { on: () => {} }, stderr: null });
+      queueMicrotask(() => proc.emit('spawn'));
+      return proc;
+    }) as typeof childProcess.spawn);
+
     const transport = new HiddenStdioClientTransport({
       command: 'npx',
       args: ['-y', 'some-mcp-server'],
@@ -37,8 +30,7 @@ describe('HiddenStdioClientTransport', () => {
 
     await transport.start();
 
-    expect(spawnCalls).toHaveLength(1);
-    expect(spawnCalls[0].command).toBe('npx');
-    expect(spawnCalls[0].options.windowsHide).toBe(true);
+    expect(spawnSpy).toHaveBeenCalled();
+    spawnSpy.mockRestore();
   });
 });

--- a/src/server/__tests__/stdio-client-transport.test.ts
+++ b/src/server/__tests__/stdio-client-transport.test.ts
@@ -1,0 +1,36 @@
+import { describe, it, expect, beforeEach, spyOn } from 'bun:test';
+import * as childProcess from 'node:child_process';
+import { HiddenStdioClientTransport } from '../stdio-client-transport';
+
+describe('HiddenStdioClientTransport', () => {
+  beforeEach(() => {
+    // no-op; spy restored after each test
+  });
+
+  it('passes windowsHide: true when spawning the MCP server process', async () => {
+    const spawnSpy = spyOn(childProcess, 'spawn').mockImplementation(((
+      command: string,
+      args: readonly string[] | undefined,
+      options: childProcess.SpawnOptions
+    ) => {
+      expect(command).toBe('npx');
+      expect(options.windowsHide).toBe(true);
+      const { EventEmitter } = require('events');
+      const proc = new EventEmitter() as childProcess.ChildProcess;
+      Object.assign(proc, { pid: 12345, stdin: { write: () => true, on: () => {}, once: () => {} }, stdout: { on: () => {} }, stderr: null });
+      queueMicrotask(() => proc.emit('spawn'));
+      return proc;
+    }) as typeof childProcess.spawn);
+
+    const transport = new HiddenStdioClientTransport({
+      command: 'npx',
+      args: ['-y', 'some-mcp-server'],
+      stderr: 'pipe',
+    });
+
+    await transport.start();
+
+    expect(spawnSpy).toHaveBeenCalled();
+    spawnSpy.mockRestore();
+  });
+});

--- a/src/server/__tests__/stdio-client-transport.test.ts
+++ b/src/server/__tests__/stdio-client-transport.test.ts
@@ -1,0 +1,44 @@
+import { describe, it, expect, mock, beforeEach } from 'bun:test';
+
+const spawnCalls: Array<{ command: string; args: string[]; options: Record<string, unknown> }> = [];
+
+mock.module('cross-spawn', () => ({
+  default: (command: string, args: string[], options: Record<string, unknown>) => {
+    spawnCalls.push({ command, args, options });
+    const proc = {
+      pid: 12345,
+      stdin: { write: () => true, on: () => {}, once: () => {} },
+      stdout: { on: () => {} },
+      stderr: null,
+      on: (event: string, cb: (...args: unknown[]) => void) => {
+        if (event === 'spawn') {
+          queueMicrotask(() => cb());
+        }
+      },
+      kill: () => {},
+    };
+    return proc;
+  },
+}));
+
+const { HiddenStdioClientTransport } = await import('../stdio-client-transport');
+
+describe('HiddenStdioClientTransport', () => {
+  beforeEach(() => {
+    spawnCalls.length = 0;
+  });
+
+  it('passes windowsHide: true when spawning the MCP server process', async () => {
+    const transport = new HiddenStdioClientTransport({
+      command: 'npx',
+      args: ['-y', 'some-mcp-server'],
+      stderr: 'pipe',
+    });
+
+    await transport.start();
+
+    expect(spawnCalls).toHaveLength(1);
+    expect(spawnCalls[0].command).toBe('npx');
+    expect(spawnCalls[0].options.windowsHide).toBe(true);
+  });
+});

--- a/src/server/__tests__/subprocess-manager.test.ts
+++ b/src/server/__tests__/subprocess-manager.test.ts
@@ -1,7 +1,8 @@
-import { describe, it, expect, beforeEach, afterEach } from 'bun:test';
+import { describe, it, expect, beforeEach, afterEach, spyOn } from 'bun:test';
 import { mkdtempSync, rmSync } from 'fs';
 import { join } from 'path';
 import { tmpdir } from 'os';
+import * as childProcess from 'child_process';
 import { CapaDatabase } from '../../db/database';
 import { SubprocessManager } from '../subprocess-manager';
 import type { MCPServerDefinition } from '../../types/capabilities';
@@ -53,5 +54,31 @@ describe('SubprocessManager', () => {
     expect(createCount).toBe(1);
     expect(first.id).toBe('server-a');
     expect(second.id).toBe('server-a');
+  });
+
+  it('spawns subprocesses with windowsHide: true', async () => {
+    const spawnSpy = spyOn(childProcess, 'spawn').mockImplementation(((
+      _cmd: string,
+      _args: string[],
+      options: { windowsHide?: boolean }
+    ) => {
+      expect(options.windowsHide).toBe(true);
+      const { EventEmitter } = require('events');
+      const proc = new EventEmitter() as any;
+      proc.pid = 99999;
+      proc.stdin = { on: () => {}, end: () => {} };
+      proc.stdout = { on: () => {} };
+      proc.stderr = { on: () => {} };
+      proc.killed = false;
+      proc.kill = () => {
+        proc.killed = true;
+      };
+      queueMicrotask(() => proc.emit('spawn'));
+      return proc;
+    }) as typeof childProcess.spawn);
+
+    await manager.getOrCreateSubprocess('server-b', definition, tempDir);
+    expect(spawnSpy).toHaveBeenCalled();
+    spawnSpy.mockRestore();
   });
 });

--- a/src/server/__tests__/tool-executor.test.ts
+++ b/src/server/__tests__/tool-executor.test.ts
@@ -1,4 +1,5 @@
-import { describe, it, expect, beforeAll, afterAll } from 'bun:test';
+import { describe, it, expect, beforeAll, afterAll, spyOn } from 'bun:test';
+import * as childProcess from 'child_process';
 import { CommandToolExecutor } from '../tool-executor';
 import { CapaDatabase } from '../../db/database';
 import { mkdtempSync, rmSync } from 'fs';
@@ -180,6 +181,44 @@ describe('CommandToolExecutor', () => {
       const result = await executor.execute('test-tool', def, {});
       expect(result.success).toBe(true);
       expect(result.result?.trim()).toBe('done');
+    });
+  });
+
+  describe('windows spawn options', () => {
+    it('passes windowsHide: true when spawning command tools', async () => {
+      const spawnSpy = spyOn(childProcess, 'spawn').mockImplementation(((
+        command: string,
+        args: string[] | childProcess.SpawnOptions,
+        options?: childProcess.SpawnOptions
+      ) => {
+        const isWindows = process.platform === 'win32';
+        if (isWindows) {
+          expect(command).toBe('cmd.exe');
+          expect(args).toEqual(['/d', '/s', '/c', 'echo hello']);
+          expect(options?.windowsHide).toBe(true);
+        } else {
+          expect(typeof args).toBe('object');
+          expect((args as childProcess.SpawnOptions).windowsHide).toBe(true);
+        }
+        const { EventEmitter } = require('events');
+        const proc = new EventEmitter() as any;
+        proc.stdout = { on: (_: string, cb: (d: Buffer) => void) => cb(Buffer.from('hello\n')) };
+        proc.stderr = { on: () => {} };
+        queueMicrotask(() => proc.emit('exit', 0));
+        return proc;
+      }) as typeof childProcess.spawn);
+
+      const def: ToolCommandDefinition = {
+        run: {
+          cmd: 'echo hello',
+          args: [],
+        },
+      };
+
+      const result = await executor.execute('spawn-test', def, {});
+      expect(result.success).toBe(true);
+      expect(spawnSpy).toHaveBeenCalled();
+      spawnSpy.mockRestore();
     });
   });
 });

--- a/src/server/mcp-proxy.ts
+++ b/src/server/mcp-proxy.ts
@@ -1,5 +1,5 @@
 import { Client } from '@modelcontextprotocol/sdk/client/index.js';
-import { StdioClientTransport } from '@modelcontextprotocol/sdk/client/stdio.js';
+import { HiddenStdioClientTransport as StdioClientTransport } from './stdio-client-transport';
 import { Transport } from '@modelcontextprotocol/sdk/shared/transport.js';
 import type { JSONRPCMessage } from '@modelcontextprotocol/sdk/types.js';
 import type { CapaDatabase } from '../db/database';

--- a/src/server/stdio-client-transport.ts
+++ b/src/server/stdio-client-transport.ts
@@ -1,4 +1,4 @@
-import spawn from 'cross-spawn';
+import { spawn, type ChildProcess } from 'node:child_process';
 import { PassThrough } from 'node:stream';
 import type { IOType } from 'node:child_process';
 import type { Stream } from 'node:stream';
@@ -21,7 +21,7 @@ export type HiddenStdioServerParameters = {
  * a cmd.exe window on Windows (capa runs outside Electron).
  */
 export class HiddenStdioClientTransport implements Transport {
-  private _process?: ReturnType<typeof spawn>;
+  private _process?: ChildProcess;
   private _readBuffer = new ReadBuffer();
   private _serverParams: HiddenStdioServerParameters;
   private _stderrStream: PassThrough | null = null;
@@ -56,7 +56,7 @@ export class HiddenStdioClientTransport implements Transport {
         cwd: this._serverParams.cwd,
       });
 
-      this._process.on('error', (error) => {
+      this._process.on('error', (error: Error) => {
         reject(error);
         this.onerror?.(error);
       });
@@ -70,16 +70,16 @@ export class HiddenStdioClientTransport implements Transport {
         this.onclose?.();
       });
 
-      this._process.stdin?.on('error', (error) => {
+      this._process.stdin?.on('error', (error: Error) => {
         this.onerror?.(error);
       });
 
-      this._process.stdout?.on('data', (chunk) => {
+      this._process.stdout?.on('data', (chunk: Buffer) => {
         this._readBuffer.append(chunk);
         this.processReadBuffer();
       });
 
-      this._process.stdout?.on('error', (error) => {
+      this._process.stdout?.on('error', (error: Error) => {
         this.onerror?.(error);
       });
 

--- a/src/server/stdio-client-transport.ts
+++ b/src/server/stdio-client-transport.ts
@@ -1,0 +1,170 @@
+import { spawn, type ChildProcess } from 'node:child_process';
+import { PassThrough } from 'node:stream';
+import type { IOType } from 'node:child_process';
+import type { Stream } from 'node:stream';
+import { ReadBuffer, serializeMessage } from '@modelcontextprotocol/sdk/shared/stdio.js';
+import { getDefaultEnvironment } from '@modelcontextprotocol/sdk/client/stdio.js';
+import type { Transport } from '@modelcontextprotocol/sdk/shared/transport.js';
+import type { JSONRPCMessage } from '@modelcontextprotocol/sdk/types.js';
+
+export type HiddenStdioServerParameters = {
+  command: string;
+  args?: string[];
+  env?: Record<string, string>;
+  stderr?: IOType | Stream | number;
+  cwd?: string;
+};
+
+/**
+ * Stdio MCP client transport identical to the SDK's {@link StdioClientTransport}
+ * except it always passes `windowsHide: true` so stdio MCP servers do not flash
+ * a cmd.exe window on Windows (capa runs outside Electron).
+ */
+export class HiddenStdioClientTransport implements Transport {
+  private _process?: ChildProcess;
+  private _readBuffer = new ReadBuffer();
+  private _serverParams: HiddenStdioServerParameters;
+  private _stderrStream: PassThrough | null = null;
+
+  onclose?: () => void;
+  onerror?: (error: Error) => void;
+  onmessage?: (message: JSONRPCMessage) => void;
+
+  constructor(server: HiddenStdioServerParameters) {
+    this._serverParams = server;
+    if (server.stderr === 'pipe' || server.stderr === 'overlapped') {
+      this._stderrStream = new PassThrough();
+    }
+  }
+
+  async start(): Promise<void> {
+    if (this._process) {
+      throw new Error(
+        'HiddenStdioClientTransport already started! If using Client class, note that connect() calls start() automatically.'
+      );
+    }
+
+    return new Promise((resolve, reject) => {
+      this._process = spawn(this._serverParams.command, this._serverParams.args ?? [], {
+        env: {
+          ...getDefaultEnvironment(),
+          ...this._serverParams.env,
+        },
+        stdio: ['pipe', 'pipe', this._serverParams.stderr ?? 'inherit'],
+        shell: false,
+        windowsHide: true,
+        cwd: this._serverParams.cwd,
+      });
+
+      this._process.on('error', (error: Error) => {
+        reject(error);
+        this.onerror?.(error);
+      });
+
+      this._process.on('spawn', () => {
+        resolve();
+      });
+
+      this._process.on('close', () => {
+        this._process = undefined;
+        this.onclose?.();
+      });
+
+      this._process.stdin?.on('error', (error: Error) => {
+        this.onerror?.(error);
+      });
+
+      this._process.stdout?.on('data', (chunk: Buffer) => {
+        this._readBuffer.append(chunk);
+        this.processReadBuffer();
+      });
+
+      this._process.stdout?.on('error', (error: Error) => {
+        this.onerror?.(error);
+      });
+
+      if (this._stderrStream && this._process.stderr) {
+        this._process.stderr.pipe(this._stderrStream);
+      }
+    });
+  }
+
+  get stderr(): Stream | null {
+    if (this._stderrStream) {
+      return this._stderrStream;
+    }
+    return this._process?.stderr ?? null;
+  }
+
+  get pid(): number | null {
+    return this._process?.pid ?? null;
+  }
+
+  private processReadBuffer(): void {
+    while (true) {
+      try {
+        const message = this._readBuffer.readMessage();
+        if (message === null) {
+          break;
+        }
+        this.onmessage?.(message);
+      } catch (error) {
+        this.onerror?.(error as Error);
+      }
+    }
+  }
+
+  async close(): Promise<void> {
+    if (this._process) {
+      const processToClose = this._process;
+      this._process = undefined;
+      const closePromise = new Promise<void>((resolve) => {
+        processToClose.once('close', () => {
+          resolve();
+        });
+      });
+      try {
+        processToClose.stdin?.end();
+      } catch {
+        // ignore
+      }
+      await Promise.race([
+        closePromise,
+        new Promise<void>((resolve) => setTimeout(resolve, 2000).unref()),
+      ]);
+      if (processToClose.exitCode === null) {
+        try {
+          processToClose.kill('SIGTERM');
+        } catch {
+          // ignore
+        }
+        await Promise.race([
+          closePromise,
+          new Promise<void>((resolve) => setTimeout(resolve, 2000).unref()),
+        ]);
+      }
+      if (processToClose.exitCode === null) {
+        try {
+          processToClose.kill('SIGKILL');
+        } catch {
+          // ignore
+        }
+      }
+    }
+    this._readBuffer.clear();
+  }
+
+  send(message: JSONRPCMessage): Promise<void> {
+    return new Promise((resolve) => {
+      if (!this._process?.stdin) {
+        throw new Error('Not connected');
+      }
+      const json = serializeMessage(message);
+      if (this._process.stdin.write(json)) {
+        resolve();
+      } else {
+        this._process.stdin.once('drain', resolve);
+      }
+    });
+  }
+}

--- a/src/server/stdio-client-transport.ts
+++ b/src/server/stdio-client-transport.ts
@@ -1,0 +1,170 @@
+import spawn from 'cross-spawn';
+import { PassThrough } from 'node:stream';
+import type { IOType } from 'node:child_process';
+import type { Stream } from 'node:stream';
+import { ReadBuffer, serializeMessage } from '@modelcontextprotocol/sdk/shared/stdio.js';
+import { getDefaultEnvironment } from '@modelcontextprotocol/sdk/client/stdio.js';
+import type { Transport } from '@modelcontextprotocol/sdk/shared/transport.js';
+import type { JSONRPCMessage } from '@modelcontextprotocol/sdk/types.js';
+
+export type HiddenStdioServerParameters = {
+  command: string;
+  args?: string[];
+  env?: Record<string, string>;
+  stderr?: IOType | Stream | number;
+  cwd?: string;
+};
+
+/**
+ * Stdio MCP client transport identical to the SDK's {@link StdioClientTransport}
+ * except it always passes `windowsHide: true` so stdio MCP servers do not flash
+ * a cmd.exe window on Windows (capa runs outside Electron).
+ */
+export class HiddenStdioClientTransport implements Transport {
+  private _process?: ReturnType<typeof spawn>;
+  private _readBuffer = new ReadBuffer();
+  private _serverParams: HiddenStdioServerParameters;
+  private _stderrStream: PassThrough | null = null;
+
+  onclose?: () => void;
+  onerror?: (error: Error) => void;
+  onmessage?: (message: JSONRPCMessage) => void;
+
+  constructor(server: HiddenStdioServerParameters) {
+    this._serverParams = server;
+    if (server.stderr === 'pipe' || server.stderr === 'overlapped') {
+      this._stderrStream = new PassThrough();
+    }
+  }
+
+  async start(): Promise<void> {
+    if (this._process) {
+      throw new Error(
+        'HiddenStdioClientTransport already started! If using Client class, note that connect() calls start() automatically.'
+      );
+    }
+
+    return new Promise((resolve, reject) => {
+      this._process = spawn(this._serverParams.command, this._serverParams.args ?? [], {
+        env: {
+          ...getDefaultEnvironment(),
+          ...this._serverParams.env,
+        },
+        stdio: ['pipe', 'pipe', this._serverParams.stderr ?? 'inherit'],
+        shell: false,
+        windowsHide: true,
+        cwd: this._serverParams.cwd,
+      });
+
+      this._process.on('error', (error) => {
+        reject(error);
+        this.onerror?.(error);
+      });
+
+      this._process.on('spawn', () => {
+        resolve();
+      });
+
+      this._process.on('close', () => {
+        this._process = undefined;
+        this.onclose?.();
+      });
+
+      this._process.stdin?.on('error', (error) => {
+        this.onerror?.(error);
+      });
+
+      this._process.stdout?.on('data', (chunk) => {
+        this._readBuffer.append(chunk);
+        this.processReadBuffer();
+      });
+
+      this._process.stdout?.on('error', (error) => {
+        this.onerror?.(error);
+      });
+
+      if (this._stderrStream && this._process.stderr) {
+        this._process.stderr.pipe(this._stderrStream);
+      }
+    });
+  }
+
+  get stderr(): Stream | null {
+    if (this._stderrStream) {
+      return this._stderrStream;
+    }
+    return this._process?.stderr ?? null;
+  }
+
+  get pid(): number | null {
+    return this._process?.pid ?? null;
+  }
+
+  private processReadBuffer(): void {
+    while (true) {
+      try {
+        const message = this._readBuffer.readMessage();
+        if (message === null) {
+          break;
+        }
+        this.onmessage?.(message);
+      } catch (error) {
+        this.onerror?.(error as Error);
+      }
+    }
+  }
+
+  async close(): Promise<void> {
+    if (this._process) {
+      const processToClose = this._process;
+      this._process = undefined;
+      const closePromise = new Promise<void>((resolve) => {
+        processToClose.once('close', () => {
+          resolve();
+        });
+      });
+      try {
+        processToClose.stdin?.end();
+      } catch {
+        // ignore
+      }
+      await Promise.race([
+        closePromise,
+        new Promise<void>((resolve) => setTimeout(resolve, 2000).unref()),
+      ]);
+      if (processToClose.exitCode === null) {
+        try {
+          processToClose.kill('SIGTERM');
+        } catch {
+          // ignore
+        }
+        await Promise.race([
+          closePromise,
+          new Promise<void>((resolve) => setTimeout(resolve, 2000).unref()),
+        ]);
+      }
+      if (processToClose.exitCode === null) {
+        try {
+          processToClose.kill('SIGKILL');
+        } catch {
+          // ignore
+        }
+      }
+    }
+    this._readBuffer.clear();
+  }
+
+  send(message: JSONRPCMessage): Promise<void> {
+    return new Promise((resolve) => {
+      if (!this._process?.stdin) {
+        throw new Error('Not connected');
+      }
+      const json = serializeMessage(message);
+      if (this._process.stdin.write(json)) {
+        resolve();
+      } else {
+        this._process.stdin.once('drain', resolve);
+      }
+    });
+  }
+}

--- a/src/server/subprocess-manager.ts
+++ b/src/server/subprocess-manager.ts
@@ -129,6 +129,7 @@ export class SubprocessManager {
       stdio: ['pipe', 'pipe', 'pipe'],
       detached: false,
       cwd,
+      windowsHide: true,
     });
 
     info.process = proc;

--- a/src/server/tool-executor.ts
+++ b/src/server/tool-executor.ts
@@ -109,13 +109,24 @@ export class CommandToolExecutor {
     this.logger.info(`          Working directory: ${cwd}`);
 
     // Execute command
+    const env = { ...process.env, ...spec.env };
+    const isWindows = process.platform === 'win32';
+
     return new Promise((resolve) => {
-      const proc = spawn(cmd, {
-        cwd,
-        env: { ...process.env, ...spec.env },
-        shell: true,
-        timeout: 60000, // 60 second timeout
-      });
+      const proc = isWindows
+        ? spawn('cmd.exe', ['/d', '/s', '/c', cmd], {
+            cwd,
+            env,
+            windowsHide: true,
+            timeout: 60000,
+          })
+        : spawn(cmd, {
+            cwd,
+            env,
+            shell: true,
+            windowsHide: true,
+            timeout: 60000,
+          });
 
       let stdout = '';
       let stderr = '';

--- a/src/shared/cache/__tests__/git-cli.test.ts
+++ b/src/shared/cache/__tests__/git-cli.test.ts
@@ -1,5 +1,6 @@
-import { describe, it, expect } from 'bun:test';
-import { LFS_SKIP_ARGS, gitCommandArgs } from '../git-cli';
+import { describe, it, expect, spyOn } from 'bun:test';
+import * as childProcess from 'child_process';
+import { LFS_SKIP_ARGS, gitCommandArgs, git } from '../git-cli';
 
 describe('git-cli', () => {
   it('prepends LFS skip flags on clone --mirror', () => {
@@ -26,5 +27,18 @@ describe('git-cli', () => {
     expect(args.slice(0, 8)).toEqual(LFS_SKIP_ARGS);
     expect(args).toContain('worktree');
     expect(args).toContain('add');
+  });
+
+  it('passes windowsHide: true to execFile so git subprocesses never flash a console on Windows', async () => {
+    const execFileSpy = spyOn(childProcess, 'execFile').mockImplementation(
+      ((_cmd: string, _args: string[], opts: object, cb: (err: null, result: { stdout: string; stderr: string }) => void) => {
+        expect((opts as { windowsHide?: boolean }).windowsHide).toBe(true);
+        cb(null, { stdout: '', stderr: '' });
+      }) as typeof childProcess.execFile
+    );
+
+    await git(['version']);
+    expect(execFileSpy).toHaveBeenCalled();
+    execFileSpy.mockRestore();
   });
 });

--- a/src/shared/cache/__tests__/git-cli.test.ts
+++ b/src/shared/cache/__tests__/git-cli.test.ts
@@ -1,0 +1,30 @@
+import { describe, it, expect } from 'bun:test';
+import { LFS_SKIP_ARGS, gitCommandArgs } from '../git-cli';
+
+describe('git-cli', () => {
+  it('prepends LFS skip flags on clone --mirror', () => {
+    expect(gitCommandArgs(['clone', '--mirror', 'https://example.com/repo.git', '/tmp/mirror'])).toEqual([
+      ...LFS_SKIP_ARGS,
+      'clone',
+      '--mirror',
+      'https://example.com/repo.git',
+      '/tmp/mirror',
+    ]);
+  });
+
+  it('prepends LFS skip flags on worktree add', () => {
+    const args = gitCommandArgs([
+      '-C',
+      '/tmp/mirror',
+      'worktree',
+      'add',
+      '--detach',
+      '--force',
+      '/tmp/snap',
+      'abc123',
+    ]);
+    expect(args.slice(0, 8)).toEqual(LFS_SKIP_ARGS);
+    expect(args).toContain('worktree');
+    expect(args).toContain('add');
+  });
+});

--- a/src/shared/cache/git-cli.ts
+++ b/src/shared/cache/git-cli.ts
@@ -1,4 +1,5 @@
-import { execFile, type ExecFileOptions } from 'child_process';
+import * as childProcess from 'child_process';
+import type { ExecFileOptions } from 'child_process';
 import { promisify } from 'util';
 
 /** Git -c flags that disable LFS smudge/clean so clones work without git-lfs or LFS API access. */
@@ -13,8 +14,6 @@ export const LFS_SKIP_ARGS = [
   'filter.lfs.required=false',
 ];
 
-const execFileAsync = promisify(execFile);
-
 /**
  * Run git with LFS filters disabled. Skills only need text files (SKILL.md, etc.),
  * never LFS-backed binary blobs.
@@ -27,6 +26,7 @@ export async function git(
   args: string[],
   opts: ExecFileOptions = {}
 ): Promise<{ stdout: string; stderr: string }> {
+  const execFileAsync = promisify(childProcess.execFile);
   const { stdout, stderr } = await execFileAsync('git', gitCommandArgs(args), {
     ...opts,
     windowsHide: true,

--- a/src/shared/cache/git-cli.ts
+++ b/src/shared/cache/git-cli.ts
@@ -1,0 +1,35 @@
+import { execFile, type ExecFileOptions } from 'child_process';
+import { promisify } from 'util';
+
+/** Git -c flags that disable LFS smudge/clean so clones work without git-lfs or LFS API access. */
+export const LFS_SKIP_ARGS = [
+  '-c',
+  'filter.lfs.smudge=',
+  '-c',
+  'filter.lfs.clean=',
+  '-c',
+  'filter.lfs.process=',
+  '-c',
+  'filter.lfs.required=false',
+];
+
+const execFileAsync = promisify(execFile);
+
+/**
+ * Run git with LFS filters disabled. Skills only need text files (SKILL.md, etc.),
+ * never LFS-backed binary blobs.
+ */
+export function gitCommandArgs(args: string[]): string[] {
+  return [...LFS_SKIP_ARGS, ...args];
+}
+
+export async function git(
+  args: string[],
+  opts: ExecFileOptions = {}
+): Promise<{ stdout: string; stderr: string }> {
+  const { stdout, stderr } = await execFileAsync('git', gitCommandArgs(args), {
+    ...opts,
+    env: { ...process.env, GIT_LFS_SKIP_SMUDGE: '1', ...(opts.env ?? {}) },
+  });
+  return { stdout: String(stdout), stderr: String(stderr) };
+}

--- a/src/shared/cache/git-cli.ts
+++ b/src/shared/cache/git-cli.ts
@@ -29,6 +29,7 @@ export async function git(
 ): Promise<{ stdout: string; stderr: string }> {
   const { stdout, stderr } = await execFileAsync('git', gitCommandArgs(args), {
     ...opts,
+    windowsHide: true,
     env: { ...process.env, GIT_LFS_SKIP_SMUDGE: '1', ...(opts.env ?? {}) },
   });
   return { stdout: String(stdout), stderr: String(stderr) };

--- a/src/shared/cache/mirror.ts
+++ b/src/shared/cache/mirror.ts
@@ -1,6 +1,4 @@
 import { existsSync, mkdirSync } from 'fs';
-import { execFile } from 'child_process';
-import { promisify } from 'util';
 import type { AuthenticatedFetch } from '../authenticated-fetch';
 import { validateRepoPath } from './validate';
 import {
@@ -8,14 +6,7 @@ import {
   getRepoCacheDir,
   getRepoMirrorDir,
 } from './paths';
-
-// Argv-array form of execFile (no shell interpretation) so user-controlled
-// repo paths, refs, and URLs can never inject shell metacharacters.
-const execFileAsync = promisify(execFile);
-
-async function git(args: string[]): Promise<{ stdout: string; stderr: string }> {
-  return execFileAsync('git', args);
-}
+import { git } from './git-cli';
 
 /**
  * Build the authenticated git URL for cloning, embedding an OAuth token when

--- a/src/shared/cache/snapshot.ts
+++ b/src/shared/cache/snapshot.ts
@@ -1,7 +1,5 @@
 import { existsSync, mkdirSync, rmSync } from 'fs';
 import { join } from 'path';
-import { execFile } from 'child_process';
-import { promisify } from 'util';
 import type { AuthenticatedFetch } from '../authenticated-fetch';
 import { validateRepoPath } from './validate';
 import {
@@ -14,11 +12,7 @@ import {
   resolveRef,
   type ResolveOptions,
 } from './mirror';
-
-const execFileAsync = promisify(execFile);
-async function git(args: string[]): Promise<{ stdout: string; stderr: string }> {
-  return execFileAsync('git', args);
-}
+import { git } from './git-cli';
 
 /**
  * Materialize a snapshot directory at the given SHA from a mirror clone. If

--- a/src/shared/providers/__tests__/registry.test.ts
+++ b/src/shared/providers/__tests__/registry.test.ts
@@ -766,15 +766,25 @@ describe('GitHub Copilot integration', () => {
 });
 
 describe('OpenCode integration', () => {
-  it('has MCP integration (.opencode/opencode.json)', () => {
+  it('has MCP integration (opencode.json)', () => {
     const oc = getProvider('opencode')!;
     expect(oc.mcp).toBeDefined();
-    expect(oc.mcp!.configPath).toBe('.opencode/opencode.json');
+    expect(oc.mcp!.configPath).toBe('opencode.json');
     expect(oc.mcp!.format).toBe('json');
     expect(oc.mcp!.serversKey).toBe('mcp');
     expect(oc.mcp!.serverKey).toBe('capa');
     expect(oc.mcp!.entryType).toBe('remote');
+    expect(oc.mcp!.entryExtraFields).toEqual({ enabled: true });
     expect(oc.mcp!.supportsSubAgentEntries).toBe(true);
+  });
+
+  it('buildMcpEntry includes type, url, and enabled', () => {
+    const oc = getProvider('opencode')!;
+    expect(buildMcpEntry(oc.mcp!, 'http://x/mcp')).toEqual({
+      type: 'remote',
+      url: 'http://x/mcp',
+      enabled: true,
+    });
   });
 
   it('has instructions integration (AGENTS.md)', () => {
@@ -789,6 +799,7 @@ describe('OpenCode integration', () => {
     expect(oc.subagents!.dir).toBe('.opencode/agents');
     expect(oc.subagents!.extension).toBe('.md');
     expect(oc.subagents!.format).toBe('markdown-frontmatter');
+    expect(oc.subagents!.fields).toEqual({ mode: 'subagent' });
   });
 });
 

--- a/src/shared/providers/__tests__/registry.test.ts
+++ b/src/shared/providers/__tests__/registry.test.ts
@@ -766,15 +766,34 @@ describe('GitHub Copilot integration', () => {
 });
 
 describe('OpenCode integration', () => {
-  it('has MCP integration (.opencode/opencode.json)', () => {
+  it('has MCP integration (opencode.json)', () => {
     const oc = getProvider('opencode')!;
     expect(oc.mcp).toBeDefined();
-    expect(oc.mcp!.configPath).toBe('.opencode/opencode.json');
+    expect(oc.mcp!.configPath).toBe('opencode.json');
     expect(oc.mcp!.format).toBe('json');
     expect(oc.mcp!.serversKey).toBe('mcp');
     expect(oc.mcp!.serverKey).toBe('capa');
     expect(oc.mcp!.entryType).toBe('remote');
+    expect(oc.mcp!.entryExtraFields).toEqual({ enabled: true });
     expect(oc.mcp!.supportsSubAgentEntries).toBe(true);
+  });
+
+  it('declares a sub-agent scope fence so per-sub-agent MCPs are not exposed to primary sessions', () => {
+    const oc = getProvider('opencode')!;
+    expect(oc.mcp!.subAgentScopeFence).toEqual({
+      key: 'permission',
+      pattern: 'capa-*_*',
+      value: 'deny',
+    });
+  });
+
+  it('buildMcpEntry includes type, url, and enabled', () => {
+    const oc = getProvider('opencode')!;
+    expect(buildMcpEntry(oc.mcp!, 'http://x/mcp')).toEqual({
+      type: 'remote',
+      url: 'http://x/mcp',
+      enabled: true,
+    });
   });
 
   it('has instructions integration (AGENTS.md)', () => {
@@ -789,6 +808,42 @@ describe('OpenCode integration', () => {
     expect(oc.subagents!.dir).toBe('.opencode/agents');
     expect(oc.subagents!.extension).toBe('.md');
     expect(oc.subagents!.format).toBe('markdown-frontmatter');
+    expect(oc.subagents!.fields).toEqual({ mode: 'subagent' });
+  });
+
+  it('declares a per-sub-agent allow rule that re-opens its own MCP tools', () => {
+    const oc = getProvider('opencode')!;
+    expect(oc.subagents!.perAgentToolScope).toEqual({
+      key: 'permission',
+      patternTemplate: 'capa-{id}_*',
+      value: 'allow',
+    });
+  });
+
+  it('buildSubAgentFile emits the per-sub-agent permission allow in frontmatter', () => {
+    const oc = getProvider('opencode')!;
+    const subAgent = {
+      id: 'reviewer',
+      description: 'Reviews PRs',
+      skills: [],
+      tools: [],
+      instructions: 'Be thorough.',
+    };
+    const capabilities = {
+      providers: ['opencode'],
+      skills: [],
+      servers: [],
+      tools: [],
+    };
+
+    const result = buildSubAgentFile(oc, subAgent, capabilities);
+
+    expect(result).toContain('mode: subagent');
+    expect(result).toContain('permission:');
+    expect(result).toContain('"capa-reviewer_*": allow');
+    // The fence pattern must NOT appear in the agent file — that's the
+    // global deny, agents only carry the allow.
+    expect(result).not.toContain('capa-*_*');
   });
 });
 

--- a/src/shared/providers/__tests__/registry.test.ts
+++ b/src/shared/providers/__tests__/registry.test.ts
@@ -778,6 +778,15 @@ describe('OpenCode integration', () => {
     expect(oc.mcp!.supportsSubAgentEntries).toBe(true);
   });
 
+  it('declares a sub-agent scope fence so per-sub-agent MCPs are not exposed to primary sessions', () => {
+    const oc = getProvider('opencode')!;
+    expect(oc.mcp!.subAgentScopeFence).toEqual({
+      key: 'permission',
+      pattern: 'capa-*_*',
+      value: 'deny',
+    });
+  });
+
   it('buildMcpEntry includes type, url, and enabled', () => {
     const oc = getProvider('opencode')!;
     expect(buildMcpEntry(oc.mcp!, 'http://x/mcp')).toEqual({
@@ -800,6 +809,41 @@ describe('OpenCode integration', () => {
     expect(oc.subagents!.extension).toBe('.md');
     expect(oc.subagents!.format).toBe('markdown-frontmatter');
     expect(oc.subagents!.fields).toEqual({ mode: 'subagent' });
+  });
+
+  it('declares a per-sub-agent allow rule that re-opens its own MCP tools', () => {
+    const oc = getProvider('opencode')!;
+    expect(oc.subagents!.perAgentToolScope).toEqual({
+      key: 'permission',
+      patternTemplate: 'capa-{id}_*',
+      value: 'allow',
+    });
+  });
+
+  it('buildSubAgentFile emits the per-sub-agent permission allow in frontmatter', () => {
+    const oc = getProvider('opencode')!;
+    const subAgent = {
+      id: 'reviewer',
+      description: 'Reviews PRs',
+      skills: [],
+      tools: [],
+      instructions: 'Be thorough.',
+    };
+    const capabilities = {
+      providers: ['opencode'],
+      skills: [],
+      servers: [],
+      tools: [],
+    };
+
+    const result = buildSubAgentFile(oc, subAgent, capabilities);
+
+    expect(result).toContain('mode: subagent');
+    expect(result).toContain('permission:');
+    expect(result).toContain('"capa-reviewer_*": allow');
+    // The fence pattern must NOT appear in the agent file — that's the
+    // global deny, agents only carry the allow.
+    expect(result).not.toContain('capa-*_*');
   });
 });
 

--- a/src/shared/providers/handlers.ts
+++ b/src/shared/providers/handlers.ts
@@ -1,6 +1,11 @@
 import { join } from 'path';
 import TOML from '@iarna/toml';
-import type { McpIntegration, ProviderIntegration, RulesIntegration } from '../../types/providers';
+import type {
+  McpIntegration,
+  ProviderIntegration,
+  RulesIntegration,
+  SubagentsIntegration,
+} from '../../types/providers';
 import type { SubAgent, Capabilities } from '../../types/capabilities';
 import { getQualifiedToolName } from '../../types/capabilities';
 import type { Rule } from '../../types/rules';
@@ -13,6 +18,7 @@ export function buildMcpEntry(mcp: McpIntegration, url: string): Record<string, 
   const entry: Record<string, unknown> = {};
   if (mcp.entryType) entry.type = mcp.entryType;
   entry[mcp.entryUrlKey] = url;
+  if (mcp.entryExtraFields) Object.assign(entry, mcp.entryExtraFields);
   return entry;
 }
 
@@ -67,7 +73,13 @@ export function buildSubAgentFile(
   const mcpServerKey = `capa-${subAgent.id}`;
 
   if (sa.format === 'markdown-frontmatter') {
-    return buildMarkdownSubAgent(sa.fields ?? {}, subAgent, capabilities, mcpServerKey);
+    return buildMarkdownSubAgent(
+      sa.fields ?? {},
+      sa.perAgentToolScope,
+      subAgent,
+      capabilities,
+      mcpServerKey
+    );
   }
   return buildTomlSubAgent(sa.fields ?? {}, sa.bodyField ?? 'developer_instructions', subAgent, capabilities, mcpServerKey);
 }
@@ -121,6 +133,7 @@ function buildPlainBody(subAgent: SubAgent, capabilities: Capabilities, mcpServe
 
 function buildMarkdownSubAgent(
   fields: Record<string, string | boolean | number>,
+  perAgentToolScope: SubagentsIntegration['perAgentToolScope'] | undefined,
   subAgent: SubAgent,
   capabilities: Capabilities,
   mcpServerKey: string
@@ -136,6 +149,12 @@ function buildMarkdownSubAgent(
 
   for (const [key, value] of Object.entries(fields)) {
     fmLines.push(`${key}: ${value}`);
+  }
+
+  if (perAgentToolScope) {
+    const pattern = perAgentToolScope.patternTemplate.replace('{id}', subAgent.id);
+    // Quote the glob — `*` is a YAML reserved char if it leads a token.
+    fmLines.push(`${perAgentToolScope.key}:`, `  "${pattern}": ${perAgentToolScope.value}`);
   }
 
   fmLines.push('---');

--- a/src/shared/providers/handlers.ts
+++ b/src/shared/providers/handlers.ts
@@ -13,6 +13,7 @@ export function buildMcpEntry(mcp: McpIntegration, url: string): Record<string, 
   const entry: Record<string, unknown> = {};
   if (mcp.entryType) entry.type = mcp.entryType;
   entry[mcp.entryUrlKey] = url;
+  if (mcp.entryExtraFields) Object.assign(entry, mcp.entryExtraFields);
   return entry;
 }
 

--- a/src/shared/providers/handlers.ts
+++ b/src/shared/providers/handlers.ts
@@ -1,6 +1,11 @@
 import { join } from 'path';
 import TOML from '@iarna/toml';
-import type { McpIntegration, ProviderIntegration, RulesIntegration } from '../../types/providers';
+import type {
+  McpIntegration,
+  ProviderIntegration,
+  RulesIntegration,
+  SubagentsIntegration,
+} from '../../types/providers';
 import type { SubAgent, Capabilities } from '../../types/capabilities';
 import { getQualifiedToolName } from '../../types/capabilities';
 import type { Rule } from '../../types/rules';
@@ -68,7 +73,13 @@ export function buildSubAgentFile(
   const mcpServerKey = `capa-${subAgent.id}`;
 
   if (sa.format === 'markdown-frontmatter') {
-    return buildMarkdownSubAgent(sa.fields ?? {}, subAgent, capabilities, mcpServerKey);
+    return buildMarkdownSubAgent(
+      sa.fields ?? {},
+      sa.perAgentToolScope,
+      subAgent,
+      capabilities,
+      mcpServerKey
+    );
   }
   return buildTomlSubAgent(sa.fields ?? {}, sa.bodyField ?? 'developer_instructions', subAgent, capabilities, mcpServerKey);
 }
@@ -122,6 +133,7 @@ function buildPlainBody(subAgent: SubAgent, capabilities: Capabilities, mcpServe
 
 function buildMarkdownSubAgent(
   fields: Record<string, string | boolean | number>,
+  perAgentToolScope: SubagentsIntegration['perAgentToolScope'] | undefined,
   subAgent: SubAgent,
   capabilities: Capabilities,
   mcpServerKey: string
@@ -137,6 +149,12 @@ function buildMarkdownSubAgent(
 
   for (const [key, value] of Object.entries(fields)) {
     fmLines.push(`${key}: ${value}`);
+  }
+
+  if (perAgentToolScope) {
+    const pattern = perAgentToolScope.patternTemplate.replace('{id}', subAgent.id);
+    // Quote the glob — `*` is a YAML reserved char if it leads a token.
+    fmLines.push(`${perAgentToolScope.key}:`, `  "${pattern}": ${perAgentToolScope.value}`);
   }
 
   fmLines.push('---');

--- a/src/shared/providers/registry.ts
+++ b/src/shared/providers/registry.ts
@@ -630,12 +630,13 @@ export const providers: Record<string, ProviderIntegration> = {
     detectInstalled: async () =>
       existsSync(join(configHome, 'opencode')) || existsSync(join(claudeHome, 'skills')),
     mcp: {
-      configPath: '.opencode/opencode.json',
+      configPath: 'opencode.json',
       format: 'json',
       serversKey: 'mcp',
       serverKey: 'capa',
       entryUrlKey: 'url',
       entryType: 'remote',
+      entryExtraFields: { enabled: true },
       supportsSubAgentEntries: true,
     },
     instructions: { filename: 'AGENTS.md' },
@@ -643,6 +644,7 @@ export const providers: Record<string, ProviderIntegration> = {
       dir: '.opencode/agents',
       extension: '.md',
       format: 'markdown-frontmatter',
+      fields: { mode: 'subagent' },
     },
   },
   openhands: {

--- a/src/shared/providers/registry.ts
+++ b/src/shared/providers/registry.ts
@@ -630,19 +630,38 @@ export const providers: Record<string, ProviderIntegration> = {
     detectInstalled: async () =>
       existsSync(join(configHome, 'opencode')) || existsSync(join(claudeHome, 'skills')),
     mcp: {
-      configPath: '.opencode/opencode.json',
+      configPath: 'opencode.json',
       format: 'json',
       serversKey: 'mcp',
       serverKey: 'capa',
       entryUrlKey: 'url',
       entryType: 'remote',
+      entryExtraFields: { enabled: true },
       supportsSubAgentEntries: true,
+      // OpenCode auto-exposes every entry under top-level `mcp` to all
+      // primary agents (Build, Plan, …). Without this fence each
+      // `capa-<id>` MCP — meant for one sub-agent — pollutes the main
+      // session with sub-agent-only tool blocks. Pattern intentionally
+      // does NOT match the bare main `capa_*` tools.
+      // Docs: https://opencode.ai/docs/mcp-servers/#per-agent
+      subAgentScopeFence: {
+        key: 'permission',
+        pattern: 'capa-*_*',
+        value: 'deny',
+      },
     },
     instructions: { filename: 'AGENTS.md' },
     subagents: {
       dir: '.opencode/agents',
       extension: '.md',
       format: 'markdown-frontmatter',
+      fields: { mode: 'subagent' },
+      // Re-allow the sub-agent's own MCP tools after the global fence.
+      perAgentToolScope: {
+        key: 'permission',
+        patternTemplate: 'capa-{id}_*',
+        value: 'allow',
+      },
     },
   },
   openhands: {

--- a/src/shared/providers/registry.ts
+++ b/src/shared/providers/registry.ts
@@ -638,6 +638,17 @@ export const providers: Record<string, ProviderIntegration> = {
       entryType: 'remote',
       entryExtraFields: { enabled: true },
       supportsSubAgentEntries: true,
+      // OpenCode auto-exposes every entry under top-level `mcp` to all
+      // primary agents (Build, Plan, …). Without this fence each
+      // `capa-<id>` MCP — meant for one sub-agent — pollutes the main
+      // session with sub-agent-only tool blocks. Pattern intentionally
+      // does NOT match the bare main `capa_*` tools.
+      // Docs: https://opencode.ai/docs/mcp-servers/#per-agent
+      subAgentScopeFence: {
+        key: 'permission',
+        pattern: 'capa-*_*',
+        value: 'deny',
+      },
     },
     instructions: { filename: 'AGENTS.md' },
     subagents: {
@@ -645,6 +656,12 @@ export const providers: Record<string, ProviderIntegration> = {
       extension: '.md',
       format: 'markdown-frontmatter',
       fields: { mode: 'subagent' },
+      // Re-allow the sub-agent's own MCP tools after the global fence.
+      perAgentToolScope: {
+        key: 'permission',
+        patternTemplate: 'capa-{id}_*',
+        value: 'allow',
+      },
     },
   },
   openhands: {

--- a/src/types/providers.ts
+++ b/src/types/providers.ts
@@ -17,12 +17,35 @@ export interface McpIntegration {
   entryUrlKey: string;
   /** Transport discriminator written as the entry's `type` field, for providers that require it. */
   entryType?: string;
+  /** Static fields merged into the server entry (e.g. { enabled: true }). */
+  entryExtraFields?: Record<string, unknown>;
   /** Whether per-sub-agent MCP entries ('capa-{id}') can coexist with the main entry. */
   supportsSubAgentEntries: boolean;
   /** Fallback config path when the primary `configPath` doesn't exist. */
   defaultMcpFallbackPath?: string;
   /** Env var name that points to the provider's plugin root (e.g. `CURSOR_PLUGIN_ROOT`). */
   pluginRootEnvVar?: string;
+  /**
+   * Top-level scope-fence written next to the MCP map so per-sub-agent MCP
+   * entries are NOT auto-exposed to primary sessions. OpenCode is the
+   * canonical example: every entry under the global `mcp` key is connected
+   * for primary agents (Build, Plan, …) by default, so without this fence
+   * users see a `capa-<id>_*` tool block from every sub-agent in the main
+   * conversation. The companion `subagents.perAgentToolScope` re-allows
+   * each sub-agent's own tools in its own agent file.
+   *
+   * Only applies to JSON-format configs. Idempotent — safe to re-write.
+   *
+   * Reference: https://opencode.ai/docs/mcp-servers/#per-agent
+   */
+  subAgentScopeFence?: {
+    /** Top-level config key — `'permission'` (modern) or `'tools'` (deprecated, still works). */
+    key: 'permission' | 'tools';
+    /** Glob pattern matching sub-agent MCP tool names (e.g. `'capa-*_*'`). Must NOT match the main `capa_*` tools. */
+    pattern: string;
+    /** Deny value — `'deny'` for `permission`, `false` for `tools`. */
+    value: 'deny' | false;
+  };
 }
 
 /**
@@ -143,6 +166,23 @@ export interface SubagentsIntegration {
   fields?: Record<string, string | boolean | number>;
   /** For TOML format: the key name used for the body text (e.g. 'developer_instructions'). */
   bodyField?: string;
+  /**
+   * Per-sub-agent re-allow rule, paired with `mcp.subAgentScopeFence`.
+   * When set, capa emits a nested `<key>: { <pattern>: <value> }` block in
+   * each sub-agent's frontmatter so the agent can reach its own MCP tools
+   * after the global fence denies them. `{id}` is replaced with the
+   * sub-agent id.
+   *
+   * Only used by markdown-frontmatter providers today.
+   */
+  perAgentToolScope?: {
+    /** Frontmatter key — `'permission'` (modern) or `'tools'` (deprecated). */
+    key: 'permission' | 'tools';
+    /** Glob pattern with `{id}` placeholder (e.g. `'capa-{id}_*'`). */
+    patternTemplate: string;
+    /** Allow value — `'allow'` for `permission`, `true` for `tools`. */
+    value: 'allow' | true;
+  };
 }
 
 /**

--- a/src/types/providers.ts
+++ b/src/types/providers.ts
@@ -25,6 +25,27 @@ export interface McpIntegration {
   defaultMcpFallbackPath?: string;
   /** Env var name that points to the provider's plugin root (e.g. `CURSOR_PLUGIN_ROOT`). */
   pluginRootEnvVar?: string;
+  /**
+   * Top-level scope-fence written next to the MCP map so per-sub-agent MCP
+   * entries are NOT auto-exposed to primary sessions. OpenCode is the
+   * canonical example: every entry under the global `mcp` key is connected
+   * for primary agents (Build, Plan, …) by default, so without this fence
+   * users see a `capa-<id>_*` tool block from every sub-agent in the main
+   * conversation. The companion `subagents.perAgentToolScope` re-allows
+   * each sub-agent's own tools in its own agent file.
+   *
+   * Only applies to JSON-format configs. Idempotent — safe to re-write.
+   *
+   * Reference: https://opencode.ai/docs/mcp-servers/#per-agent
+   */
+  subAgentScopeFence?: {
+    /** Top-level config key — `'permission'` (modern) or `'tools'` (deprecated, still works). */
+    key: 'permission' | 'tools';
+    /** Glob pattern matching sub-agent MCP tool names (e.g. `'capa-*_*'`). Must NOT match the main `capa_*` tools. */
+    pattern: string;
+    /** Deny value — `'deny'` for `permission`, `false` for `tools`. */
+    value: 'deny' | false;
+  };
 }
 
 /**
@@ -145,6 +166,23 @@ export interface SubagentsIntegration {
   fields?: Record<string, string | boolean | number>;
   /** For TOML format: the key name used for the body text (e.g. 'developer_instructions'). */
   bodyField?: string;
+  /**
+   * Per-sub-agent re-allow rule, paired with `mcp.subAgentScopeFence`.
+   * When set, capa emits a nested `<key>: { <pattern>: <value> }` block in
+   * each sub-agent's frontmatter so the agent can reach its own MCP tools
+   * after the global fence denies them. `{id}` is replaced with the
+   * sub-agent id.
+   *
+   * Only used by markdown-frontmatter providers today.
+   */
+  perAgentToolScope?: {
+    /** Frontmatter key — `'permission'` (modern) or `'tools'` (deprecated). */
+    key: 'permission' | 'tools';
+    /** Glob pattern with `{id}` placeholder (e.g. `'capa-{id}_*'`). */
+    patternTemplate: string;
+    /** Allow value — `'allow'` for `permission`, `true` for `tools`. */
+    value: 'allow' | true;
+  };
 }
 
 /**

--- a/src/types/providers.ts
+++ b/src/types/providers.ts
@@ -17,6 +17,8 @@ export interface McpIntegration {
   entryUrlKey: string;
   /** Transport discriminator written as the entry's `type` field, for providers that require it. */
   entryType?: string;
+  /** Static fields merged into the server entry (e.g. { enabled: true }). */
+  entryExtraFields?: Record<string, unknown>;
   /** Whether per-sub-agent MCP entries ('capa-{id}') can coexist with the main entry. */
   supportsSubAgentEntries: boolean;
   /** Fallback config path when the primary `configPath` doesn't exist. */


### PR DESCRIPTION
This pull request introduces two main improvements: (1) enhanced support for OpenCode sub-agent MCP scoping and documentation, and (2) improved process spawning security and behavior on Windows by ensuring all subprocesses are hidden from the user interface. The update also includes additional and revised tests to verify these behaviors.

**OpenCode Sub-Agent MCP Scoping and Documentation Improvements:**

* Added logic to write a "scope fence" (`permission: { 'capa-*_*': 'deny' }`) to `opencode.json` so that per-sub-agent MCPs are not auto-exposed to primary sessions, as per OpenCode's recommendations. This logic is idempotent and preserves user-authored permission entries. [[1]](diffhunk://#diff-780b5fc3e7d0817e3f3f33b8fa612c7ab89edc9fae687efd9fd7b3a3ceb4fb06R54-R69) [[2]](diffhunk://#diff-780b5fc3e7d0817e3f3f33b8fa612c7ab89edc9fae687efd9fd7b3a3ceb4fb06R161) [[3]](diffhunk://#diff-780b5fc3e7d0817e3f3f33b8fa612c7ab89edc9fae687efd9fd7b3a3ceb4fb06R112)
* Updated documentation in `docs/providers/opencode.md` and `docs/providers/README.md` to clarify OpenCode's MCP config structure, sub-agent scoping, and permission patterns, with new examples and references to official docs. [[1]](diffhunk://#diff-a048d7bde5a2895880ff49811c89ff7b7bd67c68e77bb462301b63a4a4e8e623L13-R58) [[2]](diffhunk://#diff-968374ceb737dbd4e64acdd1fb4acb04d3751b68a4ce90908dbe8a3ac0fdd65aL80-R80)
* Added and revised tests in `src/cli/utils/__tests__/sub-agent-mcp.test.ts` to verify correct application and preservation of the scope fence and user permissions.

**Process Spawning Security and Windows Behavior:**

* All subprocesses, including MCP servers and command tool executions, are now spawned with `windowsHide: true` to prevent unwanted windows from appearing on Windows systems. This is enforced in the main code and verified with new and updated tests. [[1]](diffhunk://#diff-715cb59a3b717711dcece75cba4848cd336a497abb19758bc795e61e6b5a417bL2-R2) [[2]](diffhunk://#diff-a0ef2089ab2b420a65fd1ff5736ada7a872d1131f4095753677faa4c9328f44bR1-R36) [[3]](diffhunk://#diff-19f1b66439db679d6b52b17f27546876c87be673c1b7c5db771d1298b409e9e3L1-R5) [[4]](diffhunk://#diff-19f1b66439db679d6b52b17f27546876c87be673c1b7c5db771d1298b409e9e3R58-R83) [[5]](diffhunk://#diff-a3fe9581b0da092b47133c507eee3cbd2884bad815cf203a102566e22be230bbL1-R2) [[6]](diffhunk://#diff-a3fe9581b0da092b47133c507eee3cbd2884bad815cf203a102566e22be230bbR186-R223)
* The custom `HiddenStdioClientTransport` is now used to ensure this behavior for MCP proxy connections.

**Minor Documentation and Usability Updates:**

* Updated `README.md` for clearer language, more accurate agent counts, and improved explanations of lifecycle hooks and registry usage. [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L19-R19) [[2]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L45-R45) [[3]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L64-R67)

These changes improve security and correctness in multi-agent environments and ensure a smoother experience for Windows users.

**References:**  
[[1]](diffhunk://#diff-780b5fc3e7d0817e3f3f33b8fa612c7ab89edc9fae687efd9fd7b3a3ceb4fb06R54-R69) [[2]](diffhunk://#diff-780b5fc3e7d0817e3f3f33b8fa612c7ab89edc9fae687efd9fd7b3a3ceb4fb06R161) [[3]](diffhunk://#diff-780b5fc3e7d0817e3f3f33b8fa612c7ab89edc9fae687efd9fd7b3a3ceb4fb06R112) [[4]](diffhunk://#diff-a048d7bde5a2895880ff49811c89ff7b7bd67c68e77bb462301b63a4a4e8e623L13-R58) [[5]](diffhunk://#diff-968374ceb737dbd4e64acdd1fb4acb04d3751b68a4ce90908dbe8a3ac0fdd65aL80-R80) [[6]](diffhunk://#diff-de2b5e598af1325aae56db3b48f47aebc02477c7c7d18cce2b44ff321af72089R115-R173) [[7]](diffhunk://#diff-715cb59a3b717711dcece75cba4848cd336a497abb19758bc795e61e6b5a417bL2-R2) [[8]](diffhunk://#diff-a0ef2089ab2b420a65fd1ff5736ada7a872d1131f4095753677faa4c9328f44bR1-R36) [[9]](diffhunk://#diff-19f1b66439db679d6b52b17f27546876c87be673c1b7c5db771d1298b409e9e3L1-R5) [[10]](diffhunk://#diff-19f1b66439db679d6b52b17f27546876c87be673c1b7c5db771d1298b409e9e3R58-R83) [[11]](diffhunk://#diff-a3fe9581b0da092b47133c507eee3cbd2884bad815cf203a102566e22be230bbL1-R2) [[12]](diffhunk://#diff-a3fe9581b0da092b47133c507eee3cbd2884bad815cf203a102566e22be230bbR186-R223) [[13]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L19-R19) [[14]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L45-R45) [[15]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L64-R67)