### PR TITLE
fix(shell): load MCP tool schemas lazily so `capa sh` never blocks on remote servers

### DIFF
--- a/src/cli/commands/sh.ts
+++ b/src/cli/commands/sh.ts
@@ -25,6 +25,22 @@ export interface ShellCommand {
   argSlugs: Map<string, string>;
   /** Default argument values */
   defaults?: Record<string, any>;
+  /**
+   * Whether `inputSchema` is populated. Command tools ship their schema with the
+   * metadata listing; MCP tool schemas are fetched lazily (see ensureSchema) only
+   * when the tool is run or `--help`'d, so this is falsy for them until resolved.
+   */
+  schemaLoaded?: boolean;
+}
+
+/** Build the slugified-arg-name → original-arg-name map from a tool input schema. */
+function buildArgSlugs(inputSchema: any): Map<string, string> {
+  const argSlugs = new Map<string, string>();
+  const props = inputSchema?.properties || {};
+  for (const argName of Object.keys(props)) {
+    argSlugs.set(slugify(argName), argName);
+  }
+  return argSlugs;
 }
 
 interface ShellGroup {
@@ -47,12 +63,7 @@ class ShellRegistry {
 
     for (const tool of tools) {
       const commandSlug = slugify(tool.id);
-      const argSlugs = new Map<string, string>();
-
-      const props = tool.inputSchema?.properties || {};
-      for (const argName of Object.keys(props)) {
-        argSlugs.set(slugify(argName), argName);
-      }
+      const argSlugs = buildArgSlugs(tool.inputSchema);
 
       const cmd: ShellCommand = {
         id: tool.id,
@@ -62,6 +73,8 @@ class ShellRegistry {
         inputSchema: tool.inputSchema,
         argSlugs,
         defaults: tool.defaults,
+        // MCP schemas are fetched on demand; command schemas arrive with the listing.
+        schemaLoaded: tool.type === 'command',
       };
 
       if (tool.type === 'mcp' && tool.serverId) {
@@ -103,18 +116,14 @@ class ShellRegistry {
         const dotIdx = tool.id.indexOf('.');
         const shortName = dotIdx >= 0 ? tool.id.slice(dotIdx + 1) : tool.id;
         const commandSlug = slugify(shortName);
-        const argSlugs = new Map<string, string>();
-        const props = tool.inputSchema?.properties || {};
-        for (const argName of Object.keys(props)) {
-          argSlugs.set(slugify(argName), argName);
-        }
         this.topLevelCommands.set(commandSlug, {
           id: tool.id,
           slug: commandSlug,
           type: tool.type,
           description: tool.description,
           inputSchema: tool.inputSchema,
-          argSlugs,
+          argSlugs: buildArgSlugs(tool.inputSchema),
+          schemaLoaded: tool.type === 'command',
         });
       } else {
         // Create the group
@@ -129,18 +138,14 @@ class ShellRegistry {
           const dotIdx = tool.id.indexOf('.');
           const shortName = dotIdx >= 0 ? tool.id.slice(dotIdx + 1) : tool.id;
           const commandSlug = slugify(shortName);
-          const argSlugs = new Map<string, string>();
-          const props = tool.inputSchema?.properties || {};
-          for (const argName of Object.keys(props)) {
-            argSlugs.set(slugify(argName), argName);
-          }
           group.commands.set(commandSlug, {
             id: tool.id,
             slug: commandSlug,
             type: tool.type,
             description: tool.description,
             inputSchema: tool.inputSchema,
-            argSlugs,
+            argSlugs: buildArgSlugs(tool.inputSchema),
+            schemaLoaded: tool.type === 'command',
           });
         }
         this.groups.set(groupSlug, group);
@@ -259,6 +264,45 @@ async function fetchShellTools(serverUrl: string, projectId: string): Promise<Sh
   }
   const data = await response.json() as { tools: ShellToolInfo[] };
   return data.tools;
+}
+
+/**
+ * Fetch the input schema for a single tool on demand. Used right before a tool is
+ * run or `--help`'d. Throws a descriptive error (e.g. remote server down / timed
+ * out / tool missing) which the caller surfaces for that one tool.
+ */
+async function fetchToolSchema(
+  serverUrl: string,
+  projectId: string,
+  toolId: string
+): Promise<{ description: string; inputSchema: any }> {
+  const response = await fetch(
+    `${serverUrl}/api/projects/${projectId}/shell-tool-schema?tool=${encodeURIComponent(toolId)}`,
+    { signal: AbortSignal.timeout(20000) }
+  );
+  if (!response.ok) {
+    const body = await response.json().catch(() => null) as { error?: string } | null;
+    throw new Error(body?.error || `Failed to load schema for "${toolId}" (${response.status})`);
+  }
+  return await response.json() as { description: string; inputSchema: any };
+}
+
+/**
+ * Ensure a command's input schema is loaded before it is run or `--help`'d.
+ * Command tools already carry their schema; MCP tool schemas are fetched lazily
+ * here so listing commands never blocks on (or fails because of) a remote server.
+ */
+async function ensureSchema(
+  cmd: ShellCommand,
+  serverUrl: string,
+  projectId: string
+): Promise<void> {
+  if (cmd.schemaLoaded) return;
+  const { description, inputSchema } = await fetchToolSchema(serverUrl, projectId, cmd.id);
+  cmd.inputSchema = inputSchema;
+  cmd.argSlugs = buildArgSlugs(inputSchema);
+  if (description) cmd.description = description;
+  cmd.schemaLoaded = true;
 }
 
 async function executeToolViaMCP(
@@ -474,6 +518,24 @@ function isHelpFlag(token: string): boolean {
   return token === '--help' || token === '-h' || token === 'help';
 }
 
+/**
+ * Load a command's schema before help/execution, exiting with a clear message if
+ * the remote server backing it is unreachable. Scoped to the single tool, so other
+ * commands in the session are unaffected.
+ */
+async function loadSchemaOrExit(
+  cmd: ShellCommand,
+  serverUrl: string,
+  projectId: string
+): Promise<void> {
+  try {
+    await ensureSchema(cmd, serverUrl, projectId);
+  } catch (err: any) {
+    console.error(`Could not load "${cmd.slug}": ${err.message}`);
+    process.exit(1);
+  }
+}
+
 async function dispatch(
   tokens: string[],
   registry: ShellRegistry,
@@ -516,6 +578,9 @@ async function dispatch(
 
     const cmd = group.commands.get(subSlug)!;
 
+    // Using a specific tool (help or run) → resolve its schema now.
+    await loadSchemaOrExit(cmd, serverUrl, projectId);
+
     // `capa sh <group> <subcommand> --help` → show command arg info
     if (subRest.length > 0 && isHelpFlag(subRest[0])) {
       printCommandHelp(cmd);
@@ -529,6 +594,9 @@ async function dispatch(
   // Top-level capa command
   if (registry.topLevelCommands.has(first)) {
     const cmd = registry.topLevelCommands.get(first)!;
+
+    // Using a specific tool (help or run) → resolve its schema now.
+    await loadSchemaOrExit(cmd, serverUrl, projectId);
 
     // `capa sh <command> --help` → show command arg info
     if (rest.length > 0 && isHelpFlag(rest[0])) {

--- a/src/server/__tests__/mcp-handler.integration.test.ts
+++ b/src/server/__tests__/mcp-handler.integration.test.ts
@@ -507,3 +507,106 @@ describe('installSubagentsTask + toolExposure: none', () => {
     expect(needsPurge(false, [])).toBe(false);
   });
 });
+
+// ─── capa shell: metadata listing vs. lazy per-tool schema ───────────────────
+//
+// `capa sh` (and group/subcommand listing) hits getAllShellTools on every
+// invocation, so it must NOT contact remote MCP servers — otherwise one slow or
+// down server stalls or crashes the whole shell. The remote round-trip is
+// deferred to getShellToolSchema, called only when a specific tool is run or
+// `--help`'d. These tests pin that split.
+
+describe('getAllShellTools / getShellToolSchema (lazy MCP schema)', () => {
+  let h: Harness;
+
+  const caps: Capabilities = {
+    providers: ['claude-code'],
+    options: {},
+    skills: [],
+    servers: [{ id: 'brave', def: { url: 'http://127.0.0.1:1/mcp' } } as any],
+    tools: [
+      {
+        id: 'run_tests',
+        type: 'command',
+        def: { run: { cmd: 'npm test', args: [{ name: 'pattern', type: 'string' }] } },
+      },
+      {
+        id: 'search',
+        type: 'mcp',
+        def: { server: '@brave', tool: 'brave_web_search' },
+      } as any,
+    ],
+  };
+
+  beforeEach(() => {
+    h = makeHarness(caps);
+  });
+
+  afterEach(() => destroyHarness(h));
+
+  it('getAllShellTools makes no remote listTools calls and omits MCP schemas', async () => {
+    let listToolsCalls = 0;
+    (h.mcp as any).mcpProxy.listTools = async () => {
+      listToolsCalls++;
+      return [];
+    };
+
+    const tools = await h.mcp.getAllShellTools(caps);
+
+    expect(listToolsCalls).toBe(0);
+
+    const cmd = tools.find((t) => t.id === 'run_tests')!;
+    expect(cmd.type).toBe('command');
+    // Command schemas are local and cheap — included up front.
+    expect(cmd.inputSchema?.properties?.pattern).toBeDefined();
+
+    const mcp = tools.find((t) => t.id === 'brave.search')!;
+    expect(mcp.type).toBe('mcp');
+    expect(mcp.serverId).toBe('brave');
+    // MCP schema is resolved lazily, so it is absent here.
+    expect(mcp.inputSchema).toBeUndefined();
+  });
+
+  it('getShellToolSchema resolves an MCP tool with exactly one remote call', async () => {
+    let listToolsCalls = 0;
+    (h.mcp as any).mcpProxy.listTools = async () => {
+      listToolsCalls++;
+      return [
+        {
+          name: 'brave_web_search',
+          description: 'Search the web',
+          inputSchema: { type: 'object', properties: { q: { type: 'string' } }, required: ['q'] },
+        },
+      ];
+    };
+
+    const schema = await h.mcp.getShellToolSchema('brave.search', caps);
+
+    expect(listToolsCalls).toBe(1);
+    expect(schema.description).toBe('Search the web');
+    expect(schema.inputSchema.properties.q).toBeDefined();
+  });
+
+  it('getShellToolSchema propagates remote failures instead of swallowing them', async () => {
+    (h.mcp as any).mcpProxy.listTools = async () => {
+      throw new Error('Could not connect to MCP server "brave"');
+    };
+
+    await expect(h.mcp.getShellToolSchema('brave.search', caps)).rejects.toThrow(
+      /Could not connect/
+    );
+  });
+
+  it('getShellToolSchema resolves command tools locally without any remote call', async () => {
+    let listToolsCalls = 0;
+    (h.mcp as any).mcpProxy.listTools = async () => {
+      listToolsCalls++;
+      return [];
+    };
+
+    const schema = await h.mcp.getShellToolSchema('run_tests', caps);
+
+    expect(listToolsCalls).toBe(0);
+    expect(schema.inputSchema.properties.pattern).toBeDefined();
+  });
+});

--- a/src/server/index.ts
+++ b/src/server/index.ts
@@ -347,11 +347,19 @@ class CapaServer {
       return this.handleGetServerTools(projectId, serverId);
     }
 
-    // Shell tools endpoint — all tools with schemas, regardless of exposure mode
+    // Shell tools endpoint — tool metadata for the capa shell, regardless of exposure mode
     const shellToolsMatch = path.match(/^\/api\/projects\/([^/]+)\/shell-tools$/);
     if (shellToolsMatch && request.method === 'GET') {
       const projectId = shellToolsMatch[1];
       return this.handleGetShellTools(projectId);
+    }
+
+    // On-demand schema for a single shell tool (?tool=<qualified-id>)
+    const shellToolSchemaMatch = path.match(/^\/api\/projects\/([^/]+)\/shell-tool-schema$/);
+    if (shellToolSchemaMatch && request.method === 'GET') {
+      const projectId = shellToolSchemaMatch[1];
+      const toolId = url.searchParams.get('tool') || '';
+      return this.handleGetShellToolSchema(projectId, toolId);
     }
 
     // Disconnect OAuth2
@@ -739,6 +747,49 @@ class CapaServer {
       return new Response(
         JSON.stringify({ error: error.message }),
         { status: 500, headers: { 'Content-Type': 'application/json' } }
+      );
+    }
+  }
+
+  private async handleGetShellToolSchema(projectId: string, toolId: string): Promise<Response> {
+    const apiLogger = this.logger.child('API');
+    apiLogger.info(`Get shell tool schema for ${projectId}: ${toolId}`);
+    try {
+      if (!toolId) {
+        return new Response(
+          JSON.stringify({ error: 'Missing "tool" query parameter' }),
+          { status: 400, headers: { 'Content-Type': 'application/json' } }
+        );
+      }
+
+      const capabilities = this.sessionManager.getProjectCapabilities(projectId);
+      if (!capabilities) {
+        return new Response(
+          JSON.stringify({ error: 'Project not configured' }),
+          { status: 404, headers: { 'Content-Type': 'application/json' } }
+        );
+      }
+
+      const mcpServer = this.getOrCreateMCPServer(projectId);
+      if (!mcpServer) {
+        return new Response(
+          JSON.stringify({ error: 'Project not found' }),
+          { status: 404, headers: { 'Content-Type': 'application/json' } }
+        );
+      }
+
+      const schema = await mcpServer.getShellToolSchema(toolId, capabilities);
+      return new Response(
+        JSON.stringify(schema),
+        { headers: { 'Content-Type': 'application/json' } }
+      );
+    } catch (error: any) {
+      apiLogger.failure(`Error resolving schema for ${toolId}: ${error.message}`);
+      // 502: the failure is upstream (remote MCP server unreachable / tool missing),
+      // not a bug in this endpoint — let the shell surface it for this one tool.
+      return new Response(
+        JSON.stringify({ error: error.message }),
+        { status: 502, headers: { 'Content-Type': 'application/json' } }
       );
     }
   }

--- a/src/server/mcp-handler.ts
+++ b/src/server/mcp-handler.ts
@@ -676,23 +676,29 @@ export class CapaMCPServer {
   }
 
   /**
-   * Return all tools with full schemas for the capa shell, regardless of toolExposure mode.
-   * Each entry includes the original tool id, type, optional server group id, description, and inputSchema.
+   * Return shell-tool metadata for the capa shell, regardless of toolExposure mode.
+   *
+   * This is the hot path for `capa sh` (top-level command list and group/subcommand
+   * listing), so it must be fast and must NOT contact remote MCP servers. Command
+   * tools carry their input schema (derived locally from the capabilities file);
+   * MCP tools are returned WITHOUT an `inputSchema` — it is resolved lazily and
+   * per-tool via {@link getShellToolSchema} only when the user runs the tool or asks
+   * for its `--help`. That keeps one slow/down server from stalling the whole shell.
    */
   async getAllShellTools(capabilities: Capabilities): Promise<ShellToolInfo[]> {
     const result: ShellToolInfo[] = [];
     for (const tool of capabilities.tools) {
-      const mcpTool = await this.convertToolToMCP(tool, capabilities);
-      const info: ShellToolInfo = {
-        id: getQualifiedToolName(tool),
-        type: tool.type as 'command' | 'mcp',
-        description: mcpTool.description || '',
-        inputSchema: mcpTool.inputSchema,
-      };
       if (tool.type === 'mcp') {
         const mcpDef = tool.def as ToolMCPDefinition;
         const serverId = mcpDef.server.replace('@', '');
-        info.serverId = serverId;
+        const info: ShellToolInfo = {
+          id: getQualifiedToolName(tool),
+          type: 'mcp',
+          description: tool.description || '',
+          // Resolved on demand — see getShellToolSchema.
+          inputSchema: undefined,
+          serverId,
+        };
         const serverDef = capabilities.servers.find((s) => s.id === serverId);
         if (serverDef?.description) {
           info.serverDescription = serverDef.description;
@@ -700,7 +706,16 @@ export class CapaMCPServer {
         if (mcpDef.defaults) {
           info.defaults = mcpDef.defaults;
         }
+        result.push(info);
       } else {
+        // Command tool — schema is built locally and is cheap, so include it.
+        const mcpTool = await this.convertToolToMCP(tool, capabilities);
+        const info: ShellToolInfo = {
+          id: getQualifiedToolName(tool),
+          type: 'command',
+          description: mcpTool.description || '',
+          inputSchema: mcpTool.inputSchema,
+        };
         if (tool.group) {
           info.group = tool.group;
         }
@@ -716,10 +731,65 @@ export class CapaMCPServer {
             info.defaults = cmdDefaults;
           }
         }
+        result.push(info);
       }
-      result.push(info);
     }
     return result;
+  }
+
+  /**
+   * Resolve the input schema for a single shell tool on demand.
+   *
+   * Used by the capa shell when the user runs a specific tool or asks for its
+   * `--help`. Unlike {@link getAllShellTools}, this DOES contact the remote MCP
+   * server for `mcp` tools and throws a descriptive error if the server is
+   * unreachable, times out, or doesn't expose the tool — so the shell can surface
+   * the failure for that one tool without affecting the rest of the session.
+   */
+  async getShellToolSchema(
+    toolId: string,
+    capabilities: Capabilities
+  ): Promise<{ description: string; inputSchema: any }> {
+    const tool = capabilities.tools.find((t) => getQualifiedToolName(t) === toolId);
+    if (!tool) {
+      throw new Error(`Tool not found: ${toolId}`);
+    }
+
+    if (tool.type === 'command') {
+      const mcpTool = await this.convertToolToMCP(tool, capabilities);
+      return { description: mcpTool.description || '', inputSchema: mcpTool.inputSchema };
+    }
+
+    const mcpDef = tool.def as ToolMCPDefinition;
+    const serverId = mcpDef.server.replace('@', '');
+    const serverDef = capabilities.servers.find((s) => s.id === serverId);
+    if (!serverDef) {
+      throw new Error(`Server not found: ${serverId}`);
+    }
+
+    const remoteTools = await this.mcpProxy.listTools(serverId, serverDef.def, {
+      throwOnError: true,
+    });
+    const remoteTool = remoteTools.find((t: any) => t.name === mcpDef.tool);
+    if (!remoteTool) {
+      const available = remoteTools.map((t: any) => t.name).join(', ');
+      throw new Error(
+        `Tool "${mcpDef.tool}" not found on server "${serverId}". Available tools: ${available || '(none)'}`
+      );
+    }
+
+    const inputSchema = remoteTool.inputSchema
+      ? JSON.parse(JSON.stringify(remoteTool.inputSchema))
+      : { type: 'object' as const, properties: {} };
+    if (mcpDef.defaults) {
+      applyDefaultsToSchema(inputSchema, mcpDef.defaults);
+    }
+
+    const description = remoteTool.description || `MCP tool: ${toolId}`;
+    // Warm the shared cache so a subsequent tools/call doesn't re-fetch.
+    this.toolSchemaCache.set(toolId, { name: toolId, description, inputSchema });
+
+    return { description, inputSchema };
   }
 
   /**

--- a/src/server/mcp-proxy.ts
+++ b/src/server/mcp-proxy.ts
@@ -122,12 +122,23 @@ export class MCPProxy {
   }
 
   /**
-   * List tools available on an MCP server
+   * List tools available on an MCP server.
+   *
+   * By default this is tolerant: connection/listing failures are logged and an
+   * empty array is returned so aggregate callers don't blow up on one bad server.
+   * Pass `throwOnError: true` (used by on-demand schema resolution) to surface
+   * the underlying failure to the caller instead. `timeoutMs` bounds the request
+   * so a hung server can't block indefinitely.
    */
-  async listTools(serverId: string, serverDefinition: MCPServerDefinition): Promise<any[]> {
+  async listTools(
+    serverId: string,
+    serverDefinition: MCPServerDefinition,
+    options: { throwOnError?: boolean; timeoutMs?: number } = {}
+  ): Promise<any[]> {
+    const { throwOnError = false, timeoutMs = 15000 } = options;
     // Strip @ prefix from server ID if present
     const cleanServerId = serverId.replace('@', '');
-    
+
     const resolvedServerDef = resolveVariablesInObject(
       serverDefinition,
       this.projectId,
@@ -136,27 +147,37 @@ export class MCPProxy {
 
     const client = await this.getOrCreateClient(cleanServerId, resolvedServerDef);
     if (!client) {
+      if (throwOnError) {
+        throw new Error(`Could not connect to MCP server "${cleanServerId}"`);
+      }
       return [];
     }
 
     try {
-      const result = await client.listTools();
+      const result = await client.listTools(undefined, { timeout: timeoutMs });
       return result.tools;
     } catch (error) {
       if (error instanceof MCPSessionExpiredError) {
         this.logger.warn(`Session expired for ${cleanServerId}, reconnecting...`);
         this.clients.delete(cleanServerId);
         const freshClient = await this.getOrCreateClient(cleanServerId, resolvedServerDef);
-        if (!freshClient) return [];
+        if (!freshClient) {
+          if (throwOnError) {
+            throw new Error(`Could not reconnect to MCP server "${cleanServerId}"`);
+          }
+          return [];
+        }
         try {
-          const result = await freshClient.listTools();
+          const result = await freshClient.listTools(undefined, { timeout: timeoutMs });
           return result.tools;
         } catch (retryError) {
           this.logger.error(`Failed to list tools from ${cleanServerId} after reconnect:`, retryError);
+          if (throwOnError) throw retryError;
           return [];
         }
       }
       this.logger.error(`Failed to list tools from ${cleanServerId}:`, error);
+      if (throwOnError) throw error;
       return [];
     }
   }


### PR DESCRIPTION
## Problem

Every `capa sh` invocation hits `GET /api/projects/:id/shell-tools`, whose handler `getAllShellTools()` looped over **every** tool and, for each MCP tool, made a **sequential, blocking** `mcpProxy.listTools()` round-trip to the remote server just to fetch its input schema.

- First-run slowness was `O(#servers) × round-trip`, fully serialized.
- `mcpProxy.listTools()` had **no request timeout**, so one hung remote server stalled the whole endpoint until the client's 10s abort fired and failed the **entire** `capa sh` — the intermittent "crash."

Listing top-level commands and group sub-commands only needs **local** metadata (id, type, server, group, description). The remote input schema is only needed for `--help` on a tool or for running it.

## Fix

**Server**
- `getAllShellTools()` is now metadata-only: command tools keep their locally-built schema; MCP tools are returned with no `inputSchema` and **zero remote calls**. The hot path can no longer hang.
- New `getShellToolSchema(toolId, caps)` + endpoint `GET /api/projects/:id/shell-tool-schema?tool=<id>` resolves **one** tool's schema on demand and **surfaces** upstream errors (`502`) instead of swallowing them.
- `mcpProxy.listTools()` gained a bounded `timeoutMs` (default 15s) and an opt-in `throwOnError` for the on-demand path. Existing callers are unchanged.

**Client (`sh.ts`)**
- Fast metadata listing builds top-level/group/subcommand views without any schema.
- `ensureSchema` loads a single tool's schema right before `--help` or execution, scoping any "server down" error to that one tool — never blocking or crashing the rest of the shell.

## Result
- `capa sh` and `capa sh <group>` return immediately, regardless of remote server health.
- `capa sh <group> <tool>` / `... --help` loads just that tool's schema, with a clean per-tool error if its server is down.

## Tests
Added 4 tests pinning the split: `getAllShellTools` makes no `listTools` calls and omits MCP schemas; `getShellToolSchema` makes exactly one call, resolves command tools locally, and propagates remote failures. Full suite: **1043 pass / 0 fail**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)