### PR TITLE
feat(rules): support installing rules from local files (closes #105)

### DIFF
--- a/README.md
+++ b/README.md
@@ -143,6 +143,15 @@ rules:
       Always use Conventional Commits (feat/fix/chore/docs/refactor).
       Subject ≤ 72 chars, imperative mood, no trailing period.
 
+  - id: typescript-conventions
+    type: local
+    description: Team TypeScript conventions
+    appliesTo:
+      - "**/*.ts"
+      - "**/*.tsx"
+    # Path is resolved relative to this capabilities file.
+    path: rules/typescript.md
+
 servers:
   - id: brave
     type: mcp

--- a/src/cli/commands/install-tasks/__tests__/install-rules.test.ts
+++ b/src/cli/commands/install-tasks/__tests__/install-rules.test.ts
@@ -1,0 +1,99 @@
+import { describe, it, expect, beforeEach, afterEach } from 'bun:test';
+import { mkdtempSync, rmSync, mkdirSync, writeFileSync } from 'fs';
+import { join } from 'path';
+import { tmpdir } from 'os';
+import type { Rule } from '../../../../types/rules';
+import type { RepoSnapshotResolver } from '../../../../shared/repo-file';
+import { resolveRuleBody, type ResolveRuleBodyDeps } from '../install-rules';
+
+// The remote / github / gitlab branches of resolveRuleBody delegate to network
+// helpers; the feature under test here is the `local` source, which (with
+// `inline`) needs no network. These deps satisfy the type while throwing if a
+// remote path is unexpectedly exercised.
+function makeDeps(capabilitiesFilePath: string): ResolveRuleBodyDeps {
+  const getRepoSnapshot: RepoSnapshotResolver = () => {
+    throw new Error('getRepoSnapshot should not be called for local/inline rules');
+  };
+  return {
+    capabilitiesFilePath,
+    authFetch: (() => {
+      throw new Error('authFetch should not be called for local/inline rules');
+    }) as unknown as ResolveRuleBodyDeps['authFetch'],
+    getRepoSnapshot,
+  };
+}
+
+describe('resolveRuleBody', () => {
+  let projectDir: string;
+  let capabilitiesFilePath: string;
+
+  beforeEach(() => {
+    projectDir = mkdtempSync(join(tmpdir(), 'capa-install-rules-'));
+    capabilitiesFilePath = join(projectDir, 'capa.yaml');
+    writeFileSync(capabilitiesFilePath, 'providers: [cursor]\n', 'utf-8');
+  });
+
+  afterEach(() => {
+    rmSync(projectDir, { recursive: true, force: true });
+  });
+
+  it('returns inline content verbatim', async () => {
+    const rule: Rule = { id: 'r', type: 'inline', content: 'Be concise.' };
+    expect(await resolveRuleBody(rule, makeDeps(capabilitiesFilePath))).toBe('Be concise.');
+  });
+
+  it('reads a local file resolved relative to the capabilities file directory', async () => {
+    mkdirSync(join(projectDir, 'rules'), { recursive: true });
+    writeFileSync(join(projectDir, 'rules', 'typescript.md'), '# TS conventions\nUse strict mode.\n', 'utf-8');
+
+    const rule: Rule = {
+      id: 'typescript-conventions',
+      type: 'local',
+      path: 'rules/typescript.md',
+    };
+
+    const body = await resolveRuleBody(rule, makeDeps(capabilitiesFilePath));
+    expect(body).toBe('# TS conventions\nUse strict mode.\n');
+  });
+
+  it('resolves local paths relative to the capabilities file, not the process cwd', async () => {
+    // Capabilities file lives in a nested dir; a bare relative path must resolve
+    // against that dir.
+    const nestedDir = join(projectDir, 'config');
+    mkdirSync(nestedDir, { recursive: true });
+    const nestedCapFile = join(nestedDir, 'capa.yaml');
+    writeFileSync(nestedCapFile, 'providers: [cursor]\n', 'utf-8');
+    writeFileSync(join(nestedDir, 'rule.md'), 'nested body', 'utf-8');
+
+    const rule: Rule = { id: 'r', type: 'local', path: 'rule.md' };
+    expect(await resolveRuleBody(rule, makeDeps(nestedCapFile))).toBe('nested body');
+  });
+
+  it('throws when a local rule has no path', async () => {
+    const rule: Rule = { id: 'r', type: 'local' };
+    await expect(resolveRuleBody(rule, makeDeps(capabilitiesFilePath))).rejects.toThrow(
+      /is type 'local' but has no path/
+    );
+  });
+
+  it('throws a descriptive error when the local file does not exist', async () => {
+    const rule: Rule = { id: 'r', type: 'local', path: 'rules/missing.md' };
+    await expect(resolveRuleBody(rule, makeDeps(capabilitiesFilePath))).rejects.toThrow(
+      /local file not found/
+    );
+  });
+
+  it('throws when inline content is missing', async () => {
+    const rule: Rule = { id: 'r', type: 'inline' };
+    await expect(resolveRuleBody(rule, makeDeps(capabilitiesFilePath))).rejects.toThrow(
+      /is type 'inline' but has no content/
+    );
+  });
+
+  it('throws on an unknown rule type', async () => {
+    const rule = { id: 'r', type: 'mystery' } as unknown as Rule;
+    await expect(resolveRuleBody(rule, makeDeps(capabilitiesFilePath))).rejects.toThrow(
+      /Unknown rule type: mystery/
+    );
+  });
+});

--- a/src/cli/commands/install-tasks/install-rules.ts
+++ b/src/cli/commands/install-tasks/install-rules.ts
@@ -1,7 +1,10 @@
+import { existsSync, readFileSync } from 'fs';
+import { dirname, resolve } from 'path';
 import type { Task } from '../../ui';
 import { createAuthenticatedFetch, AuthenticatedFetch } from '../../../shared/authenticated-fetch';
 import { installRules } from '../../utils/rules-installer';
-import { fetchRepoFile, fetchTextFile } from '../../../shared/repo-file';
+import { fetchRepoFile, fetchTextFile, type RepoSnapshotResolver } from '../../../shared/repo-file';
+import type { Rule } from '../../../types/rules';
 import {
   loadBlockedPhrases,
   checkBlockedPhrases,
@@ -11,9 +14,65 @@ import {
   isCharacterSanitizationEnabled,
   reportBlockedPhraseAndExit,
 } from '../../../shared/skill-security';
-import type { CachePlatform } from '../../../shared/cache';
 import type { InstallCtx } from './context';
 import { getRepoSnapshot } from './helpers/repo-snapshot';
+
+/** Dependencies needed to resolve a rule's body content. */
+export interface ResolveRuleBodyDeps {
+  /** Absolute path of the capabilities file — resolves `local` rule paths. */
+  capabilitiesFilePath: string;
+  authFetch: AuthenticatedFetch;
+  getRepoSnapshot: RepoSnapshotResolver;
+  noCache?: boolean;
+}
+
+/**
+ * Resolve a single rule's markdown body from its source.
+ *
+ *   - `inline`            : `content` is the literal body
+ *   - `local`             : `path` is read from disk (relative to the capabilities file)
+ *   - `remote`            : `url` is fetched at install time
+ *   - `github` / `gitlab` : `def.repo` is cloned and the file read off the snapshot
+ *
+ * Throws a descriptive error when the required field for the type is missing or,
+ * for `local`, when the referenced file does not exist.
+ */
+export async function resolveRuleBody(rule: Rule, deps: ResolveRuleBodyDeps): Promise<string> {
+  if (rule.type === 'inline') {
+    if (!rule.content) throw new Error(`Rule "${rule.id}" is type 'inline' but has no content.`);
+    return rule.content;
+  }
+  if (rule.type === 'local') {
+    if (!rule.path) throw new Error(`Rule "${rule.id}" is type 'local' but has no path.`);
+    const baseDir = dirname(deps.capabilitiesFilePath);
+    const fullPath = resolve(baseDir, rule.path);
+    if (!existsSync(fullPath)) {
+      throw new Error(
+        `Rule "${rule.id}" local file not found: ${fullPath} (resolved from path "${rule.path}").`
+      );
+    }
+    return readFileSync(fullPath, 'utf-8');
+  }
+  if (rule.type === 'remote') {
+    if (!rule.url) throw new Error(`Rule "${rule.id}" is type 'remote' but has no url.`);
+    return await fetchTextFile(rule.url, {
+      authFetch: deps.authFetch,
+      sourceLabel: `rule "${rule.id}"`,
+    });
+  }
+  if (rule.type === 'github' || rule.type === 'gitlab') {
+    if (!rule.def?.repo) throw new Error(`Rule "${rule.id}" is type '${rule.type}' but missing def.repo.`);
+    const result = await fetchRepoFile(
+      rule.type,
+      rule.def.repo,
+      deps.getRepoSnapshot,
+      deps.authFetch,
+      { noCache: deps.noCache }
+    );
+    return result.content;
+  }
+  throw new Error(`Unknown rule type: ${(rule as any).type}`);
+}
 
 export function installRulesTask(): Task<InstallCtx> {
   return {
@@ -22,12 +81,8 @@ export function installRulesTask(): Task<InstallCtx> {
     task: async (ctx, task) => {
       const currentRules = ctx.capabilitiesToUse.rules ?? [];
       const repoFetchAuth = createAuthenticatedFetch(ctx.db);
-      const repoFetchCtx = {
-        authFetch: repoFetchAuth,
-        getRepoSnapshot: (platform: CachePlatform, repoPath: string, auth: AuthenticatedFetch, opts: any) =>
-          getRepoSnapshot(platform, repoPath, auth, opts),
-        noCache: ctx.noCache,
-      };
+      const snapshotResolver: RepoSnapshotResolver = (platform, repoPath, auth, opts) =>
+        getRepoSnapshot(platform, repoPath, auth, opts);
       const providers = ctx.capabilitiesToUse.providers ?? ctx.resolvedProviders;
       ctx.ruleBodies = new Map();
 
@@ -36,29 +91,12 @@ export function installRulesTask(): Task<InstallCtx> {
         const rule = currentRules[i];
         task.output = `[${i + 1}/${totalRules}] ${rule.id}`;
 
-        let body: string;
-        if (rule.type === 'inline') {
-          if (!rule.content) throw new Error(`Rule "${rule.id}" is type 'inline' but has no content.`);
-          body = rule.content;
-        } else if (rule.type === 'remote') {
-          if (!rule.url) throw new Error(`Rule "${rule.id}" is type 'remote' but has no url.`);
-          body = await fetchTextFile(rule.url, {
-            authFetch: repoFetchAuth,
-            sourceLabel: `rule "${rule.id}"`,
-          });
-        } else if (rule.type === 'github' || rule.type === 'gitlab') {
-          if (!rule.def?.repo) throw new Error(`Rule "${rule.id}" is type '${rule.type}' but missing def.repo.`);
-          const result = await fetchRepoFile(
-            rule.type,
-            rule.def.repo,
-            repoFetchCtx.getRepoSnapshot,
-            repoFetchAuth,
-            { noCache: ctx.noCache },
-          );
-          body = result.content;
-        } else {
-          throw new Error(`Unknown rule type: ${(rule as any).type}`);
-        }
+        let body = await resolveRuleBody(rule, {
+          capabilitiesFilePath: ctx.capabilitiesFile.path,
+          authFetch: repoFetchAuth,
+          getRepoSnapshot: snapshotResolver,
+          noCache: ctx.noCache,
+        });
         const security = ctx.capabilitiesToUse.options?.security;
         if (isBlockedPhrasesEnabled(security)) {
           const blockedPhrases = loadBlockedPhrases(security, ctx.capabilitiesFile.path);

--- a/src/types/rules.ts
+++ b/src/types/rules.ts
@@ -12,7 +12,7 @@ import type { AgentSnippetDef } from './capabilities';
 export interface Rule {
   /** Unique identifier, used as the filename stem and capa marker id. */
   id: string;
-  type: 'inline' | 'remote' | 'github' | 'gitlab';
+  type: 'inline' | 'remote' | 'github' | 'gitlab' | 'local';
   /** Restrict this rule to specific providers. When empty/omitted, applies to all. */
   providers?: string[];
   /** Glob patterns for auto-attached rules (Cursor `globs`, Copilot `applyTo`). */
@@ -25,6 +25,11 @@ export interface Rule {
   content?: string;
   /** Raw URL to fetch content from (required when type is 'remote'). */
   url?: string;
+  /**
+   * Path to a local markdown file (required when type is 'local'). Relative
+   * paths are resolved from the directory containing the capabilities file.
+   */
+  path?: string;
   /** Repository + file definition (required when type is 'github' or 'gitlab'). */
   def?: AgentSnippetDef;
 }


### PR DESCRIPTION
Closes #105.

## What

Adds a `local` rule type so rule content can be managed in a separate file instead of inline YAML:

```yaml
rules:
  - id: typescript-conventions
    type: local
    description: Team TypeScript conventions
    appliesTo:
      - "**/*.ts"
      - "**/*.tsx"
    path: rules/typescript.md
```

`path` is resolved relative to the directory containing the capabilities file — the same convention already used by `local` **agents** and **hooks**, so it's consistent across the config.

> Note: the issue's snippet paired `type: remote` with `path:`. `remote` already means "fetch from a URL," so this implements the established `type: local` + `path` convention instead (matches skills/agents/hooks).

## How

- `src/types/rules.ts` — add `'local'` to the `Rule` type union and a documented `path` field.
- `src/cli/commands/install-tasks/install-rules.ts` — extract the per-rule body resolution into an exported, unit-testable `resolveRuleBody()` and add the `local` branch (reads the file off disk; throws a descriptive error if `path` is missing or the file doesn't exist). The writer (`installRules`) is content-agnostic and needed no change.
- `README.md` — document the new type with an example in the rules block.

## Tests

New `install-rules.test.ts` covers: local resolution, resolution relative to the capabilities file (not cwd), missing-`path` error, missing-file error, inline regression, and unknown-type error. Full suite: **1046 pass / 0 fail**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)