### PR TITLE
fix(git): non-interactive clones (no hang, #104) + blobless partial clone for speed (#91)

### DIFF
--- a/src/cli/commands/install-tasks/helpers/__tests__/git.test.ts
+++ b/src/cli/commands/install-tasks/helpers/__tests__/git.test.ts
@@ -1,0 +1,45 @@
+import { describe, it, expect } from 'bun:test';
+import { explainGitError } from '../git';
+
+describe('explainGitError', () => {
+  it('maps "terminal prompts disabled" to an access error mentioning the repo', () => {
+    // This is exactly what git emits once GIT_TERMINAL_PROMPT=0 stops it from
+    // hanging on an interactive credential prompt for a private repo.
+    const err = {
+      stderr:
+        "fatal: could not read Username for 'https://github.com': terminal prompts disabled",
+    };
+    const out = explainGitError(err, 'github', 'owner/private-repo', false);
+
+    // Must be actionable, not a hang. For the no-auth case it should point the
+    // user at connecting the integration.
+    expect(out.message).toContain('owner/private-repo');
+    expect(out.message).toMatch(/private or does not exist/i);
+    // Keep the substrings install-one-skill keys off to append an integrations link.
+    expect(out.message).toMatch(/authentication failed/i);
+    expect(out.message).toMatch(/not accessible/i);
+  });
+
+  it('gives a token-focused hint when auth is configured but still fails', () => {
+    const err = { stderr: 'remote: Authentication failed for ...' };
+    const out = explainGitError(err, 'gitlab', 'group/proj', true);
+    expect(out.message).toMatch(/token may be expired or lacks access/i);
+  });
+
+  it('detects a missing git binary', () => {
+    const out = explainGitError({ code: 'ENOENT' }, 'github', 'a/b', false);
+    expect(out.message).toMatch(/git is not installed/i);
+  });
+
+  it('detects a not-found / no-permission repo', () => {
+    const err = { stderr: "fatal: repository 'https://github.com/a/b' not found" };
+    const out = explainGitError(err, 'github', 'a/b', false);
+    expect(out.message).toMatch(/not accessible/i);
+  });
+
+  it('detects a network failure', () => {
+    const err = { stderr: 'fatal: unable to access ... Could not resolve host: github.com' };
+    const out = explainGitError(err, 'github', 'a/b', true);
+    expect(out.message).toMatch(/network error/i);
+  });
+});

--- a/src/cli/commands/install-tasks/helpers/git.ts
+++ b/src/cli/commands/install-tasks/helpers/git.ts
@@ -60,9 +60,19 @@ export function explainGitError(
 
   if (
     errorMessage.includes('Authentication failed') ||
-    errorMessage.includes('could not read Username')
+    errorMessage.includes('could not read Username') ||
+    errorMessage.includes('could not read Password') ||
+    // git emits this when GIT_TERMINAL_PROMPT=0 stops it prompting for creds.
+    errorMessage.includes('terminal prompts disabled')
   ) {
-    return new Error(`${platformName} authentication failed — token may be expired; reconnect in the integrations page.`);
+    // Keep the substrings "authentication failed" and "not accessible" in the
+    // message — install-one-skill keys off them to append an integrations link.
+    const hint = hasAuth
+      ? `Your ${platformName} token may be expired or lacks access — reconnect in the integrations page.`
+      : `${repoPath} is private or does not exist. Connect ${platformName} in the integrations page if it's private, then re-run \`capa install\`.`;
+    return new Error(
+      `${platformName} authentication failed for ${repoPath} (repository not accessible)\n${repoUrl}\n${hint}`
+    );
   }
 
   if (

--- a/src/shared/__tests__/cache.test.ts
+++ b/src/shared/__tests__/cache.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, beforeAll, beforeEach, afterEach, afterAll } from 'bun:test';
+import { describe, it, expect, beforeAll, beforeEach, afterEach, afterAll, spyOn } from 'bun:test';
 import {
   existsSync,
   mkdirSync,
@@ -9,6 +9,7 @@ import {
 } from 'fs';
 import { tmpdir } from 'os';
 import { join } from 'path';
+import * as childProcess from 'child_process';
 import { exec } from 'child_process';
 import { promisify } from 'util';
 import {
@@ -281,6 +282,36 @@ describe('cache', () => {
       const mirrorDir = await seedMirrorFromFixture('github', 'owner/repo', fixture.url);
       const result = await ensureMirrorClone('github', 'owner/repo', noAuthFetch);
       expect(result).toBe(mirrorDir);
+    });
+
+    it('blobless clone still materializes a complete snapshot (no regression)', async () => {
+      // Drives the real ensureMirrorClone (which now passes --filter=blob:none).
+      // Over file:// the filter is ignored and git does a full clone, but this
+      // guards the end-to-end path: cloning then materializing must still produce
+      // every file at the revision, since consumers walk the snapshot tree.
+      const mirrorDir = await ensureMirrorClone('github', 'owner/repo', noAuthFetch, fixture.url);
+      const { sha } = await resolveRef(mirrorDir, { version: fixture.tag });
+      const snapshotDir = await materializeSnapshot(mirrorDir, 'github', 'owner/repo', sha);
+      expect(existsSync(join(snapshotDir, 'SKILL.md'))).toBe(true);
+      expect(existsSync(join(snapshotDir, 'README.md'))).toBe(true);
+    });
+
+    it('requests a blobless partial clone (--filter=blob:none right after --mirror)', async () => {
+      let capturedArgs: string[] = [];
+      const execFileSpy = spyOn(childProcess, 'execFile').mockImplementation(
+        ((_cmd: string, args: string[], _opts: object, cb: (err: null, result: { stdout: string; stderr: string }) => void) => {
+          capturedArgs = args;
+          cb(null, { stdout: '', stderr: '' });
+        }) as typeof childProcess.execFile
+      );
+
+      await ensureMirrorClone('github', 'owner/repo', noAuthFetch, 'https://example.com/owner/repo.git');
+
+      const mirrorIdx = capturedArgs.indexOf('--mirror');
+      expect(mirrorIdx).toBeGreaterThanOrEqual(0);
+      expect(capturedArgs[mirrorIdx + 1]).toBe('--filter=blob:none');
+
+      execFileSpy.mockRestore();
     });
   });
 });

--- a/src/shared/cache/__tests__/git-cli.test.ts
+++ b/src/shared/cache/__tests__/git-cli.test.ts
@@ -45,8 +45,8 @@ describe('git-cli', () => {
   it('runs git non-interactively so a missing credential never hangs the install', async () => {
     let capturedEnv: Record<string, string | undefined> = {};
     const execFileSpy = spyOn(childProcess, 'execFile').mockImplementation(
-      ((_cmd: string, _args: string[], opts: { env?: Record<string, string | undefined> }, cb: (err: null, result: { stdout: string; stderr: string }) => void) => {
-        capturedEnv = opts.env ?? {};
+      ((_cmd: string, _args: string[], opts: object, cb: (err: null, result: { stdout: string; stderr: string }) => void) => {
+        capturedEnv = (opts as { env?: Record<string, string | undefined> }).env ?? {};
         cb(null, { stdout: '', stderr: '' });
       }) as typeof childProcess.execFile
     );
@@ -66,8 +66,8 @@ describe('git-cli', () => {
   it('lets a caller-provided env override the non-interactive defaults', async () => {
     let capturedEnv: Record<string, string | undefined> = {};
     const execFileSpy = spyOn(childProcess, 'execFile').mockImplementation(
-      ((_cmd: string, _args: string[], opts: { env?: Record<string, string | undefined> }, cb: (err: null, result: { stdout: string; stderr: string }) => void) => {
-        capturedEnv = opts.env ?? {};
+      ((_cmd: string, _args: string[], opts: object, cb: (err: null, result: { stdout: string; stderr: string }) => void) => {
+        capturedEnv = (opts as { env?: Record<string, string | undefined> }).env ?? {};
         cb(null, { stdout: '', stderr: '' });
       }) as typeof childProcess.execFile
     );

--- a/src/shared/cache/__tests__/git-cli.test.ts
+++ b/src/shared/cache/__tests__/git-cli.test.ts
@@ -41,4 +41,40 @@ describe('git-cli', () => {
     expect(execFileSpy).toHaveBeenCalled();
     execFileSpy.mockRestore();
   });
+
+  it('runs git non-interactively so a missing credential never hangs the install', async () => {
+    let capturedEnv: Record<string, string | undefined> = {};
+    const execFileSpy = spyOn(childProcess, 'execFile').mockImplementation(
+      ((_cmd: string, _args: string[], opts: { env?: Record<string, string | undefined> }, cb: (err: null, result: { stdout: string; stderr: string }) => void) => {
+        capturedEnv = opts.env ?? {};
+        cb(null, { stdout: '', stderr: '' });
+      }) as typeof childProcess.execFile
+    );
+
+    await git(['clone', '--mirror', 'https://github.com/owner/private.git', '/tmp/m']);
+
+    // The actual fix: git must not fall back to an interactive prompt.
+    expect(capturedEnv.GIT_TERMINAL_PROMPT).toBe('0');
+    expect(capturedEnv.GCM_INTERACTIVE).toBe('never');
+    expect(capturedEnv.GIT_SSH_COMMAND).toContain('BatchMode=yes');
+    // Existing behaviour preserved.
+    expect(capturedEnv.GIT_LFS_SKIP_SMUDGE).toBe('1');
+
+    execFileSpy.mockRestore();
+  });
+
+  it('lets a caller-provided env override the non-interactive defaults', async () => {
+    let capturedEnv: Record<string, string | undefined> = {};
+    const execFileSpy = spyOn(childProcess, 'execFile').mockImplementation(
+      ((_cmd: string, _args: string[], opts: { env?: Record<string, string | undefined> }, cb: (err: null, result: { stdout: string; stderr: string }) => void) => {
+        capturedEnv = opts.env ?? {};
+        cb(null, { stdout: '', stderr: '' });
+      }) as typeof childProcess.execFile
+    );
+
+    await git(['version'], { env: { GIT_TERMINAL_PROMPT: '1' } });
+    expect(capturedEnv.GIT_TERMINAL_PROMPT).toBe('1');
+
+    execFileSpy.mockRestore();
+  });
 });

--- a/src/shared/cache/git-cli.ts
+++ b/src/shared/cache/git-cli.ts
@@ -22,6 +22,24 @@ export function gitCommandArgs(args: string[]): string[] {
   return [...LFS_SKIP_ARGS, ...args];
 }
 
+/**
+ * Environment that forces git to run non-interactively. Without these, cloning a
+ * private repo with no usable credentials makes git block forever on a terminal
+ * prompt (`Username for 'https://github.com':`) that capa never answers — the
+ * install just hangs. With them set, git fails fast and the error is surfaced to
+ * the user (see `explainGitError`).
+ */
+const NON_INTERACTIVE_GIT_ENV: Record<string, string> = {
+  // Don't fall back to an interactive terminal prompt for HTTP(S) credentials.
+  GIT_TERMINAL_PROMPT: '0',
+  // Don't let Git Credential Manager open an interactive GUI/browser prompt.
+  GCM_INTERACTIVE: 'never',
+  // Defensive: if a repo resolves to SSH, fail fast instead of blocking on a
+  // password/passphrase or host-key confirmation. A user-set GIT_SSH_COMMAND wins.
+  GIT_SSH_COMMAND:
+    process.env.GIT_SSH_COMMAND ?? 'ssh -o BatchMode=yes -o ConnectTimeout=10',
+};
+
 export async function git(
   args: string[],
   opts: ExecFileOptions = {}
@@ -30,7 +48,12 @@ export async function git(
   const { stdout, stderr } = await execFileAsync('git', gitCommandArgs(args), {
     ...opts,
     windowsHide: true,
-    env: { ...process.env, GIT_LFS_SKIP_SMUDGE: '1', ...(opts.env ?? {}) },
+    env: {
+      ...process.env,
+      GIT_LFS_SKIP_SMUDGE: '1',
+      ...NON_INTERACTIVE_GIT_ENV,
+      ...(opts.env ?? {}),
+    },
   });
   return { stdout: String(stdout), stderr: String(stderr) };
 }

--- a/src/shared/cache/mirror.ts
+++ b/src/shared/cache/mirror.ts
@@ -48,7 +48,22 @@ export async function ensureMirrorClone(
   }
   mkdirSync(getRepoCacheDir(platform, repoPath), { recursive: true });
   const url = repoUrl ?? buildAuthenticatedRepoUrl(platform, repoPath, authFetch);
-  await git(['clone', '--mirror', url, mirrorDir]);
+  // Blobless partial clone: fetch the full commit/tree graph (so any SHA, tag,
+  // or branch still resolves offline via resolveRef) but skip all historical
+  // file contents. On a big repo (e.g. remotion) this avoids downloading every
+  // blob across all history — the dominant cost. The blobs for the single
+  // revision we actually check out are fetched lazily by `git worktree add`
+  // during materializeSnapshot, so snapshots stay byte-identical and no consumer
+  // (skills/rules/hooks/plugins, `@`-search or `::`-exact) is affected.
+  //
+  // Why not sparse-checkout per file? Consumers walk whole trees (`@` search)
+  // and copy entire skill directories that reference sibling files, so we can't
+  // know the full file set up front without risking regressions. Blobless keeps
+  // the materialized tree complete while still skipping the expensive history.
+  //
+  // Requires git >= 2.19. Servers without partial-clone support degrade
+  // gracefully to a full clone (git warns and ignores the filter).
+  await git(['clone', '--mirror', '--filter=blob:none', url, mirrorDir]);
   return mirrorDir;
 }
 


### PR DESCRIPTION
Closes #104 and #91. Two related improvements to repository cloning.

---

## 1. Private-repo installs fail fast instead of hanging (#104)

### Problem
Cloning a private repo with no usable credentials made `capa install` **hang forever**: git fell back to an interactive terminal prompt (`Username for 'https://...':`) that capa never answers.

### Fix
Force git non-interactive in the central `git()` wrapper, so every clone/fetch (skills, rules, hooks, plugins, registries) fails fast and the error is surfaced:
- `GIT_TERMINAL_PROMPT=0` — no interactive HTTP(S) credential prompt
- `GCM_INTERACTIVE=never` — no Git Credential Manager GUI/browser popup
- `GIT_SSH_COMMAND=ssh -o BatchMode=yes -o ConnectTimeout=10` — defensive; a user-set value still wins

A caller-supplied `opts.env` still overrides these. `explainGitError()` now recognises git's `terminal prompts disabled` output and, for the no-auth case, tells the user the repo is private/inaccessible and to connect the integration.

---

## 2. Blobless partial clone for faster big-repo installs (#91)

### Problem
`git clone --mirror` downloads **every blob across all history** — slow on large repos (e.g. remotion).

### Fix
Switch the mirror clone to a **blobless partial clone** (`--filter=blob:none`): fetch the full commit/tree graph (so any SHA/tag/branch still resolves offline in `resolveRef`) but skip historical file contents. The blobs for the single revision we actually check out are fetched lazily by `git worktree add` during `materializeSnapshot`, so the snapshot tree stays **byte-identical** and no consumer is affected.

**Why not the sparse-checkout-per-file approach from the issue?** Consumers walk whole trees (`@`-basename search for skills/rules/hooks/plugins) and copy entire skill directories that reference sibling files — the full file set isn't knowable up front. Blobless keeps the materialized tree complete while still skipping the expensive history: the speedup without the regression risk the issue explicitly cautions about (skills/rules/hooks/plugins must not regress).

**Safety:**
- Requires git ≥ 2.19. Servers without partial-clone support **degrade gracefully** to a full clone (git warns and ignores the filter) — verified with `file://` fixtures, which still materialize completely.
- Offline cache hits (pinned-SHA snapshot already on disk) are unaffected — only the first materialize of a SHA needs blobs.
- Existing full-clone mirrors on disk keep working untouched.

---

## Verification
- Confirmed a clone of an inaccessible repo exits in ~1s with an actionable error (no hang).
- Confirmed end-to-end that a blobless clone + `worktree add` materializes every file at the revision.
- Tests: non-interactive env is passed (and overridable); `explainGitError` prompt-disabled/no-auth/token/not-found/network cases; blobless clone issues `--filter=blob:none` and still materializes a complete snapshot.
- `bunx tsc --noEmit` clean; full suite **1048 pass / 0 fail**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)