### PR TITLE
fix(hooks): reference local hook scripts by a portable relative path

### DIFF
--- a/src/cli/utils/__tests__/hooks-installer.test.ts
+++ b/src/cli/utils/__tests__/hooks-installer.test.ts
@@ -159,10 +159,11 @@ describe('hooks-installer (claude inline-config)', () => {
     expect(result.warnings.some((w) => /no mapping/.test(w))).toBe(true);
   });
 
-  it('source.type=local references the user\'s script directly (no copy under ~/.capa)', async () => {
-    // Place a script alongside the (synthetic) capabilities file and point
-    // the hook at it via a relative path. capa should embed the absolute
-    // path of THAT script in the provider config, not a path under ~/.capa.
+  it('source.type=local inside the project is referenced by a portable relative path', async () => {
+    // Place a script inside the project and point the hook at it. Because the
+    // script lives in the repo, capa must embed a PROJECT-RELATIVE path in the
+    // provider config (not the author's absolute, machine-specific path) so the
+    // committed config works for everyone who clones the repo.
     require('fs').mkdirSync(join(projectPath, 'scripts'), { recursive: true });
     const scriptPath = join(projectPath, 'scripts', 'lint.sh');
     writeFileSync(scriptPath, '#!/bin/sh\necho lint\n', 'utf-8');
@@ -189,13 +190,48 @@ describe('hooks-installer (claude inline-config)', () => {
       readFileSync(join(projectPath, '.claude', 'settings.json'), 'utf-8'),
     ) as any;
     const entry = settings.hooks.PostToolUse[0].hooks[0];
-    expect(entry.command).toBe(scriptPath);
+    // Relative, forward-slashed, ./-prefixed — and crucially NOT absolute.
+    expect(entry.command).toBe('./scripts/lint.sh');
+    expect(entry.command).not.toContain(projectPath);
 
     // No copy in ~/.capa — managed_hooks.scriptPath stays null so clean
     // never tries to unlink the user's file.
     const rows = db.getManagedHooks(projectId);
     expect(rows).toHaveLength(1);
     expect(rows[0].scriptPath).toBeNull();
+  });
+
+  it('source.type=local outside the project keeps the absolute path', async () => {
+    // A script that lives outside the project can't be committed, so a relative
+    // path would be meaningless — capa keeps the absolute path in that case.
+    const outsideDir = join(tempDir, 'outside');
+    require('fs').mkdirSync(outsideDir, { recursive: true });
+    const scriptPath = join(outsideDir, 'global-hook.sh');
+    writeFileSync(scriptPath, '#!/bin/sh\necho hi\n', 'utf-8');
+
+    const result = await installHooks({
+      projectPath,
+      projectId,
+      capabilitiesFilePath: join(projectPath, 'capabilities.yaml'),
+      hooks: [
+        {
+          id: 'global-edit',
+          on: 'afterFileEdit',
+          source: { type: 'local', path: '../outside/global-hook.sh' },
+        },
+      ],
+      providers: ['claude-code'],
+      db,
+      authFetch: makeAuthFetch(),
+      getRepoSnapshot: stubGetRepoSnapshot,
+    });
+    expect(result.installed).toBe(1);
+
+    const settings = JSON.parse(
+      readFileSync(join(projectPath, '.claude', 'settings.json'), 'utf-8'),
+    ) as any;
+    const entry = settings.hooks.PostToolUse[0].hooks[0];
+    expect(entry.command).toBe(scriptPath);
   });
 
   it('prompt-type local source reads the file contents as the prompt text', async () => {

--- a/src/cli/utils/hooks-installer.ts
+++ b/src/cli/utils/hooks-installer.ts
@@ -23,7 +23,7 @@
  */
 
 import { existsSync, mkdirSync, readFileSync, writeFileSync, chmodSync, unlinkSync } from 'fs';
-import { dirname, join, resolve as resolvePath, sep as pathSep } from 'path';
+import { dirname, join, relative as relativePath, isAbsolute, resolve as resolvePath, sep as pathSep } from 'path';
 import { createHash } from 'crypto';
 import type { CapaDatabase } from '../../db/database';
 import type { ManagedHookRow } from '../../db/managed-hooks';
@@ -110,8 +110,12 @@ export async function installHooks(opts: InstallHooksOptions): Promise<InstallHo
   // Step 2: figure out the run reference for each command-type hook.
   //
   //  - inline `command:` (no source) -> use the literal command string;
-  //  - `source.type=local`           -> reference the user's script in place
-  //                                     via its absolute path (no copy);
+  //  - `source.type=local`           -> reference the user's script in place.
+  //                                     When the script lives inside the project
+  //                                     it's referenced by a project-relative
+  //                                     path (so the committed provider config is
+  //                                     portable across machines); otherwise its
+  //                                     absolute path is used. No copy either way.
   //  - inline / remote / github / gitlab -> materialise to
   //                                     ~/.capa/hooks/<projectId>/<hookId>
   //                                     and reference that absolute path.
@@ -127,7 +131,7 @@ export async function installHooks(opts: InstallHooksOptions): Promise<InstallHo
     }
 
     if (body.localPath) {
-      hookScriptPaths.set(hook.id, body.localPath);
+      hookScriptPaths.set(hook.id, toPortableHookReference(body.localPath, projectPath));
       continue;
     }
 
@@ -310,14 +314,38 @@ interface ResolvedHookBody {
   needsMaterialisation: boolean;
   /**
    * Set for `source.type='local'`: the absolute path of the user's script.
-   * The provider entry's `command` is set to this path verbatim, so the
-   * user's file becomes the live hook script — no copy in ~/.capa, no
-   * scriptPath tracked in `managed_hooks`, no chmod, and edits to the
-   * file take effect immediately without re-running `capa install`.
+   * The provider entry's `command` points at this file (project-relative when
+   * it lives inside the project — see toPortableHookReference — otherwise
+   * absolute), so the user's file becomes the live hook script: no copy in
+   * ~/.capa, no scriptPath tracked in `managed_hooks`, no chmod, and edits to
+   * the file take effect immediately without re-running `capa install`.
    */
   localPath?: string;
   /** Optional lockfile pin for remote / repo sources. */
   lockEntry?: LockHookEntry;
+}
+
+/**
+ * Turn the absolute path of a `local` hook script into the reference written
+ * into the provider config.
+ *
+ * Provider hooks run with their working directory at the project root, so a
+ * script that lives inside the project is referenced by a project-relative
+ * path (forward slashes, `./`-prefixed so it executes as a path rather than a
+ * PATH lookup). That keeps the committed config portable — other clones don't
+ * inherit the author's absolute, machine-specific path.
+ *
+ * A script outside the project can't be committed meaningfully, so its
+ * absolute path is kept as-is.
+ */
+function toPortableHookReference(absScriptPath: string, projectPath: string): string {
+  const rel = relativePath(projectPath, absScriptPath);
+  // Empty (same path), climbs out with `..`, or absolute (e.g. a different
+  // Windows drive) all mean the script isn't inside the project → keep absolute.
+  if (!rel || rel.startsWith('..') || isAbsolute(rel)) {
+    return absScriptPath;
+  }
+  return `./${rel.split(pathSep).join('/')}`;
 }
 
 async function resolveHookBody(hook: Hook, opts: InstallHooksOptions): Promise<ResolvedHookBody> {


### PR DESCRIPTION
## Problem

A `source.type=local` command hook is wired into the provider config by its **absolute path**:

```jsonc
// .claude/settings.json (committed to the repo)
{ "type": "command", "command": "/Users/alice/proj/scripts/lint.sh", "name": "capa:lint" }
```

When that config is committed to git, every teammate who clones inherits Alice's machine-specific path, and the hook breaks for all of them.

## Fix

When a local hook's script lives **inside the project**, emit a **project-relative** reference instead:

```jsonc
{ "type": "command", "command": "./scripts/lint.sh", "name": "capa:lint" }
```

- Forward-slashed and `./`-prefixed. Provider hooks run with their working directory at the project root, so the relative path resolves correctly and executes as a path (not a `$PATH` lookup).
- A script **outside** the project keeps its absolute path — a relative one would be meaningless and it can't be committed anyway.
- Only the run reference's *representation* changes. There's still no copy, no chmod, and `managed_hooks.scriptPath` stays `null` for local sources, so `clean`/`prune` continue to never touch the user's file. Idempotent re-installs update the entry in place by name tag.

## Tests

- A local script inside the project is referenced as `./scripts/lint.sh` (and asserted **not** to contain the absolute project path).
- A local script outside the project keeps its absolute path.

`bunx tsc --noEmit` clean; full suite green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)