### PR TITLE
Improve shell tool loading, local rule support, and git handling

### DIFF
--- a/README.md
+++ b/README.md
@@ -143,6 +143,15 @@ rules:
       Always use Conventional Commits (feat/fix/chore/docs/refactor).
       Subject ≤ 72 chars, imperative mood, no trailing period.
 
+  - id: typescript-conventions
+    type: local
+    description: Team TypeScript conventions
+    appliesTo:
+      - "**/*.ts"
+      - "**/*.tsx"
+    # Path is resolved relative to this capabilities file.
+    path: rules/typescript.md
+
 servers:
   - id: brave
     type: mcp

--- a/src/cli/commands/__tests__/sh.test.ts
+++ b/src/cli/commands/__tests__/sh.test.ts
@@ -14,6 +14,7 @@ function makeCommand(overrides: Partial<ShellCommand> = {}): ShellCommand {
       required: [],
     },
     argSlugs: new Map(),
+    schemaLoaded: true,
     ...overrides,
   };
 }

--- a/src/cli/commands/install-tasks/__tests__/install-rules.test.ts
+++ b/src/cli/commands/install-tasks/__tests__/install-rules.test.ts
@@ -1,0 +1,99 @@
+import { describe, it, expect, beforeEach, afterEach } from 'bun:test';
+import { mkdtempSync, rmSync, mkdirSync, writeFileSync } from 'fs';
+import { join } from 'path';
+import { tmpdir } from 'os';
+import type { Rule } from '../../../../types/rules';
+import type { RepoSnapshotResolver } from '../../../../shared/repo-file';
+import { resolveRuleBody, type ResolveRuleBodyDeps } from '../install-rules';
+
+// The remote / github / gitlab branches of resolveRuleBody delegate to network
+// helpers; the feature under test here is the `local` source, which (with
+// `inline`) needs no network. These deps satisfy the type while throwing if a
+// remote path is unexpectedly exercised.
+function makeDeps(capabilitiesFilePath: string): ResolveRuleBodyDeps {
+  const getRepoSnapshot: RepoSnapshotResolver = () => {
+    throw new Error('getRepoSnapshot should not be called for local/inline rules');
+  };
+  return {
+    capabilitiesFilePath,
+    authFetch: (() => {
+      throw new Error('authFetch should not be called for local/inline rules');
+    }) as unknown as ResolveRuleBodyDeps['authFetch'],
+    getRepoSnapshot,
+  };
+}
+
+describe('resolveRuleBody', () => {
+  let projectDir: string;
+  let capabilitiesFilePath: string;
+
+  beforeEach(() => {
+    projectDir = mkdtempSync(join(tmpdir(), 'capa-install-rules-'));
+    capabilitiesFilePath = join(projectDir, 'capa.yaml');
+    writeFileSync(capabilitiesFilePath, 'providers: [cursor]\n', 'utf-8');
+  });
+
+  afterEach(() => {
+    rmSync(projectDir, { recursive: true, force: true });
+  });
+
+  it('returns inline content verbatim', async () => {
+    const rule: Rule = { id: 'r', type: 'inline', content: 'Be concise.' };
+    expect(await resolveRuleBody(rule, makeDeps(capabilitiesFilePath))).toBe('Be concise.');
+  });
+
+  it('reads a local file resolved relative to the capabilities file directory', async () => {
+    mkdirSync(join(projectDir, 'rules'), { recursive: true });
+    writeFileSync(join(projectDir, 'rules', 'typescript.md'), '# TS conventions\nUse strict mode.\n', 'utf-8');
+
+    const rule: Rule = {
+      id: 'typescript-conventions',
+      type: 'local',
+      path: 'rules/typescript.md',
+    };
+
+    const body = await resolveRuleBody(rule, makeDeps(capabilitiesFilePath));
+    expect(body).toBe('# TS conventions\nUse strict mode.\n');
+  });
+
+  it('resolves local paths relative to the capabilities file, not the process cwd', async () => {
+    // Capabilities file lives in a nested dir; a bare relative path must resolve
+    // against that dir.
+    const nestedDir = join(projectDir, 'config');
+    mkdirSync(nestedDir, { recursive: true });
+    const nestedCapFile = join(nestedDir, 'capa.yaml');
+    writeFileSync(nestedCapFile, 'providers: [cursor]\n', 'utf-8');
+    writeFileSync(join(nestedDir, 'rule.md'), 'nested body', 'utf-8');
+
+    const rule: Rule = { id: 'r', type: 'local', path: 'rule.md' };
+    expect(await resolveRuleBody(rule, makeDeps(nestedCapFile))).toBe('nested body');
+  });
+
+  it('throws when a local rule has no path', async () => {
+    const rule: Rule = { id: 'r', type: 'local' };
+    await expect(resolveRuleBody(rule, makeDeps(capabilitiesFilePath))).rejects.toThrow(
+      /is type 'local' but has no path/
+    );
+  });
+
+  it('throws a descriptive error when the local file does not exist', async () => {
+    const rule: Rule = { id: 'r', type: 'local', path: 'rules/missing.md' };
+    await expect(resolveRuleBody(rule, makeDeps(capabilitiesFilePath))).rejects.toThrow(
+      /local file not found/
+    );
+  });
+
+  it('throws when inline content is missing', async () => {
+    const rule: Rule = { id: 'r', type: 'inline' };
+    await expect(resolveRuleBody(rule, makeDeps(capabilitiesFilePath))).rejects.toThrow(
+      /is type 'inline' but has no content/
+    );
+  });
+
+  it('throws on an unknown rule type', async () => {
+    const rule = { id: 'r', type: 'mystery' } as unknown as Rule;
+    await expect(resolveRuleBody(rule, makeDeps(capabilitiesFilePath))).rejects.toThrow(
+      /Unknown rule type: mystery/
+    );
+  });
+});

--- a/src/cli/commands/install-tasks/helpers/__tests__/git.test.ts
+++ b/src/cli/commands/install-tasks/helpers/__tests__/git.test.ts
@@ -1,0 +1,45 @@
+import { describe, it, expect } from 'bun:test';
+import { explainGitError } from '../git';
+
+describe('explainGitError', () => {
+  it('maps "terminal prompts disabled" to an access error mentioning the repo', () => {
+    // This is exactly what git emits once GIT_TERMINAL_PROMPT=0 stops it from
+    // hanging on an interactive credential prompt for a private repo.
+    const err = {
+      stderr:
+        "fatal: could not read Username for 'https://github.com': terminal prompts disabled",
+    };
+    const out = explainGitError(err, 'github', 'owner/private-repo', false);
+
+    // Must be actionable, not a hang. For the no-auth case it should point the
+    // user at connecting the integration.
+    expect(out.message).toContain('owner/private-repo');
+    expect(out.message).toMatch(/private or does not exist/i);
+    // Keep the substrings install-one-skill keys off to append an integrations link.
+    expect(out.message).toMatch(/authentication failed/i);
+    expect(out.message).toMatch(/not accessible/i);
+  });
+
+  it('gives a token-focused hint when auth is configured but still fails', () => {
+    const err = { stderr: 'remote: Authentication failed for ...' };
+    const out = explainGitError(err, 'gitlab', 'group/proj', true);
+    expect(out.message).toMatch(/token may be expired or lacks access/i);
+  });
+
+  it('detects a missing git binary', () => {
+    const out = explainGitError({ code: 'ENOENT' }, 'github', 'a/b', false);
+    expect(out.message).toMatch(/git is not installed/i);
+  });
+
+  it('detects a not-found / no-permission repo', () => {
+    const err = { stderr: "fatal: repository 'https://github.com/a/b' not found" };
+    const out = explainGitError(err, 'github', 'a/b', false);
+    expect(out.message).toMatch(/not accessible/i);
+  });
+
+  it('detects a network failure', () => {
+    const err = { stderr: 'fatal: unable to access ... Could not resolve host: github.com' };
+    const out = explainGitError(err, 'github', 'a/b', true);
+    expect(out.message).toMatch(/network error/i);
+  });
+});

--- a/src/cli/commands/install-tasks/helpers/git.ts
+++ b/src/cli/commands/install-tasks/helpers/git.ts
@@ -60,9 +60,19 @@ export function explainGitError(
 
   if (
     errorMessage.includes('Authentication failed') ||
-    errorMessage.includes('could not read Username')
+    errorMessage.includes('could not read Username') ||
+    errorMessage.includes('could not read Password') ||
+    // git emits this when GIT_TERMINAL_PROMPT=0 stops it prompting for creds.
+    errorMessage.includes('terminal prompts disabled')
   ) {
-    return new Error(`${platformName} authentication failed — token may be expired; reconnect in the integrations page.`);
+    // Keep the substrings "authentication failed" and "not accessible" in the
+    // message — install-one-skill keys off them to append an integrations link.
+    const hint = hasAuth
+      ? `Your ${platformName} token may be expired or lacks access — reconnect in the integrations page.`
+      : `${repoPath} is private or does not exist. Connect ${platformName} in the integrations page if it's private, then re-run \`capa install\`.`;
+    return new Error(
+      `${platformName} authentication failed for ${repoPath} (repository not accessible)\n${repoUrl}\n${hint}`
+    );
   }
 
   if (

--- a/src/cli/commands/install-tasks/install-rules.ts
+++ b/src/cli/commands/install-tasks/install-rules.ts
@@ -1,7 +1,10 @@
+import { existsSync, readFileSync } from 'fs';
+import { dirname, resolve } from 'path';
 import type { Task } from '../../ui';
 import { createAuthenticatedFetch, AuthenticatedFetch } from '../../../shared/authenticated-fetch';
 import { installRules } from '../../utils/rules-installer';
-import { fetchRepoFile, fetchTextFile } from '../../../shared/repo-file';
+import { fetchRepoFile, fetchTextFile, type RepoSnapshotResolver } from '../../../shared/repo-file';
+import type { Rule } from '../../../types/rules';
 import {
   loadBlockedPhrases,
   checkBlockedPhrases,
@@ -11,9 +14,65 @@ import {
   isCharacterSanitizationEnabled,
   reportBlockedPhraseAndExit,
 } from '../../../shared/skill-security';
-import type { CachePlatform } from '../../../shared/cache';
 import type { InstallCtx } from './context';
 import { getRepoSnapshot } from './helpers/repo-snapshot';
+
+/** Dependencies needed to resolve a rule's body content. */
+export interface ResolveRuleBodyDeps {
+  /** Absolute path of the capabilities file — resolves `local` rule paths. */
+  capabilitiesFilePath: string;
+  authFetch: AuthenticatedFetch;
+  getRepoSnapshot: RepoSnapshotResolver;
+  noCache?: boolean;
+}
+
+/**
+ * Resolve a single rule's markdown body from its source.
+ *
+ *   - `inline`            : `content` is the literal body
+ *   - `local`             : `path` is read from disk (relative to the capabilities file)
+ *   - `remote`            : `url` is fetched at install time
+ *   - `github` / `gitlab` : `def.repo` is cloned and the file read off the snapshot
+ *
+ * Throws a descriptive error when the required field for the type is missing or,
+ * for `local`, when the referenced file does not exist.
+ */
+export async function resolveRuleBody(rule: Rule, deps: ResolveRuleBodyDeps): Promise<string> {
+  if (rule.type === 'inline') {
+    if (!rule.content) throw new Error(`Rule "${rule.id}" is type 'inline' but has no content.`);
+    return rule.content;
+  }
+  if (rule.type === 'local') {
+    if (!rule.path) throw new Error(`Rule "${rule.id}" is type 'local' but has no path.`);
+    const baseDir = dirname(deps.capabilitiesFilePath);
+    const fullPath = resolve(baseDir, rule.path);
+    if (!existsSync(fullPath)) {
+      throw new Error(
+        `Rule "${rule.id}" local file not found: ${fullPath} (resolved from path "${rule.path}").`
+      );
+    }
+    return readFileSync(fullPath, 'utf-8');
+  }
+  if (rule.type === 'remote') {
+    if (!rule.url) throw new Error(`Rule "${rule.id}" is type 'remote' but has no url.`);
+    return await fetchTextFile(rule.url, {
+      authFetch: deps.authFetch,
+      sourceLabel: `rule "${rule.id}"`,
+    });
+  }
+  if (rule.type === 'github' || rule.type === 'gitlab') {
+    if (!rule.def?.repo) throw new Error(`Rule "${rule.id}" is type '${rule.type}' but missing def.repo.`);
+    const result = await fetchRepoFile(
+      rule.type,
+      rule.def.repo,
+      deps.getRepoSnapshot,
+      deps.authFetch,
+      { noCache: deps.noCache }
+    );
+    return result.content;
+  }
+  throw new Error(`Unknown rule type: ${(rule as any).type}`);
+}
 
 export function installRulesTask(): Task<InstallCtx> {
   return {
@@ -22,12 +81,8 @@ export function installRulesTask(): Task<InstallCtx> {
     task: async (ctx, task) => {
       const currentRules = ctx.capabilitiesToUse.rules ?? [];
       const repoFetchAuth = createAuthenticatedFetch(ctx.db);
-      const repoFetchCtx = {
-        authFetch: repoFetchAuth,
-        getRepoSnapshot: (platform: CachePlatform, repoPath: string, auth: AuthenticatedFetch, opts: any) =>
-          getRepoSnapshot(platform, repoPath, auth, opts),
-        noCache: ctx.noCache,
-      };
+      const snapshotResolver: RepoSnapshotResolver = (platform, repoPath, auth, opts) =>
+        getRepoSnapshot(platform, repoPath, auth, opts);
       const providers = ctx.capabilitiesToUse.providers ?? ctx.resolvedProviders;
       ctx.ruleBodies = new Map();
 
@@ -36,29 +91,12 @@ export function installRulesTask(): Task<InstallCtx> {
         const rule = currentRules[i];
         task.output = `[${i + 1}/${totalRules}] ${rule.id}`;
 
-        let body: string;
-        if (rule.type === 'inline') {
-          if (!rule.content) throw new Error(`Rule "${rule.id}" is type 'inline' but has no content.`);
-          body = rule.content;
-        } else if (rule.type === 'remote') {
-          if (!rule.url) throw new Error(`Rule "${rule.id}" is type 'remote' but has no url.`);
-          body = await fetchTextFile(rule.url, {
-            authFetch: repoFetchAuth,
-            sourceLabel: `rule "${rule.id}"`,
-          });
-        } else if (rule.type === 'github' || rule.type === 'gitlab') {
-          if (!rule.def?.repo) throw new Error(`Rule "${rule.id}" is type '${rule.type}' but missing def.repo.`);
-          const result = await fetchRepoFile(
-            rule.type,
-            rule.def.repo,
-            repoFetchCtx.getRepoSnapshot,
-            repoFetchAuth,
-            { noCache: ctx.noCache },
-          );
-          body = result.content;
-        } else {
-          throw new Error(`Unknown rule type: ${(rule as any).type}`);
-        }
+        let body = await resolveRuleBody(rule, {
+          capabilitiesFilePath: ctx.capabilitiesFile.path,
+          authFetch: repoFetchAuth,
+          getRepoSnapshot: snapshotResolver,
+          noCache: ctx.noCache,
+        });
         const security = ctx.capabilitiesToUse.options?.security;
         if (isBlockedPhrasesEnabled(security)) {
           const blockedPhrases = loadBlockedPhrases(security, ctx.capabilitiesFile.path);

--- a/src/cli/commands/sh.ts
+++ b/src/cli/commands/sh.ts
@@ -25,6 +25,22 @@ export interface ShellCommand {
   argSlugs: Map<string, string>;
   /** Default argument values */
   defaults?: Record<string, any>;
+  /**
+   * Whether `inputSchema` is populated. Command tools ship their schema with the
+   * metadata listing; MCP tool schemas are fetched lazily (see ensureSchema) only
+   * when the tool is run or `--help`'d, so this is falsy for them until resolved.
+   */
+  schemaLoaded?: boolean;
+}
+
+/** Build the slugified-arg-name → original-arg-name map from a tool input schema. */
+function buildArgSlugs(inputSchema: any): Map<string, string> {
+  const argSlugs = new Map<string, string>();
+  const props = inputSchema?.properties || {};
+  for (const argName of Object.keys(props)) {
+    argSlugs.set(slugify(argName), argName);
+  }
+  return argSlugs;
 }
 
 interface ShellGroup {
@@ -47,12 +63,7 @@ class ShellRegistry {
 
     for (const tool of tools) {
       const commandSlug = slugify(tool.id);
-      const argSlugs = new Map<string, string>();
-
-      const props = tool.inputSchema?.properties || {};
-      for (const argName of Object.keys(props)) {
-        argSlugs.set(slugify(argName), argName);
-      }
+      const argSlugs = buildArgSlugs(tool.inputSchema);
 
       const cmd: ShellCommand = {
         id: tool.id,
@@ -62,6 +73,8 @@ class ShellRegistry {
         inputSchema: tool.inputSchema,
         argSlugs,
         defaults: tool.defaults,
+        // MCP schemas are fetched on demand; command schemas arrive with the listing.
+        schemaLoaded: tool.type === 'command',
       };
 
       if (tool.type === 'mcp' && tool.serverId) {
@@ -103,18 +116,14 @@ class ShellRegistry {
         const dotIdx = tool.id.indexOf('.');
         const shortName = dotIdx >= 0 ? tool.id.slice(dotIdx + 1) : tool.id;
         const commandSlug = slugify(shortName);
-        const argSlugs = new Map<string, string>();
-        const props = tool.inputSchema?.properties || {};
-        for (const argName of Object.keys(props)) {
-          argSlugs.set(slugify(argName), argName);
-        }
         this.topLevelCommands.set(commandSlug, {
           id: tool.id,
           slug: commandSlug,
           type: tool.type,
           description: tool.description,
           inputSchema: tool.inputSchema,
-          argSlugs,
+          argSlugs: buildArgSlugs(tool.inputSchema),
+          schemaLoaded: tool.type === 'command',
         });
       } else {
         // Create the group
@@ -129,18 +138,14 @@ class ShellRegistry {
           const dotIdx = tool.id.indexOf('.');
           const shortName = dotIdx >= 0 ? tool.id.slice(dotIdx + 1) : tool.id;
           const commandSlug = slugify(shortName);
-          const argSlugs = new Map<string, string>();
-          const props = tool.inputSchema?.properties || {};
-          for (const argName of Object.keys(props)) {
-            argSlugs.set(slugify(argName), argName);
-          }
           group.commands.set(commandSlug, {
             id: tool.id,
             slug: commandSlug,
             type: tool.type,
             description: tool.description,
             inputSchema: tool.inputSchema,
-            argSlugs,
+            argSlugs: buildArgSlugs(tool.inputSchema),
+            schemaLoaded: tool.type === 'command',
           });
         }
         this.groups.set(groupSlug, group);
@@ -259,6 +264,45 @@ async function fetchShellTools(serverUrl: string, projectId: string): Promise<Sh
   }
   const data = await response.json() as { tools: ShellToolInfo[] };
   return data.tools;
+}
+
+/**
+ * Fetch the input schema for a single tool on demand. Used right before a tool is
+ * run or `--help`'d. Throws a descriptive error (e.g. remote server down / timed
+ * out / tool missing) which the caller surfaces for that one tool.
+ */
+async function fetchToolSchema(
+  serverUrl: string,
+  projectId: string,
+  toolId: string
+): Promise<{ description: string; inputSchema: any }> {
+  const response = await fetch(
+    `${serverUrl}/api/projects/${projectId}/shell-tool-schema?tool=${encodeURIComponent(toolId)}`,
+    { signal: AbortSignal.timeout(20000) }
+  );
+  if (!response.ok) {
+    const body = await response.json().catch(() => null) as { error?: string } | null;
+    throw new Error(body?.error || `Failed to load schema for "${toolId}" (${response.status})`);
+  }
+  return await response.json() as { description: string; inputSchema: any };
+}
+
+/**
+ * Ensure a command's input schema is loaded before it is run or `--help`'d.
+ * Command tools already carry their schema; MCP tool schemas are fetched lazily
+ * here so listing commands never blocks on (or fails because of) a remote server.
+ */
+async function ensureSchema(
+  cmd: ShellCommand,
+  serverUrl: string,
+  projectId: string
+): Promise<void> {
+  if (cmd.schemaLoaded) return;
+  const { description, inputSchema } = await fetchToolSchema(serverUrl, projectId, cmd.id);
+  cmd.inputSchema = inputSchema;
+  cmd.argSlugs = buildArgSlugs(inputSchema);
+  if (description) cmd.description = description;
+  cmd.schemaLoaded = true;
 }
 
 async function executeToolViaMCP(
@@ -474,6 +518,24 @@ function isHelpFlag(token: string): boolean {
   return token === '--help' || token === '-h' || token === 'help';
 }
 
+/**
+ * Load a command's schema before help/execution, exiting with a clear message if
+ * the remote server backing it is unreachable. Scoped to the single tool, so other
+ * commands in the session are unaffected.
+ */
+async function loadSchemaOrExit(
+  cmd: ShellCommand,
+  serverUrl: string,
+  projectId: string
+): Promise<void> {
+  try {
+    await ensureSchema(cmd, serverUrl, projectId);
+  } catch (err: any) {
+    console.error(`Could not load "${cmd.slug}": ${err.message}`);
+    process.exit(1);
+  }
+}
+
 async function dispatch(
   tokens: string[],
   registry: ShellRegistry,
@@ -516,6 +578,9 @@ async function dispatch(
 
     const cmd = group.commands.get(subSlug)!;
 
+    // Using a specific tool (help or run) → resolve its schema now.
+    await loadSchemaOrExit(cmd, serverUrl, projectId);
+
     // `capa sh <group> <subcommand> --help` → show command arg info
     if (subRest.length > 0 && isHelpFlag(subRest[0])) {
       printCommandHelp(cmd);
@@ -529,6 +594,9 @@ async function dispatch(
   // Top-level capa command
   if (registry.topLevelCommands.has(first)) {
     const cmd = registry.topLevelCommands.get(first)!;
+
+    // Using a specific tool (help or run) → resolve its schema now.
+    await loadSchemaOrExit(cmd, serverUrl, projectId);
 
     // `capa sh <command> --help` → show command arg info
     if (rest.length > 0 && isHelpFlag(rest[0])) {

--- a/src/cli/commands/sh.ts
+++ b/src/cli/commands/sh.ts
@@ -28,9 +28,9 @@ export interface ShellCommand {
   /**
    * Whether `inputSchema` is populated. Command tools ship their schema with the
    * metadata listing; MCP tool schemas are fetched lazily (see ensureSchema) only
-   * when the tool is run or `--help`'d, so this is falsy for them until resolved.
+   * when the tool is run or `--help`'d, so this is false for them until resolved.
    */
-  schemaLoaded?: boolean;
+  schemaLoaded: boolean;
 }
 
 /** Build the slugified-arg-name → original-arg-name map from a tool input schema. */

--- a/src/cli/utils/__tests__/hooks-installer.test.ts
+++ b/src/cli/utils/__tests__/hooks-installer.test.ts
@@ -159,10 +159,11 @@ describe('hooks-installer (claude inline-config)', () => {
     expect(result.warnings.some((w) => /no mapping/.test(w))).toBe(true);
   });
 
-  it('source.type=local references the user\'s script directly (no copy under ~/.capa)', async () => {
-    // Place a script alongside the (synthetic) capabilities file and point
-    // the hook at it via a relative path. capa should embed the absolute
-    // path of THAT script in the provider config, not a path under ~/.capa.
+  it('source.type=local inside the project is referenced by a portable relative path', async () => {
+    // Place a script inside the project and point the hook at it. Because the
+    // script lives in the repo, capa must embed a PROJECT-RELATIVE path in the
+    // provider config (not the author's absolute, machine-specific path) so the
+    // committed config works for everyone who clones the repo.
     require('fs').mkdirSync(join(projectPath, 'scripts'), { recursive: true });
     const scriptPath = join(projectPath, 'scripts', 'lint.sh');
     writeFileSync(scriptPath, '#!/bin/sh\necho lint\n', 'utf-8');
@@ -189,13 +190,48 @@ describe('hooks-installer (claude inline-config)', () => {
       readFileSync(join(projectPath, '.claude', 'settings.json'), 'utf-8'),
     ) as any;
     const entry = settings.hooks.PostToolUse[0].hooks[0];
-    expect(entry.command).toBe(scriptPath);
+    // Relative, forward-slashed, ./-prefixed — and crucially NOT absolute.
+    expect(entry.command).toBe('./scripts/lint.sh');
+    expect(entry.command).not.toContain(projectPath);
 
     // No copy in ~/.capa — managed_hooks.scriptPath stays null so clean
     // never tries to unlink the user's file.
     const rows = db.getManagedHooks(projectId);
     expect(rows).toHaveLength(1);
     expect(rows[0].scriptPath).toBeNull();
+  });
+
+  it('source.type=local outside the project keeps the absolute path', async () => {
+    // A script that lives outside the project can't be committed, so a relative
+    // path would be meaningless — capa keeps the absolute path in that case.
+    const outsideDir = join(tempDir, 'outside');
+    require('fs').mkdirSync(outsideDir, { recursive: true });
+    const scriptPath = join(outsideDir, 'global-hook.sh');
+    writeFileSync(scriptPath, '#!/bin/sh\necho hi\n', 'utf-8');
+
+    const result = await installHooks({
+      projectPath,
+      projectId,
+      capabilitiesFilePath: join(projectPath, 'capabilities.yaml'),
+      hooks: [
+        {
+          id: 'global-edit',
+          on: 'afterFileEdit',
+          source: { type: 'local', path: '../outside/global-hook.sh' },
+        },
+      ],
+      providers: ['claude-code'],
+      db,
+      authFetch: makeAuthFetch(),
+      getRepoSnapshot: stubGetRepoSnapshot,
+    });
+    expect(result.installed).toBe(1);
+
+    const settings = JSON.parse(
+      readFileSync(join(projectPath, '.claude', 'settings.json'), 'utf-8'),
+    ) as any;
+    const entry = settings.hooks.PostToolUse[0].hooks[0];
+    expect(entry.command).toBe(scriptPath);
   });
 
   it('prompt-type local source reads the file contents as the prompt text', async () => {

--- a/src/cli/utils/__tests__/rules-installer.test.ts
+++ b/src/cli/utils/__tests__/rules-installer.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, beforeEach, afterEach } from 'bun:test';
-import { existsSync, mkdtempSync, rmSync, writeFileSync } from 'fs';
+import { existsSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from 'fs';
 import { join } from 'path';
 import { tmpdir } from 'os';
 import type { Rule } from '../../../types/rules';
@@ -47,6 +47,117 @@ describe('rules-installer', () => {
 
     cleanRules(projectPath, ['cursor'], ['style-guide']);
     expect(existsSync(rulePath)).toBe(false);
+  });
+
+  it('installRules merges body frontmatter with capa fields, capa wins, appliesTo synonyms dropped (claude-code)', () => {
+    const bodyWithCursorFm = [
+      '---',
+      'description: legacy cursor-style frontmatter',
+      'globs: **/*.sql',
+      'alwaysApply: false',
+      '---',
+      '',
+      '# Real body',
+      'do the thing',
+      '',
+    ].join('\n');
+    const rules: Rule[] = [
+      {
+        id: 'with-fm',
+        type: 'local',
+        path: 'rules/with-fm.md',
+        description: 'capa-side description',
+        appliesTo: ['**/*.sql'],
+      },
+    ];
+    const content = new Map([['with-fm', bodyWithCursorFm]]);
+
+    installRules(projectPath, rules, ['claude-code'], content);
+
+    const installed = readFileSync(
+      join(projectPath, '.claude', 'rules', 'with-fm.md'),
+      'utf8'
+    );
+    // Exactly one frontmatter block — the merged one.
+    const fmBlocks = installed.match(/^---[\s\S]*?\n---/gm) ?? [];
+    expect(fmBlocks.length).toBe(1);
+    const fm = fmBlocks[0];
+    // Capa's appliesTo → paths (claude-code dialect)
+    expect(fm).toContain('paths:');
+    // Source's `globs` is a synonym for `paths` and must be dropped
+    expect(fm).not.toContain('globs:');
+    // Source extras that don't collide survive
+    expect(fm).toContain('alwaysApply: false');
+    // claude-code's fieldMap has no `description`, so source's `description` survives
+    expect(fm).toContain('description: legacy cursor-style frontmatter');
+    expect(installed).toContain('# Real body');
+  });
+
+  it('installRules preserves a body with no leading frontmatter unchanged', () => {
+    const plainBody = '# Plain rule\n\nno frontmatter here.\n';
+    const rules: Rule[] = [
+      { id: 'plain', type: 'local', path: 'rules/plain.md', appliesTo: ['**/*.ts'] },
+    ];
+    const content = new Map([['plain', plainBody]]);
+
+    installRules(projectPath, rules, ['claude-code'], content);
+
+    const installed = readFileSync(
+      join(projectPath, '.claude', 'rules', 'plain.md'),
+      'utf8'
+    );
+    expect(installed).toContain('paths:');
+    expect(installed).toContain('# Plain rule');
+    expect(installed).toContain('no frontmatter here.');
+  });
+
+  it('installRules preserves source frontmatter when capa would emit nothing of its own', () => {
+    // claude-code with no appliesTo / alwaysApply / etc. → capa emits empty fm.
+    // Source's frontmatter should reach the installed file intact.
+    const bodyWithFm = '---\nkeep: me\nalso: this\n---\n\n# Body\n';
+    const rules: Rule[] = [{ id: 'no-fm-fields', type: 'local', path: 'rules/x.md' }];
+    const content = new Map([['no-fm-fields', bodyWithFm]]);
+
+    installRules(projectPath, rules, ['claude-code'], content);
+
+    const installed = readFileSync(
+      join(projectPath, '.claude', 'rules', 'no-fm-fields.md'),
+      'utf8'
+    );
+    const fmBlocks = installed.match(/^---[\s\S]*?\n---/gm) ?? [];
+    expect(fmBlocks.length).toBe(1);
+    expect(installed).toContain('keep: me');
+    expect(installed).toContain('also: this');
+  });
+
+  it('installRules with cursor provider drops source `globs` and emits cursor-shaped frontmatter', () => {
+    // Same source body, different provider — verifies appliesTo synonym collection
+    // doesn't accidentally drop the provider's OWN appliesTo key name.
+    const bodyWithFm = '---\ndescription: from source\nglobs: **/*.md\n---\n\nbody\n';
+    const rules: Rule[] = [
+      {
+        id: 'cursor-rule',
+        type: 'local',
+        path: 'rules/cursor-rule.md',
+        description: 'capa description',
+        appliesTo: ['**/*.ts'],
+      },
+    ];
+    const content = new Map([['cursor-rule', bodyWithFm]]);
+
+    installRules(projectPath, rules, ['cursor'], content);
+
+    const installed = readFileSync(
+      join(projectPath, '.cursor', 'rules', 'cursor-rule.mdc'),
+      'utf8'
+    );
+    // Cursor's appliesTo → globs, so capa's value must win and the *single*
+    // globs entry must reference `**/*.ts` (not the source's `**/*.md`).
+    expect(installed).toMatch(/globs: \*\*\/\*\.ts/);
+    expect(installed).not.toMatch(/globs: \*\*\/\*\.md/);
+    // Cursor's fieldMap covers description, so capa's value wins there too.
+    expect(installed).toContain('description: capa description');
+    expect(installed).not.toContain('description: from source');
   });
 
   it('pruneRules returns empty result when nothing is stale', () => {

--- a/src/cli/utils/__tests__/rules-installer.test.ts
+++ b/src/cli/utils/__tests__/rules-installer.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, beforeEach, afterEach } from 'bun:test';
-import { existsSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from 'fs';
+import { existsSync, mkdtempSync, readFileSync, rmSync } from 'fs';
 import { join } from 'path';
 import { tmpdir } from 'os';
 import type { Rule } from '../../../types/rules';

--- a/src/cli/utils/hooks-installer.ts
+++ b/src/cli/utils/hooks-installer.ts
@@ -23,7 +23,7 @@
  */
 
 import { existsSync, mkdirSync, readFileSync, writeFileSync, chmodSync, unlinkSync } from 'fs';
-import { dirname, join, resolve as resolvePath, sep as pathSep } from 'path';
+import { dirname, join, relative as relativePath, isAbsolute, resolve as resolvePath, sep as pathSep } from 'path';
 import { createHash } from 'crypto';
 import type { CapaDatabase } from '../../db/database';
 import type { ManagedHookRow } from '../../db/managed-hooks';
@@ -110,8 +110,12 @@ export async function installHooks(opts: InstallHooksOptions): Promise<InstallHo
   // Step 2: figure out the run reference for each command-type hook.
   //
   //  - inline `command:` (no source) -> use the literal command string;
-  //  - `source.type=local`           -> reference the user's script in place
-  //                                     via its absolute path (no copy);
+  //  - `source.type=local`           -> reference the user's script in place.
+  //                                     When the script lives inside the project
+  //                                     it's referenced by a project-relative
+  //                                     path (so the committed provider config is
+  //                                     portable across machines); otherwise its
+  //                                     absolute path is used. No copy either way.
   //  - inline / remote / github / gitlab -> materialise to
   //                                     ~/.capa/hooks/<projectId>/<hookId>
   //                                     and reference that absolute path.
@@ -127,7 +131,7 @@ export async function installHooks(opts: InstallHooksOptions): Promise<InstallHo
     }
 
     if (body.localPath) {
-      hookScriptPaths.set(hook.id, body.localPath);
+      hookScriptPaths.set(hook.id, toPortableHookReference(body.localPath, projectPath));
       continue;
     }
 
@@ -310,14 +314,38 @@ interface ResolvedHookBody {
   needsMaterialisation: boolean;
   /**
    * Set for `source.type='local'`: the absolute path of the user's script.
-   * The provider entry's `command` is set to this path verbatim, so the
-   * user's file becomes the live hook script — no copy in ~/.capa, no
-   * scriptPath tracked in `managed_hooks`, no chmod, and edits to the
-   * file take effect immediately without re-running `capa install`.
+   * The provider entry's `command` points at this file (project-relative when
+   * it lives inside the project — see toPortableHookReference — otherwise
+   * absolute), so the user's file becomes the live hook script: no copy in
+   * ~/.capa, no scriptPath tracked in `managed_hooks`, no chmod, and edits to
+   * the file take effect immediately without re-running `capa install`.
    */
   localPath?: string;
   /** Optional lockfile pin for remote / repo sources. */
   lockEntry?: LockHookEntry;
+}
+
+/**
+ * Turn the absolute path of a `local` hook script into the reference written
+ * into the provider config.
+ *
+ * Provider hooks run with their working directory at the project root, so a
+ * script that lives inside the project is referenced by a project-relative
+ * path (forward slashes, `./`-prefixed so it executes as a path rather than a
+ * PATH lookup). That keeps the committed config portable — other clones don't
+ * inherit the author's absolute, machine-specific path.
+ *
+ * A script outside the project can't be committed meaningfully, so its
+ * absolute path is kept as-is.
+ */
+function toPortableHookReference(absScriptPath: string, projectPath: string): string {
+  const rel = relativePath(projectPath, absScriptPath);
+  // Empty (same path), climbs out with `..`, or absolute (e.g. a different
+  // Windows drive) all mean the script isn't inside the project → keep absolute.
+  if (!rel || rel.startsWith('..') || isAbsolute(rel)) {
+    return absScriptPath;
+  }
+  return `./${rel.split(pathSep).join('/')}`;
 }
 
 async function resolveHookBody(hook: Hook, opts: InstallHooksOptions): Promise<ResolvedHookBody> {

--- a/src/cli/utils/rules-installer.ts
+++ b/src/cli/utils/rules-installer.ts
@@ -69,7 +69,7 @@ function loadFrontmatterYaml(text: string): unknown {
     const requoted = text.replace(
       /^([ \t]*[\w-]+[ \t]*:[ \t]*)(\*[^\n#]*?)(\s*)$/gm,
       (_m, prefix, value, trailing) =>
-        `${prefix}"${(value as string).replace(/"/g, '\\"')}"${trailing}`
+        `${prefix}"${(value as string).replace(/\\/g, '\\\\').replace(/"/g, '\\"')}"${trailing}`
     );
     if (requoted === text) return null;
     try {

--- a/src/cli/utils/rules-installer.ts
+++ b/src/cli/utils/rules-installer.ts
@@ -1,7 +1,8 @@
 import { existsSync, mkdirSync, readFileSync, writeFileSync, readdirSync, unlinkSync } from 'fs';
 import { join, dirname, basename, sep } from 'path';
+import yaml from 'js-yaml';
 import type { Rule } from '../../types/rules';
-import { getProvider } from '../../shared/providers';
+import { getAllProviders, getProvider } from '../../shared/providers';
 import { buildRuleFrontmatter } from '../../shared/providers/handlers';
 import { taskLog } from '../ui';
 
@@ -36,6 +37,62 @@ function buildYamlFrontmatter(fields: Record<string, unknown>): string {
   }
   lines.push('---');
   return lines.join('\n');
+}
+
+/**
+ * Provider-dialect names for the `appliesTo` rule concept (claude-code calls
+ * it `paths`, Cursor `globs`, GitHub Copilot `applyTo`). Used to drop a
+ * source file's already-translated synonym when capa is emitting its own.
+ * Captured lazily so `getAllProviders()` is only walked once.
+ */
+let APPLIES_TO_SYNONYMS: Set<string> | null = null;
+function appliesToSynonyms(): Set<string> {
+  if (APPLIES_TO_SYNONYMS) return APPLIES_TO_SYNONYMS;
+  APPLIES_TO_SYNONYMS = new Set(
+    getAllProviders()
+      .map((p) => p.rules?.fieldMap?.appliesTo)
+      .filter((s): s is string => Boolean(s))
+  );
+  return APPLIES_TO_SYNONYMS;
+}
+
+/**
+ * Permissive YAML load for rule frontmatter. Cursor-style `.mdc` files
+ * allow unquoted glob values that strict YAML rejects as alias references
+ * (anything starting with `*`), e.g. an unquoted `globs:` line. We retry
+ * once with such values quoted so we can still merge surrounding metadata.
+ */
+function loadFrontmatterYaml(text: string): unknown {
+  try {
+    return yaml.load(text);
+  } catch {
+    const requoted = text.replace(
+      /^([ \t]*[\w-]+[ \t]*:[ \t]*)(\*[^\n#]*?)(\s*)$/gm,
+      (_m, prefix, value, trailing) =>
+        `${prefix}"${(value as string).replace(/"/g, '\\"')}"${trailing}`
+    );
+    if (requoted === text) return null;
+    try {
+      return yaml.load(requoted);
+    } catch {
+      return null;
+    }
+  }
+}
+
+/**
+ * Parse a leading YAML frontmatter block (`---\n...\n---`) from `body`.
+ * Returns the parsed object and the remaining body, or `null` if there is
+ * no well-formed frontmatter (so the caller can leave `body` untouched).
+ */
+function parseLeadingFrontmatter(
+  body: string
+): { data: Record<string, unknown>; rest: string } | null {
+  const m = body.match(/^---\r?\n([\s\S]*?)\r?\n---(\r?\n|$)/);
+  if (!m) return null;
+  const parsed = loadFrontmatterYaml(m[1]);
+  if (!parsed || typeof parsed !== 'object' || Array.isArray(parsed)) return null;
+  return { data: parsed as Record<string, unknown>, rest: body.slice(m[0].length) };
 }
 
 // ---------------------------------------------------------------------------
@@ -178,13 +235,30 @@ export function installRules(
         if (!content) continue;
 
         let fileContent = '';
+        let body = content;
         if (provider.rules.frontmatter === 'yaml' && provider.rules.fieldMap) {
           const fm = buildRuleFrontmatter(provider.rules, rule);
+          const parsed = parseLeadingFrontmatter(body);
+          if (parsed) {
+            body = parsed.rest;
+            // Merge source extras after capa's fields: capa wins on literal-key
+            // collisions, and any source synonym for an `appliesTo` field capa
+            // already emitted (e.g. source `globs:` when capa wrote `paths:`)
+            // is dropped so the same concept isn't duplicated.
+            const appliesToKey = provider.rules.fieldMap.appliesTo;
+            const capaEmitsAppliesTo = !!appliesToKey && appliesToKey in fm;
+            const synonyms = capaEmitsAppliesTo ? appliesToSynonyms() : null;
+            for (const [k, v] of Object.entries(parsed.data)) {
+              if (k in fm) continue;
+              if (synonyms?.has(k)) continue;
+              fm[k] = v;
+            }
+          }
           if (Object.keys(fm).length > 0) {
             fileContent = buildYamlFrontmatter(fm) + '\n';
           }
         }
-        fileContent += content;
+        fileContent += body;
         if (!fileContent.endsWith('\n')) fileContent += '\n';
 
         const filePath = join(rulesDir, `${rule.id}${provider.rules.extension}`);

--- a/src/server/__tests__/mcp-handler.integration.test.ts
+++ b/src/server/__tests__/mcp-handler.integration.test.ts
@@ -507,3 +507,106 @@ describe('installSubagentsTask + toolExposure: none', () => {
     expect(needsPurge(false, [])).toBe(false);
   });
 });
+
+// ─── capa shell: metadata listing vs. lazy per-tool schema ───────────────────
+//
+// `capa sh` (and group/subcommand listing) hits getAllShellTools on every
+// invocation, so it must NOT contact remote MCP servers — otherwise one slow or
+// down server stalls or crashes the whole shell. The remote round-trip is
+// deferred to getShellToolSchema, called only when a specific tool is run or
+// `--help`'d. These tests pin that split.
+
+describe('getAllShellTools / getShellToolSchema (lazy MCP schema)', () => {
+  let h: Harness;
+
+  const caps: Capabilities = {
+    providers: ['claude-code'],
+    options: {},
+    skills: [],
+    servers: [{ id: 'brave', def: { url: 'http://127.0.0.1:1/mcp' } } as any],
+    tools: [
+      {
+        id: 'run_tests',
+        type: 'command',
+        def: { run: { cmd: 'npm test', args: [{ name: 'pattern', type: 'string' }] } },
+      },
+      {
+        id: 'search',
+        type: 'mcp',
+        def: { server: '@brave', tool: 'brave_web_search' },
+      } as any,
+    ],
+  };
+
+  beforeEach(() => {
+    h = makeHarness(caps);
+  });
+
+  afterEach(() => destroyHarness(h));
+
+  it('getAllShellTools makes no remote listTools calls and omits MCP schemas', async () => {
+    let listToolsCalls = 0;
+    (h.mcp as any).mcpProxy.listTools = async () => {
+      listToolsCalls++;
+      return [];
+    };
+
+    const tools = await h.mcp.getAllShellTools(caps);
+
+    expect(listToolsCalls).toBe(0);
+
+    const cmd = tools.find((t) => t.id === 'run_tests')!;
+    expect(cmd.type).toBe('command');
+    // Command schemas are local and cheap — included up front.
+    expect(cmd.inputSchema?.properties?.pattern).toBeDefined();
+
+    const mcp = tools.find((t) => t.id === 'brave.search')!;
+    expect(mcp.type).toBe('mcp');
+    expect(mcp.serverId).toBe('brave');
+    // MCP schema is resolved lazily, so it is absent here.
+    expect(mcp.inputSchema).toBeUndefined();
+  });
+
+  it('getShellToolSchema resolves an MCP tool with exactly one remote call', async () => {
+    let listToolsCalls = 0;
+    (h.mcp as any).mcpProxy.listTools = async () => {
+      listToolsCalls++;
+      return [
+        {
+          name: 'brave_web_search',
+          description: 'Search the web',
+          inputSchema: { type: 'object', properties: { q: { type: 'string' } }, required: ['q'] },
+        },
+      ];
+    };
+
+    const schema = await h.mcp.getShellToolSchema('brave.search', caps);
+
+    expect(listToolsCalls).toBe(1);
+    expect(schema.description).toBe('Search the web');
+    expect(schema.inputSchema.properties.q).toBeDefined();
+  });
+
+  it('getShellToolSchema propagates remote failures instead of swallowing them', async () => {
+    (h.mcp as any).mcpProxy.listTools = async () => {
+      throw new Error('Could not connect to MCP server "brave"');
+    };
+
+    await expect(h.mcp.getShellToolSchema('brave.search', caps)).rejects.toThrow(
+      /Could not connect/
+    );
+  });
+
+  it('getShellToolSchema resolves command tools locally without any remote call', async () => {
+    let listToolsCalls = 0;
+    (h.mcp as any).mcpProxy.listTools = async () => {
+      listToolsCalls++;
+      return [];
+    };
+
+    const schema = await h.mcp.getShellToolSchema('run_tests', caps);
+
+    expect(listToolsCalls).toBe(0);
+    expect(schema.inputSchema.properties.pattern).toBeDefined();
+  });
+});

--- a/src/server/__tests__/mcp-proxy.test.ts
+++ b/src/server/__tests__/mcp-proxy.test.ts
@@ -77,4 +77,45 @@ describe('mcp-proxy', () => {
       expect(shouldSkipTlsVerify(true, 'MCP HTTP transport (test-server)')).toBe(true);
     });
   });
+
+  describe('OAuth2 disconnected handling', () => {
+    function makeOauthServerDef(): MCPServerDefinition {
+      return {
+        url: 'https://mcp.example.com',
+        oauth2: { clientId: 'x', authorizationUrl: 'a', tokenUrl: 't' },
+      } as MCPServerDefinition;
+    }
+
+    function makeProxyWithDisconnectedOauth(): MCPProxy {
+      const proxy = new MCPProxy(makeMockDb(), 'proj-1', '/tmp/project');
+      (proxy as any).oauth2Manager = { isServerConnected: () => false };
+      return proxy;
+    }
+
+    it('listTools throws an auth-specific error (not "could not connect") when throwOnError is true', async () => {
+      const proxy = makeProxyWithDisconnectedOauth();
+      await expect(
+        proxy.listTools('atlassian', makeOauthServerDef(), { throwOnError: true })
+      ).rejects.toThrow(/Authentication failed for "atlassian"\. Please reconnect OAuth2/);
+    });
+
+    it('listTools returns [] silently when throwOnError is false (default install path)', async () => {
+      const proxy = makeProxyWithDisconnectedOauth();
+      const result = await proxy.listTools('atlassian', makeOauthServerDef());
+      expect(result).toEqual([]);
+    });
+
+    it('executeTool returns auth-specific failure (not "failed to connect") when OAuth disconnected', async () => {
+      const proxy = makeProxyWithDisconnectedOauth();
+      const result = await proxy.executeTool(
+        'atlassian.search',
+        { server: 'atlassian', tool: 'search' } as any,
+        makeOauthServerDef(),
+        { query: 'abc' }
+      );
+      expect(result.success).toBe(false);
+      expect(result.error).toMatch(/Authentication failed for "atlassian"\. Please reconnect OAuth2/);
+      expect(result.error).not.toMatch(/Failed to connect/);
+    });
+  });
 });

--- a/src/server/index.ts
+++ b/src/server/index.ts
@@ -347,11 +347,19 @@ class CapaServer {
       return this.handleGetServerTools(projectId, serverId);
     }
 
-    // Shell tools endpoint — all tools with schemas, regardless of exposure mode
+    // Shell tools endpoint — tool metadata for the capa shell, regardless of exposure mode
     const shellToolsMatch = path.match(/^\/api\/projects\/([^/]+)\/shell-tools$/);
     if (shellToolsMatch && request.method === 'GET') {
       const projectId = shellToolsMatch[1];
       return this.handleGetShellTools(projectId);
+    }
+
+    // On-demand schema for a single shell tool (?tool=<qualified-id>)
+    const shellToolSchemaMatch = path.match(/^\/api\/projects\/([^/]+)\/shell-tool-schema$/);
+    if (shellToolSchemaMatch && request.method === 'GET') {
+      const projectId = shellToolSchemaMatch[1];
+      const toolId = url.searchParams.get('tool') || '';
+      return this.handleGetShellToolSchema(projectId, toolId);
     }
 
     // Disconnect OAuth2
@@ -739,6 +747,49 @@ class CapaServer {
       return new Response(
         JSON.stringify({ error: error.message }),
         { status: 500, headers: { 'Content-Type': 'application/json' } }
+      );
+    }
+  }
+
+  private async handleGetShellToolSchema(projectId: string, toolId: string): Promise<Response> {
+    const apiLogger = this.logger.child('API');
+    apiLogger.info(`Get shell tool schema for ${projectId}: ${toolId}`);
+    try {
+      if (!toolId) {
+        return new Response(
+          JSON.stringify({ error: 'Missing "tool" query parameter' }),
+          { status: 400, headers: { 'Content-Type': 'application/json' } }
+        );
+      }
+
+      const capabilities = this.sessionManager.getProjectCapabilities(projectId);
+      if (!capabilities) {
+        return new Response(
+          JSON.stringify({ error: 'Project not configured' }),
+          { status: 404, headers: { 'Content-Type': 'application/json' } }
+        );
+      }
+
+      const mcpServer = this.getOrCreateMCPServer(projectId);
+      if (!mcpServer) {
+        return new Response(
+          JSON.stringify({ error: 'Project not found' }),
+          { status: 404, headers: { 'Content-Type': 'application/json' } }
+        );
+      }
+
+      const schema = await mcpServer.getShellToolSchema(toolId, capabilities);
+      return new Response(
+        JSON.stringify(schema),
+        { headers: { 'Content-Type': 'application/json' } }
+      );
+    } catch (error: any) {
+      apiLogger.failure(`Error resolving schema for ${toolId}: ${error.message}`);
+      // 502: the failure is upstream (remote MCP server unreachable / tool missing),
+      // not a bug in this endpoint — let the shell surface it for this one tool.
+      return new Response(
+        JSON.stringify({ error: error.message }),
+        { status: 502, headers: { 'Content-Type': 'application/json' } }
       );
     }
   }

--- a/src/server/mcp-handler.ts
+++ b/src/server/mcp-handler.ts
@@ -676,23 +676,29 @@ export class CapaMCPServer {
   }
 
   /**
-   * Return all tools with full schemas for the capa shell, regardless of toolExposure mode.
-   * Each entry includes the original tool id, type, optional server group id, description, and inputSchema.
+   * Return shell-tool metadata for the capa shell, regardless of toolExposure mode.
+   *
+   * This is the hot path for `capa sh` (top-level command list and group/subcommand
+   * listing), so it must be fast and must NOT contact remote MCP servers. Command
+   * tools carry their input schema (derived locally from the capabilities file);
+   * MCP tools are returned WITHOUT an `inputSchema` — it is resolved lazily and
+   * per-tool via {@link getShellToolSchema} only when the user runs the tool or asks
+   * for its `--help`. That keeps one slow/down server from stalling the whole shell.
    */
   async getAllShellTools(capabilities: Capabilities): Promise<ShellToolInfo[]> {
     const result: ShellToolInfo[] = [];
     for (const tool of capabilities.tools) {
-      const mcpTool = await this.convertToolToMCP(tool, capabilities);
-      const info: ShellToolInfo = {
-        id: getQualifiedToolName(tool),
-        type: tool.type as 'command' | 'mcp',
-        description: mcpTool.description || '',
-        inputSchema: mcpTool.inputSchema,
-      };
       if (tool.type === 'mcp') {
         const mcpDef = tool.def as ToolMCPDefinition;
         const serverId = mcpDef.server.replace('@', '');
-        info.serverId = serverId;
+        const info: ShellToolInfo = {
+          id: getQualifiedToolName(tool),
+          type: 'mcp',
+          description: tool.description || '',
+          // Resolved on demand — see getShellToolSchema.
+          inputSchema: undefined,
+          serverId,
+        };
         const serverDef = capabilities.servers.find((s) => s.id === serverId);
         if (serverDef?.description) {
           info.serverDescription = serverDef.description;
@@ -700,7 +706,16 @@ export class CapaMCPServer {
         if (mcpDef.defaults) {
           info.defaults = mcpDef.defaults;
         }
+        result.push(info);
       } else {
+        // Command tool — schema is built locally and is cheap, so include it.
+        const mcpTool = await this.convertToolToMCP(tool, capabilities);
+        const info: ShellToolInfo = {
+          id: getQualifiedToolName(tool),
+          type: 'command',
+          description: mcpTool.description || '',
+          inputSchema: mcpTool.inputSchema,
+        };
         if (tool.group) {
           info.group = tool.group;
         }
@@ -716,10 +731,65 @@ export class CapaMCPServer {
             info.defaults = cmdDefaults;
           }
         }
+        result.push(info);
       }
-      result.push(info);
     }
     return result;
+  }
+
+  /**
+   * Resolve the input schema for a single shell tool on demand.
+   *
+   * Used by the capa shell when the user runs a specific tool or asks for its
+   * `--help`. Unlike {@link getAllShellTools}, this DOES contact the remote MCP
+   * server for `mcp` tools and throws a descriptive error if the server is
+   * unreachable, times out, or doesn't expose the tool — so the shell can surface
+   * the failure for that one tool without affecting the rest of the session.
+   */
+  async getShellToolSchema(
+    toolId: string,
+    capabilities: Capabilities
+  ): Promise<{ description: string; inputSchema: any }> {
+    const tool = capabilities.tools.find((t) => getQualifiedToolName(t) === toolId);
+    if (!tool) {
+      throw new Error(`Tool not found: ${toolId}`);
+    }
+
+    if (tool.type === 'command') {
+      const mcpTool = await this.convertToolToMCP(tool, capabilities);
+      return { description: mcpTool.description || '', inputSchema: mcpTool.inputSchema };
+    }
+
+    const mcpDef = tool.def as ToolMCPDefinition;
+    const serverId = mcpDef.server.replace('@', '');
+    const serverDef = capabilities.servers.find((s) => s.id === serverId);
+    if (!serverDef) {
+      throw new Error(`Server not found: ${serverId}`);
+    }
+
+    const remoteTools = await this.mcpProxy.listTools(serverId, serverDef.def, {
+      throwOnError: true,
+    });
+    const remoteTool = remoteTools.find((t: any) => t.name === mcpDef.tool);
+    if (!remoteTool) {
+      const available = remoteTools.map((t: any) => t.name).join(', ');
+      throw new Error(
+        `Tool "${mcpDef.tool}" not found on server "${serverId}". Available tools: ${available || '(none)'}`
+      );
+    }
+
+    const inputSchema = remoteTool.inputSchema
+      ? JSON.parse(JSON.stringify(remoteTool.inputSchema))
+      : { type: 'object' as const, properties: {} };
+    if (mcpDef.defaults) {
+      applyDefaultsToSchema(inputSchema, mcpDef.defaults);
+    }
+
+    const description = remoteTool.description || `MCP tool: ${toolId}`;
+    // Warm the shared cache so a subsequent tools/call doesn't re-fetch.
+    this.toolSchemaCache.set(toolId, { name: toolId, description, inputSchema });
+
+    return { description, inputSchema };
   }
 
   /**

--- a/src/server/mcp-proxy.ts
+++ b/src/server/mcp-proxy.ts
@@ -122,12 +122,23 @@ export class MCPProxy {
   }
 
   /**
-   * List tools available on an MCP server
+   * List tools available on an MCP server.
+   *
+   * By default this is tolerant: connection/listing failures are logged and an
+   * empty array is returned so aggregate callers don't blow up on one bad server.
+   * Pass `throwOnError: true` (used by on-demand schema resolution) to surface
+   * the underlying failure to the caller instead. `timeoutMs` bounds the request
+   * so a hung server can't block indefinitely.
    */
-  async listTools(serverId: string, serverDefinition: MCPServerDefinition): Promise<any[]> {
+  async listTools(
+    serverId: string,
+    serverDefinition: MCPServerDefinition,
+    options: { throwOnError?: boolean; timeoutMs?: number } = {}
+  ): Promise<any[]> {
+    const { throwOnError = false, timeoutMs = 15000 } = options;
     // Strip @ prefix from server ID if present
     const cleanServerId = serverId.replace('@', '');
-    
+
     const resolvedServerDef = resolveVariablesInObject(
       serverDefinition,
       this.projectId,
@@ -136,27 +147,37 @@ export class MCPProxy {
 
     const client = await this.getOrCreateClient(cleanServerId, resolvedServerDef);
     if (!client) {
+      if (throwOnError) {
+        throw new Error(`Could not connect to MCP server "${cleanServerId}"`);
+      }
       return [];
     }
 
     try {
-      const result = await client.listTools();
+      const result = await client.listTools(undefined, { timeout: timeoutMs });
       return result.tools;
     } catch (error) {
       if (error instanceof MCPSessionExpiredError) {
         this.logger.warn(`Session expired for ${cleanServerId}, reconnecting...`);
         this.clients.delete(cleanServerId);
         const freshClient = await this.getOrCreateClient(cleanServerId, resolvedServerDef);
-        if (!freshClient) return [];
+        if (!freshClient) {
+          if (throwOnError) {
+            throw new Error(`Could not reconnect to MCP server "${cleanServerId}"`);
+          }
+          return [];
+        }
         try {
-          const result = await freshClient.listTools();
+          const result = await freshClient.listTools(undefined, { timeout: timeoutMs });
           return result.tools;
         } catch (retryError) {
           this.logger.error(`Failed to list tools from ${cleanServerId} after reconnect:`, retryError);
+          if (throwOnError) throw retryError;
           return [];
         }
       }
       this.logger.error(`Failed to list tools from ${cleanServerId}:`, error);
+      if (throwOnError) throw error;
       return [];
     }
   }

--- a/src/server/mcp-proxy.ts
+++ b/src/server/mcp-proxy.ts
@@ -24,6 +24,21 @@ class MCPSessionExpiredError extends Error {
   }
 }
 
+/**
+ * Thrown from `createHttpClient` when an OAuth2-protected server has no
+ * active connection. Tolerant callers (install-time validation, default
+ * `listTools`) catch this and degrade silently — so a disconnected server
+ * doesn't spam 401s. On-demand callers (an explicit `capa sh` tool call,
+ * `listTools` with `throwOnError`) rethrow it as a user-facing
+ * "Authentication failed" instead of the misleading "Could not connect."
+ */
+class MCPOAuthDisconnectedError extends Error {
+  constructor(public readonly serverId: string) {
+    super(`Authentication failed for "${serverId}". Please reconnect OAuth2.`);
+    this.name = 'MCPOAuthDisconnectedError';
+  }
+}
+
 export class MCPProxy {
   private db: CapaDatabase;
   private projectId: string;
@@ -71,7 +86,16 @@ export class MCPProxy {
     }
 
     // Get or create MCP client
-    const client = await this.getOrCreateClient(serverId, resolvedServerDef);
+    let client: Client | null;
+    try {
+      client = await this.getOrCreateClient(serverId, resolvedServerDef);
+    } catch (error) {
+      if (error instanceof MCPOAuthDisconnectedError) {
+        this.logger.failure(error.message);
+        return { success: false, error: error.message };
+      }
+      throw error;
+    }
 
     if (!client) {
       this.logger.failure('Failed to get client');
@@ -97,7 +121,15 @@ export class MCPProxy {
       if (error instanceof MCPSessionExpiredError) {
         this.logger.warn(`Session expired for ${serverId}, reconnecting and retrying tool call...`);
         this.clients.delete(serverId);
-        const freshClient = await this.getOrCreateClient(serverId, resolvedServerDef);
+        let freshClient: Client | null;
+        try {
+          freshClient = await this.getOrCreateClient(serverId, resolvedServerDef);
+        } catch (reconnectError) {
+          if (reconnectError instanceof MCPOAuthDisconnectedError) {
+            return { success: false, error: reconnectError.message };
+          }
+          throw reconnectError;
+        }
         if (!freshClient) {
           return { success: false, error: `Failed to reconnect to MCP server: ${serverId}` };
         }
@@ -145,7 +177,16 @@ export class MCPProxy {
       this.db
     );
 
-    const client = await this.getOrCreateClient(cleanServerId, resolvedServerDef);
+    let client: Client | null;
+    try {
+      client = await this.getOrCreateClient(cleanServerId, resolvedServerDef);
+    } catch (error) {
+      if (error instanceof MCPOAuthDisconnectedError) {
+        if (throwOnError) throw error;
+        return [];
+      }
+      throw error;
+    }
     if (!client) {
       if (throwOnError) {
         throw new Error(`Could not connect to MCP server "${cleanServerId}"`);
@@ -160,7 +201,16 @@ export class MCPProxy {
       if (error instanceof MCPSessionExpiredError) {
         this.logger.warn(`Session expired for ${cleanServerId}, reconnecting...`);
         this.clients.delete(cleanServerId);
-        const freshClient = await this.getOrCreateClient(cleanServerId, resolvedServerDef);
+        let freshClient: Client | null;
+        try {
+          freshClient = await this.getOrCreateClient(cleanServerId, resolvedServerDef);
+        } catch (reconnectError) {
+          if (reconnectError instanceof MCPOAuthDisconnectedError) {
+            if (throwOnError) throw reconnectError;
+            return [];
+          }
+          throw reconnectError;
+        }
         if (!freshClient) {
           if (throwOnError) {
             throw new Error(`Could not reconnect to MCP server "${cleanServerId}"`);
@@ -212,13 +262,17 @@ export class MCPProxy {
     serverId: string,
     serverDefinition: MCPServerDefinition
   ): Promise<Client | null> {
-    try {
-      // Skip connecting to OAuth2 servers until the user has connected (avoids 401 during install/validation)
-      if (serverDefinition.oauth2 && !this.oauth2Manager.isServerConnected(this.projectId, serverId)) {
-        this.logger.debug(`Skipping HTTP client for ${serverId} (OAuth2 required, not connected)`);
-        return null;
-      }
+    // Surface OAuth-disconnect as a typed error rather than a bare `null`, so
+    // on-demand callers (e.g. `capa sh <tool>`) can show "Authentication
+    // failed" instead of the misleading "Could not connect." Tolerant callers
+    // catch this and degrade silently, preserving the no-401-during-install
+    // behavior that the original early-return guaranteed.
+    if (serverDefinition.oauth2 && !this.oauth2Manager.isServerConnected(this.projectId, serverId)) {
+      this.logger.debug(`Skipping HTTP client for ${serverId} (OAuth2 required, not connected)`);
+      throw new MCPOAuthDisconnectedError(serverId);
+    }
 
+    try {
       this.logger.info(`Creating HTTP client for: ${serverId}`);
       this.logger.debug(`URL: ${serverDefinition.url}`);
 

--- a/src/shared/__tests__/cache.test.ts
+++ b/src/shared/__tests__/cache.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, beforeAll, beforeEach, afterEach, afterAll } from 'bun:test';
+import { describe, it, expect, beforeAll, beforeEach, afterEach, afterAll, spyOn } from 'bun:test';
 import {
   existsSync,
   mkdirSync,
@@ -9,6 +9,7 @@ import {
 } from 'fs';
 import { tmpdir } from 'os';
 import { join } from 'path';
+import * as childProcess from 'child_process';
 import { exec } from 'child_process';
 import { promisify } from 'util';
 import {
@@ -281,6 +282,36 @@ describe('cache', () => {
       const mirrorDir = await seedMirrorFromFixture('github', 'owner/repo', fixture.url);
       const result = await ensureMirrorClone('github', 'owner/repo', noAuthFetch);
       expect(result).toBe(mirrorDir);
+    });
+
+    it('blobless clone still materializes a complete snapshot (no regression)', async () => {
+      // Drives the real ensureMirrorClone (which now passes --filter=blob:none).
+      // Over file:// the filter is ignored and git does a full clone, but this
+      // guards the end-to-end path: cloning then materializing must still produce
+      // every file at the revision, since consumers walk the snapshot tree.
+      const mirrorDir = await ensureMirrorClone('github', 'owner/repo', noAuthFetch, fixture.url);
+      const { sha } = await resolveRef(mirrorDir, { version: fixture.tag });
+      const snapshotDir = await materializeSnapshot(mirrorDir, 'github', 'owner/repo', sha);
+      expect(existsSync(join(snapshotDir, 'SKILL.md'))).toBe(true);
+      expect(existsSync(join(snapshotDir, 'README.md'))).toBe(true);
+    });
+
+    it('requests a blobless partial clone (--filter=blob:none right after --mirror)', async () => {
+      let capturedArgs: string[] = [];
+      const execFileSpy = spyOn(childProcess, 'execFile').mockImplementation(
+        ((_cmd: string, args: string[], _opts: object, cb: (err: null, result: { stdout: string; stderr: string }) => void) => {
+          capturedArgs = args;
+          cb(null, { stdout: '', stderr: '' });
+        }) as typeof childProcess.execFile
+      );
+
+      await ensureMirrorClone('github', 'owner/repo', noAuthFetch, 'https://example.com/owner/repo.git');
+
+      const mirrorIdx = capturedArgs.indexOf('--mirror');
+      expect(mirrorIdx).toBeGreaterThanOrEqual(0);
+      expect(capturedArgs[mirrorIdx + 1]).toBe('--filter=blob:none');
+
+      execFileSpy.mockRestore();
     });
   });
 });

--- a/src/shared/cache/__tests__/git-cli.test.ts
+++ b/src/shared/cache/__tests__/git-cli.test.ts
@@ -45,8 +45,8 @@ describe('git-cli', () => {
   it('runs git non-interactively so a missing credential never hangs the install', async () => {
     let capturedEnv: Record<string, string | undefined> = {};
     const execFileSpy = spyOn(childProcess, 'execFile').mockImplementation(
-      ((_cmd: string, _args: string[], opts: { env?: Record<string, string | undefined> }, cb: (err: null, result: { stdout: string; stderr: string }) => void) => {
-        capturedEnv = opts.env ?? {};
+      ((_cmd: string, _args: string[], opts: object, cb: (err: null, result: { stdout: string; stderr: string }) => void) => {
+        capturedEnv = (opts as { env?: Record<string, string | undefined> }).env ?? {};
         cb(null, { stdout: '', stderr: '' });
       }) as typeof childProcess.execFile
     );
@@ -66,8 +66,8 @@ describe('git-cli', () => {
   it('lets a caller-provided env override the non-interactive defaults', async () => {
     let capturedEnv: Record<string, string | undefined> = {};
     const execFileSpy = spyOn(childProcess, 'execFile').mockImplementation(
-      ((_cmd: string, _args: string[], opts: { env?: Record<string, string | undefined> }, cb: (err: null, result: { stdout: string; stderr: string }) => void) => {
-        capturedEnv = opts.env ?? {};
+      ((_cmd: string, _args: string[], opts: object, cb: (err: null, result: { stdout: string; stderr: string }) => void) => {
+        capturedEnv = (opts as { env?: Record<string, string | undefined> }).env ?? {};
         cb(null, { stdout: '', stderr: '' });
       }) as typeof childProcess.execFile
     );

--- a/src/shared/cache/__tests__/git-cli.test.ts
+++ b/src/shared/cache/__tests__/git-cli.test.ts
@@ -41,4 +41,40 @@ describe('git-cli', () => {
     expect(execFileSpy).toHaveBeenCalled();
     execFileSpy.mockRestore();
   });
+
+  it('runs git non-interactively so a missing credential never hangs the install', async () => {
+    let capturedEnv: Record<string, string | undefined> = {};
+    const execFileSpy = spyOn(childProcess, 'execFile').mockImplementation(
+      ((_cmd: string, _args: string[], opts: { env?: Record<string, string | undefined> }, cb: (err: null, result: { stdout: string; stderr: string }) => void) => {
+        capturedEnv = opts.env ?? {};
+        cb(null, { stdout: '', stderr: '' });
+      }) as typeof childProcess.execFile
+    );
+
+    await git(['clone', '--mirror', 'https://github.com/owner/private.git', '/tmp/m']);
+
+    // The actual fix: git must not fall back to an interactive prompt.
+    expect(capturedEnv.GIT_TERMINAL_PROMPT).toBe('0');
+    expect(capturedEnv.GCM_INTERACTIVE).toBe('never');
+    expect(capturedEnv.GIT_SSH_COMMAND).toContain('BatchMode=yes');
+    // Existing behaviour preserved.
+    expect(capturedEnv.GIT_LFS_SKIP_SMUDGE).toBe('1');
+
+    execFileSpy.mockRestore();
+  });
+
+  it('lets a caller-provided env override the non-interactive defaults', async () => {
+    let capturedEnv: Record<string, string | undefined> = {};
+    const execFileSpy = spyOn(childProcess, 'execFile').mockImplementation(
+      ((_cmd: string, _args: string[], opts: { env?: Record<string, string | undefined> }, cb: (err: null, result: { stdout: string; stderr: string }) => void) => {
+        capturedEnv = opts.env ?? {};
+        cb(null, { stdout: '', stderr: '' });
+      }) as typeof childProcess.execFile
+    );
+
+    await git(['version'], { env: { GIT_TERMINAL_PROMPT: '1' } });
+    expect(capturedEnv.GIT_TERMINAL_PROMPT).toBe('1');
+
+    execFileSpy.mockRestore();
+  });
 });

--- a/src/shared/cache/git-cli.ts
+++ b/src/shared/cache/git-cli.ts
@@ -22,6 +22,24 @@ export function gitCommandArgs(args: string[]): string[] {
   return [...LFS_SKIP_ARGS, ...args];
 }
 
+/**
+ * Environment that forces git to run non-interactively. Without these, cloning a
+ * private repo with no usable credentials makes git block forever on a terminal
+ * prompt (`Username for 'https://github.com':`) that capa never answers — the
+ * install just hangs. With them set, git fails fast and the error is surfaced to
+ * the user (see `explainGitError`).
+ */
+const NON_INTERACTIVE_GIT_ENV: Record<string, string> = {
+  // Don't fall back to an interactive terminal prompt for HTTP(S) credentials.
+  GIT_TERMINAL_PROMPT: '0',
+  // Don't let Git Credential Manager open an interactive GUI/browser prompt.
+  GCM_INTERACTIVE: 'never',
+  // Defensive: if a repo resolves to SSH, fail fast instead of blocking on a
+  // password/passphrase or host-key confirmation. A user-set GIT_SSH_COMMAND wins.
+  GIT_SSH_COMMAND:
+    process.env.GIT_SSH_COMMAND ?? 'ssh -o BatchMode=yes -o ConnectTimeout=10',
+};
+
 export async function git(
   args: string[],
   opts: ExecFileOptions = {}
@@ -30,7 +48,12 @@ export async function git(
   const { stdout, stderr } = await execFileAsync('git', gitCommandArgs(args), {
     ...opts,
     windowsHide: true,
-    env: { ...process.env, GIT_LFS_SKIP_SMUDGE: '1', ...(opts.env ?? {}) },
+    env: {
+      ...process.env,
+      GIT_LFS_SKIP_SMUDGE: '1',
+      ...NON_INTERACTIVE_GIT_ENV,
+      ...(opts.env ?? {}),
+    },
   });
   return { stdout: String(stdout), stderr: String(stderr) };
 }

--- a/src/shared/cache/mirror.ts
+++ b/src/shared/cache/mirror.ts
@@ -48,7 +48,22 @@ export async function ensureMirrorClone(
   }
   mkdirSync(getRepoCacheDir(platform, repoPath), { recursive: true });
   const url = repoUrl ?? buildAuthenticatedRepoUrl(platform, repoPath, authFetch);
-  await git(['clone', '--mirror', url, mirrorDir]);
+  // Blobless partial clone: fetch the full commit/tree graph (so any SHA, tag,
+  // or branch still resolves offline via resolveRef) but skip all historical
+  // file contents. On a big repo (e.g. remotion) this avoids downloading every
+  // blob across all history — the dominant cost. The blobs for the single
+  // revision we actually check out are fetched lazily by `git worktree add`
+  // during materializeSnapshot, so snapshots stay byte-identical and no consumer
+  // (skills/rules/hooks/plugins, `@`-search or `::`-exact) is affected.
+  //
+  // Why not sparse-checkout per file? Consumers walk whole trees (`@` search)
+  // and copy entire skill directories that reference sibling files, so we can't
+  // know the full file set up front without risking regressions. Blobless keeps
+  // the materialized tree complete while still skipping the expensive history.
+  //
+  // Requires git >= 2.19. Servers without partial-clone support degrade
+  // gracefully to a full clone (git warns and ignores the filter).
+  await git(['clone', '--mirror', '--filter=blob:none', url, mirrorDir]);
   return mirrorDir;
 }
 

--- a/src/types/rules.ts
+++ b/src/types/rules.ts
@@ -12,7 +12,7 @@ import type { AgentSnippetDef } from './capabilities';
 export interface Rule {
   /** Unique identifier, used as the filename stem and capa marker id. */
   id: string;
-  type: 'inline' | 'remote' | 'github' | 'gitlab';
+  type: 'inline' | 'remote' | 'github' | 'gitlab' | 'local';
   /** Restrict this rule to specific providers. When empty/omitted, applies to all. */
   providers?: string[];
   /** Glob patterns for auto-attached rules (Cursor `globs`, Copilot `applyTo`). */
@@ -25,6 +25,11 @@ export interface Rule {
   content?: string;
   /** Raw URL to fetch content from (required when type is 'remote'). */
   url?: string;
+  /**
+   * Path to a local markdown file (required when type is 'local'). Relative
+   * paths are resolved from the directory containing the capabilities file.
+   */
+  path?: string;
   /** Repository + file definition (required when type is 'github' or 'gitlab'). */
   def?: AgentSnippetDef;
 }


### PR DESCRIPTION
This pull request introduces several improvements and refactorings across the CLI codebase, focusing on more robust rule resolution, better error handling, and enhancements to the shell command system. The most significant changes include extracting and testing rule body resolution logic, improving error messages for git authentication failures, and implementing lazy loading of tool schemas in the shell command interface.

**Rule resolution and testing improvements:**

* Extracted the rule body resolution logic into a new `resolveRuleBody` function in `install-rules.ts`, supporting all rule types (`inline`, `local`, `remote`, `github`, `gitlab`) with clear error messages for missing or invalid fields. This logic is now unit tested in `install-rules.test.ts`. [[1]](diffhunk://#diff-e12b6e6696ba369d12775732044f5603bda9a3e043f2a03be25fa7fe931d1df2L14-R85) [[2]](diffhunk://#diff-e12b6e6696ba369d12775732044f5603bda9a3e043f2a03be25fa7fe931d1df2L39-L61) [[3]](diffhunk://#diff-8a4fda0f988d210be2ca28c328b8ec068c4494e7693efd59cc02940e3fd9a028R1-R99)
* Updated the capabilities file example in `README.md` to clarify how local TypeScript convention rules are referenced.

**Error handling enhancements:**

* Improved `explainGitError` to provide more actionable and descriptive error messages for various git authentication and network failure scenarios, with new unit tests verifying these cases. [[1]](diffhunk://#diff-3d8c3aa9dfb7761ba0ff07f0168b59bbf843bdd3753bd819c04508a68740d456L63-R75) [[2]](diffhunk://#diff-17073e81a3745f06b50ed320563ac83650ea1deb501624e20c36a2f40af946dbR1-R45)

**Shell command system improvements:**

* Refactored the shell command registry to use a helper for argument slug mapping and introduced a `schemaLoaded` flag to track whether a tool's input schema is loaded. [[1]](diffhunk://#diff-42cf91dc84dd9ec326934a0cd23c26f8a36a92e40412cad4d5a0978cad7131cbR28-R43) [[2]](diffhunk://#diff-42cf91dc84dd9ec326934a0cd23c26f8a36a92e40412cad4d5a0978cad7131cbL50-R66) [[3]](diffhunk://#diff-42cf91dc84dd9ec326934a0cd23c26f8a36a92e40412cad4d5a0978cad7131cbR76-R77) [[4]](diffhunk://#diff-42cf91dc84dd9ec326934a0cd23c26f8a36a92e40412cad4d5a0978cad7131cbL106-R126) [[5]](diffhunk://#diff-42cf91dc84dd9ec326934a0cd23c26f8a36a92e40412cad4d5a0978cad7131cbL132-R148)
* Implemented lazy loading of MCP tool schemas with `fetchToolSchema` and `ensureSchema`, so schemas are fetched only when needed, improving performance and resilience when listing commands.
* Added robust error handling for schema loading with `loadSchemaOrExit`, ensuring clear user feedback if a remote server is unreachable and isolating failures to the affected tool only. [[1]](diffhunk://#diff-42cf91dc84dd9ec326934a0cd23c26f8a36a92e40412cad4d5a0978cad7131cbR521-R538) [[2]](diffhunk://#diff-42cf91dc84dd9ec326934a0cd23c26f8a36a92e40412cad4d5a0978cad7131cbR581-R583) [[3]](diffhunk://#diff-42cf91dc84dd9ec326934a0cd23c26f8a36a92e40412cad4d5a0978cad7131cbR598-R600)