### PR TITLE
feat(skills): add bootstrap skill for capifying existing projects

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -87,3 +87,7 @@ capa-docs
 # Web UI build artifacts
 web-ui/dist/
 web-ui/src/.generated/
+.claude/
+capabilities.yaml
+capabilities.lock
+skills/bootstrap-workspace/

--- a/skills/bootstrap/SKILL.md
+++ b/skills/bootstrap/SKILL.md
@@ -1,0 +1,265 @@
+---
+name: bootstrap
+description: Capify an existing project. Scans the repo for already-installed MCP servers, skills, rules, hooks, sub-agents, and plugins (across .claude, .cursor, .codex, .gemini, etc.), consolidates them into shared top-level directories (skills/, rules/, hooks/), and synthesizes a sound capabilities.yaml from the inventory. Use whenever the user says "bootstrap capa", "capify this project", "onboard capa onto an existing repo", "inventory my agent setup", or asks how to turn an ad-hoc Claude/Cursor/Codex configuration into a capabilities file. Use even when the user only mentions one provider — discovery should still sweep all of them.
+---
+
+# Bootstrap
+
+Turn an existing project that has accumulated MCP servers, skills, rules, hooks, and sub-agents across several provider-specific directories into a clean, reproducible `capabilities.yaml` managed by capa.
+
+## When to use
+
+The user has a repo that already works with at least one AI coding agent (Claude Code, Cursor, Codex, Gemini, Copilot, etc.) but has never run `capa init`. They want capa to take over so the configuration is shared across providers and version-controlled in one place.
+
+Trigger words and shapes: "bootstrap capa", "capify", "set capa up on this repo", "convert my .claude/.cursor config to capa", "I have a bunch of skills and rules already — onboard them".
+
+If `capabilities.yaml` already exists at the repo root, this skill is the wrong tool — point the user at the `capabilities-manager` skill instead, which knows how to extend an existing file.
+
+## How this relates to `capabilities-manager`
+
+Bootstrap is the one-time on-boarding helper. It produces a `capabilities.yaml` from scratch. `capabilities-manager` is the long-term editor — adding skills, registering MCP servers, configuring hooks on an already-bootstrapped project. **Read `capabilities-manager` for schema details and YAML examples** rather than re-deriving them here; this skill focuses on discovery and migration, and defers all schema questions to it.
+
+When you (the agent) need to know the exact shape of a `skills:` entry, a `hooks:` entry, the canonical event names, the difference between `@` and `::` in `def.repo`, or any other schema-level detail — load the `capabilities-manager` skill rather than guessing. Bootstrap calls schema decisions out by name, but never inlines the schema reference.
+
+## The flow at a glance
+
+1. **Preflight** — verify capa is installed, decide whether to branch, check for an existing `capabilities.yaml`.
+2. **Discover** — sweep the repo for every flavor of agent config, including symlinks and submodules.
+3. **Plan** — present the inventory to the user, propose moves, get sign-off before touching files.
+4. **Migrate** — move provider-specific items into shared top-level dirs.
+5. **Synthesize** — write `capabilities.yaml` and update `.gitignore`.
+6. **Verify** — run `capa install` and surface anything that didn't take.
+7. **Inspect tools** — for each registered MCP server, ask capa what tools it exposes and add the relevant ones to `tools:`. Servers with zero tools usually mean unfinished auth — tell the user and wait.
+
+Each phase is described below. Don't skip a phase; each one's output is the next one's input.
+
+## Phase 1 — Preflight
+
+Before scanning, confirm three things:
+
+**Capa is installed.** Run `capa --version`. If it isn't installed, stop and ask the user to install it (point them at the README); don't attempt to bootstrap blind.
+
+**Git state is sane.** Run `git status --porcelain` and `git rev-parse --abbrev-ref HEAD`. If the working tree has uncommitted changes that aren't agent-config files (i.e., user is mid-edit on real code), tell them and ask whether to proceed; bootstrap will move files and they may want a clean slate first.
+
+**Branch decision.** Look at the current branch:
+- If it's `main`, `master`, `trunk`, or matches the repo's default branch (from `git symbolic-ref refs/remotes/origin/HEAD` — fall back to `main` if unset), create a new branch named `capa/bootstrap` (or a unique suffix if that already exists) with `git checkout -b capa/bootstrap`. Bootstrap touches many files; isolating that in a branch makes it trivially revertable.
+- If it's anything else, the user is already working on something — stay on that branch and tell them so. Don't switch.
+
+**Existing capabilities file.** If `capabilities.yaml` or `capabilities.json` already exists at the repo root, stop. Tell the user the project is already bootstrapped and they should use `capabilities-manager` to extend it.
+
+## Phase 2 — Discover
+
+Sweep the project for every kind of agent configuration. **Run the searches in parallel** — they're independent and reading them sequentially wastes time on large repos. Always exclude `node_modules`, `dist`, `build`, `.git`, `vendor`, and `target` from globs.
+
+For each category below, also resolve **symlinks** (`find . -type l -not -path './node_modules/*' -not -path './.git/*'`) and check **git submodules** (`git submodule status` — if any submodule is itself an agent-config repo, surface it). A symlinked `.cursor` pointing at `~/dotfiles` is a real finding that affects what you do with it.
+
+See `references/discovery.md` for the exhaustive search matrix — every file glob, every JSON/TOML key, every provider quirk. Use that file rather than memorizing locations; provider directories change and the reference is updated when capa learns a new one.
+
+The shape of the inventory you build should look like:
+
+```
+discovered:
+  mcp_servers:
+    - source: .cursor/mcp.json
+      id: postgres
+      kind: local-subprocess
+      def: { cmd: ..., args: ..., env: ... }
+  skills:
+    - source: .claude/skills/code-review/SKILL.md
+      id: code-review
+      provider: claude-code
+  rules:
+    - source: .cursor/rules/typescript.mdc
+      id: typescript
+      provider: cursor
+      applies_to: ["**/*.ts", "**/*.tsx"]
+  hooks:
+    - source: .claude/settings.json
+      event: PreToolUse
+      provider: claude-code
+      command: "..."
+  subagents:
+    - source: .claude/agents/api-reviewer.md
+      id: api-reviewer
+  symlinks: [...]
+  submodules: [...]
+  ignored_dirs_present: [".claude", ".cursor"]
+```
+
+You don't have to use that exact format — it's a checklist. Whatever you produce should let the user see, at a glance, what's about to be migrated.
+
+## Phase 3 — Plan
+
+Show the inventory to the user. **Before moving any files**, propose:
+
+**Why moves are necessary** (lead with this — users often resist file moves until they understand): capa's install model assumes it owns the provider-specific directories. On every `capa install`, it rewrites `.claude/skills/`, `.cursor/skills/`, etc. from a separate source-of-truth location. If a skill stays under `.claude/skills/` and is also declared as `type: local` pointing at the same dir, install fails with "directory already exists and is not managed by capa." So the source has to live outside provider dirs — that's the whole reason for the move, not aesthetics.
+
+If the project's own conventions designate `.claude/skills/` (or similar provider dir) as the shared canonical location (often documented in an `AGENTS.md` at that path), call that out and explain that the convention worked pre-capa but capa-managed projects need a separate source dir. Offer to update the project's AGENTS.md as part of the migration so it reflects the new layout.
+
+1. **Which items to migrate into shared dirs**, and what they'll become:
+   - `.claude/skills/foo/` → `skills/foo/` referenced as `type: local`, `def.path: ./skills/foo`
+   - `.cursor/skills/bar/` → `skills/bar/` (or merged with an existing one of the same name; flag the conflict)
+   - `.cursor/rules/*.mdc` → `rules/*.md` referenced as `type: inline` (small) or moved with a `path:` (for now, capa supports inline/remote/github/gitlab — there is no `type: local` for rules, so the bootstrap default is `type: inline` with the file content embedded; flag this trade-off with the user if files are large)
+   - `.claude/agents/*.md` → entries in the top-level `subagents:` section (capa regenerates the file on install)
+   - Hooks in `.claude/settings.json` / `.cursor/hooks.json` → top-level `hooks:` entries, using canonical event names. For non-trivial hook scripts, move the script under `hooks/<id>.sh` and reference via `source: { type: local, path: ./hooks/<id>.sh }`. Inline one-liners stay inline.
+   - MCP servers from `.cursor/mcp.json`, `.claude/settings.json` `mcpServers`, `.codex/config.toml` `mcp_servers` → top-level `servers:` entries. Merge duplicates by id; flag mismatched configs (e.g., two providers point a server with the same id at different commands).
+
+2. **Which providers to declare** in `options.providers` (or to omit so capa resolves at install time). Default: declare exactly the providers whose config dirs you found.
+
+3. **Which directories to `.gitignore`** — by default, ignore generated subpaths only:
+   ```
+   .claude/skills/
+   .claude/agents/
+   .cursor/skills/
+   .cursor/rules/
+   .cursor/mcp.json
+   ```
+   `.claude/settings.json` and `.cursor/settings.json` often contain user-specific bits the user wants to keep editing by hand, so leave them tracked. If the user has nothing hand-authored there, they can broaden to `.claude/` / `.cursor/` themselves.
+
+4. **Conflicts and ambiguities** — call them out explicitly:
+   - Two skills with the same name in different provider dirs (likely the same skill installed twice — confirm before merging)
+   - A symlinked config dir (user probably wants this preserved, not moved)
+   - A rule with provider-specific frontmatter that won't round-trip into capa's inline form (note the loss and ask)
+   - A submodule that itself ships skills (probably should become a plugin or a github-typed skill — don't auto-vendor it)
+
+**Wait for confirmation** before Phase 4. The user may want to skip some items, rename others, or change the target layout. Don't move files without sign-off — bootstrap's whole value is being the careful path.
+
+## Phase 4 — Migrate
+
+Execute the plan. Use `git mv` rather than `mv` so history follows the files. Keep moves atomic per category — easier to revert if something looks wrong.
+
+After moving, run `git status` and show the user the rename list so they can spot-check before you write the capabilities file.
+
+## Phase 5 — Synthesize
+
+Compose `capabilities.yaml` at the project root. The skeleton:
+
+```yaml
+providers:
+  # only the ones actually present in the project
+options:
+  toolExposure: on-demand
+skills:
+  - id: capabilities-manager
+    type: github
+    def:
+      repo: infragate/capa@capabilities-manager
+      description: Guide for managing capabilities with capa CLI
+  # then everything discovered, sorted by id
+servers: []
+tools: []
+rules: []
+hooks: []
+subagents: []
+plugins: []
+```
+
+Rules of composition:
+
+- **Always include `capabilities-manager`** so future edits have the schema available to the agent.
+- **Sort entries by `id`** within each section. Stable order makes future diffs readable.
+- **Don't invent ids.** Use the directory or file basename for discovered items, kebab-cased.
+- **For each MCP server**, prefer the most complete config from any source (e.g., if `.cursor/mcp.json` has env vars and `.claude/settings.json` doesn't, take Cursor's). Replace literal secrets with `${VarName}` placeholders and warn the user that capa will prompt for them on `capa install`.
+- **For rules**, default to `type: inline` with `content:` — capa doesn't currently have a `type: local` for rules. If the rule file is big (> ~100 lines), ask the user whether to keep it inline (simple) or push it to a github repo (cleaner but requires a follow-up).
+- **For hooks**, translate provider event names to canonical names using the table in `references/event-mapping.md`. If a hook's provider event has no canonical mapping, keep the provider-scoped form (`cursor:beforeShellExecution`) — don't drop it.
+- **Don't include empty sections** unless they're useful as placeholders. `servers: []` and `tools: []` belong (so users know where to add things); `subagents: []` only belongs if you actually expect them to add some.
+
+For the exact field-by-field shape of every entry type, consult the `capabilities-manager` skill's `references/capabilities-schema.md` — bootstrap should never duplicate that.
+
+Then update `.gitignore` per the plan from Phase 3. Append a clearly-marked block so the user can see what bootstrap added:
+
+```
+# Added by capa bootstrap — generated agent configs
+.claude/skills/
+.claude/agents/
+.cursor/skills/
+.cursor/rules/
+.cursor/mcp.json
+```
+
+## Phase 6 — Verify
+
+Run `capa install` and watch the output. Three things to surface to the user:
+
+1. **What got installed** — list of skills/rules/hooks/servers that capa wrote to disk.
+2. **Anything blocked** — a forbidden phrase, a missing CLI prerequisite, an unreachable remote. Don't silently swallow these.
+3. **What's left to do** — credentials capa will prompt for, optional fields the user might want to fill in (descriptions, sub-agent instructions, etc.).
+
+If install fails, **don't auto-rollback** — the user is on a branch, and the partial state is debuggable. Tell them what failed and let them decide whether to fix forward or `git reset`.
+
+## Phase 7 — Inspect tools and populate `tools:`
+
+Discovered MCP servers are now registered with capa, but the synthesized file has `tools: []`. Capa's server can introspect what each MCP server actually exposes — fill in the `tools:` section from that introspection so the agent has named entries it can require, group, or pre-default.
+
+**Look up the project id.** Capa assigns each project a stable id like `<basename>-<hash>`. `GET http://127.0.0.1:5912/api/projects` returns a `projects` array; match by `path == $(pwd)` and read `.id`.
+
+**For each server in `capabilities.yaml`**, hit:
+
+```
+GET http://127.0.0.1:5912/api/projects/<project-id>/servers/<server-id>/tools
+```
+
+The response is always `{"tools": [...]}`. Each tool has `name`, `description`, `inputSchema` (and sometimes `outputSchema`, `_meta` with FastMCP tags).
+
+**If the tools array is populated:** add relevant entries to the `tools:` section of `capabilities.yaml`. "Relevant" means: tools the project actually needs based on what the README/AGENTS.md says the project does. Don't dump every tool — a server with 37 tools probably only has 4–8 the project will use. Group related tools by setting a shared `group:` on command-style tools, or just let them sit at the top level for MCP tools. Use the FastMCP `_meta.fastmcp.tags` (when present) as a hint for grouping.
+
+Capa entry shape for an MCP tool:
+
+```yaml
+tools:
+  - id: create_mr
+    type: mcp
+    description: Create a GitLab MR. (Short; the agent sees this in tool descriptions.)
+    def:
+      server: "@gitlab"
+      tool: gitlab_create_merge_request
+```
+
+The `id` is the local-friendly name the agent uses; `def.tool` is the remote MCP tool name. Skills `require:` the tools with `@<server-id>.<id>`.
+
+**Important — don't repeat the server name in the id.** Capa already groups tools by server: an entry under `@gitlab` shows up in `capa sh` as `gitlab search-projects`, and skills refer to it as `@gitlab.search_projects`. If you write `id: gitlab_search_projects`, you get `gitlab gitlab-search-projects` — noisy and redundant. Pick `id`s that describe the function alone (`search_projects`, `get_mr`, `list_pipelines`), not the server. The same principle applies when the upstream MCP tool name already includes the server prefix (e.g. `gitlab_gatekeeper_searchProjects`): strip the prefix in `id`, keep the full name in `def.tool` since that's what the remote server actually exposes.
+
+**If the tools array is empty (`[]`):** assume the server needs authentication that hasn't been completed yet. Tell the user explicitly:
+
+> The `<server-id>` MCP server returned 0 tools, which usually means authentication isn't done. Complete the auth flow (open the server's web UI, paste an API key, finish OAuth — whatever its README says) and let me know when you're done. I'll re-fetch the tool list and add the relevant ones to `capabilities.yaml`.
+
+Then **wait for the user** to confirm. When they do, re-fetch and proceed. Don't guess at tool names from documentation — the live tool list is the source of truth, and the names sometimes differ from docs.
+
+**After tool inspection is complete**, ensure any skill that declares a `requires:` list points to real `@<server-id>.<tool-id>` entries that now exist in `tools:`. If a discovered local skill required a tool that doesn't show up in any server's tool list, flag it — the skill may have been written against a different version of the server, or the user may need to add a different MCP server.
+
+**Watch for the "declared but unused" trap.** With `options.toolExposure: on-demand` (the default `capa init` writes), capa only exposes tools the agent will see after a skill calls `setup_tools(['<skill>'])`. The exposure list is computed from each skill's `requires:` field — so a tool that's declared in `tools:` but not in any skill's `requires:` ends up invisible to the agent. `capa install` warns about this:
+
+> 13 tool(s) are not exposed to MCP clients (not required by any skill): gitlab.search_projects, gitlab.get_mr, ... Add them to a skill's `requires` list to expose.
+
+If you see that warning, decide with the user: either add `requires:` entries to the relevant local skills (the right answer when the skills clearly use specific tools) or switch `options.toolExposure: expose-all` (the right answer when the project uses many tools ad-hoc and `requires:` would be guesswork). Bootstrap shouldn't silently choose — surface the warning and the options.
+
+## Wrap-up
+
+End with a one-paragraph summary: which branch you're on, what was migrated, what tools got added (and which servers are pending auth), what to do next (commit, `capa restart`, open PR).
+
+## What this skill never does
+
+- **Never edits `capabilities.yaml` after the first write.** Hand off to `capabilities-manager` for ongoing edits.
+- **Never deletes the original provider-specific files.** `git mv` moves them; if the user wants the originals back, the rename is in git history.
+- **Never bypasses confirmation.** Bootstrap mutates a lot at once; every phase that touches the working tree gets explicit sign-off.
+- **Never assumes a single provider.** Even if the user only mentions Cursor, sweep for Claude/Codex/Gemini too — they probably have leftover configs the user forgot about.
+- **Never tries to keep skills inside provider dirs.** Even if the project's own AGENTS.md declares `.claude/skills/` as the shared location, capa needs source-of-truth outside provider dirs (see Phase 3). Explain and migrate; don't try to be clever.
+
+## Things capa can't model
+
+When discovery surfaces something capa has no first-class representation for, **note it in the inventory and leave it in place**. Don't try to force a fit. Today this list includes:
+
+- **Cursor slash commands** (`.cursor/commands/*.md`) — Cursor-only feature with no Claude equivalent. Document them in the migration summary and leave the files where they are.
+- **Provider-specific permissions blocks** (e.g., `.claude/settings.json` → `permissions.allow`) — capa doesn't write these; tell the user this file stays under their control and only the `mcpServers`/`hooks` sections will be regenerated.
+- **Duplicate config files at root** (e.g., both `.mcp.json` and a sibling `mcp.json` with identical content) — flag the duplicate and recommend removing the non-standard one (`mcp.json` is not part of any provider spec; `.mcp.json` is the Claude standard). Show the user the diff before removing.
+- **Empty agent-related directories** (e.g., an empty `ai-skills/` left by a partial migration attempt) — surface them; the user may want to delete or keep.
+- **Submodules without agent-relevant content** — most submodules in a real repo are application code, not agent configuration. Use the two-pass strategy in `references/discovery.md`: shortlist by name (anything matching `skill|agent|prompt|mcp|context`), init only the shortlist, scan for `SKILL.md`, register as `type: github`/`type: gitlab` pinned to the submodule's commit SHA. Don't list 70+ application-code submodules individually; one summary line is enough.
+
+## References
+
+| Topic | File |
+|-------|------|
+| Where to look for each kind of config (full search matrix) | `references/discovery.md` |
+| Provider event names → canonical hook names | `references/event-mapping.md` |
+| Capabilities file schema | (load `capabilities-manager` skill → `references/capabilities-schema.md`) |
+| Commands (`capa init`, `capa install`, etc.) | (load `capabilities-manager` skill → `references/commands.md`) |

--- a/skills/bootstrap/SKILL.md
+++ b/skills/bootstrap/SKILL.md
@@ -235,6 +235,14 @@ If you see that warning, decide with the user: either add `requires:` entries to
 
 ## Wrap-up
 
+**Offer to remove the bootstrap skill itself from `capabilities.yaml`.** Bootstrap is one-shot: once the file exists, future capabilities edits go through `capabilities-manager`, not bootstrap. Leaving `- id: bootstrap` in `skills:` is harmless but installs an unused skill into every provider, adds a line to every diff, and confuses future readers ("why is the on-boarding skill still here?"). Ask the user:
+
+> Bootstrap is finished. Should I remove the `bootstrap` skill entry from `capabilities.yaml` so future runs of `capa install` skip it? (The `capa init` default re-adds it for new projects; this only affects this file.)
+
+If they say yes: delete the entry (and any trailing comment that explained it), re-run `capa install` to confirm the file still parses and to deregister the skill from providers, then commit. If they say no: leave it; some users keep it as a self-documenting marker.
+
+Do not auto-remove without asking. The skill never edits `capabilities.yaml` silently after Phase 5 — every change since gets the user's sign-off, and self-removal is no exception.
+
 End with a one-paragraph summary: which branch you're on, what was migrated, what tools got added (and which servers are pending auth), what to do next (commit, `capa restart`, open PR).
 
 ## What this skill never does

--- a/skills/bootstrap/evals/evals.json
+++ b/skills/bootstrap/evals/evals.json
@@ -1,0 +1,19 @@
+{
+  "skill_name": "bootstrap",
+  "evals": [
+    {
+      "id": 0,
+      "name": "cursor-only-project",
+      "prompt": "I want to start using capa on this Cursor project. The project has Cursor-specific config in .cursor/ and a legacy .cursorrules file. Please bootstrap capa onto it: generate a capabilities.yaml that captures the MCP servers and rules I already have, move things into shared top-level directories where it makes sense, and update .gitignore. Don't run capa install at the end — just stop after the capabilities.yaml is written and tell me what you did. Work on a new branch.",
+      "expected_output": "capabilities.yaml at project root with discovered MCP servers (postgres, github) and the two .cursor/rules captured. A new branch capa/bootstrap (or similar) created. .gitignore updated. Secrets in env replaced with ${...} placeholders.",
+      "files": []
+    },
+    {
+      "id": 1,
+      "name": "claude-cursor-multi-provider",
+      "prompt": "Please bootstrap capa onto this project. It already has both Claude Code and Cursor configured — there's a sub-agent in .claude/agents/, a skill in .claude/skills/, MCP servers in both .claude/settings.json and .cursor/mcp.json (postgres is registered twice with the same config), hooks in .claude/settings.json, and rules in .cursor/. There's also a shell script the hooks reference. Generate the capabilities.yaml, move things into shared dirs, dedupe the postgres entry, and update .gitignore. Don't run capa install — stop once the file is written and tell me what you migrated. Work on a new branch.",
+      "expected_output": "capabilities.yaml at project root with: providers (claude-code, cursor), the local skill referenced via type:local, the sub-agent in subagents:, hooks translated to canonical events, MCP servers deduped (one postgres entry), the audit-shell.sh script referenced via source:type:local. A new branch created. .gitignore updated. Secrets replaced with ${...} placeholders.",
+      "files": []
+    }
+  ]
+}

--- a/skills/bootstrap/references/discovery.md
+++ b/skills/bootstrap/references/discovery.md
@@ -1,0 +1,165 @@
+# Discovery search matrix
+
+The exhaustive list of where agent configuration hides on disk. Run these searches in parallel; group findings by category before showing the user.
+
+Always exclude: `node_modules/`, `dist/`, `build/`, `.git/`, `vendor/`, `target/`, `.next/`, `.venv/`, `__pycache__/`.
+
+## MCP servers
+
+| Where | Format | What to extract |
+|---|---|---|
+| `.cursor/mcp.json` | JSON `{ "mcpServers": { id: { command, args, env } } }` | One server per key |
+| `.mcp.json` (project root) | JSON `{ "mcpServers": ... }` | Same shape as Cursor; Claude Code's standard location |
+| `mcp.json` (project root, no dot) | JSON | NOT a real provider standard. Usually a duplicate of `.mcp.json` left over from an editor that hid dotfiles. Diff against `.mcp.json` — if identical, recommend removing it; if different, ask which one is authoritative. |
+| `.claude/settings.json` → `mcpServers` | JSON map | Same shape |
+| `.codex/config.toml` → `[mcp_servers.<id>]` | TOML tables | `command`, `args`, `env` |
+| `.gemini/settings.json` → `mcpServers` | JSON map | Same shape |
+| `.vscode/mcp.json` | JSON map | Continue / VS Code MCP |
+| Any `**/mcp.json` outside the above | JSON | Likely a sub-project or vendored config — flag, don't auto-include |
+
+**HTTP/SSE servers**: when a server entry has `"type": "http"` / `"type": "sse"` and a `"url"`, treat as remote (capa entry: `def.url` + optional `def.headers`). When it has `"command"` and `"args"`, treat as local subprocess (`def.cmd`, `def.args`, optional `def.env`). Don't mix them up — remote servers have no `cmd`, local servers have no `url`.
+
+**Dedup across sources**: when the same id appears in multiple files (e.g., `postgres` in both `.cursor/mcp.json` and `.claude/settings.json`), diff the configs. If identical, emit one entry. If they differ, surface the diff and ask which one is authoritative — don't silently pick one.
+
+Also grep for `mcpServers` inside any `package.json` or `pyproject.toml` — some tools embed MCP config there.
+
+**Normalization rules:**
+- Local subprocess: capa entry is `type: mcp` + `def.cmd`, `def.args`, optional `def.env`.
+- Remote HTTP: capa entry uses `def.url` + optional `def.headers`.
+- Replace literal secrets (anything matching `(?i)(token|key|secret|password|api[_-]?key)`) in env/headers with `${VarName}` placeholders.
+
+## Skills
+
+| Where | Layout |
+|---|---|
+| `.claude/skills/<id>/SKILL.md` | Per-skill directory |
+| `.cursor/skills/<id>/SKILL.md` | Per-skill directory |
+| `skills/<id>/SKILL.md` | Shared (already in the target shape) |
+| `.codex/skills/<id>/SKILL.md` | Per-skill directory |
+| `~/.claude/skills/<id>/SKILL.md` | **User-level** — do NOT vendor. Note it exists; user keeps it. |
+
+Read the frontmatter (`name`, `description`, `requires`) from each `SKILL.md` to populate inventory metadata.
+
+## Rules
+
+| Where | Format | Notes |
+|---|---|---|
+| `.cursor/rules/**/*.mdc` | Markdown with YAML frontmatter (`description`, `globs`, `alwaysApply`) | Modern Cursor |
+| `.cursor/rules/**/*.md` | Same | Older Cursor |
+| `.cursorrules` (file at root) | Plain markdown, no frontmatter | Legacy — treat as one `inline` rule with `alwaysApply: true` |
+| `AGENTS.md` (root) | Plain markdown | Manages via capa `agents` section, NOT a rule — record separately |
+| `CLAUDE.md` (root) | Plain markdown | Same as AGENTS.md — record under `agents.additional` |
+| `.github/copilot-instructions.md` | Plain markdown | Treat as an `inline` rule scoped to provider `copilot` |
+| `.gemini/GEMINI.md` | Plain markdown | Treat under `agents` for Gemini, not a rule |
+| `.codex/AGENTS.md` | Plain markdown | Same as root AGENTS.md |
+| `.windsurfrules` | Plain markdown | Legacy Windsurf — inline rule |
+
+When Cursor's `globs` field is present, map it to capa's `appliesTo`. When `alwaysApply: true`, keep it.
+
+## Hooks
+
+| Provider | File | Section |
+|---|---|---|
+| Claude Code | `.claude/settings.json` | `hooks.<EventName>` → `[{ matcher, hooks: [{ type, command }] }]` |
+| Cursor | `.cursor/hooks.json` | `hooks.<eventName>` → array |
+| Codex | `.codex/config.toml` | `[[hooks.<EventName>]]` + `[[hooks.<EventName>.hooks]]` |
+| Gemini | `.gemini/settings.json` | `hooks.<EventName>` — claude-style |
+
+For each hook entry, capture: event name, matcher (if any), command or script path, timeout.
+
+If the hook references a script file (e.g., `command: "/path/to/script.sh"`), check whether the script is in the repo. If yes, it'll move under `hooks/<id>.sh` and be referenced via `source: { type: local }`. If it's outside the repo, leave it as an inline command pointing at the absolute path and warn the user.
+
+## Sub-agents
+
+| Where | Format |
+|---|---|
+| `.claude/agents/<id>.md` | Markdown with optional YAML frontmatter (`description`, `tools`) |
+| `.cursor/agents/<id>.md` | Same |
+
+Capture id (filename stem), description (frontmatter), tools list, and the body (becomes `instructions`).
+
+## Cursor slash commands (not migratable today)
+
+`.cursor/commands/*.md` are Cursor-specific user-invocable commands. Capa has no equivalent concept. Don't move them, don't reference them in `capabilities.yaml`, but **do** list them in the inventory and the migration summary so the user knows they're staying put. A frequent pattern is a `.cursor/commands/foo.md` that's just a thin wrapper around a skill (often documented in a `.claude/skills/AGENTS.md` mapping table) — note the wrapper relationships when you spot them.
+
+## Plugins
+
+Plugins are rare in pre-capa projects. The signals:
+
+- `.claude/plugins/<name>/` directory with a manifest (`plugin.json`)
+- A git submodule whose root contains a manifest matching capa's plugin schema
+- A `plugins/` directory at repo root with sub-projects
+
+Don't auto-include plugins — surface them and ask the user. Most "plugins" found in the wild are really just skill collections that should be referenced via `type: github` instead.
+
+## Symbolic links
+
+```
+find . -type l -not -path './node_modules/*' -not -path './.git/*' -not -path './dist/*'
+```
+
+For each symlink:
+- Resolve target (`readlink -f` on Linux, `readlink` on macOS — fall back to `python -c "import os; print(os.path.realpath('PATH'))"`)
+- Classify: is the target inside the repo, inside the user's home, on a network mount, broken?
+- If the symlink IS one of the discovered config dirs (e.g., `.cursor -> ~/dotfiles/cursor`), surface it loudly — moving it would break the user's dotfile setup. Bootstrap should NOT migrate it without explicit instruction.
+
+## Git submodules
+
+```
+git submodule status            # `-` prefix means uninitialized
+grep -h '^\s*path' .gitmodules  # all submodule paths
+```
+
+Submodules are common in large repos — and most of them are application code, not agent config. Don't init all 50+ of them blindly. The cost is real: clones take time, may need different auth (SSH vs HTTPS), and most return nothing.
+
+**Two-pass strategy:**
+
+1. **Shortlist by name.** Match basename or URL repo name against `(skill|agent|prompt|mcp|context)` (case-insensitive). Anything matching probably contains agent config; everything else probably doesn't. Show the shortlist to the user before initializing — they can add more, remove false positives, or say "skip all submodules."
+
+2. **For each shortlisted submodule:**
+   - Get the pinned SHA: `git ls-tree HEAD <path>` (the second column is the commit SHA).
+   - Init it: `git submodule update --init <path>`. If the clone fails because the URL uses SSH (`git@host:…`) but the user authenticates over HTTPS, retry with `git -c url."https://<host>/".insteadOf="git@<host>:" submodule update --init <path>`.
+   - Walk the checked-out tree for `SKILL.md` **at any depth** — `find <path> -name SKILL.md` (do NOT use `-maxdepth`; skills routinely live at `<root>/.claude/skills/<name>/SKILL.md`, which is four levels deep from the submodule root, and a depth limit will miss them).
+   - For each `SKILL.md` found, capture: the submodule's remote URL (`git config -f .gitmodules submodule.<name>.url`), the pinned SHA, the path to the skill inside the submodule, and the skill `name` from the SKILL.md frontmatter (this is what `@<basename>` matches against).
+
+3. **Capture each found skill as a remote reference** (NOT vendored). The reason: capa can fetch from private GitLab/GitHub repos using the user's OAuth tokens, and pinning to the same commit the submodule pinned keeps reproducibility identical. The submodule itself becomes redundant for capa purposes — the user may keep it or remove it.
+
+   Reference shape — GitHub:
+   ```yaml
+   skills:
+     - id: my-skill
+       type: github
+       def:
+         repo: owner/repo@my-skill#<sha>            # @ = recursive search by basename
+         # or, when the path inside is unambiguous:
+         # repo: owner/repo::skills/my-skill#<sha>  # :: = exact path
+   ```
+
+   Reference shape — GitLab (note: subgroups are supported):
+   ```yaml
+   skills:
+     - id: my-skill
+       type: gitlab
+       def:
+         repo: group/subgroup/repo@my-skill#<sha>
+   ```
+
+4. **Watch for duplicates against local skills.** If a submodule SKILL.md has the same `name` (or directory basename) as a skill you already discovered in `.claude/skills/`, `.cursor/skills/`, or `skills/`, that local copy is almost certainly a vendored copy of the submodule's skill — someone copied it in once and the submodule has since become the source of truth. Surface the conflict to the user with this recommendation:
+
+   > Skill `<name>` exists both at `<local-path>` and at `<submodule>/<sub-path>` pinned to `<sha>`. The submodule is the canonical source; would you like me to delete the local copy and reference the submodule version via `type: gitlab` (or `github`)? This keeps the project lighter and the canonical source authoritative.
+
+   Default to "yes" unless the local copy has clearly diverged (diff the SKILL.md frontmatter and body). If they've diverged, ask which one wins instead of guessing.
+
+5. **Submodules without `SKILL.md`** (init succeeded but the repo had no skills at the pinned commit) — note them in the inventory ("X submodule pinned at <sha> contains no SKILL.md right now; not added to capabilities.yaml") and move on. Don't error out — the submodule may be in flux.
+
+6. **All other submodules** (everything not shortlisted) — summarize in one line in the inventory: "67 other submodules in .gitmodules (mostly data pipelines) — not initialized, not scanned. Re-run with `--all-submodules` if you want exhaustive coverage." Don't list them individually; that's noise.
+
+## Per-project vs per-user
+
+Several providers honor both project-local and user-level configs:
+
+- Claude Code: `.claude/` (project) and `~/.claude/` (user)
+- Cursor: `.cursor/` (project) and `~/.cursor/` (user)
+- Codex: `.codex/` (project) and `~/.codex/` (user)
+
+Bootstrap **only operates on project-local** configs. Mention user-level configs in the inventory ("FYI: ~/.claude/skills/foo exists, but we won't touch it") so the user knows where their other context comes from, but never vendor user-level items into the project.

--- a/skills/bootstrap/references/event-mapping.md
+++ b/skills/bootstrap/references/event-mapping.md
@@ -1,0 +1,77 @@
+# Hook event mapping
+
+When discovering hooks in provider-specific files, translate the provider's event name to capa's canonical event before writing it into `capabilities.yaml`. Hooks whose provider event has no canonical mapping should be written using the `<provider>:<event>` override form so they continue to install for that provider only.
+
+The canonical event list is owned by capa's provider registry. Treat this file as a snapshot — if a provider you're discovering uses an event not listed here, default to keeping the provider-scoped form rather than guessing a canonical name.
+
+## Canonical events
+
+| Canonical | Fires when |
+|---|---|
+| `sessionStart` | Agent session begins |
+| `sessionEnd` | Agent session ends |
+| `userPromptSubmit` | User submits a prompt to the agent |
+| `beforeTool` | Before any tool call |
+| `afterTool` | After any tool call completes successfully |
+| `afterToolFailure` | After any tool call fails |
+| `beforeShell` | Before a shell command runs (subset of `beforeTool` for shell-only) |
+| `afterShell` | After a shell command runs |
+| `beforeFileRead` | Before reading a file |
+| `afterFileEdit` | After editing a file |
+| `beforeMcpCall` | Before an MCP tool call |
+| `afterMcpCall` | After an MCP tool call |
+| `subagentStart` | A sub-agent task begins |
+| `subagentStop` | A sub-agent task ends |
+| `preCompact` | Before context compaction |
+| `stop` | The agent stops (different from sessionEnd in some providers) |
+
+## Provider event → canonical
+
+### Claude Code (`.claude/settings.json` → `hooks`)
+
+| Provider event | Canonical |
+|---|---|
+| `SessionStart` | `sessionStart` |
+| `SessionEnd` | `sessionEnd` |
+| `UserPromptSubmit` | `userPromptSubmit` |
+| `PreToolUse` | `beforeTool` (or `beforeShell` if matcher is `Bash`/`Shell`; `beforeMcpCall` if matcher targets MCP tools) |
+| `PostToolUse` | `afterTool` (same matcher logic — narrow to `afterShell`/`afterMcpCall` when applicable) |
+| `Stop` | `stop` |
+| `SubagentStop` | `subagentStop` |
+| `PreCompact` | `preCompact` |
+| `Notification` | (no canonical — keep as `claude-code:Notification`) |
+
+### Cursor (`.cursor/hooks.json`)
+
+| Provider event | Canonical |
+|---|---|
+| `beforeShellExecution` | `beforeShell` |
+| `afterShellExecution` | `afterShell` |
+| `beforeFileEdit` | (no exact canonical — use `cursor:beforeFileEdit`) |
+| `afterFileEdit` | `afterFileEdit` |
+| `beforeMcpCall` | `beforeMcpCall` |
+| `afterMcpCall` | `afterMcpCall` |
+
+### Codex (`.codex/config.toml` → `[hooks]`)
+
+Codex events generally mirror Claude's casing (`PreToolUse`, `PostToolUse`, etc.). Apply the Claude mapping.
+
+### Gemini (`.gemini/settings.json` → `hooks`)
+
+Gemini follows the Claude shape. Apply the Claude mapping.
+
+## Narrowing PreToolUse / PostToolUse
+
+`PreToolUse` is fired for every tool. When a discovered hook has a `matcher` that's specific (`Bash`, `Shell`, `mcp__*`), prefer the narrower canonical name — it makes the intent obvious in `capabilities.yaml`:
+
+- matcher matches shell tools only → `beforeShell` / `afterShell`
+- matcher matches MCP tools only (e.g., `mcp__server__tool`) → `beforeMcpCall` / `afterMcpCall`
+- matcher is `*` or absent or matches multiple categories → `beforeTool` / `afterTool`
+
+When in doubt, keep `beforeTool` — capa will fan it out to every provider's "pre any tool" event.
+
+## Inline command vs script file
+
+- Single-line `command` (e.g. `'date >> ~/.capa/audit.log'`) → keep inline in the capabilities file under `command:`.
+- Multi-line script, or `command` that's actually a path to a `.sh`/`.py`/`.js` file in the repo → move the script under `hooks/<id>.sh` and reference via `source: { type: local, path: ./hooks/<id>.sh }`. This is the version-controlled form; capa won't copy or chmod the file, so the user should make sure it's executable.
+- Path to a script outside the repo → keep inline as a `command` pointing at the absolute path; warn the user that this won't be portable across machines.

--- a/src/shared/__tests__/capabilities.test.ts
+++ b/src/shared/__tests__/capabilities.test.ts
@@ -138,10 +138,19 @@ describe('capabilities', () => {
 
     it('should include default skills', () => {
       const capabilities = createDefaultCapabilities();
-      
+
       expect(capabilities.skills.length).toBeGreaterThan(0);
       const abilityManager = capabilities.skills.find(s => s.id === 'capabilities-manager');
       expect(abilityManager).toBeDefined();
+    });
+
+    it('should include the bootstrap skill so new projects can capify existing setups', () => {
+      const capabilities = createDefaultCapabilities();
+
+      const bootstrap = capabilities.skills.find(s => s.id === 'bootstrap');
+      expect(bootstrap).toBeDefined();
+      expect(bootstrap?.type).toBe('github');
+      expect((bootstrap?.def as { repo?: string })?.repo).toBe('infragate/capa@bootstrap');
     });
 
     it('should start with an empty tools array', () => {

--- a/src/shared/capabilities.ts
+++ b/src/shared/capabilities.ts
@@ -83,6 +83,15 @@ export function createDefaultCapabilities(): Capabilities {
           description: 'Guide for managing capabilities with capa CLI',
         },
       },
+      {
+        id: 'bootstrap',
+        type: 'github',
+        def: {
+          repo: 'infragate/capa@bootstrap',
+          description:
+            'Capify an existing project: discover skills/rules/hooks/MCP servers across all providers and synthesize capabilities.yaml',
+        },
+      },
     ],
     servers: [],
     tools: [],


### PR DESCRIPTION
## Summary

Closes #112.

Adds a new `bootstrap` skill that on-boards capa onto an existing project that already has agent configuration scattered across `.claude/`, `.cursor/`, `.codex/`, `.gemini/`, root `.mcp.json`, `AGENTS.md`, etc. — without making the user redo it by hand.

The skill walks the agent through a 7-phase flow:

1. **Preflight** — verify capa is installed; branch from main; refuse if `capabilities.yaml` already exists (hand off to `capabilities-manager`).
2. **Discover** — sweep every provider directory, root mcp configs, symlinks, and shortlisted submodules. Search matrix lives in `references/discovery.md`.
3. **Plan** — show the inventory before touching files. Explains *why* moves are necessary (capa's install model rewrites provider dirs, so source-of-truth has to live separately).
4. **Migrate** — `git mv` into shared top-level `skills/`, `rules/`, `hooks/`.
5. **Synthesize** — write `capabilities.yaml` and update `.gitignore`.
6. **Verify** — run `capa install`; surface anything blocked rather than swallowing.
7. **Inspect tools** — call `GET /api/projects/<id>/servers/<id>/tools` for each registered MCP server and populate the `tools:` section. Treat an empty result as "auth not done — wait for the user."

Reference material covers the discovery search matrix (every provider's config locations, dedupe rules for duplicate root `mcp.json`, two-pass submodule strategy that shortlists by name match and registers found `SKILL.md` as `type: github`/`type: gitlab` pinned to the submodule's commit SHA) and the provider-event → canonical-event mapping for hooks.

`capa init` now seeds the `bootstrap` skill alongside `capabilities-manager` in the default capabilities.yaml, so new users land with a one-shot path to migrate any pre-existing agent setup.

`.gitignore` picks up dev workspace artifacts (the capa-install output and the skill-eval scaffolding) so they don't accidentally get committed during local iteration.

## Test plan

Skill evaluation:
- [x] Two fixture eval cases (Cursor-only and mixed Claude+Cursor multi-provider) executed with-skill vs. without-skill via parallel subagents
- [x] With-skill: ~93% assertion pass-rate (only failures were sandbox-blocked `git checkout -b`); without-skill: ~47% (baseline died on the simpler fixture)
- [x] Validated against a real-world repo with both Claude Code and Cursor configured, four remote MCP servers, ~20 skills, hooks in two providers, and 72 submodules (one of which contained 9 SKILL.md files vendored locally as duplicates)

Manual:
- [x] `bun test src/shared/__tests__/capabilities.test.ts` — 21 passing (new pin on the bootstrap default entry included)
- [x] `bun test src/cli/commands/__tests__/init-command.test.ts` — 2 passing
- [ ] Maintainer to verify `capa init` output includes both `capabilities-manager` and `bootstrap` after this lands
- [ ] Maintainer to walk through the skill end-to-end on a fresh project after it's published to `infragate/capa@bootstrap`

## Known follow-ups (not in this PR)

- `capa install` appends a duplicate hook entry to `.claude/settings.json` when the user already has a hand-authored hook on the same event as a bootstrap-installed one. Worth a separate issue.

🤖 Generated with [Claude Code](https://claude.com/claude-code)