### PR TITLE
feat(cli): registry search + capabilities-manager skill refresh

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -91,3 +91,4 @@ web-ui/src/.generated/
 capabilities.yaml
 capabilities.lock
 skills/bootstrap-workspace/
+skills/capabilities-manager-workspace/

--- a/skills/capabilities-manager/SKILL.md
+++ b/skills/capabilities-manager/SKILL.md
@@ -1,142 +1,94 @@
 ---
 name: capabilities-manager
-description: Manages capabilities.yaml (or .json), CAPA CLI commands, skills, tools, MCP servers. Use when editing the capabilities file, installing or cleaning capabilities, or running tools via capa sh.
+description: Manage capa CLI configuration — `capabilities.yaml` / `capabilities.json`, skills, MCP servers, tools, hooks, sub-agents, rules, plugins, AGENTS.md / CLAUDE.md, security options, and tool exposure modes. Use whenever the user edits the capabilities file, runs any `capa` command (init, install, add, clean, sh, start/stop/restart/status, auth, upgrade, cache, registry), wires up an MCP server, adds a skill from GitHub / GitLab / a registry / a remote URL / a local path, configures secrets via `${VarName}` placeholders, installs lifecycle hooks, defines sub-agents, or troubleshoots a failed install. Use even when the user only names a fragment ("add a skill", "wire up brave search", "block this phrase in skills") without saying "capa" — if a `capabilities.yaml` or `capabilities.json` lives at the project root, this is almost certainly the right skill. If the project does NOT yet have a capabilities file, point at the `bootstrap` skill instead.
 ---
 
 # Capabilities Manager
 
-Manages agent capabilities with the CAPA CLI: define and install skills, configure MCP servers and tools, and control AGENTS.md/CLAUDE.md via the capabilities file.
+The capa CLI keeps a single source-of-truth file — `capabilities.yaml` (or `.json`) — that describes everything an agent can do in this project: skills, MCP servers, tools, hooks, sub-agents, rules, plugins, and per-provider files (`AGENTS.md`, `CLAUDE.md`). Editing that file and running the right `capa` command is the whole loop.
 
-**Detail** lives in `references/`: full command reference, schema, workflows, examples, and troubleshooting. Read the relevant file when you need step-by-step or YAML examples.
+This skill is the routing layer for that loop. The actual command reference, schema, full YAML examples, and troubleshooting tables live in `references/`. Load the one you need rather than re-deriving its contents — they are kept up to date and are the authoritative source.
 
-## When to Use
+## How capa works (one screen)
 
-Use this skill when:
-- User wants to initialize a new capabilities file
-- User needs to add or manage skills for an agent
-- User wants to configure MCP servers and tools
-- User asks about capabilities file structure or format
-- User needs to install or clean capabilities
-- User wants to find available skills from the skills.sh ecosystem
-- User needs to manage the CAPA server (start/stop/restart/status)
-- User wants to understand tool exposure modes (on-demand vs expose-all)
-- User needs to configure security (blocked phrases, character sanitization)
-- User wants to manage AGENTS.md or CLAUDE.md content (the `agents` section)
-- User wants to run tools from the command line or explore available tools with `capa sh`
-- User needs to define provider-specific rules (Cursor rules, Copilot rules, etc.)
-- User wants to add remote plugins that bundle skills, servers, and tools
-- User needs to configure sub-agents with scoped tools and instructions
-- User wants to install lifecycle hooks (e.g. Claude Code `PreToolUse`, Cursor `beforeShellExecution`)
-- User wants to manage the remote source cache or bypass it
+1. **The file is the source of truth.** `capabilities.yaml` declares what gets installed. Capa never auto-discovers anything from `.claude/`, `.cursor/`, etc. — if it's not in the file, capa won't manage it. (Onboarding an already-configured project is the `bootstrap` skill's job.)
+2. **`capa install` writes everything.** Skill directories under each provider, MCP client config (`.mcp.json`, `.cursor/mcp.json`, etc.), `AGENTS.md` / `CLAUDE.md` blocks, hook entries, rules — all rewritten from the file. Anything labeled `name: capa:<id>` is capa's; entries the user authored by hand are left alone.
+3. **`capa clean` removes only what capa wrote.** Safe to run; doesn't touch user-authored files or settings entries.
+4. **A background server at `localhost:5912`** handles credential prompts, tool execution (`capa sh`), and the MCP endpoints providers connect to. Started by `capa install`; lifecycle is `capa start | stop | restart | status`.
+5. **Secrets are `${VarName}` placeholders** anywhere in the file. Capa prompts for them via web UI on install, or loads from `.env` with `capa install -e`.
 
-## Core Concepts
+## Routing — load the reference that matches the task
 
-### Capabilities File
+| If the user is… | Read first | Then |
+|---|---|---|
+| Running a CLI command (init/install/add/clean/sh/server/auth/cache/registry/upgrade) or asking what flags exist | `references/commands.md` | Run the command and report results |
+| Editing the file — adding a skill, server, tool, hook, sub-agent, rule, plugin, agents block, security setting | `references/capabilities-schema.md` | Edit `capabilities.yaml`; run `capa install` |
+| Asking how to wire up a common pattern (web search, file ops, on-demand mode, plugins, etc.) | `references/workflows-and-examples.md` | Adapt the closest example |
+| Hitting an install error, credential prompt issue, server crash, missing tools, stale cache, TLS error, blocked phrase | `references/troubleshooting.md` | Apply the diagnostic flow listed for that symptom |
 
-The `capabilities.yaml` (or `capabilities.json`) file defines everything an agent can do. It has these main sections:
+The references are sized for selective reads (each ≤ ~600 lines, with table-of-contents at the top of the larger ones). Don't load all four if only one applies.
 
-1. **providers** (optional): MCP clients where skills are installed (e.g. `cursor`, `claude-code`). When omitted, `capa install` resolves providers via `--provider` flag, DB memory, or interactive prompt.
-2. **options**: Tool exposure (`toolExposure`), security (`security`), CLI prerequisites (`requiresCommands`)
-3. **skills**: Modular knowledge packages (when/how to use tools)
-4. **servers**: MCP servers (local subprocess or remote HTTP)
-5. **tools**: Executable capabilities (MCP or shell commands)
-6. **agents**: (Optional) Manages `AGENTS.md` / `CLAUDE.md` content in the project root
-7. **subagents**: (Optional) Named sub-agent configurations with filtered tool access
-8. **rules**: (Optional) Provider rules installed into each provider's rules directory or instructions file
-9. **hooks**: (Optional) Lifecycle hooks installed into each provider's hook config (canonical events translate per provider)
-10. **plugins**: (Optional) Remote plugin packages that bundle skills, servers, and tools
+## Pitfalls worth heading off
 
-### Skills vs Tools
+These are the mistakes an agent makes when it improvises the YAML instead of consulting the schema. Skim them before writing or editing a capabilities file.
 
-- **Skills**: Knowledge and context (non-executable markdown). Teach when and how to use capabilities.
-- **Tools**: Perform operations (API calls, commands, file ops).
+### `@` vs `::` in `def.repo`
 
-### Tool Exposure
+The repo string used by `skills`, `rules`, `plugins`, hook sources, and agent snippets has two grammars with different resolution semantics:
 
-- **expose-all** (default): All tools from all skills are exposed when the MCP client connects.
-- **on-demand**: Tools are exposed only after the agent calls `setup_tools(["skill-id"])`.
+- `owner/repo@<basename>` — capa **searches** the repo recursively for an entry matching `<basename>` (a directory containing `SKILL.md` for skills, a file with that basename for rules / snippets). The right-hand side must have no slashes.
+- `owner/repo::<exact/path>` — **no search**; the path must point exactly at the right thing from the repo root.
 
-### Security Options (`options.security`)
+Use `@` when the name is unique and stable. Use `::` when the file location is part of what the user told you (e.g. "the file is at `rules/typescript.md`") or when collisions are possible. Both forms accept pinning: `:v1.2.0` (tag/branch) or `#abc1234` (commit SHA).
 
-- **blockedPhrases**: Block install if any skill file contains a forbidden phrase. Inline list or `{ file: "./path.txt" }`. Omit to disable.
-- **allowedCharacters**: Extra regex character class beyond the always-preserved baseline (printable ASCII, tab, LF, CR). `""` = baseline only; `"[\\u00A0-\\uFFFF]"` = allow all Unicode. Omit to disable sanitization.
+### `${VarName}` is a **capa** placeholder, not a shell variable
 
-Only properties that are present are applied. If a blocked phrase is detected during `capa install`, installation stops and reports which skill and phrase caused the block.
+`${BraveApiKey}` in `capabilities.yaml` is resolved by capa at install time from its credential store or a `.env` file. It has nothing to do with the runtime environment of any spawned process. In particular: **providers do not export tool input as env vars to hooks** — each fired hook receives a JSON payload on **stdin**. If a hook needs to inspect the command being run, write a local script that reads stdin with `jq` (see the hook example in `references/capabilities-schema.md`), not an inline command with `${...}` placeholders expecting the command text to be interpolated.
 
-## Commands (Summary)
+### Tool naming: `@server.tool` vs plain id
 
-| Command | Purpose |
-|--------|--------|
-| `capa init [--format json\|yaml]` | Create a new capabilities file |
-| `capa install [-e [file]] [-p <id>] [--no-cache]` | Install skills, agents, rules, register servers; prompt for credentials |
-| `capa add <source> [--plugin\|--skill]` | Add a skill or plugin (GitHub, GitLab, registry, remote URL, or local path). `type: installed` / `type: plugin` skills are declared directly in `capabilities.yaml`. |
-| `capa clean` | Remove CAPA-installed skills, rules, and agent blocks |
-| `capa sh [group] [subcommand] [--arg value]` | List or run tools; unknown commands pass through to the OS shell |
-| `capa start \| stop \| restart \| status` | Manage the CAPA server |
-| `capa auth [provider]` | Authenticate with Git providers (github.com, gitlab.com, etc.) |
-| `capa upgrade` | Upgrade capa to the latest version |
-| `capa cache` | Show cache stats; `capa cache clean` to wipe |
+- **MCP tools** are referenced from skills as `@server-id.tool-id` (e.g. `@brave.search`). The `@` distinguishes them from command tools.
+- **Command tools** use the plain tool id (`hello_world`, `deploy_service`).
+- In `capa sh`, both are slugified to kebab-case (`@gitlab.list_merge_requests` → `capa sh gitlab list-merge-requests`).
 
-**Full command reference**: See `references/commands.md`.
+When binding tools to skills via `requires:`, mismatching the `@` prefix is the #1 cause of "tool not found" at install time.
 
-## Capabilities File Structure (Summary)
+### Tool exposure mode shapes everything downstream
 
-- **Providers**: Optional. When omitted, resolved at install time via `--provider` flag → DB memory → interactive prompt.
-- **Skills**: Seven types — `inline`, `github`, `gitlab`, `remote`, `local`, `installed`, `plugin`. Each has `id`, `type`, `def` (and for inline, `content`; for others, `repo`/`url`/`path` plus optional `requires`, `description`). The `plugin` type binds tools to a skill shipped by a configured plugin.
-- **Servers**: `type: mcp` with `def.cmd`/`args`/`env` (local) or `def.url`/`headers` (remote). Optional `tlsSkipVerify: true`, `description`.
-- **Tools**: `type: mcp` (def: `server`, `tool`, optional `defaults`) or `type: command` (def: `run.cmd`/`args`, optional `init`, `group`, `description`).
-- **Agents**: Optional `base` (ref or type+def) and `additional` list (inline, remote, github, gitlab snippets). Managed files: `AGENTS.md` always; `CLAUDE.md` when a Claude provider is present.
-- **Subagents**: Named sub-agent configurations with filtered tool access, per-provider MCP endpoints and agent files.
-- **Rules**: Types `inline`, `remote`, `github`, `gitlab`. Each has `id`, optional `providers`, `appliesTo` (glob), `alwaysApply`, `description`. Installed as files (Cursor `.cursor/rules/`) or folded into instructions files.
-- **Hooks**: A canonical event name (e.g. `beforeShell`, `afterFileEdit`, `sessionStart`) plus a `command` (or `prompt`) and optional `source` (inline / remote / github / gitlab / local). capa translates each hook to the provider-specific event name and edits the provider's hooks config (`.claude/settings.json`, `.cursor/hooks.json`, `.codex/config.toml`, `.gemini/settings.json`) with `name: capa:<id>` tags so it can update or remove its own entries without touching user-authored ones.
-- **Plugins**: Remote packages (`type: github` or `type: gitlab`, with `def.repo` + optional `def.subpath`) that bundle skills, servers, and tools from a provider manifest.
+`options.toolExposure` has three values and they change what `capa install` writes:
 
-**Full schema and YAML examples**: See `references/capabilities-schema.md`.
+- `expose-all` (default): every tool any active skill requires shows up in the MCP `tools/list`. Simplest.
+- `on-demand`: only `setup_tools` and `call_tool` are exposed at startup; the agent activates skills on demand. Keeps the active toolset small for long contexts.
+- `none`: capa writes **no** project-local MCP config files at all. The agent is expected to invoke tools via `capa sh <group> <tool>` instead. Useful when policy forbids per-project `.mcp.json` edits.
 
-## Workflows and Examples
+Pick deliberately — switching modes later cleans up old entries on the next install but the choice colours the install output.
 
-Common flows: starting a new project (`capa init` → edit file → `capa install` → `capa status`), adding a community or local skill (`capa add` or edit YAML then install), creating an inline skill, using `capa sh` to run tools, and managing the server lifecycle.
+## Conventions that prevent surprises
 
-**Step-by-step workflows and full YAML examples** (web research, file ops, mixed tools, on-demand loading, CLI prerequisites): See `references/workflows-and-examples.md`.
+- **Keep secrets out of the file.** Always use `${VarName}` placeholders; never paste literal API keys. Capa stores values per-project in `~/.capa/capa.db`.
+- **Set `requires:` on every skill.** Skills without `requires:` get no tools exposed under `on-demand` and clutter the install warnings under `expose-all`. The `requires:` list is also how capa wires the dependency graph.
+- **Prefer `@` for skill repos, `::` for rule / snippet paths.** Skill basenames are usually unique inside a repo; rule files have known paths and you want the install to fail loudly if the file ever moves.
+- **Don't repeat the server name in tool ids.** A tool under `@gitlab` should be `id: search_projects`, not `id: gitlab_search_projects` — capa already groups by server, so the prefix becomes noise (`capa sh gitlab gitlab-search-projects`).
+- **Test the install loop after every change.** `capa install` is idempotent and surfaces every problem (missing CLI, blocked phrase, unreachable remote, OAuth probe failure). Run it; don't infer.
 
-## Best Practices
+## After making changes
 
-1. **Organize by domain**: Group related skills and tools (e.g. web research + search tools).
-2. **Use descriptive IDs**: Prefer kebab-case like `web-researcher`, `file-manager`.
-3. **Document tool requirements**: Always set `requires` on skills.
-4. **Secure credentials**: Use `${VarName}` placeholders; never commit secrets. CAPA prompts via web UI or `-e` .env.
-5. **Test incrementally**: After changes, run `capa install`, then `capa restart`, and verify in the MCP client.
-6. **Keep skills focused**: One clear purpose per skill.
-7. **Prefer community skills**: Check skills.sh / vercel-labs/agent-skills before writing custom ones.
+Most edits follow the same cycle:
 
-## Troubleshooting
+1. Edit `capabilities.yaml`.
+2. `capa install` — installs/updates everything, prompts for any new credentials.
+3. `capa restart` — only needed if you changed server commands, server env vars, or tool exposure mode. Skill content, rule content, hook bodies, and agents-block content all take effect on the next install without a restart.
+4. Verify in the client (Cursor reloads; Claude Code reloads on next session start) or with `capa sh <group> <tool> --help` to confirm the tool is registered.
 
-If the server won’t start, skills don’t appear, credentials don’t prompt, an MCP server crashes, install is blocked by a forbidden phrase, you see TLS or token-auth errors, or tools are not found — use the diagnostic steps and resolutions in **`references/troubleshooting.md`**.
-
-## Tools
-
-This skill does not require any tools. It provides context and guidance
-for using the `capa` CLI directly from the terminal.
+If an install fails or behaves unexpectedly, jump directly to `references/troubleshooting.md` — the symptoms there are indexed by what the user actually sees in the terminal.
 
 ## References
 
-| Topic | File |
-|-------|------|
-| Commands (init, install, add, clean, sh, server, auth, upgrade, cache) | `references/commands.md` |
-| Capabilities schema (skills, servers, tools, rules, plugins, security, agents, subagents) | `references/capabilities-schema.md` |
-| Workflows and full examples | `references/workflows-and-examples.md` |
-| Troubleshooting | `references/troubleshooting.md` |
+| Need | File | Notes |
+|---|---|---|
+| Every `capa` command and flag, with concrete invocations | `references/commands.md` | Includes `.env` flow, provider resolution rules, registry adapters |
+| Field-by-field schema for skills / servers / tools / hooks / sub-agents / rules / plugins / security / `agents` | `references/capabilities-schema.md` | Includes the `@` vs `::` table and the tool exposure matrix |
+| End-to-end YAML examples for the most common patterns | `references/workflows-and-examples.md` | Web research, file ops, on-demand loading, plugins, optional providers |
+| Symptoms → diagnoses for install / server / credential / tool failures | `references/troubleshooting.md` | Indexed by the error message the user sees |
 
-## Additional Resources
-
-- **CAPA GitHub**: https://github.com/infragate/capa
-- **Skills.sh Ecosystem**: https://skills.sh
-- **MCP Protocol**: https://modelcontextprotocol.io
-- **Community Skills**: https://github.com/vercel-labs/agent-skills
-
-## Notes
-
-- CAPA is compatible with the skills.sh standard. Skills are installed as directories with SKILL.md.
-- Server runs at `http://localhost:5912`. Credentials in `~/.capa/capa.db`. Logs in `~/.capa/logs/`.
-- Tool naming: MCP tools are `server_id.tool_id`; in skills use `@server_id.tool_id`; command tools use plain ID. `capa sh` slugifies to kebab-case.
-- OAuth2 probe is skipped for servers that already have an `Authorization` header. Use `tlsSkipVerify: true` for trusted self-signed servers. `capa sh` is non-interactive (one command per invocation).
+External: [CAPA on GitHub](https://github.com/infragate/capa) · [skills.sh registry](https://skills.sh) · [MCP protocol](https://modelcontextprotocol.io)

--- a/skills/capabilities-manager/evals/evals.json
+++ b/skills/capabilities-manager/evals/evals.json
@@ -1,0 +1,55 @@
+{
+  "skill_name": "capabilities-manager",
+  "evals": [
+    {
+      "id": 1,
+      "eval_name": "fresh-setup-with-mcp-server-and-secret",
+      "prompt": "I just installed capa. I want it to manage a Brave Search MCP server for me so my agent can do web research. Set me up from scratch — fresh capabilities.yaml, the server, a `search` tool, and a skill that uses it. I'll be using Cursor. How do I get my Brave API key into it?",
+      "expected_output": "A capabilities.yaml that includes providers (cursor), an MCP server with `${BraveApiKey}` placeholder, a tool referencing the server via @-prefix, and an inline skill that `requires` the tool. Plus a clear explanation of capa install's prompt flow OR the -e flag for .env loading.",
+      "files": [],
+      "assertions": [
+        "capabilities.yaml exists and is valid YAML",
+        "Declares `cursor` in providers (or omits providers with an explicit justification)",
+        "Includes a `servers:` entry with `type: mcp` for Brave Search",
+        "Includes a `tools:` entry with `type: mcp` that references the server via @-prefix",
+        "Includes a `skills:` entry whose `requires:` lists the tool in `@server.tool` form",
+        "Uses `${BraveApiKey}` (or similarly-named) placeholder — no literal API key embedded",
+        "Answer.md explains how secrets get loaded — web UI prompt or `-e` flag",
+        "Answer.md tells the user to run `capa install` after dropping in the file"
+      ]
+    },
+    {
+      "id": 2,
+      "eval_name": "add-github-skill-and-rule-with-pinning",
+      "prompt": "Add the `code-review` skill from `anthropics/skills` to my capabilities file, pinned to `v1.2.0`. Also add a typescript rule from `my-org/standards` — the file is at `rules/typescript.md` in that repo and I want it pinned to the same version.",
+      "expected_output": "A capabilities.yaml snippet adding a github skill with `@code-review:v1.2.0` (search form, no path collision) and a github rule with `::rules/typescript.md:v1.2.0` (exact path because the file location is given). Bonus if the response explains why @ vs :: was chosen.",
+      "files": [],
+      "assertions": [
+        "Skill entry has `type: github` and `def.repo` contains `anthropics/skills`",
+        "Skill entry uses the `@code-review` recursive-search form",
+        "Skill is pinned to `v1.2.0`",
+        "Rule entry has `type: github` and `def.repo` contains `my-org/standards`",
+        "Rule entry uses the `::rules/typescript.md` exact-path form",
+        "Rule is pinned to `v1.2.0`",
+        "Answer.md explicitly justifies the @ vs :: choice (and is correct)",
+        "Answer.md tells the user to run `capa install` after editing"
+      ]
+    },
+    {
+      "id": 3,
+      "eval_name": "hook-with-stdin-gotcha",
+      "prompt": "I want to log every shell command Claude runs to ~/.capa/audit.log, with a timestamp. I'm on Claude Code. Set up a hook for me.",
+      "expected_output": "A hooks entry using canonical event `beforeShell`. The skill should produce a solution that actually captures the command — either a local-source script that reads stdin with jq (correct), or it should at minimum NOT use `${...}` inline expecting it to interpolate the command (the common gotcha). Acknowledges providers pass tool input via stdin JSON, not env vars.",
+      "files": [],
+      "assertions": [
+        "Hook uses canonical event `beforeShell`",
+        "Solution actually captures the command text (not just a timestamp) via stdin/jq or equivalent",
+        "Does NOT use `${command}` / `${tool_input}` / `${...}` inline expecting it to substitute the shell command",
+        "Answer.md correctly explains that providers pass tool input via stdin JSON, not env vars",
+        "Answer.md warns about the `${...}` interpolation pitfall",
+        "If a `source: local` script is used, includes shebang + `jq` to read stdin",
+        "Appends to `~/.capa/audit.log` with timestamp + command"
+      ]
+    }
+  ]
+}

--- a/src/cli/commands/__tests__/registry.test.ts
+++ b/src/cli/commands/__tests__/registry.test.ts
@@ -9,8 +9,10 @@ import {
   registryListCommand,
   registryRefreshCommand,
   registryRemoveCommand,
+  registrySearchCommand,
   registrySetEnabledCommand,
 } from '../registry';
+import { setFlags } from '../../ui';
 
 const VALID_ADAPTER = `export default {
   manifest: { id: 'demo-registry', name: 'Demo', capabilities: ['skills'] },
@@ -211,5 +213,252 @@ describe('registry CLI commands', () => {
     await expect(registryRemoveCommand('nope')).rejects.toThrow(/process\.exit\(1\)/);
     await expect(registryRefreshCommand('nope')).rejects.toThrow(/process\.exit\(1\)/);
     await expect(registrySetEnabledCommand('nope', true)).rejects.toThrow(/process\.exit\(1\)/);
+  });
+});
+
+const SEARCH_ADAPTER_SKILLS = `export default {
+  manifest: { id: 'search-one', name: 'Search One', capabilities: ['skills'] },
+  search: async ({ query }) => ({
+    items: [
+      { id: 'foo-skill', capability: 'skills', title: 'Foo Skill', description: 'A skill matching ' + (query ?? '') },
+      { id: 'bar-skill', capability: 'skills', title: 'Bar Skill', description: 'Another skill' },
+    ],
+  }),
+  view: async () => ({
+    id: 'foo-skill', capability: 'skills', title: 'Foo Skill', preview: '',
+    installSnippet: { id: 'foo-skill', type: 'inline', def: { content: '' } },
+  }),
+};`;
+
+const SEARCH_ADAPTER_PLUGINS = `export default {
+  manifest: { id: 'search-two', name: 'Search Two', capabilities: ['plugins'] },
+  search: async ({ query }) => ({
+    items: [
+      { id: 'baz-plugin', capability: 'plugins', title: 'Baz Plugin', description: 'A plugin matching ' + (query ?? '') },
+    ],
+  }),
+  view: async () => ({
+    id: 'baz-plugin', capability: 'plugins', title: 'Baz Plugin', preview: '',
+    installSnippet: { id: 'baz-plugin', type: 'inline', def: { content: '' } },
+  }),
+};`;
+
+const SEARCH_ADAPTER_THROWS = `export default {
+  manifest: { id: 'search-broken', name: 'Search Broken', capabilities: ['skills'] },
+  search: async () => { throw new Error('upstream exploded'); },
+  view: async () => ({
+    id: 'x', capability: 'skills', title: 'x', preview: '',
+    installSnippet: { id: 'x', type: 'inline', def: { content: '' } },
+  }),
+};`;
+
+describe('registry search CLI command', () => {
+  let tempDir: string;
+  let managedDir: string;
+  let dbPath: string;
+  let getDbPathSpy: ReturnType<typeof spyOn>;
+  let getManagedDirSpy: ReturnType<typeof spyOn>;
+  let exitSpy: ReturnType<typeof spyOn>;
+  let originalProcessExit: typeof process.exit;
+  let server: ReturnType<typeof Bun.serve>;
+  let consoleLogSpy: ReturnType<typeof spyOn>;
+  let stdoutSpy: ReturnType<typeof spyOn>;
+  let logs: string[];
+  let stdoutChunks: string[];
+
+  beforeEach(() => {
+    tempDir = mkdtempSync(join(tmpdir(), 'capa-registry-search-test-'));
+    managedDir = join(tempDir, 'registries-managed');
+    dbPath = join(tempDir, 'test.db');
+    getDbPathSpy = spyOn(config, 'getDatabasePath').mockReturnValue(dbPath);
+    getManagedDirSpy = spyOn(config, 'getManagedRegistriesDir').mockReturnValue(managedDir);
+
+    originalProcessExit = process.exit;
+    exitSpy = spyOn(process, 'exit').mockImplementation((code?: any) => {
+      throw new Error(`process.exit(${code ?? 0})`);
+    });
+
+    const skillsAdapter = join(tempDir, 'skills-adapter.ts');
+    const pluginsAdapter = join(tempDir, 'plugins-adapter.ts');
+    const brokenAdapter = join(tempDir, 'broken-adapter.ts');
+    writeFileSync(skillsAdapter, SEARCH_ADAPTER_SKILLS);
+    writeFileSync(pluginsAdapter, SEARCH_ADAPTER_PLUGINS);
+    writeFileSync(brokenAdapter, SEARCH_ADAPTER_THROWS);
+
+    server = Bun.serve({
+      port: 0,
+      fetch(req) {
+        const path = new URL(req.url).pathname;
+        if (path.endsWith('/skills-adapter.ts')) {
+          return new Response(readFileSync(skillsAdapter, 'utf-8'), {
+            headers: { 'content-type': 'application/typescript' },
+          });
+        }
+        if (path.endsWith('/plugins-adapter.ts')) {
+          return new Response(readFileSync(pluginsAdapter, 'utf-8'), {
+            headers: { 'content-type': 'application/typescript' },
+          });
+        }
+        if (path.endsWith('/broken-adapter.ts')) {
+          return new Response(readFileSync(brokenAdapter, 'utf-8'), {
+            headers: { 'content-type': 'application/typescript' },
+          });
+        }
+        return new Response('not found', { status: 404 });
+      },
+    });
+
+    logs = [];
+    consoleLogSpy = spyOn(console, 'log').mockImplementation((...args: unknown[]) => {
+      logs.push(args.map((a) => (typeof a === 'string' ? a : String(a))).join(' '));
+    });
+    stdoutChunks = [];
+    stdoutSpy = spyOn(process.stdout, 'write').mockImplementation((chunk: any) => {
+      stdoutChunks.push(typeof chunk === 'string' ? chunk : chunk.toString());
+      return true;
+    });
+  });
+
+  afterEach(() => {
+    setFlags({ json: false, quiet: false, verbose: false });
+    server.stop();
+    consoleLogSpy.mockRestore();
+    stdoutSpy.mockRestore();
+    exitSpy.mockRestore();
+    process.exit = originalProcessExit;
+    getDbPathSpy.mockRestore();
+    getManagedDirSpy.mockRestore();
+    try {
+      rmSync(tempDir, { recursive: true, force: true });
+    } catch (error: any) {
+      if (error?.code !== 'EBUSY') throw error;
+    }
+  });
+
+  async function installSearchRegistries(): Promise<{ skills: string; plugins: string; broken: string }> {
+    const skillsUrl = `http://localhost:${server.port}/skills-adapter.ts`;
+    const pluginsUrl = `http://localhost:${server.port}/plugins-adapter.ts`;
+    const brokenUrl = `http://localhost:${server.port}/broken-adapter.ts`;
+    await registryAddCommand(skillsUrl, 'search-one', { type: 'url' });
+    await registryAddCommand(pluginsUrl, 'search-two', { type: 'url' });
+    await registryAddCommand(brokenUrl, 'search-broken', { type: 'url' });
+    return { skills: skillsUrl, plugins: pluginsUrl, broken: brokenUrl };
+  }
+
+  function resetCaptured(): void {
+    logs.length = 0;
+    stdoutChunks.length = 0;
+  }
+
+  function findJsonResults(): any {
+    // The shared logger writes adapter-load messages to stdout, so the search's
+    // JSON payload is one line among many. Pick the line that parses as a
+    // search payload (has a `results` key).
+    const lines = stdoutChunks.join('').split('\n').filter(Boolean);
+    for (const line of lines) {
+      try {
+        const obj = JSON.parse(line);
+        if (obj && typeof obj === 'object' && 'results' in obj) return obj;
+      } catch { /* not JSON */ }
+    }
+    throw new Error(`No search payload in stdout. Got:\n${lines.join('\n')}`);
+  }
+
+  it('searches a single registry by slug and prints a table', async () => {
+    await installSearchRegistries();
+    resetCaptured();
+
+    await registrySearchCommand('foo', { slug: 'search-one' });
+
+    const out = logs.join('\n');
+    expect(out).toContain('Name');
+    expect(out).toContain('Source');
+    expect(out).toContain('Type');
+    expect(out).toContain('Description');
+    expect(out).toContain('foo-skill');
+    expect(out).toContain('search-one');
+    expect(out).toContain('skill');
+    // Did not search the other registry.
+    expect(out).not.toContain('baz-plugin');
+  });
+
+  it('searches all enabled registries when no slug is provided', async () => {
+    await installSearchRegistries();
+    await registrySetEnabledCommand('search-broken', false);
+    resetCaptured();
+
+    await registrySearchCommand('match');
+
+    const out = logs.join('\n');
+    expect(out).toContain('foo-skill');
+    expect(out).toContain('baz-plugin');
+    // search-broken was disabled, so it should not appear as a failure row.
+    expect(out).not.toContain('search-broken');
+  });
+
+  it('emits a single JSON payload with --json', async () => {
+    await installSearchRegistries();
+    await registrySetEnabledCommand('search-broken', false);
+    setFlags({ json: true });
+    resetCaptured();
+
+    await registrySearchCommand('hit', { slug: 'search-one' });
+
+    const payload = findJsonResults();
+    expect(payload.query).toBe('hit');
+    expect(payload.total).toBe(2);
+    expect(payload.results).toHaveLength(2);
+    expect(payload.results[0]).toMatchObject({
+      id: 'foo-skill',
+      source: 'search-one',
+      type: 'skill',
+      capability: 'skills',
+    });
+  });
+
+  it('reports zero results without erroring out', async () => {
+    await installSearchRegistries();
+    await registrySetEnabledCommand('search-broken', false);
+    await registrySetEnabledCommand('search-two', false);
+    setFlags({ json: true });
+    resetCaptured();
+
+    // The skills adapter returns items regardless of query, so use a capability
+    // filter the registry does not declare to produce empty results deterministically.
+    await registrySearchCommand('anything', { slug: 'search-one', capability: 'plugins' });
+
+    const payload = findJsonResults();
+    expect(payload.total).toBe(0);
+    expect(payload.results).toEqual([]);
+  });
+
+  it('errors when the slug is unknown', async () => {
+    await installSearchRegistries();
+    await expect(registrySearchCommand('x', { slug: 'nope' })).rejects.toThrow(/process\.exit\(1\)/);
+  });
+
+  it('errors when the slug is disabled', async () => {
+    await installSearchRegistries();
+    await registrySetEnabledCommand('search-one', false);
+    await expect(registrySearchCommand('x', { slug: 'search-one' })).rejects.toThrow(/process\.exit\(1\)/);
+  });
+
+  it('errors when the query is empty', async () => {
+    await installSearchRegistries();
+    await expect(registrySearchCommand('   ')).rejects.toThrow(/process\.exit\(1\)/);
+  });
+
+  it('reports per-registry failures without dropping the rest of the results', async () => {
+    await installSearchRegistries();
+    setFlags({ json: true });
+    resetCaptured();
+
+    await registrySearchCommand('q');
+
+    const payload = findJsonResults();
+    expect(payload.failures).toBeDefined();
+    expect(payload.failures.some((f: any) => f.slug === 'search-broken')).toBe(true);
+    expect(payload.results.some((r: any) => r.source === 'search-one')).toBe(true);
+    expect(payload.results.some((r: any) => r.source === 'search-two')).toBe(true);
   });
 });

--- a/src/cli/commands/registry.ts
+++ b/src/cli/commands/registry.ts
@@ -9,7 +9,8 @@ import {
 } from '../../shared/registries/installer';
 import { createAuthenticatedFetch } from '../../shared/authenticated-fetch';
 import type { RegistrySourceType } from '../../types/database';
-import { runTasks, header, footer, success, info, warn, error, type Task } from '../ui';
+import type { RegistryCapability, RegistryItemSummary } from '../../types/registry';
+import { runTasks, header, footer, success, info, warn, error, isJson, isVerbose, c, type Task } from '../ui';
 
 interface RegistryAddOptions {
   type?: RegistrySourceType;
@@ -330,4 +331,186 @@ export async function registrySetEnabledCommand(slug: string, enabled: boolean):
   } finally {
     try { db.close(); } catch {}
   }
+}
+
+const CAPABILITY_LABEL: Record<RegistryCapability, string> = {
+  skills: 'skill',
+  plugins: 'plugin',
+};
+
+export interface RegistrySearchOptions {
+  slug?: string;
+  capability?: RegistryCapability;
+  limit?: number;
+}
+
+interface SearchHit {
+  source: string;
+  type: string;
+  item: RegistryItemSummary;
+}
+
+export async function registrySearchCommand(
+  query: string,
+  options: RegistrySearchOptions = {},
+): Promise<void> {
+  const trimmedQuery = query?.trim();
+  if (!trimmedQuery) {
+    error('A search query is required.');
+    process.exit(1);
+  }
+
+  const settings = await loadSettings();
+  const db = new CapaDatabase(getDatabasePath(settings));
+
+  try {
+    const records = db.listRegistries().filter((r) => r.enabled && r.status === 'installed');
+
+    let targets = records;
+    if (options.slug) {
+      const match = records.find((r) => r.slug === options.slug);
+      if (!match) {
+        const existing = db.getRegistry(options.slug);
+        if (!existing) {
+          error(`Registry "${options.slug}" not found.`);
+        } else if (!existing.enabled) {
+          error(`Registry "${options.slug}" is disabled. Enable it with: capa registry enable ${options.slug}`);
+        } else {
+          error(`Registry "${options.slug}" is not installed (status: ${existing.status}). Try: capa registry refresh ${options.slug}`);
+        }
+        process.exit(1);
+      }
+      targets = [match];
+    }
+
+    if (targets.length === 0) {
+      if (isJson()) {
+        process.stdout.write(JSON.stringify({ query: trimmedQuery, results: [], total: 0 }) + '\n');
+        return;
+      }
+      info('No enabled registries to search. Add one with: capa registry add <source>');
+      return;
+    }
+
+    const manager = new RegistryManager(db);
+    const manifests = await manager.list();
+    const manifestBySlug = new Map(manifests.map((m) => [m.id, m]));
+
+    const hits: SearchHit[] = [];
+    const failures: { slug: string; capability: RegistryCapability; error: string }[] = [];
+
+    const calls: Promise<void>[] = [];
+    for (const r of targets) {
+      const manifest = manifestBySlug.get(r.slug);
+      if (!manifest) {
+        failures.push({ slug: r.slug, capability: 'skills', error: 'adapter not loaded' });
+        continue;
+      }
+      const capsToSearch: RegistryCapability[] = options.capability
+        ? manifest.capabilities.includes(options.capability) ? [options.capability] : []
+        : manifest.capabilities;
+
+      for (const capability of capsToSearch) {
+        calls.push(
+          manager
+            .search(r.slug, { capability, query: trimmedQuery, limit: options.limit })
+            .then((result) => {
+              for (const item of result.items) {
+                hits.push({ source: r.slug, type: CAPABILITY_LABEL[capability], item });
+              }
+            })
+            .catch((err: unknown) => {
+              const message = err instanceof Error ? err.message : String(err);
+              failures.push({ slug: r.slug, capability, error: message });
+            }),
+        );
+      }
+    }
+
+    await Promise.all(calls);
+
+    if (isJson()) {
+      const payload = {
+        query: trimmedQuery,
+        results: hits.map((h) => ({
+          id: h.item.id,
+          title: h.item.title,
+          description: h.item.description,
+          source: h.source,
+          type: h.type,
+          capability: h.item.capability,
+          author: h.item.author,
+          version: h.item.version,
+          tags: h.item.tags,
+          homepage: h.item.homepage,
+          updatedAt: h.item.updatedAt,
+        })),
+        total: hits.length,
+        failures: failures.length > 0 ? failures : undefined,
+      };
+      process.stdout.write(JSON.stringify(payload) + '\n');
+      return;
+    }
+
+    if (failures.length > 0) {
+      for (const f of failures) {
+        warn(`Registry "${f.slug}" (${f.capability}): ${f.error}`);
+      }
+    }
+
+    if (hits.length === 0) {
+      info(`No results for "${trimmedQuery}".`);
+      return;
+    }
+
+    if (isVerbose()) {
+      printVerboseResults(hits);
+    } else {
+      printSearchTable(hits);
+    }
+    info(`${hits.length} result${hits.length === 1 ? '' : 's'} for "${trimmedQuery}".`);
+  } finally {
+    try { db.close(); } catch {}
+  }
+}
+
+function printSearchTable(hits: SearchHit[]): void {
+  const rows: [string, string, string, string][] = hits.map((h) => [
+    h.item.id,
+    h.source,
+    h.type,
+    truncate(h.item.description ?? '', 60),
+  ]);
+  const headers: [string, string, string, string] = ['Name', 'Source', 'Type', 'Description'];
+  const widths = [0, 1, 2, 3].map((i) =>
+    Math.max(headers[i].length, ...rows.map((r) => r[i].length)),
+  );
+
+  const fmt = (cells: readonly string[]) =>
+    cells.map((cell, i) => i === cells.length - 1 ? cell : cell.padEnd(widths[i])).join('  ');
+
+  console.log(c.bold(fmt(headers)));
+  console.log(c.dim(widths.map((w) => '-'.repeat(w)).join('  ')));
+  for (const r of rows) console.log(fmt(r));
+}
+
+function printVerboseResults(hits: SearchHit[]): void {
+  for (const h of hits) {
+    console.log(c.bold(h.item.id) + c.dim(`  (${h.source} · ${h.type})`));
+    if (h.item.title && h.item.title !== h.item.id) console.log(`  ${h.item.title}`);
+    if (h.item.description) console.log(`  ${h.item.description}`);
+    const extras: string[] = [];
+    if (h.item.author) extras.push(`author: ${h.item.author}`);
+    if (h.item.version) extras.push(`version: ${h.item.version}`);
+    if (h.item.updatedAt) extras.push(`updated: ${h.item.updatedAt}`);
+    if (h.item.homepage) extras.push(h.item.homepage);
+    if (extras.length) console.log(c.dim('  ' + extras.join(' · ')));
+    if (h.item.tags && h.item.tags.length) console.log(c.dim(`  tags: ${h.item.tags.join(', ')}`));
+    console.log();
+  }
+}
+
+function truncate(s: string, max: number): string {
+  if (s.length <= max) return s;
+  return s.slice(0, Math.max(0, max - 1)) + '…';
 }

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -19,8 +19,10 @@ import {
   registryRemoveCommand,
   registryRefreshCommand,
   registrySetEnabledCommand,
+  registrySearchCommand,
 } from './commands/registry';
 import type { RegistrySourceType } from '../types/database';
+import type { RegistryCapability } from '../types/registry';
 import { checkForUpdates } from './utils/version-check';
 import { VERSION } from '../version';
 import { setFlags, ExitCode, error } from './ui';
@@ -228,6 +230,49 @@ if (process.argv[2] === '__server__') {
       .option('--no-cache', 'Bypass the on-disk repo cache when refreshing')
       .action(async (slug: string, opts: { cache?: boolean }) => {
         await registryRefreshCommand(slug, { noCache: opts.cache === false });
+      });
+
+    registryCmd
+      .command('search [slug] [query]')
+      .description('Search registries for skills and plugins (omit slug to search all enabled registries)')
+      .option('-q, --query <query>', 'Search query (alternative to positional)')
+      .option('-c, --capability <capability>', 'Restrict to one capability: skills or plugins')
+      .option('-l, --limit <n>', 'Max results per registry', (v) => Number.parseInt(v, 10))
+      .action(async (
+        slugArg: string | undefined,
+        queryArg: string | undefined,
+        opts: { query?: string; capability?: string; limit?: number },
+      ) => {
+        // Accept either positional form: `search <slug> <query>` or `search <query>`.
+        // The --query flag, if provided, always wins.
+        let slug: string | undefined;
+        let query: string | undefined = opts.query;
+        if (!query) {
+          if (queryArg !== undefined) {
+            slug = slugArg;
+            query = queryArg;
+          } else {
+            query = slugArg;
+          }
+        } else {
+          slug = slugArg ?? queryArg;
+        }
+
+        if (!query) {
+          error('A search query is required. Usage: capa registry search [slug] <query>');
+          process.exit(ExitCode.USER_ERROR);
+        }
+
+        let capability: RegistryCapability | undefined;
+        if (opts.capability) {
+          if (opts.capability !== 'skills' && opts.capability !== 'plugins') {
+            error(`Invalid --capability "${opts.capability}". Expected one of: skills, plugins.`);
+            process.exit(ExitCode.USER_ERROR);
+          }
+          capability = opts.capability;
+        }
+
+        await registrySearchCommand(query, { slug, capability, limit: opts.limit });
       });
 
     registryCmd


### PR DESCRIPTION
## Summary
- Add `capa registry search [slug] <query>` — fans out across all enabled+installed registries when no slug is given, restricts to one when a slug is given. Reuses `RegistryManager.search()` so CLI results match the web UI. Default table output; `--json` and `--verbose` supported.
- Rework the `capabilities-manager` skill to follow Anthropic's skill-creator best practices: tighter SKILL.md, evals suite added.

## Closes
- Closes #75
- Closes #74

## Test plan
- [x] `bun test` — 1076 pass / 0 fail
- [x] `tsc --noEmit` — clean
- [x] Manual: `capa registry search cursor-marketplace databricks` produces the table from issue #75
- [x] Manual: `capa registry search databricks` unions results from all enabled registries
- [x] Manual: `--json` emits a single payload with per-item metadata and any per-registry failures
- [x] Reviewer: spot-check the capabilities-manager evals

🤖 Generated with [Claude Code](https://claude.com/claude-code)