### PR TITLE
feat(subagents): expand skills/tools blocks with descriptions and capa sh form

### DIFF
--- a/src/cli/commands/__tests__/sh.test.ts
+++ b/src/cli/commands/__tests__/sh.test.ts
@@ -1,6 +1,7 @@
 import { describe, it, expect } from 'bun:test';
-import { slugify, parseInlineArgs, resolveArgs, coerceValue } from '../sh';
+import { parseInlineArgs, resolveArgs, coerceValue } from '../sh';
 import type { ShellCommand } from '../sh';
+import { slugify } from '../../../shared/slug';
 
 function makeCommand(overrides: Partial<ShellCommand> = {}): ShellCommand {
   return {

--- a/src/cli/commands/install-tasks/install-subagents.ts
+++ b/src/cli/commands/install-tasks/install-subagents.ts
@@ -13,13 +13,28 @@ import type { Capabilities } from '../../../types/capabilities';
 import type { InstallCtx } from './context';
 
 /**
+ * Strip a single pair of matching surrounding quotes (either `"` or `'`).
+ * Conservative on purpose: `He said "hi"` keeps both quotes; only `"foo"` or
+ * `'foo'` are unwrapped.
+ */
+function stripSurroundingQuotes(value: string): string {
+  if (value.length < 2) return value;
+  const first = value[0];
+  if ((first === '"' || first === "'") && value[value.length - 1] === first) {
+    return value.slice(1, -1);
+  }
+  return value;
+}
+
+/**
  * For each skill referenced by the active capabilities, read its installed
- * SKILL.md from the first provider whose `skillsDir` contains it, parse the
- * frontmatter, and return a `skillId → description` map.
+ * SKILL.md from the first provider whose `skillsDir` contains a valid copy,
+ * parse the frontmatter, and return a `skillId → description` map.
  *
  * Skills with no SKILL.md on disk (e.g. `installed` / `plugin` types) or a
  * SKILL.md missing the `description` field are silently absent from the map;
- * the renderer falls back to printing the bare skill id.
+ * the renderer falls back to printing the bare skill id. A malformed SKILL.md
+ * in one provider's dir does NOT block us from trying another provider's copy.
  */
 function buildSkillDescriptions(
   projectPath: string,
@@ -35,14 +50,18 @@ function buildSkillDescriptions(
       if (!existsSync(skillMdPath)) continue;
       try {
         const { metadata } = parseSkillMd(readFileSync(skillMdPath, 'utf-8'));
-        const desc = metadata.description?.replace(/^["']|["']$/g, '').trim();
+        const desc = metadata.description ? stripSurroundingQuotes(metadata.description).trim() : '';
         if (desc) {
           map.set(skill.id, desc);
         }
+        // Successful parse — stop searching providers for this skill, whether
+        // or not a description was present (all providers receive the same
+        // SKILL.md content from install, so the answer is consistent).
+        break;
       } catch {
-        // Malformed SKILL.md — skip silently; the renderer falls back to id-only.
+        // Malformed SKILL.md — try the next provider instead of giving up
+        // (another provider's copy might be intact).
       }
-      break;
     }
   }
   return map;

--- a/src/cli/commands/install-tasks/install-subagents.ts
+++ b/src/cli/commands/install-tasks/install-subagents.ts
@@ -1,3 +1,5 @@
+import { existsSync, readFileSync } from 'fs';
+import { join } from 'path';
 import type { Task } from '../../ui';
 import { getProvider } from '../../../shared/providers';
 import {
@@ -6,7 +8,45 @@ import {
   purgeCursorSubAgentMCPEntries,
 } from '../../utils/mcp-client-manager';
 import { installSubAgentInstructions, removeSubAgentInstructions } from '../../utils/agents-file';
+import { parseSkillMd } from '../../../shared/skill-md';
+import type { Capabilities } from '../../../types/capabilities';
 import type { InstallCtx } from './context';
+
+/**
+ * For each skill referenced by the active capabilities, read its installed
+ * SKILL.md from the first provider whose `skillsDir` contains it, parse the
+ * frontmatter, and return a `skillId → description` map.
+ *
+ * Skills with no SKILL.md on disk (e.g. `installed` / `plugin` types) or a
+ * SKILL.md missing the `description` field are silently absent from the map;
+ * the renderer falls back to printing the bare skill id.
+ */
+function buildSkillDescriptions(
+  projectPath: string,
+  capabilities: Capabilities,
+  providers: string[]
+): Map<string, string> {
+  const map = new Map<string, string>();
+  for (const skill of capabilities.skills ?? []) {
+    for (const pid of providers) {
+      const provider = getProvider(pid);
+      if (!provider) continue;
+      const skillMdPath = join(projectPath, provider.skillsDir, skill.id, 'SKILL.md');
+      if (!existsSync(skillMdPath)) continue;
+      try {
+        const { metadata } = parseSkillMd(readFileSync(skillMdPath, 'utf-8'));
+        const desc = metadata.description?.replace(/^["']|["']$/g, '').trim();
+        if (desc) {
+          map.set(skill.id, desc);
+        }
+      } catch {
+        // Malformed SKILL.md — skip silently; the renderer falls back to id-only.
+      }
+      break;
+    }
+  }
+  return map;
+}
 
 export function installSubagentsTask(): Task<InstallCtx> {
   return {
@@ -52,6 +92,15 @@ export function installSubagentsTask(): Task<InstallCtx> {
         );
       });
 
+      // Built once before the loop — by the time we run, installSkillsTask
+      // has already materialised every SKILL.md under each provider's
+      // skillsDir, so we can pull descriptions from frontmatter directly.
+      const skillDescriptions = buildSkillDescriptions(
+        ctx.projectPath,
+        ctx.capabilitiesToUse,
+        providers
+      );
+
       const total = (needsPurge ? 1 : 0) + removedAgents.length + currentSubagents.length;
       let step = 0;
 
@@ -88,7 +137,13 @@ export function installSubagentsTask(): Task<InstallCtx> {
         // describe the agent's purpose. The agent file itself encodes the
         // expected MCP server key, but missing entries simply mean those
         // tools won't be available to that sub-agent (an explicit choice).
-        installSubAgentInstructions(ctx.projectPath, subAgent, ctx.capabilitiesToUse, providers);
+        installSubAgentInstructions(
+          ctx.projectPath,
+          subAgent,
+          ctx.capabilitiesToUse,
+          providers,
+          skillDescriptions
+        );
         ctx.db.upsertSubAgent(ctx.projectId, subAgent.id);
         ctx.added++;
       }

--- a/src/cli/commands/sh.ts
+++ b/src/cli/commands/sh.ts
@@ -3,6 +3,7 @@ import { parseCapabilitiesFile } from '../../shared/capabilities';
 import { getServerStatus } from '../utils/server-manager';
 import type { Capabilities } from '../../types/capabilities';
 import { getQualifiedToolName } from '../../types/capabilities';
+import { slugify } from '../../shared/slug';
 
 interface ShellToolInfo {
   id: string;
@@ -154,15 +155,7 @@ class ShellRegistry {
   }
 }
 
-export function slugify(name: string): string {
-  return name
-    .replace(/([a-z])([A-Z])/g, '$1-$2')
-    .replace(/([A-Z]+)([A-Z][a-z])/g, '$1-$2')
-    .toLowerCase()
-    .replace(/[_\s]+/g, '-')
-    .replace(/-+/g, '-')
-    .replace(/^-|-$/g, '');
-}
+export { slugify };
 
 export function parseInlineArgs(tokens: string[]): Record<string, string> {
   const result: Record<string, string> = {};

--- a/src/cli/commands/sh.ts
+++ b/src/cli/commands/sh.ts
@@ -155,7 +155,6 @@ class ShellRegistry {
   }
 }
 
-export { slugify };
 
 export function parseInlineArgs(tokens: string[]): Record<string, string> {
   const result: Record<string, string> = {};

--- a/src/cli/utils/__tests__/sub-agent-instructions.test.ts
+++ b/src/cli/utils/__tests__/sub-agent-instructions.test.ts
@@ -6,9 +6,10 @@ import { installSubAgentInstructions, removeSubAgentInstructions } from '../agen
 import type { SubAgent, Capabilities, Tool } from '../../../types/capabilities';
 
 // Minimal capabilities fixture with two tools
-const makeTool = (id: string, serverId: string): Tool => ({
+const makeTool = (id: string, serverId: string, description?: string): Tool => ({
   id,
   type: 'mcp',
+  ...(description ? { description } : {}),
   def: { server: `@${serverId}`, tool: id },
 });
 
@@ -17,10 +18,10 @@ const capabilities: Capabilities = {
   skills: [],
   servers: [],
   tools: [
-    makeTool('search_cdk_docs', 'aws-iac'),
-    makeTool('validate_cfn', 'aws-iac'),
+    makeTool('search_cdk_docs', 'aws-iac', 'Search CDK docs'),
+    makeTool('validate_cfn', 'aws-iac', 'Validate a CloudFormation template'),
     makeTool('get_lambda_guidance', 'aws-serverless'),
-    makeTool('sam_logs', 'aws-serverless'),
+    makeTool('sam_logs', 'aws-serverless', 'Tail SAM logs'),
   ],
 };
 
@@ -75,6 +76,67 @@ describe('installSubAgentInstructions', () => {
     expect(agentFile).toContain('aws-iac.search_cdk_docs');
     expect(agentFile).toContain('aws-iac.validate_cfn');
     expect(agentFile).not.toContain('aws-serverless');
+  });
+
+  it('renders tools as dashed bullets with both qualified and capa-sh forms and description', () => {
+    const subAgent: SubAgent = {
+      id: 'infra-agent',
+      description: '',
+      skills: [],
+      tools: ['search_cdk_docs', 'validate_cfn'],
+    };
+
+    installSubAgentInstructions(tempDir, subAgent, capabilities, ['claude-code']);
+
+    const agentFile = readClaudeAgent('infra-agent');
+    // capa sh form kebab-cases each segment (matches the shell registry's slugify).
+    expect(agentFile).toContain(
+      '- `aws-iac.search_cdk_docs` (`capa sh aws-iac search-cdk-docs`) — Search CDK docs'
+    );
+    expect(agentFile).toContain(
+      '- `aws-iac.validate_cfn` (`capa sh aws-iac validate-cfn`) — Validate a CloudFormation template'
+    );
+  });
+
+  it('renders skills as dashed bullets with frontmatter descriptions from the map', () => {
+    const subAgent: SubAgent = {
+      id: 'infra-agent',
+      description: '',
+      skills: ['infragate-iac', 'infragate-extras'],
+      tools: [],
+    };
+    const skillDescriptions = new Map([
+      ['infragate-iac', 'CDK and Terraform helpers'],
+    ]);
+
+    installSubAgentInstructions(
+      tempDir,
+      subAgent,
+      capabilities,
+      ['claude-code'],
+      skillDescriptions
+    );
+
+    const agentFile = readClaudeAgent('infra-agent');
+    expect(agentFile).toContain('- `infragate-iac` — CDK and Terraform helpers');
+    // No description provided → bare id without em-dash.
+    expect(agentFile).toContain('- `infragate-extras`');
+    expect(agentFile).not.toContain('infragate-extras —');
+  });
+
+  it('renders "(none)" placeholders when skills or tools are empty', () => {
+    const subAgent: SubAgent = {
+      id: 'infra-agent',
+      description: '',
+      skills: [],
+      tools: [],
+    };
+
+    installSubAgentInstructions(tempDir, subAgent, capabilities, ['claude-code']);
+
+    const agentFile = readClaudeAgent('infra-agent');
+    expect(agentFile).toContain('**Skills:**\n- (none)');
+    expect(agentFile).toContain('**Tools:**\n- (none)');
   });
 
   it('includes custom instructions in the agent file body', () => {

--- a/src/cli/utils/agents-file.ts
+++ b/src/cli/utils/agents-file.ts
@@ -11,7 +11,10 @@ import {
   reportBlockedPhraseAndExit,
 } from '../../shared/skill-security';
 import { getProvider, getAllProviders } from '../../shared/providers';
-import { buildSubAgentFile as buildSubAgentFileContent } from '../../shared/providers/handlers';
+import {
+  buildSubAgentFile as buildSubAgentFileContent,
+  renderSubAgentSkillsAndTools,
+} from '../../shared/providers/handlers';
 import type { AuthenticatedFetch } from '../../shared/authenticated-fetch';
 import { fetchRepoFile, fetchTextFile, type RepoSnapshotResolver } from '../../shared/repo-file';
 import { parseGitRawUrl } from '../../shared/git-providers/registry';
@@ -450,7 +453,9 @@ function writesSubAgentInstructionsContext(provider: NonNullable<ReturnType<type
 function upsertSubAgentInstructionsSnippet(
   projectPath: string,
   provider: NonNullable<ReturnType<typeof getProvider>>,
-  subAgent: SubAgent
+  subAgent: SubAgent,
+  capabilities: Capabilities,
+  skillDescriptions: Map<string, string>
 ): void {
   if (!provider.instructions) return;
 
@@ -461,7 +466,8 @@ function upsertSubAgentInstructionsSnippet(
     ...(subAgent.description ? ['', subAgent.description] : []),
     '',
     `**MCP server key:** \`${mcpServerKey}\``,
-    `**Skills:** ${subAgent.skills.length > 0 ? subAgent.skills.join(', ') : '(none)'}`,
+    '',
+    ...renderSubAgentSkillsAndTools(subAgent, capabilities, skillDescriptions),
   ];
   if (subAgent.instructions) {
     bodyLines.push('', subAgent.instructions.trimEnd());
@@ -496,7 +502,8 @@ function writeSubAgentFile(
   projectPath: string,
   providerId: string,
   subAgent: SubAgent,
-  capabilities: Capabilities
+  capabilities: Capabilities,
+  skillDescriptions: Map<string, string>
 ): void {
   const provider = getProvider(providerId);
   if (!provider?.subagents) return;
@@ -506,7 +513,7 @@ function writeSubAgentFile(
   mkdirSync(agentsDir, { recursive: true });
 
   const filePath = join(agentsDir, `${subAgent.id}${sa.extension}`);
-  const content = buildSubAgentFileContent(provider, subAgent, capabilities);
+  const content = buildSubAgentFileContent(provider, subAgent, capabilities, skillDescriptions);
   writeFileSync(filePath, content, 'utf8');
 
   taskLog(`  ✓ ${sa.dir}/${subAgent.id}${sa.extension} written`);
@@ -540,17 +547,24 @@ export function installSubAgentInstructions(
   projectPath: string,
   subAgent: SubAgent,
   capabilities: Capabilities,
-  providers: string[]
+  providers: string[],
+  skillDescriptions: Map<string, string> = new Map()
 ): void {
   for (const pid of providers) {
     const provider = getProvider(pid);
     if (!provider) continue;
 
     if (provider.subagents) {
-      writeSubAgentFile(projectPath, pid, subAgent, capabilities);
+      writeSubAgentFile(projectPath, pid, subAgent, capabilities, skillDescriptions);
     }
     if (writesSubAgentInstructionsContext(provider)) {
-      upsertSubAgentInstructionsSnippet(projectPath, provider, subAgent);
+      upsertSubAgentInstructionsSnippet(
+        projectPath,
+        provider,
+        subAgent,
+        capabilities,
+        skillDescriptions
+      );
     }
   }
 }

--- a/src/shared/providers/__tests__/registry.test.ts
+++ b/src/shared/providers/__tests__/registry.test.ts
@@ -320,17 +320,81 @@ describe('Codex pilot integration', () => {
       providers: ['codex'],
       skills: [],
       servers: [],
-      tools: [{ id: 'tool-x', type: 'mcp' as const, def: { server: '@s', tool: 'tool-x' } }],
+      tools: [
+        {
+          id: 'tool-x',
+          type: 'mcp' as const,
+          description: 'Does the X thing',
+          def: { server: '@s', tool: 'tool-x' },
+        },
+      ],
     };
+    const skillDescriptions = new Map([['skill-a', 'Skill A frontmatter description']]);
 
-    const result = buildSubAgentFile(codex, subAgent, capabilities);
+    const result = buildSubAgentFile(codex, subAgent, capabilities, skillDescriptions);
     const parsed = TOML.parse(result) as any;
 
     expect(parsed.name).toBe('test-agent');
     expect(parsed.description).toBe('A test sub-agent');
     expect(parsed.developer_instructions).toBeString();
-    expect(parsed.developer_instructions).toContain('skill-a');
-    expect(parsed.developer_instructions).toContain('s.tool-x');
+    // Dashed list with skill description from the map.
+    expect(parsed.developer_instructions).toContain('- skill-a — Skill A frontmatter description');
+    // Tool bullet has both qualified name and `capa sh` form (kebab-cased) + description.
+    expect(parsed.developer_instructions).toContain(
+      '- s.tool-x (capa sh s tool-x) — Does the X thing'
+    );
+  });
+
+  it('buildSubAgentFile kebab-cases snake_case tool ids in the capa sh form', () => {
+    const codex = getProvider('codex')!;
+    const subAgent = {
+      id: 'test-agent',
+      description: '',
+      skills: [],
+      tools: ['sql_read_only'],
+    };
+    const capabilities = {
+      providers: ['codex'],
+      skills: [],
+      servers: [],
+      tools: [
+        {
+          id: 'sql_read_only',
+          type: 'mcp' as const,
+          def: { server: '@dbx', tool: 'execute_sql_read_only' },
+        },
+      ],
+    };
+
+    const result = buildSubAgentFile(codex, subAgent, capabilities);
+    const parsed = TOML.parse(result) as any;
+
+    // Qualified form preserves underscores; capa sh form kebab-cases them.
+    expect(parsed.developer_instructions).toContain('- dbx.sql_read_only (capa sh dbx sql-read-only)');
+  });
+
+  it('buildSubAgentFile renders skill id only when description is missing', () => {
+    const codex = getProvider('codex')!;
+    const subAgent = {
+      id: 'test-agent',
+      description: 'A test sub-agent',
+      skills: ['skill-no-desc'],
+      tools: [],
+    };
+    const capabilities = {
+      providers: ['codex'],
+      skills: [],
+      servers: [],
+      tools: [],
+    };
+
+    const result = buildSubAgentFile(codex, subAgent, capabilities);
+    const parsed = TOML.parse(result) as any;
+
+    // No em-dash when description is absent.
+    expect(parsed.developer_instructions).toContain('- skill-no-desc');
+    expect(parsed.developer_instructions).not.toContain('skill-no-desc —');
+    expect(parsed.developer_instructions).toContain('- (none)');
   });
 });
 

--- a/src/shared/providers/handlers.ts
+++ b/src/shared/providers/handlers.ts
@@ -8,6 +8,7 @@ import type {
 } from '../../types/providers';
 import type { SubAgent, Capabilities } from '../../types/capabilities';
 import { getQualifiedToolName } from '../../types/capabilities';
+import { slugify } from '../slug';
 import type { Rule } from '../../types/rules';
 
 /**
@@ -63,11 +64,16 @@ export function buildRuleFrontmatter(
  * Build the complete file content for a sub-agent definition.
  * Interprets the provider's `subagents` descriptor to produce either
  * markdown-frontmatter or TOML output.
+ *
+ * `skillDescriptions` maps skill id → description (sourced from the skill's
+ * SKILL.md frontmatter at install time). Optional; missing entries render
+ * the bare skill id without an em-dash.
  */
 export function buildSubAgentFile(
   provider: ProviderIntegration,
   subAgent: SubAgent,
-  capabilities: Capabilities
+  capabilities: Capabilities,
+  skillDescriptions: Map<string, string> = new Map()
 ): string {
   const sa = provider.subagents!;
   const mcpServerKey = `capa-${subAgent.id}`;
@@ -78,33 +84,102 @@ export function buildSubAgentFile(
       sa.perAgentToolScope,
       subAgent,
       capabilities,
-      mcpServerKey
+      mcpServerKey,
+      skillDescriptions
     );
   }
-  return buildTomlSubAgent(sa.fields ?? {}, sa.bodyField ?? 'developer_instructions', subAgent, capabilities, mcpServerKey);
+  return buildTomlSubAgent(
+    sa.fields ?? {},
+    sa.bodyField ?? 'developer_instructions',
+    subAgent,
+    capabilities,
+    mcpServerKey,
+    skillDescriptions
+  );
 }
 
 // ---------------------------------------------------------------------------
 // Internal helpers
 // ---------------------------------------------------------------------------
 
-function resolveToolNames(subAgent: SubAgent, capabilities: Capabilities): string {
-  return subAgent.tools
-    .map((toolId) => {
-      const tool = capabilities.tools.find((t) => t.id === toolId);
-      return tool ? getQualifiedToolName(tool) : toolId;
-    })
-    .join(', ');
+/**
+ * Translate a qualified tool name (e.g. `dbx.sql_read_only` or `getJiraIssue`)
+ * into the equivalent `capa sh` invocation. Each segment is slugified the same
+ * way the shell registry does (`snake_case`/`camelCase` → `kebab-case`), so the
+ * printed form is exactly what the user types — e.g.
+ * `dbx.sql_read_only` → `capa sh dbx sql-read-only`. Ungrouped command tools
+ * collapse to `capa sh <tool>`.
+ */
+function qualifiedToCapaSh(qualified: string): string {
+  return `capa sh ${qualified.split('.').map(slugify).join(' ')}`;
 }
 
-function buildMarkdownBody(subAgent: SubAgent, capabilities: Capabilities, mcpServerKey: string): string {
-  const toolNames = resolveToolNames(subAgent, capabilities);
-  const skillList = subAgent.skills.length > 0 ? subAgent.skills.join(', ') : '(none)';
+interface ResolvedTool {
+  toolId: string;
+  qualified: string;
+  capaSh: string;
+  description?: string;
+}
 
+function resolveTool(toolId: string, capabilities: Capabilities): ResolvedTool {
+  const tool = capabilities.tools.find((t) => t.id === toolId);
+  const qualified = tool ? getQualifiedToolName(tool) : toolId;
+  return {
+    toolId,
+    qualified,
+    capaSh: qualifiedToCapaSh(qualified),
+    description: tool?.description,
+  };
+}
+
+function renderSkillsBlock(
+  subAgent: SubAgent,
+  skillDescriptions: Map<string, string>,
+  opts: { backtick: boolean }
+): string[] {
+  const header = opts.backtick ? '**Skills:**' : 'Skills:';
+  if (subAgent.skills.length === 0) {
+    return [header, '- (none)'];
+  }
+  const bullets = subAgent.skills.map((skillId) => {
+    const desc = skillDescriptions.get(skillId);
+    const name = opts.backtick ? `\`${skillId}\`` : skillId;
+    return desc ? `- ${name} — ${desc}` : `- ${name}`;
+  });
+  return [header, ...bullets];
+}
+
+function renderToolsBlock(
+  subAgent: SubAgent,
+  capabilities: Capabilities,
+  opts: { backtick: boolean }
+): string[] {
+  const header = opts.backtick ? '**Tools:**' : 'Tools:';
+  if (subAgent.tools.length === 0) {
+    return [header, '- (none)'];
+  }
+  const bullets = subAgent.tools.map((toolId) => {
+    const { qualified, capaSh, description } = resolveTool(toolId, capabilities);
+    const name = opts.backtick ? `\`${qualified}\`` : qualified;
+    const cli = opts.backtick ? `\`${capaSh}\`` : capaSh;
+    const prefix = `- ${name} (${cli})`;
+    return description ? `${prefix} — ${description}` : prefix;
+  });
+  return [header, ...bullets];
+}
+
+function buildMarkdownBody(
+  subAgent: SubAgent,
+  capabilities: Capabilities,
+  mcpServerKey: string,
+  skillDescriptions: Map<string, string>
+): string {
   const lines: string[] = [
     `**MCP server key:** \`${mcpServerKey}\``,
-    `**Skills:** ${skillList}`,
-    `**Tools:** ${toolNames || '(none)'}`,
+    '',
+    ...renderSkillsBlock(subAgent, skillDescriptions, { backtick: true }),
+    '',
+    ...renderToolsBlock(subAgent, capabilities, { backtick: true }),
   ];
 
   if (subAgent.instructions) {
@@ -114,14 +189,18 @@ function buildMarkdownBody(subAgent: SubAgent, capabilities: Capabilities, mcpSe
   return lines.join('\n');
 }
 
-function buildPlainBody(subAgent: SubAgent, capabilities: Capabilities, mcpServerKey: string): string {
-  const toolNames = resolveToolNames(subAgent, capabilities);
-  const skillList = subAgent.skills.length > 0 ? subAgent.skills.join(', ') : '(none)';
-
+function buildPlainBody(
+  subAgent: SubAgent,
+  capabilities: Capabilities,
+  mcpServerKey: string,
+  skillDescriptions: Map<string, string>
+): string {
   const lines: string[] = [
     `MCP server key: ${mcpServerKey}`,
-    `Skills: ${skillList}`,
-    `Tools: ${toolNames || '(none)'}`,
+    '',
+    ...renderSkillsBlock(subAgent, skillDescriptions, { backtick: false }),
+    '',
+    ...renderToolsBlock(subAgent, capabilities, { backtick: false }),
   ];
 
   if (subAgent.instructions) {
@@ -136,9 +215,10 @@ function buildMarkdownSubAgent(
   perAgentToolScope: SubagentsIntegration['perAgentToolScope'] | undefined,
   subAgent: SubAgent,
   capabilities: Capabilities,
-  mcpServerKey: string
+  mcpServerKey: string,
+  skillDescriptions: Map<string, string>
 ): string {
-  const body = buildMarkdownBody(subAgent, capabilities, mcpServerKey);
+  const body = buildMarkdownBody(subAgent, capabilities, mcpServerKey, skillDescriptions);
   const description = subAgent.description || subAgent.id;
 
   const fmLines: string[] = [
@@ -167,9 +247,10 @@ function buildTomlSubAgent(
   bodyField: string,
   subAgent: SubAgent,
   capabilities: Capabilities,
-  mcpServerKey: string
+  mcpServerKey: string,
+  skillDescriptions: Map<string, string>
 ): string {
-  const body = buildPlainBody(subAgent, capabilities, mcpServerKey);
+  const body = buildPlainBody(subAgent, capabilities, mcpServerKey, skillDescriptions);
 
   const data: Record<string, any> = {
     name: subAgent.id,
@@ -185,3 +266,20 @@ function buildTomlSubAgent(
 
   return TOML.stringify(data as any);
 }
+
+/**
+ * Exported for use by `agents-file.ts` when rendering the dashed skill/tool
+ * blocks into the universal AGENTS.md/CLAUDE.md sub-agent snippet.
+ */
+export function renderSubAgentSkillsAndTools(
+  subAgent: SubAgent,
+  capabilities: Capabilities,
+  skillDescriptions: Map<string, string>
+): string[] {
+  return [
+    ...renderSkillsBlock(subAgent, skillDescriptions, { backtick: true }),
+    '',
+    ...renderToolsBlock(subAgent, capabilities, { backtick: true }),
+  ];
+}
+

--- a/src/shared/slug.ts
+++ b/src/shared/slug.ts
@@ -1,0 +1,22 @@
+/**
+ * Convert a tool / server / group id into the kebab-case slug used by the
+ * `capa sh` CLI. Mirrors what the shell registry does when building command
+ * trees, so any caller that needs to print a `capa sh ...` invocation gets
+ * the exact form the user would actually type.
+ *
+ * Rules:
+ *   - camelCase → camel-case
+ *   - snake_case → snake-case
+ *   - whitespace → '-'
+ *   - collapse repeated '-' and trim leading/trailing '-'
+ *   - everything lowercased
+ */
+export function slugify(name: string): string {
+  return name
+    .replace(/([a-z])([A-Z])/g, '$1-$2')
+    .replace(/([A-Z]+)([A-Z][a-z])/g, '$1-$2')
+    .toLowerCase()
+    .replace(/[_\s]+/g, '-')
+    .replace(/-+/g, '-')
+    .replace(/^-|-$/g, '');
+}


### PR DESCRIPTION
## Summary

- Render each subagent's `Skills` and `Tools` sections as dashed lists instead of comma-joined single lines.
- Skill bullets now include the description sourced from the skill's installed `SKILL.md` frontmatter (not from `capabilities.yaml`). Bullets gracefully degrade to id-only when no SKILL.md is present.
- Tool bullets show both forms side by side: the qualified `` `<server>.<tool>` `` reference and the equivalent `` `capa sh <server> <tool>` `` invocation, plus the tool's description.
- Each segment of the `capa sh` form is slugified the same way the shell registry does, so `dbx.sql_read_only` prints as `capa sh dbx sql-read-only` — exactly what the user types. `slugify` moved to `src/shared/slug.ts` and is re-exported from `src/cli/commands/sh.ts` to keep both surfaces aligned to one definition.
- The AGENTS.md / CLAUDE.md subagent snippet rendered into the instructions file picks up the same Skills + Tools layout for consistency.

### Before
```
**Skills:** general-data-analysis, general-databricks-cli, general-bigquery-cli, general-json-transform, productivity-analyze
**Tools:** dbx.sql_read_only, dbx.poll_sql_result
```

### After
```
**Skills:**
- `general-data-analysis` — Query and analyze data in Databricks using SQL...
- `general-databricks-cli` — Databricks CLI setup, configuration, and job management...
- ...

**Tools:**
- `dbx.sql_read_only` (`capa sh dbx sql-read-only`) — Execute read-only SQL queries in Databricks
- `dbx.poll_sql_result` (`capa sh dbx poll-sql-result`) — Poll for SQL execution results using a statement ID
```

### Files
- `src/shared/providers/handlers.ts` — new `qualifiedToCapaSh`, `renderSkillsBlock`, `renderToolsBlock`, exported `renderSubAgentSkillsAndTools`; `buildSubAgentFile` accepts an optional `skillDescriptions: Map<string, string>` (default empty).
- `src/cli/commands/install-tasks/install-subagents.ts` — new `buildSkillDescriptions` reads each `<provider.skillsDir>/<skill.id>/SKILL.md` once before the per-subagent loop and parses the frontmatter via the existing `parseSkillMd` helper.
- `src/cli/utils/agents-file.ts` — threads the map through `installSubAgentInstructions` → `writeSubAgentFile` / `upsertSubAgentInstructionsSnippet`.
- `src/shared/slug.ts` (new) — single source of truth for tool/group/server slugification.
- `src/cli/commands/sh.ts` — re-exports `slugify` from the shared module.

## Test plan
- [x] `bun test` — 1081/1081 pass
- [x] New tests cover: dashed list shape, skill descriptions sourced from the map, missing-description fallback (id-only, no em-dash), `(none)` placeholders for empty lists, kebab-case slugification of snake_case tool ids in the `capa sh` form
- [x] Built the binary and ran `capa install` against a project with several subagents — verified the rendered `.claude/agents/*.md` files match expectations and that the qualified-name / `capa sh` forms in the tool bullets are accurate
- [x] Reviewer: confirm wording / format choice for skill+tool bullets reads well in your IDE