### PR TITLE
feat(install): warn on unknown subagent skill/tool references

### DIFF
--- a/src/cli/commands/install-tasks/helpers/__tests__/tool-warnings.test.ts
+++ b/src/cli/commands/install-tasks/helpers/__tests__/tool-warnings.test.ts
@@ -1,0 +1,89 @@
+import { describe, it, expect } from 'bun:test';
+import type { Capabilities } from '../../../../../types/capabilities';
+import { collectSubagentRefWarnings } from '../tool-warnings';
+
+const baseCapabilities = (): Capabilities => ({
+  providers: ['claude-code'],
+  skills: [
+    { id: 'general-data-analysis', type: 'local', def: { path: './skills/general-data-analysis' } },
+    { id: 'general-databricks-cli', type: 'local', def: { path: './skills/general-databricks-cli' } },
+  ],
+  servers: [],
+  tools: [
+    { id: 'sql_read_only', type: 'mcp', def: { server: '@dbx', tool: 'execute_sql_read_only' } },
+    { id: 'poll_sql_result', type: 'mcp', def: { server: '@dbx', tool: 'poll_sql_result' } },
+  ],
+});
+
+describe('collectSubagentRefWarnings', () => {
+  it('returns no warnings when every reference resolves', () => {
+    const cap = baseCapabilities();
+    cap.subagents = [
+      {
+        id: 'data-analyst',
+        description: '',
+        skills: ['general-data-analysis', 'general-databricks-cli'],
+        tools: ['sql_read_only', 'poll_sql_result'],
+      },
+    ];
+    expect(collectSubagentRefWarnings(cap)).toEqual([]);
+  });
+
+  it('warns once per unknown skill id, naming the subagent', () => {
+    const cap = baseCapabilities();
+    cap.subagents = [
+      {
+        id: 'data-analyst',
+        description: '',
+        skills: ['general-data-analysis', 'general-data-analyiss'],
+        tools: [],
+      },
+    ];
+    const warnings = collectSubagentRefWarnings(cap);
+    expect(warnings).toHaveLength(1);
+    expect(warnings[0]).toContain('"data-analyst"');
+    expect(warnings[0]).toContain('"general-data-analyiss"');
+    expect(warnings[0]).toContain('unknown skill');
+  });
+
+  it('warns once per unknown tool id, naming the subagent', () => {
+    const cap = baseCapabilities();
+    cap.subagents = [
+      {
+        id: 'data-analyst',
+        description: '',
+        skills: [],
+        tools: ['sql_read_only', 'slq_read_only'],
+      },
+    ];
+    const warnings = collectSubagentRefWarnings(cap);
+    expect(warnings).toHaveLength(1);
+    expect(warnings[0]).toContain('"data-analyst"');
+    expect(warnings[0]).toContain('"slq_read_only"');
+    expect(warnings[0]).toContain('unknown tool');
+  });
+
+  it('emits one warning per typo across multiple subagents', () => {
+    const cap = baseCapabilities();
+    cap.subagents = [
+      { id: 'a1', description: '', skills: ['missing-1'], tools: ['missing-tool'] },
+      { id: 'a2', description: '', skills: ['missing-2'], tools: [] },
+    ];
+    const warnings = collectSubagentRefWarnings(cap);
+    expect(warnings).toHaveLength(3);
+    expect(warnings.some((w) => w.includes('"a1"') && w.includes('missing-1'))).toBe(true);
+    expect(warnings.some((w) => w.includes('"a1"') && w.includes('missing-tool'))).toBe(true);
+    expect(warnings.some((w) => w.includes('"a2"') && w.includes('missing-2'))).toBe(true);
+  });
+
+  it('returns an empty list when there are no subagents', () => {
+    const cap = baseCapabilities();
+    expect(collectSubagentRefWarnings(cap)).toEqual([]);
+  });
+
+  it('tolerates a subagent missing the optional skills/tools fields', () => {
+    const cap = baseCapabilities();
+    cap.subagents = [{ id: 'a', description: '' } as any];
+    expect(collectSubagentRefWarnings(cap)).toEqual([]);
+  });
+});

--- a/src/cli/commands/install-tasks/helpers/tool-warnings.ts
+++ b/src/cli/commands/install-tasks/helpers/tool-warnings.ts
@@ -45,6 +45,40 @@ export function collectPluginSkillWarnings(capabilities: Capabilities): string[]
   return warnings;
 }
 
+// Warn for each subagent that references a skill or tool id that is not
+// declared in the top-level `skills` / `tools` arrays. Today these typos
+// pass silently: rendered files include junk bullets and the subagent loses
+// access to the tool at runtime with no signal. One line per typo, so a
+// `general-data-analyiss` mistake is obvious in install output.
+export function collectSubagentRefWarnings(capabilities: Capabilities): string[] {
+  const subagents = capabilities.subagents ?? [];
+  if (subagents.length === 0) return [];
+
+  const knownSkillIds = new Set(capabilities.skills.map((s) => s.id));
+  const knownToolIds = new Set(capabilities.tools.map((t) => t.id));
+
+  const warnings: string[] = [];
+  for (const sa of subagents) {
+    for (const skillId of sa.skills ?? []) {
+      if (!knownSkillIds.has(skillId)) {
+        warnings.push(
+          `Subagent "${sa.id}" references unknown skill "${skillId}". ` +
+          `Add it under top-level \`skills\` or remove it from the subagent.`,
+        );
+      }
+    }
+    for (const toolId of sa.tools ?? []) {
+      if (!knownToolIds.has(toolId)) {
+        warnings.push(
+          `Subagent "${sa.id}" references unknown tool "${toolId}". ` +
+          `Add it under top-level \`tools\` or remove it from the subagent.`,
+        );
+      }
+    }
+  }
+  return warnings;
+}
+
 // Warn when a plugin server contributes tools but no user-declared tool
 // references it. An unreferenced plugin server is almost always a misconfig.
 export function collectUnreferencedPluginServerWarnings(capabilities: Capabilities): string[] {

--- a/src/cli/commands/install-tasks/index.ts
+++ b/src/cli/commands/install-tasks/index.ts
@@ -15,6 +15,7 @@ import { installRulesTask } from './install-rules';
 import { configureToolsTask } from './configure-tools';
 import { registerMcpServerTask } from './register-mcp-server';
 import { installSubagentsTask } from './install-subagents';
+import { validateSubagentRefsTask } from './validate-subagent-refs';
 import { pruneOrphanHooksTask } from './prune-orphan-hooks';
 import { installHooksTask } from './install-hooks';
 import { openCredentialSetupTask } from './open-credential-setup';
@@ -40,6 +41,7 @@ export function buildInstallTasks(reqCmds?: RequiredCommand[]): Task<InstallCtx>
     installRulesTask(),
     configureToolsTask(),
     registerMcpServerTask(),
+    validateSubagentRefsTask(),
     installSubagentsTask(),
     pruneOrphanHooksTask(),
     installHooksTask(),

--- a/src/cli/commands/install-tasks/validate-subagent-refs.ts
+++ b/src/cli/commands/install-tasks/validate-subagent-refs.ts
@@ -1,0 +1,19 @@
+import type { Task } from '../../ui';
+import type { InstallCtx } from './context';
+import { collectSubagentRefWarnings } from './helpers/tool-warnings';
+
+/**
+ * Surface a warning for each subagent that references a skill or tool id
+ * not declared in the top-level `skills` / `tools` arrays. Otherwise these
+ * typos pass silently through install and renderer, and only surface as
+ * "the subagent can't find its tool" later at runtime.
+ */
+export function validateSubagentRefsTask(): Task<InstallCtx> {
+  return {
+    title: 'Validating sub-agent references',
+    enabled: (ctx) => (ctx.capabilitiesToUse.subagents ?? []).length > 0,
+    task: async (ctx) => {
+      ctx.warnings.push(...collectSubagentRefWarnings(ctx.capabilitiesToUse));
+    },
+  };
+}


### PR DESCRIPTION
## Summary

Follow-up to #118.

Subagent definitions can reference any string id under `skills` / `tools`. Until now a typo passed silently through every surface:

- `parseCapabilitiesFile` / `normalizeCapabilities` — no cross-ref check.
- Install — never compares subagent ids against the top-level arrays.
- Renderer — writes a bare-id bullet with no description and (for tools) a `capa sh` form derived from the raw id.
- MCP server — silently drops the unknown tool id from the subagent's allowed set.

So a typo like `general-data-analyiss` or `slq_read_only` produced a clean install, a rendered `.claude/agents/*.md` with junk-looking bullets, and a subagent that quietly couldn't reach its tool at runtime.

This PR adds a non-fatal warning, surfaced through the existing `ctx.warnings` channel that already carries the unreferenced-plugin-server / unexposed-tool messages:

```
▲ Subagent "data-analyst" references unknown skill "general-data-analyiss". Add it under top-level `skills` or remove it from the subagent.
▲ Subagent "data-analyst" references unknown tool "slq_read_only". Add it under top-level `tools` or remove it from the subagent.
```

### Files
- `src/cli/commands/install-tasks/helpers/tool-warnings.ts` — new `collectSubagentRefWarnings` colocated with the existing plugin/tool linters; one warning per typo.
- `src/cli/commands/install-tasks/validate-subagent-refs.ts` (new) — tiny task that pushes the warnings into `ctx.warnings`; enabled only when subagents exist; runs just before `installSubagentsTask`.
- `src/cli/commands/install-tasks/index.ts` — wires the new task into the install pipeline.
- `src/cli/commands/install-tasks/helpers/__tests__/tool-warnings.test.ts` (new) — covers happy path, unknown skill, unknown tool, multiple subagents, no subagents, and missing optional fields.

## Test plan
- [x] `bun test` — 1087/1087 pass (6 new tests)
- [x] Reviewer: confirm the warning copy reads usefully in install output