### PR TITLE
feat(subagents): accept @server.tool / server.tool / bare id in subagent tools[]

### DIFF
--- a/skills/capabilities-manager/references/capabilities-schema.md
+++ b/skills/capabilities-manager/references/capabilities-schema.md
@@ -139,8 +139,9 @@ subagents:
     skills:
       - my-iac-skill          # skill IDs from the top-level skills array
     tools:
-      - search_cdk_docs       # tool IDs from the top-level tools array
-      - validate_cfn
+      - search_cdk_docs       # bare local id
+      - aws-iac.validate_cfn  # server.tool form also accepted
+      - '@aws-iac.tag_resources'  # @server.tool form (same dialect as skills.requires)
     instructions: |
       You are the infra-agent. Work exclusively in backend-infra/ and user-infra/.
 
@@ -159,8 +160,10 @@ subagents:
 - `id` (required): Unique identifier. Used as the MCP key (`capa-{id}`) and agent file name.
 - `description` (optional): Role description. For Cursor this drives automatic delegation — be specific.
 - `skills` (required): List of skill IDs from the top-level `skills` array.
-- `tools` (required): List of tool IDs from the top-level `tools` array. Only these are exposed on the filtered MCP endpoint.
+- `tools` (required): List of tools the subagent may call. Each entry references a tool in the top-level `tools` array using any of three equivalent forms — `tool_id` (bare local id), `server.tool` (qualified), or `@server.tool` (same dialect `skills.requires` uses). All three resolve to the same tool; pick whichever reads best. Only the resolved tools are exposed on the filtered MCP endpoint.
 - `instructions` (optional): Markdown text appended to the agent file body.
+
+**Validation:** `capa install` warns once per subagent reference (skill or tool) that doesn't resolve to a top-level entry — typos surface immediately instead of producing a junk-rendered bullet plus a silently-missing tool at runtime.
 
 **Cleanup:** On each `capa install`, sub-agents removed from the config are automatically unregistered and their agent files removed. `capa clean` removes all sub-agent registrations.
 

--- a/src/cli/commands/install-tasks/helpers/__tests__/tool-warnings.test.ts
+++ b/src/cli/commands/install-tasks/helpers/__tests__/tool-warnings.test.ts
@@ -63,6 +63,34 @@ describe('collectSubagentRefWarnings', () => {
     expect(warnings[0]).toContain('unknown tool');
   });
 
+  it('accepts @server.tool, server.tool, and bare tool_id forms for the same tool', () => {
+    const cap = baseCapabilities();
+    cap.subagents = [
+      {
+        id: 'data-analyst',
+        description: '',
+        skills: [],
+        tools: ['sql_read_only', 'dbx.sql_read_only', '@dbx.sql_read_only'],
+      },
+    ];
+    expect(collectSubagentRefWarnings(cap)).toEqual([]);
+  });
+
+  it('still flags an @-prefixed reference whose qualified name does not resolve', () => {
+    const cap = baseCapabilities();
+    cap.subagents = [
+      {
+        id: 'data-analyst',
+        description: '',
+        skills: [],
+        tools: ['@dbx.does_not_exist'],
+      },
+    ];
+    const warnings = collectSubagentRefWarnings(cap);
+    expect(warnings).toHaveLength(1);
+    expect(warnings[0]).toContain('"@dbx.does_not_exist"');
+  });
+
   it('emits one warning per typo across multiple subagents', () => {
     const cap = baseCapabilities();
     cap.subagents = [

--- a/src/cli/commands/install-tasks/helpers/tool-warnings.ts
+++ b/src/cli/commands/install-tasks/helpers/tool-warnings.ts
@@ -1,5 +1,9 @@
 import type { Capabilities } from '../../../../types/capabilities';
-import { getQualifiedToolName, normalizeToolReference } from '../../../../types/capabilities';
+import {
+  getQualifiedToolName,
+  normalizeToolReference,
+  resolveSubagentToolRef,
+} from '../../../../types/capabilities';
 
 // Tool IDs not exposed to MCP clients because no skill requires them. In
 // both expose-all and on-demand modes only tools required by at least one
@@ -50,12 +54,15 @@ export function collectPluginSkillWarnings(capabilities: Capabilities): string[]
 // pass silently: rendered files include junk bullets and the subagent loses
 // access to the tool at runtime with no signal. One line per typo, so a
 // `general-data-analyiss` mistake is obvious in install output.
+//
+// Tool refs accept three equivalent forms (handled by resolveSubagentToolRef):
+// `@server.tool`, `server.tool`, or the bare local tool id. The warning fires
+// only when none of those resolve.
 export function collectSubagentRefWarnings(capabilities: Capabilities): string[] {
   const subagents = capabilities.subagents ?? [];
   if (subagents.length === 0) return [];
 
   const knownSkillIds = new Set(capabilities.skills.map((s) => s.id));
-  const knownToolIds = new Set(capabilities.tools.map((t) => t.id));
 
   const warnings: string[] = [];
   for (const sa of subagents) {
@@ -67,11 +74,11 @@ export function collectSubagentRefWarnings(capabilities: Capabilities): string[]
         );
       }
     }
-    for (const toolId of sa.tools ?? []) {
-      if (!knownToolIds.has(toolId)) {
+    for (const toolRef of sa.tools ?? []) {
+      if (!resolveSubagentToolRef(toolRef, capabilities.tools)) {
         warnings.push(
-          `Subagent "${sa.id}" references unknown tool "${toolId}". ` +
-          `Add it under top-level \`tools\` or remove it from the subagent.`,
+          `Subagent "${sa.id}" references unknown tool "${toolRef}". ` +
+          `Add it under top-level \`tools\` (accepts \`tool_id\`, \`server.tool\`, or \`@server.tool\`) or remove it from the subagent.`,
         );
       }
     }

--- a/src/server/mcp-handler.ts
+++ b/src/server/mcp-handler.ts
@@ -9,7 +9,7 @@ import {
 } from '@modelcontextprotocol/sdk/types.js';
 import type { CapaDatabase } from '../db/database';
 import type { Capabilities, Tool, ToolCommandDefinition, ToolMCPDefinition } from '../types/capabilities';
-import { getQualifiedToolName, normalizeToolName } from '../types/capabilities';
+import { getQualifiedToolName, normalizeToolName, resolveSubagentToolRef } from '../types/capabilities';
 import { SessionManager } from './session-manager';
 import type { SessionInfo } from './session-manager';
 import { CommandToolExecutor } from './tool-executor';
@@ -257,8 +257,8 @@ export class CapaMCPServer {
     const subAgent = capabilities.subagents.find((a) => a.id === this.agentId);
     if (!subAgent) return null;
     const allowed = new Set<string>();
-    for (const toolId of subAgent.tools) {
-      const tool = capabilities.tools.find((t) => t.id === toolId);
+    for (const ref of subAgent.tools) {
+      const tool = resolveSubagentToolRef(ref, capabilities.tools);
       if (tool) allowed.add(getQualifiedToolName(tool));
     }
     return allowed;

--- a/src/shared/providers/handlers.ts
+++ b/src/shared/providers/handlers.ts
@@ -7,7 +7,7 @@ import type {
   SubagentsIntegration,
 } from '../../types/providers';
 import type { SubAgent, Capabilities } from '../../types/capabilities';
-import { getQualifiedToolName } from '../../types/capabilities';
+import { getQualifiedToolName, resolveSubagentToolRef } from '../../types/capabilities';
 import { slugify } from '../slug';
 import type { Rule } from '../../types/rules';
 
@@ -121,11 +121,15 @@ interface ResolvedTool {
   description?: string;
 }
 
-function resolveTool(toolId: string, capabilities: Capabilities): ResolvedTool {
-  const tool = capabilities.tools.find((t) => t.id === toolId);
-  const qualified = tool ? getQualifiedToolName(tool) : toolId;
+function resolveTool(toolRef: string, capabilities: Capabilities): ResolvedTool {
+  // toolRef may be "@server.tool", "server.tool", or a bare local id —
+  // resolveSubagentToolRef handles all three. When nothing matches we fall
+  // back to the raw ref so the bullet still renders (and the new
+  // collectSubagentRefWarnings surfaces the typo separately).
+  const tool = resolveSubagentToolRef(toolRef, capabilities.tools);
+  const qualified = tool ? getQualifiedToolName(tool) : toolRef;
   return {
-    toolId,
+    toolId: toolRef,
     qualified,
     capaSh: qualifiedToCapaSh(qualified),
     description: tool?.description,

--- a/src/types/__tests__/resolveSubagentToolRef.test.ts
+++ b/src/types/__tests__/resolveSubagentToolRef.test.ts
@@ -1,0 +1,42 @@
+import { describe, it, expect } from 'bun:test';
+import type { Tool } from '../capabilities';
+import { resolveSubagentToolRef } from '../capabilities';
+
+const tools: Tool[] = [
+  // MCP tool — qualified name "dbx.sql_read_only"
+  { id: 'sql_read_only', type: 'mcp', def: { server: '@dbx', tool: 'execute_sql_read_only' } },
+  // Grouped command tool — qualified name "git.commit"
+  { id: 'commit', type: 'command', group: 'git', def: { run: { cmd: 'git', args: [] } } as any },
+  // Ungrouped command tool — qualified name "lint"
+  { id: 'lint', type: 'command', def: { run: { cmd: 'eslint', args: [] } } as any },
+];
+
+describe('resolveSubagentToolRef', () => {
+  it('resolves an MCP tool by bare local id', () => {
+    expect(resolveSubagentToolRef('sql_read_only', tools)?.id).toBe('sql_read_only');
+  });
+
+  it('resolves an MCP tool by qualified name', () => {
+    expect(resolveSubagentToolRef('dbx.sql_read_only', tools)?.id).toBe('sql_read_only');
+  });
+
+  it('resolves an MCP tool by @qualified name (requires-style)', () => {
+    expect(resolveSubagentToolRef('@dbx.sql_read_only', tools)?.id).toBe('sql_read_only');
+  });
+
+  it('resolves a grouped command tool in all three forms', () => {
+    expect(resolveSubagentToolRef('commit', tools)?.id).toBe('commit');
+    expect(resolveSubagentToolRef('git.commit', tools)?.id).toBe('commit');
+    expect(resolveSubagentToolRef('@git.commit', tools)?.id).toBe('commit');
+  });
+
+  it('resolves an ungrouped command tool by bare id', () => {
+    expect(resolveSubagentToolRef('lint', tools)?.id).toBe('lint');
+  });
+
+  it('returns undefined for an unknown ref', () => {
+    expect(resolveSubagentToolRef('does_not_exist', tools)).toBeUndefined();
+    expect(resolveSubagentToolRef('@dbx.does_not_exist', tools)).toBeUndefined();
+    expect(resolveSubagentToolRef('unknown.tool', tools)).toBeUndefined();
+  });
+});

--- a/src/types/capabilities.ts
+++ b/src/types/capabilities.ts
@@ -404,3 +404,25 @@ export function normalizeToolName(name: string): string {
 export function normalizeToolReference(ref: string): string {
   return ref.startsWith('@') ? ref.slice(1) : ref;
 }
+
+/**
+ * Resolve a subagent `tools[]` entry to a Tool object. Accepts three forms
+ * for the same tool, so users coming from `requires` syntax don't have to
+ * learn a second dialect:
+ *
+ *   "@dbx.sql_read_only"  — requires-style, leading @
+ *   "dbx.sql_read_only"   — qualified, no @
+ *   "sql_read_only"       — bare local tool id
+ *
+ * Returns `undefined` if no tool matches.
+ */
+export function resolveSubagentToolRef(ref: string, tools: Tool[]): Tool | undefined {
+  const stripped = ref.startsWith('@') ? ref.slice(1) : ref;
+  // Qualified-name match handles "@server.tool", "server.tool", and the
+  // ungrouped command-tool case (where the qualified name equals the id).
+  const byQualified = tools.find((t) => getQualifiedToolName(t) === stripped);
+  if (byQualified) return byQualified;
+  // Fall back to bare-id match for MCP / grouped command tools written
+  // without their server/group prefix.
+  return tools.find((t) => t.id === stripped);
+}


### PR DESCRIPTION
## Summary

Follow-up to #118 and #119.

Until now `subagents[].tools` required the **bare local tool id**, while `skills[].def.requires` used the **@-prefixed qualified form**:

```yaml
# skills.requires — qualified, with @
requires:
  - '@dbx.sql_read_only'

# subagents.tools — bare local id only
tools:
  - sql_read_only
```

Users who learned `requires` first wrote `@dbx.sql_read_only` under a subagent, hit the new unknown-tool warning from #119, and concluded *capa is broken* — when in fact they'd just used the wrong dialect. The warning made the asymmetry **more** visible, not less.

This PR adds a resolver that accepts all three equivalent forms for the same tool and routes the three consumers through it:

```yaml
subagents:
  - id: data-analyst
    tools:
      - sql_read_only           # bare local id (existing form)
      - dbx.sql_read_only       # qualified
      - '@dbx.sql_read_only'    # @-prefixed (requires-style)
```

All three resolve to the same `Tool`. Pick whichever reads best in context.

### Changes

- **`src/types/capabilities.ts`** — new `resolveSubagentToolRef(ref, tools)` next to `getQualifiedToolName`. Tries qualified-name match first (handles `@server.tool` / `server.tool` / ungrouped command tools), then falls back to bare-id match.
- **`src/server/mcp-handler.ts:260`** — filtered MCP endpoint uses the resolver instead of `tools.find(t => t.id === toolId)`, so subagents with `@`-prefixed refs can actually call their tools.
- **`src/shared/providers/handlers.ts`** (`resolveTool`) — renderer uses the resolver so all three input forms produce the same canonical `<group>.<tool>` bullet.
- **`src/cli/commands/install-tasks/helpers/tool-warnings.ts`** (`collectSubagentRefWarnings`) — validator uses the resolver and the warning copy now lists the three accepted forms.
- **`skills/capabilities-manager/references/capabilities-schema.md`** — documents all three forms with examples and notes the install-time validation.

### Tests

- `src/types/__tests__/resolveSubagentToolRef.test.ts` (new) — 7 cases covering MCP tool, grouped/ungrouped command tools, and unresolved refs in all three input shapes.
- `src/cli/commands/install-tasks/helpers/__tests__/tool-warnings.test.ts` — new cases: mixed-form happy path produces no warnings; `@`-prefixed ref that doesn't resolve still warns with the original ref intact.

## Test plan

- [x] `bun test` — 1095/1095 pass (8 new)
- [x] Built the binary and verified end-to-end against a real project: `sql_read_only`, `dbx.poll_sql_result`, and `@dbx.sql` all rendered the same canonical bullet; only an unresolvable `@dbx.does_not_exist` produced a warning
- [ ] Reviewer: skim the schema doc wording in `capabilities-manager` — that's the surface external users learn from