### PR TITLE
Add optional MCP tool formatter (closes #131)

### DIFF
--- a/skills/capabilities-manager/references/capabilities-schema.md
+++ b/skills/capabilities-manager/references/capabilities-schema.md
@@ -108,6 +108,7 @@ List of `{ cli: "executable", description?: "hint" }`. Install fails if any comm
 ## Tools Section
 
 - **MCP tool**: `def.server: "@server-id"`, `def.tool: tool_name`. Optional `def.defaults` for pre-filled args. Reference in skills as `@server_id.tool_id`.
+- **MCP formatter** (optional): `def.formatter.cmd` pipes the serialized tool output through a shell command on the CAPA server before returning it to MCP clients and `capa sh`. Use for human-oriented output (e.g. `jq` to turn JSON rows into TSV). On failure or timeout (default 3000ms, override with `def.formatter.timeout`) the original output is returned unchanged. Command-type tools do not use `formatter` — pipe inside `def.run.cmd` instead. Use `capa sh --json <tool>` to skip formatting and get raw JSON.
 - **Command tool**: `def.run.cmd` with `{arg}` placeholders, `def.run.args` (name, type, description, required, optional `default`). Optional `def.init.cmd` for one-time setup. Optional `group` for nesting in `capa sh`.
 
 Optional top-level `description` for MCP schema and `capa sh`.

--- a/src/cli/commands/__tests__/sh.test.ts
+++ b/src/cli/commands/__tests__/sh.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'bun:test';
-import { parseInlineArgs, resolveArgs, coerceValue } from '../sh';
+import { parseInlineArgs, resolveArgs, coerceValue, parseShellGlobalFlags } from '../sh';
 import type { ShellCommand } from '../sh';
 import { slugify } from '../../../shared/slug';
 
@@ -19,6 +19,22 @@ function makeCommand(overrides: Partial<ShellCommand> = {}): ShellCommand {
     ...overrides,
   };
 }
+
+describe('parseShellGlobalFlags', () => {
+  it('detects and removes --json', () => {
+    expect(parseShellGlobalFlags(['--json', 'my-tool', '--x', '1'])).toEqual({
+      jsonMode: true,
+      tokens: ['my-tool', '--x', '1'],
+    });
+  });
+
+  it('defaults jsonMode to false', () => {
+    expect(parseShellGlobalFlags(['my-tool'])).toEqual({
+      jsonMode: false,
+      tokens: ['my-tool'],
+    });
+  });
+});
 
 describe('parseInlineArgs', () => {
   it('should parse key-value pairs', () => {

--- a/src/cli/commands/sh.ts
+++ b/src/cli/commands/sh.ts
@@ -4,6 +4,7 @@ import { getServerStatus } from '../utils/server-manager';
 import type { Capabilities } from '../../types/capabilities';
 import { getQualifiedToolName } from '../../types/capabilities';
 import { slugify } from '../../shared/slug';
+import { CAPA_JSON_ARG } from '../../server/tool-formatter';
 
 interface ShellToolInfo {
   id: string;
@@ -156,6 +157,16 @@ class ShellRegistry {
 }
 
 
+export function parseShellGlobalFlags(args: string[]): { jsonMode: boolean; tokens: string[] } {
+  const tokens = [...args];
+  let jsonMode = false;
+  while (tokens.length > 0 && tokens[0] === '--json') {
+    jsonMode = true;
+    tokens.shift();
+  }
+  return { jsonMode, tokens };
+}
+
 export function parseInlineArgs(tokens: string[]): Record<string, string> {
   const result: Record<string, string> = {};
   let i = 0;
@@ -301,8 +312,10 @@ async function executeToolViaMCP(
   serverUrl: string,
   projectId: string,
   toolId: string,
-  args: Record<string, any>
+  args: Record<string, any>,
+  jsonMode = false
 ): Promise<string> {
+  const callArgs = jsonMode ? { ...args, [CAPA_JSON_ARG]: true } : args;
   // Send initialize first to establish a session (needed for on-demand mode)
   await fetch(`${serverUrl}/${projectId}/mcp`, {
     method: 'POST',
@@ -327,7 +340,7 @@ async function executeToolViaMCP(
       jsonrpc: '2.0',
       id: 2,
       method: 'tools/call',
-      params: { name: toolId, arguments: args },
+      params: { name: toolId, arguments: callArgs },
     }),
     signal: AbortSignal.timeout(60000),
   });
@@ -406,6 +419,7 @@ function printAvailableCommands(registry: ShellRegistry): void {
   console.log('  capa sh <group>                      List tools in a group');
   console.log('  capa sh <group> <tool> [--arg val]   Run a tool');
   console.log('  capa sh <command> [--arg val]        Run a top-level command');
+  console.log('  capa sh --json <command> [--arg val] Return raw JSON (skip formatter)');
   console.log('  capa sh <other>                      Pass through to OS shell\n');
 }
 
@@ -462,7 +476,8 @@ async function execCommand(
   cmd: ShellCommand,
   rawArgTokens: string[],
   serverUrl: string,
-  projectId: string
+  projectId: string,
+  jsonMode = false
 ): Promise<void> {
   const rawArgs = parseInlineArgs(rawArgTokens);
   const resolved = resolveArgs(cmd, rawArgs);
@@ -497,7 +512,7 @@ async function execCommand(
     process.exit(1);
   }
 
-  const result = await executeToolViaMCP(serverUrl, projectId, cmd.id, resolved);
+  const result = await executeToolViaMCP(serverUrl, projectId, cmd.id, resolved, jsonMode);
   try {
     const parsed = JSON.parse(result);
     console.log(JSON.stringify(parsed, null, 2));
@@ -532,7 +547,8 @@ async function dispatch(
   tokens: string[],
   registry: ShellRegistry,
   serverUrl: string,
-  projectId: string
+  projectId: string,
+  jsonMode = false
 ): Promise<void> {
   if (tokens.length === 0) {
     printAvailableCommands(registry);
@@ -579,7 +595,7 @@ async function dispatch(
       return;
     }
 
-    await execCommand(cmd, subRest, serverUrl, projectId);
+    await execCommand(cmd, subRest, serverUrl, projectId, jsonMode);
     return;
   }
 
@@ -596,7 +612,7 @@ async function dispatch(
       return;
     }
 
-    await execCommand(cmd, rest, serverUrl, projectId);
+    await execCommand(cmd, rest, serverUrl, projectId, jsonMode);
     return;
   }
 
@@ -672,5 +688,7 @@ export async function shellCommand(args: string[]): Promise<void> {
   const registry = new ShellRegistry();
   registry.build(tools);
 
-  await dispatch(args, registry, serverUrl, projectId);
+  const { jsonMode, tokens } = parseShellGlobalFlags(args);
+
+  await dispatch(tokens, registry, serverUrl, projectId, jsonMode);
 }

--- a/src/server/__tests__/tool-formatter.test.ts
+++ b/src/server/__tests__/tool-formatter.test.ts
@@ -1,0 +1,112 @@
+import { describe, it, expect } from 'bun:test';
+import {
+  applyToolFormatter,
+  buildToolCallText,
+  extractCapaShellMeta,
+  serializeToolResult,
+  CAPA_JSON_ARG,
+} from '../tool-formatter';
+import type { Tool } from '../../types/capabilities';
+
+describe('extractCapaShellMeta', () => {
+  it('returns args unchanged when meta key is absent', () => {
+    expect(extractCapaShellMeta({ query: 'select 1' })).toEqual({
+      cleanArgs: { query: 'select 1' },
+      skipFormatter: false,
+    });
+  });
+
+  it('strips _capa_json and sets skipFormatter', () => {
+    expect(extractCapaShellMeta({ query: 'x', [CAPA_JSON_ARG]: true })).toEqual({
+      cleanArgs: { query: 'x' },
+      skipFormatter: true,
+    });
+  });
+
+  it('treats string "true" as skipFormatter', () => {
+    expect(extractCapaShellMeta({ [CAPA_JSON_ARG]: 'true' }).skipFormatter).toBe(true);
+  });
+});
+
+describe('serializeToolResult', () => {
+  it('unwraps command tool success output', () => {
+    expect(serializeToolResult({ success: true, result: 'hello' })).toBe('hello');
+  });
+
+  it('unwraps MCP proxy text content', () => {
+    expect(
+      serializeToolResult({
+        result: [{ type: 'text', text: '{"a":1}' }],
+      })
+    ).toBe('{\n  "a": 1\n}');
+  });
+});
+
+describe('buildToolCallText', () => {
+  const mcpTool: Tool = {
+    id: 'query',
+    type: 'mcp',
+    def: {
+      server: '@db',
+      tool: 'run_query',
+      formatter: { cmd: "sed 's/OLD/NEW/'" },
+    },
+  };
+
+  it('applies formatter for MCP tools', async () => {
+    const text = await buildToolCallText({ success: true, result: 'OLD value' }, mcpTool);
+    expect(text).toBe('NEW value');
+  });
+
+  it('skips formatter when requested', async () => {
+    const text = await buildToolCallText(
+      { success: true, result: 'OLD value' },
+      mcpTool,
+      { skipFormatter: true }
+    );
+    expect(text).toBe('OLD value');
+  });
+
+  it('ignores formatter on command tools', async () => {
+    const commandTool: Tool = {
+      id: 'echo',
+      type: 'command',
+      def: { run: { cmd: 'echo hi' } },
+    };
+    const text = await buildToolCallText({ success: true, result: 'OLD value' }, commandTool);
+    expect(text).toBe('OLD value');
+  });
+});
+
+describe('applyToolFormatter', () => {
+  it('returns transformed stdout on success', async () => {
+    const out = await applyToolFormatter('{"name":"alice"}', {
+      cmd: "jq -r '.name'",
+    });
+    expect(out).toBe('alice');
+  });
+
+  it('preserves tab and newline characters in output', async () => {
+    const out = await applyToolFormatter('a\tb\nc', {
+      cmd: 'cat',
+    });
+    expect(out).toBe('a\tb\nc');
+  });
+
+  it('returns original input when command fails', async () => {
+    const input = '{"keep":true}';
+    const out = await applyToolFormatter(input, {
+      cmd: 'exit 1',
+    });
+    expect(out).toBe(input);
+  });
+
+  it('returns original input on timeout', async () => {
+    const input = 'slow';
+    const out = await applyToolFormatter(input, {
+      cmd: 'sleep 5',
+      timeout: 50,
+    });
+    expect(out).toBe(input);
+  });
+});

--- a/src/server/mcp-handler.ts
+++ b/src/server/mcp-handler.ts
@@ -14,6 +14,7 @@ import { SessionManager } from './session-manager';
 import type { SessionInfo } from './session-manager';
 import { CommandToolExecutor } from './tool-executor';
 import { MCPProxy } from './mcp-proxy';
+import { buildToolCallText, extractCapaShellMeta } from './tool-formatter';
 import { VERSION } from '../version';
 import { logger } from '../shared/logger';
 
@@ -341,17 +342,20 @@ export class CapaMCPServer {
     // Call tool handler
     this.server.setRequestHandler(CallToolRequestSchema, async (request) => {
       const { name, arguments: args } = request.params;
+      const { cleanArgs, skipFormatter } = extractCapaShellMeta(
+        (args ?? {}) as Record<string, any>
+      );
       const capabilities = this.sessionManager.getProjectCapabilities(this.projectId);
       const toolExposureMode = capabilities?.options?.toolExposure || 'expose-all';
 
       // Handle setup_tools
       if (name === 'setup_tools' && toolExposureMode === 'on-demand') {
-        return await this.handleSetupTools(args as { skills: string[] });
+        return await this.handleSetupTools(cleanArgs as { skills: string[] });
       }
 
       // Handle call_tool in on-demand mode
       if (name === 'call_tool' && toolExposureMode === 'on-demand') {
-        return await this.handleCallTool(args as { name: string; data: object });
+        return await this.handleCallTool(cleanArgs as { name: string; data: object });
       }
 
       // Prevent meta-tools from being called in expose-all mode
@@ -421,7 +425,7 @@ export class CapaMCPServer {
         result = await executor.execute(
           name,
           toolDef.def as ToolCommandDefinition,
-          args as Record<string, any>
+          cleanArgs
         );
       } else if (toolDef.type === 'mcp') {
         const mcpDef = toolDef.def as ToolMCPDefinition;
@@ -451,17 +455,15 @@ export class CapaMCPServer {
           };
         }
 
-        result = await this.mcpProxy.executeTool(name, mcpDef, serverDef.def, mergeDefaults(mcpDef.defaults, args as Record<string, any>));
+        result = await this.mcpProxy.executeTool(
+          name,
+          mcpDef,
+          serverDef.def,
+          mergeDefaults(mcpDef.defaults, cleanArgs)
+        );
       }
 
-      return {
-        content: [
-          {
-            type: 'text',
-            text: this.serializeToolResult(result),
-          },
-        ],
-      };
+      return await this.buildToolCallContent(result, toolDef, { skipFormatter });
     });
   }
 
@@ -584,7 +586,9 @@ export class CapaMCPServer {
 
   private async handleCallTool(args: { name: string; data: object }): Promise<any> {
     const toolName = args.name;
-    const toolData = args.data || {};
+    const { cleanArgs: toolData, skipFormatter } = extractCapaShellMeta(
+      (args.data ?? {}) as Record<string, any>
+    );
     try {
       const session = this.ensureSession();
       this.logger.info(`Calling tool via call_tool: ${toolName}`);
@@ -664,13 +668,16 @@ export class CapaMCPServer {
         }
 
         this.logger.debug(`Using MCP server: ${serverId}`);
-        result = await this.mcpProxy.executeTool(toolName, mcpDef, serverDef.def, mergeDefaults(mcpDef.defaults, toolData as Record<string, any>));
+        result = await this.mcpProxy.executeTool(
+          toolName,
+          mcpDef,
+          serverDef.def,
+          mergeDefaults(mcpDef.defaults, toolData)
+        );
         this.logger.debug('MCP tool executed');
       }
 
-      return {
-        content: [{ type: 'text', text: this.serializeToolResult(result) }],
-      };
+      return await this.buildToolCallContent(result, toolDef, { skipFormatter });
     } catch (error: any) {
       this.logger.failure(`call_tool execution error: ${error.message}`);
       // Likely an arg/schema problem — attach the schema so the agent can retry.
@@ -1048,50 +1055,16 @@ export class CapaMCPServer {
   }
 
   /**
-   * Serialize a tool execution result into a text string suitable for an MCP content item.
-   *
-   * For MCP proxy results — where result.result is an array of upstream content items
-   * (each with { type, text }) — this unwraps the array, tries to JSON-parse each item's
-   * text, and returns:
-   *   - a single item directly (not wrapped in an array) when there is only one entry
-   *   - a JSON array of all items when there are multiple entries
-   *
-   * For command tool results ({success, result/error}) the inner result/error string
-   * is returned directly without the wrapper envelope.
+   * Build the MCP content payload for a successful tool execution, applying an
+   * optional formatter for MCP tools unless bypassed via `capa sh --json`.
    */
-  private serializeToolResult(result: any): string {
-    const items: any[] = result?.result;
-
-    // Detect MCP proxy result: result.result is a non-empty array of {type, text} objects
-    if (
-      Array.isArray(items) &&
-      items.length > 0 &&
-      items.every((i) => i !== null && typeof i === 'object' && 'type' in i && 'text' in i)
-    ) {
-      const processed = items.map((item) => {
-        const raw = typeof item.text === 'string' ? item.text : JSON.stringify(item);
-        try {
-          return JSON.parse(raw);   // unescape nested JSON strings
-        } catch {
-          return raw;               // not JSON — return as plain string
-        }
-      });
-
-      const value = processed.length === 1 ? processed[0] : processed;
-      return typeof value === 'string' ? value : JSON.stringify(value, null, 2);
-    }
-
-    // Command tool result: unwrap the {success, result/error} envelope
-    if (result && typeof result === 'object' && 'success' in result) {
-      if (result.success && typeof result.result === 'string') {
-        return result.result;
-      }
-      if (!result.success && typeof result.error === 'string') {
-        return result.error;
-      }
-    }
-
-    return JSON.stringify(result);
+  private async buildToolCallContent(
+    result: unknown,
+    toolDef: Tool,
+    options?: { skipFormatter?: boolean }
+  ): Promise<{ content: Array<{ type: 'text'; text: string }> }> {
+    const text = await buildToolCallText(result, toolDef, options);
+    return { content: [{ type: 'text', text }] };
   }
 
   getServer(): Server {
@@ -1224,6 +1197,9 @@ export class CapaMCPServer {
     // Handle tools/call
     if (message.method === 'tools/call') {
       const { name, arguments: args } = message.params;
+      const { cleanArgs, skipFormatter } = extractCapaShellMeta(
+        (args ?? {}) as Record<string, any>
+      );
       this.logger.info(`Call tool: ${name}`);
       this.logger.debug(`Arguments: ${JSON.stringify(args)}`);
 
@@ -1290,7 +1266,9 @@ export class CapaMCPServer {
         }
 
         const toolName = args?.name;
-        const toolData = args?.data || {};
+        const { cleanArgs: toolData, skipFormatter } = extractCapaShellMeta(
+          (args?.data ?? {}) as Record<string, any>
+        );
 
         try {
           const session = this.ensureSession();
@@ -1337,7 +1315,7 @@ export class CapaMCPServer {
             result = await executor.execute(
               toolName,
               toolDef.def as ToolCommandDefinition,
-              toolData as Record<string, any>
+              toolData
             );
             this.logger.debug(`Command executed, success: ${result.success}`);
             // Command-tool failures land here as `{success: false, error}`
@@ -1387,21 +1365,20 @@ export class CapaMCPServer {
             }
 
             this.logger.debug(`Using MCP server: ${serverId}`);
-            result = await this.mcpProxy.executeTool(toolName, mcpDef, serverDef.def, mergeDefaults(mcpDef.defaults, toolData as Record<string, any>));
+            result = await this.mcpProxy.executeTool(
+              toolName,
+              mcpDef,
+              serverDef.def,
+              mergeDefaults(mcpDef.defaults, toolData)
+            );
             this.logger.debug('MCP tool executed');
           }
 
+          const content = await this.buildToolCallContent(result, toolDef, { skipFormatter });
           return {
             jsonrpc: '2.0',
             id: message.id,
-            result: {
-              content: [
-                {
-                  type: 'text',
-                  text: this.serializeToolResult(result),
-                },
-              ],
-            },
+            result: content,
           };
         } catch (error: any) {
           this.logger.failure(`call_tool execution error: ${error.message}`);
@@ -1497,7 +1474,7 @@ export class CapaMCPServer {
           result = await executor.execute(
             name,
             toolDef.def as ToolCommandDefinition,
-            args as Record<string, any>
+            cleanArgs
           );
           this.logger.debug(`Command executed, success: ${result.success}`);
         } else if (toolDef.type === 'mcp') {
@@ -1532,21 +1509,20 @@ export class CapaMCPServer {
           }
 
           this.logger.debug(`Using MCP server: ${serverId}`);
-          result = await this.mcpProxy.executeTool(name, mcpDef, serverDef.def, mergeDefaults(mcpDef.defaults, args as Record<string, any>));
+          result = await this.mcpProxy.executeTool(
+            name,
+            mcpDef,
+            serverDef.def,
+            mergeDefaults(mcpDef.defaults, cleanArgs)
+          );
           this.logger.debug('MCP tool executed');
         }
 
+        const content = await this.buildToolCallContent(result, toolDef, { skipFormatter });
         return {
           jsonrpc: '2.0',
           id: message.id,
-          result: {
-            content: [
-              {
-                type: 'text',
-                text: this.serializeToolResult(result),
-              },
-            ],
-          },
+          result: content,
         };
       } catch (error: any) {
         this.logger.failure(`Tool execution error: ${error.message}`);

--- a/src/server/tool-formatter.ts
+++ b/src/server/tool-formatter.ts
@@ -1,0 +1,152 @@
+import { spawn } from 'child_process';
+import type { Tool, ToolFormatterDefinition, ToolMCPDefinition } from '../types/capabilities';
+import { logger } from '../shared/logger';
+
+const formatterLogger = logger.child('ToolFormatter');
+
+export const CAPA_JSON_ARG = '_capa_json';
+
+const DEFAULT_FORMATTER_TIMEOUT_MS = 3000;
+
+/**
+ * Strip the reserved `capa sh --json` meta-argument before forwarding tool args
+ * to upstream servers. When present, the gateway skips the formatter.
+ */
+export function extractCapaShellMeta(args: Record<string, any>): {
+  cleanArgs: Record<string, any>;
+  skipFormatter: boolean;
+} {
+  if (!args || typeof args !== 'object' || Array.isArray(args)) {
+    return { cleanArgs: {}, skipFormatter: false };
+  }
+  if (!(CAPA_JSON_ARG in args)) {
+    return { cleanArgs: { ...args }, skipFormatter: false };
+  }
+  const { [CAPA_JSON_ARG]: capaJson, ...cleanArgs } = args;
+  const skipFormatter = capaJson === true || capaJson === 'true';
+  return { cleanArgs, skipFormatter };
+}
+
+/**
+ * Serialize a tool execution result into a text string suitable for an MCP content item.
+ */
+export function serializeToolResult(result: any): string {
+  const items: any[] = result?.result;
+
+  if (
+    Array.isArray(items) &&
+    items.length > 0 &&
+    items.every((i) => i !== null && typeof i === 'object' && 'type' in i && 'text' in i)
+  ) {
+    const processed = items.map((item) => {
+      const raw = typeof item.text === 'string' ? item.text : JSON.stringify(item);
+      try {
+        return JSON.parse(raw);
+      } catch {
+        return raw;
+      }
+    });
+
+    const value = processed.length === 1 ? processed[0] : processed;
+    return typeof value === 'string' ? value : JSON.stringify(value, null, 2);
+  }
+
+  if (result && typeof result === 'object' && 'success' in result) {
+    if (result.success && typeof result.result === 'string') {
+      return result.result;
+    }
+    if (!result.success && typeof result.error === 'string') {
+      return result.error;
+    }
+  }
+
+  return JSON.stringify(result);
+}
+
+/**
+ * Pipe serialized tool output through an optional MCP formatter, returning the
+ * final text for the MCP content item.
+ */
+export async function buildToolCallText(
+  result: unknown,
+  toolDef: Tool,
+  options?: { skipFormatter?: boolean }
+): Promise<string> {
+  let text = serializeToolResult(result);
+
+  if (options?.skipFormatter || toolDef.type !== 'mcp') {
+    return text;
+  }
+
+  const formatter = (toolDef.def as ToolMCPDefinition).formatter;
+  if (!formatter) {
+    return text;
+  }
+
+  return applyToolFormatter(text, formatter);
+}
+
+/**
+ * Run an operator-defined formatter command with the tool output on stdin.
+ * On failure or timeout, returns the original input unchanged.
+ */
+export async function applyToolFormatter(
+  input: string,
+  formatter: ToolFormatterDefinition
+): Promise<string> {
+  const timeout = formatter.timeout ?? DEFAULT_FORMATTER_TIMEOUT_MS;
+  const isWindows = process.platform === 'win32';
+  const shell = isWindows ? 'cmd.exe' : '/bin/sh';
+  const shellFlag = isWindows ? '/C' : '-c';
+
+  return new Promise((resolve) => {
+    let settled = false;
+    const finish = (value: string) => {
+      if (settled) return;
+      settled = true;
+      resolve(value);
+    };
+
+    const proc = spawn(shell, [shellFlag, formatter.cmd], {
+      stdio: ['pipe', 'pipe', 'pipe'],
+      windowsHide: true,
+    });
+
+    let stdout = '';
+    let stderr = '';
+
+    const timer = setTimeout(() => {
+      formatterLogger.warn(`Formatter timed out after ${timeout}ms, returning original output`);
+      proc.kill();
+      finish(input);
+    }, timeout);
+
+    proc.stdout?.on('data', (data) => {
+      stdout += data.toString();
+    });
+
+    proc.stderr?.on('data', (data) => {
+      stderr += data.toString();
+    });
+
+    proc.on('error', (error) => {
+      clearTimeout(timer);
+      formatterLogger.warn(`Formatter failed to start: ${error.message}`);
+      finish(input);
+    });
+
+    proc.on('exit', (code) => {
+      clearTimeout(timer);
+      if (code === 0) {
+        finish(stdout.replace(/\n$/, ''));
+        return;
+      }
+      const detail = (stderr || stdout || `exit code ${code}`).trim();
+      formatterLogger.warn(`Formatter exited with code ${code}: ${detail}`);
+      finish(input);
+    });
+
+    proc.stdin?.write(input);
+    proc.stdin?.end();
+  });
+}

--- a/src/shared/registries/__tests__/installer.test.ts
+++ b/src/shared/registries/__tests__/installer.test.ts
@@ -130,13 +130,21 @@ describe('installer — url installs', () => {
   });
 
   it('cleans up the managed dir when fetch fails', async () => {
-    await expect(
-      installRegistry(
-        { slug: 'unit', type: 'url', source: 'https://example.invalid-host-name.test/a.ts' },
-        authFetch,
-      ),
-    ).rejects.toThrow();
-    expect(existsSync(join(managedDir, 'unit'))).toBe(false);
+    const server = Bun.serve({
+      port: 0,
+      fetch() {
+        return new Response('unavailable', { status: 503 });
+      },
+    });
+    try {
+      const url = `http://127.0.0.1:${server.port}/adapter.ts`;
+      await expect(
+        installRegistry({ slug: 'unit', type: 'url', source: url }, authFetch),
+      ).rejects.toThrow(/Failed to fetch/);
+      expect(existsSync(join(managedDir, 'unit'))).toBe(false);
+    } finally {
+      server.stop();
+    }
   });
 
   it('rejects an adapter file whose default export has the wrong shape', async () => {

--- a/src/types/capabilities.ts
+++ b/src/types/capabilities.ts
@@ -342,11 +342,20 @@ export interface Tool {
   group?: string;
 }
 
+export interface ToolFormatterDefinition {
+  /** Shell command that reads the serialized tool output on stdin and writes transformed output to stdout. */
+  cmd: string;
+  /** Max time in ms before the original output is returned unchanged. @default 3000 */
+  timeout?: number;
+}
+
 export interface ToolMCPDefinition {
   server: string; // Reference to server ID with @ prefix
   tool: string;   // Tool name on the remote MCP server
   /** Default argument values merged at call time; defaulted params become optional in the schema. */
   defaults?: Record<string, any>;
+  /** Optional post-processor for MCP tool output (MCP tools only). */
+  formatter?: ToolFormatterDefinition;
 }
 
 export interface ToolCommandDefinition {


### PR DESCRIPTION
## Summary

- Add optional `formatter` block to MCP tool definitions (`def.formatter.cmd`, optional `timeout`) so serialized tool output can be piped through operator-defined shell commands at the CAPA gateway before returning to clients
- Apply formatting in all MCP tool-call paths; on failure or timeout, fall back to the original output unchanged
- Add `capa sh --json` to skip formatting and return raw JSON (uses internal `_capa_json` meta-arg, stripped server-side)
- Fix flaky `installer — url installs` test that hung on slow DNS by using a local server returning 503

## Example

```yaml
tools:
  - id: query
    type: mcp
    def:
      server: "@db"
      tool: run_query
      formatter:
        cmd: "jq -r '.rows[] | [.id, .name] | @tsv'"
```

## Verified

- `bun test src/server/__tests__/tool-formatter.test.ts` — 12 passed
- `bun test src/cli/commands/__tests__/sh.test.ts` — 41 passed
- `bun test` — 1125 passed
- `bun run build` — succeeded (`dist/capa`)


Made with [Cursor](https://cursor.com)