### PR TITLE
fix(cache): refresh stale mirror for unpinned skill references

### DIFF
--- a/src/shared/__tests__/cache.test.ts
+++ b/src/shared/__tests__/cache.test.ts
@@ -242,6 +242,94 @@ describe('cache', () => {
     });
   });
 
+  describe('getOrCreateSnapshot refreshes stale mirrors for unpinned refs', () => {
+    /**
+     * Build an isolated fixture repo (its own source dir) with a single commit
+     * and NO semver tag, so unpinned resolution falls through to HEAD. Returns
+     * the file:// URL and a helper to append a new commit later.
+     */
+    async function makeMutableFixture(name: string): Promise<{
+      url: string;
+      repoDir: string;
+      addCommit: (file: string, contents: string) => Promise<string>;
+    }> {
+      const repoDir = join(testRoot, name);
+      mkdirSync(repoDir, { recursive: true });
+      await execAsync(`git init -b main`, { cwd: repoDir });
+      await execAsync(`git config user.email "capa-test@example.com"`, { cwd: repoDir });
+      await execAsync(`git config user.name "capa-test"`, { cwd: repoDir });
+      writeFileSync(join(repoDir, 'first.md'), 'first\n');
+      await execAsync(`git add -A`, { cwd: repoDir });
+      await execAsync(`git commit -m "first"`, { cwd: repoDir });
+
+      const addCommit = async (file: string, contents: string): Promise<string> => {
+        writeFileSync(join(repoDir, file), contents);
+        await execAsync(`git add -A`, { cwd: repoDir });
+        await execAsync(`git commit -m "add ${file}"`, { cwd: repoDir });
+        const { stdout } = await execAsync(`git rev-parse HEAD`, { cwd: repoDir });
+        return stdout.trim();
+      };
+
+      const url = `file://${repoDir.replace(/\\/g, '/')}`;
+      return { url, repoDir, addCommit };
+    }
+
+    it('picks up a commit pushed after the mirror was first cloned', async () => {
+      const fx = await makeMutableFixture('stale-fixture.git-src');
+
+      // First install: clones the mirror and materializes HEAD.
+      const first = await getOrCreateSnapshot({
+        platform: 'github',
+        repoPath: 'owner/stale',
+        authFetch: noAuthFetch,
+        repoUrl: fx.url,
+      });
+      expect(existsSync(join(first.snapshotDir, 'first.md'))).toBe(true);
+      expect(existsSync(join(first.snapshotDir, 'late.md'))).toBe(false);
+
+      // Upstream gains a new commit *after* the initial clone.
+      const latestSha = await fx.addCommit('late.md', 'late\n');
+
+      // Second install (still unpinned): must refresh the stale mirror and see
+      // the new commit rather than resolving the cached HEAD forever.
+      const second = await getOrCreateSnapshot({
+        platform: 'github',
+        repoPath: 'owner/stale',
+        authFetch: noAuthFetch,
+        repoUrl: fx.url,
+      });
+      expect(second.resolvedSha).toBe(latestSha);
+      expect(existsSync(join(second.snapshotDir, 'late.md'))).toBe(true);
+    });
+
+    it('picks up a semver tag published after the mirror was first cloned', async () => {
+      const fx = await makeMutableFixture('stale-tag-fixture.git-src');
+      await execAsync(`git tag v1.0.0`, { cwd: fx.repoDir });
+
+      const first = await getOrCreateSnapshot({
+        platform: 'github',
+        repoPath: 'owner/stale-tag',
+        authFetch: noAuthFetch,
+        repoUrl: fx.url,
+      });
+      expect(first.resolvedVersion).toBe('v1.0.0');
+
+      // Publish a newer release upstream.
+      const taggedSha = await fx.addCommit('v2.md', 'v2\n');
+      await execAsync(`git tag v2.0.0`, { cwd: fx.repoDir });
+
+      const second = await getOrCreateSnapshot({
+        platform: 'github',
+        repoPath: 'owner/stale-tag',
+        authFetch: noAuthFetch,
+        repoUrl: fx.url,
+      });
+      expect(second.resolvedVersion).toBe('v2.0.0');
+      expect(second.resolvedSha).toBe(taggedSha);
+      expect(existsSync(join(second.snapshotDir, 'v2.md'))).toBe(true);
+    });
+  });
+
   describe('getCacheStats / cleanCache', () => {
     it('reports an empty cache when nothing exists', () => {
       // Use a brand-new dir for this test so the seeded mirrors elsewhere don't leak in.

--- a/src/shared/cache/snapshot.ts
+++ b/src/shared/cache/snapshot.ts
@@ -5,10 +5,12 @@ import { validateRepoPath } from './validate';
 import {
   type CachePlatform,
   getRepoCacheDir,
+  getRepoMirrorDir,
   getSnapshotDir,
 } from './paths';
 import {
   ensureMirrorClone,
+  fetchMirror,
   resolveRef,
   type ResolveOptions,
 } from './mirror';
@@ -132,7 +134,27 @@ export async function getOrCreateSnapshot(
     }
   }
 
+  // Remember whether a mirror was already on disk *before* ensureMirrorClone
+  // runs — a freshly cloned mirror is already current and never needs a refresh.
+  const mirrorPreexisted = existsSync(getRepoMirrorDir(platform, repoPath));
   const mirrorDir = await ensureMirrorClone(platform, repoPath, authFetch, opts.repoUrl);
+
+  // Unpinned reference ("track latest"): nothing in resolveRef's unpinned path
+  // fetches, so a pre-existing mirror can resolve a stale latest tag / HEAD
+  // forever. A skill or tag published upstream *after* the initial clone would
+  // never be found until `--no-cache` wiped the cache. Refresh once so "latest"
+  // means latest. Only needed when the mirror pre-existed (a fresh clone is
+  // already current) and best-effort so offline installs still resolve from the
+  // cached mirror.
+  const isUnpinned = !opts.pinnedSha && !opts.ref && !opts.version;
+  if (isUnpinned && mirrorPreexisted) {
+    try {
+      await fetchMirror(mirrorDir);
+    } catch {
+      // Offline or transient network failure — fall back to the cached mirror.
+    }
+  }
+
   const { sha, version } = await resolveRef(mirrorDir, {
     version: opts.version,
     ref: opts.ref,


### PR DESCRIPTION
## Summary

`capa install` fails with `Skill "<name>" not found in repository` for a skill that clearly exists upstream — reproduced with `meta`'s `capabilities.yaml`, which references `infragate/capa@bootstrap` and `infragate/capa@capabilities-manager`. `capabilities-manager` installed fine while `bootstrap` was "not found", and `--no-cache` made both succeed.

### Root cause

Both references are **unpinned** (no `:version`, no `#sha`, no lockfile entry), which is meant to track the latest published state. `capa` resolves unpinned refs to the latest semver tag (falling back to `HEAD`) against the on-disk mirror clone. But nothing in `resolveRef`'s unpinned path ever fetched: `ensureMirrorClone` only clones when the mirror is missing, and the unpinned branch has no "ref not found" fallback that triggers a fetch (unlike the pinned/ref/version branches).

So once a mirror existed, unpinned resolution kept returning the same stale latest tag forever. `bootstrap` was added in `v1.9.16`; any mirror whose newest cached tag was `<= v1.9.15` could never see it — hence "not found" for `bootstrap` but success for the older `capabilities-manager`. `--no-cache` "fixed" it only by wiping and re-cloning.

### Fix

`getOrCreateSnapshot` now refreshes the mirror once (`git remote update --prune`) for unpinned references when the mirror **pre-existed** on disk (a freshly cloned mirror is already current, so no extra round-trip on first install). The fetch is best-effort — on network failure it falls back to the cached mirror so offline installs still resolve. Pinned SHA / ref / version paths are unchanged, including the fully-offline pinned-SHA fast path.

## Test plan

- [x] `bun test` — full suite green (1113 pass, 0 fail).
- [x] New regression tests in `src/shared/__tests__/cache.test.ts`: an unpinned `getOrCreateSnapshot` picks up (a) a commit and (b) a semver tag pushed upstream *after* the mirror was first cloned. Both fail without this change.
- [x] End-to-end with a local build against a deliberately stale mirror (latest tag forced to `v1.9.15`): `capa install` fetched, restored `v1.9.16`/`v1.9.17`, resolved `v1.9.17`, and installed `bootstrap` + `capabilities-manager`.
