### PR TITLE
feat(web-ui): make installed capabilities more informative

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -65,7 +65,7 @@ jobs:
       - name: Setup Bun
         uses: oven-sh/setup-bun@v2
         with:
-          bun-version: latest
+          bun-version: "1.3.14"
 
       - name: Install dependencies
         run: bun install

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -14,7 +14,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, windows-latest, macos-latest]
-        bun-version: [latest]
+        bun-version: ["1.3.14"]
     
     steps:
       - name: Checkout code
@@ -57,7 +57,7 @@ jobs:
       - name: Setup Bun
         uses: oven-sh/setup-bun@v2
         with:
-          bun-version: latest
+          bun-version: "1.3.14"
       
       - name: Install dependencies
         run: bun install

--- a/src/server/index.ts
+++ b/src/server/index.ts
@@ -28,6 +28,7 @@ import { logger } from '../shared/logger';
 import { projectUiUrl } from '../shared/ui-urls';
 import { initAuth, requireAuth, isLoopbackHost } from './auth-middleware';
 import { oauthBridgeResponse } from './oauth-bridge';
+import { resolveSkillContentById, resolveSkillDescription, resolveSkillSourceUrl } from './skill-content';
 
 // Import the React SPA bundle as text at compile time - this bundles it into the binary
 import spaHtml from '../../web-ui/dist/index.html' with { type: 'text' };
@@ -359,6 +360,14 @@ class CapaServer {
       return this.handleGetServerTools(projectId, serverId);
     }
 
+    // Skill SKILL.md content for the project-detail UI
+    const skillContentMatch = path.match(/^\/api\/projects\/([^/]+)\/skills\/([^/]+)\/content$/);
+    if (skillContentMatch && request.method === 'GET') {
+      const projectId = skillContentMatch[1];
+      const skillId = decodeURIComponent(skillContentMatch[2]);
+      return this.handleGetSkillContent(projectId, skillId);
+    }
+
     // Shell tools endpoint — tool metadata for the capa shell, regardless of exposure mode
     const shellToolsMatch = path.match(/^\/api\/projects\/([^/]+)\/shell-tools$/);
     if (shellToolsMatch && request.method === 'GET') {
@@ -565,13 +574,22 @@ class CapaServer {
         created_at: project.created_at,
         updated_at: project.updated_at,
         capabilities: capabilities ? {
-          skills: capabilities.skills.map(s => ({
-            id: s.id,
-            type: s.type,
-            description: s.def?.description || null,
-            requires: s.def?.requires || [],
-            sourcePlugin: s.sourcePlugin || null,
-          })),
+          skills: capabilities.skills.map(s => {
+            const { description, descriptionSource } = resolveSkillDescription(
+              project.path,
+              s,
+              capabilities.providers || [],
+            );
+            return {
+              id: s.id,
+              type: s.type,
+              description,
+              descriptionSource,
+              requires: s.def?.requires || [],
+              sourcePlugin: s.sourcePlugin || null,
+              sourceUrl: resolveSkillSourceUrl(s, capabilities.resolvedPlugins),
+            };
+          }),
           tools: capabilities.tools.map(t => {
             const base: Record<string, any> = {
               id: t.id,
@@ -586,6 +604,7 @@ class CapaServer {
               const cmdDef = t.def as ToolCommandDefinition;
               base.command = cmdDef.run.cmd;
               base.commandArgs = cmdDef.run.args || [];
+              if (t.group) base.group = t.group;
             }
             return base;
           }),
@@ -736,6 +755,60 @@ class CapaServer {
       return new Response(
         JSON.stringify({ error: message }),
         { status: 502, headers: { 'Content-Type': 'application/json' } }
+      );
+    }
+  }
+
+  private async handleGetSkillContent(projectId: string, skillId: string): Promise<Response> {
+    const apiLogger = this.logger.child('API');
+    apiLogger.info(`Get skill content: ${skillId} in project: ${projectId}`);
+    try {
+      const project = this.db.getProject(projectId);
+      if (!project) {
+        return new Response(
+          JSON.stringify({ error: 'Project not found' }),
+          { status: 404, headers: { 'Content-Type': 'application/json' } }
+        );
+      }
+
+      const capabilities = this.sessionManager.getProjectCapabilities(projectId);
+      if (!capabilities) {
+        return new Response(
+          JSON.stringify({ error: 'Project not configured' }),
+          { status: 404, headers: { 'Content-Type': 'application/json' } }
+        );
+      }
+
+      const skill = (capabilities.skills ?? []).find((s) => s.id === skillId);
+      if (!skill) {
+        return new Response(
+          JSON.stringify({ error: 'Skill not found' }),
+          { status: 404, headers: { 'Content-Type': 'application/json' } }
+        );
+      }
+
+      const resolved = resolveSkillContentById(project.path, capabilities, skillId);
+      if (!resolved) {
+        return new Response(
+          JSON.stringify({ error: 'Skill content not available' }),
+          { status: 404, headers: { 'Content-Type': 'application/json' } }
+        );
+      }
+
+      return new Response(
+        JSON.stringify({
+          id: skillId,
+          content: resolved.content,
+          metadata: resolved.metadata,
+          files: resolved.files,
+        }),
+        { headers: { 'Content-Type': 'application/json' } }
+      );
+    } catch (error: any) {
+      apiLogger.failure(`Error: ${error.message}`);
+      return new Response(
+        JSON.stringify({ error: error.message }),
+        { status: 500, headers: { 'Content-Type': 'application/json' } }
       );
     }
   }

--- a/src/server/skill-content.ts
+++ b/src/server/skill-content.ts
@@ -1,0 +1,211 @@
+/**
+ * Resolve and read a skill's SKILL.md for a project.
+ * Used by the project-detail API for frontmatter descriptions and the skill content endpoint.
+ */
+import { existsSync, readdirSync, readFileSync, statSync } from 'fs';
+import { isAbsolute, join, relative } from 'path';
+import { getProvider } from '../shared/providers';
+import { parseSkillMd, type SkillMetadata } from '../shared/skill-md';
+import { parseRepoString } from '../shared/repo-string';
+import type { Capabilities, Skill } from '../types/capabilities';
+import type { ResolvedPluginInfo } from '../types/plugin';
+
+export interface SkillContentResult {
+  content: string;
+  metadata: SkillMetadata;
+  files: string[];
+}
+
+function stripSurroundingQuotes(value: string): string {
+  if (
+    (value.startsWith('"') && value.endsWith('"')) ||
+    (value.startsWith("'") && value.endsWith("'"))
+  ) {
+    return value.slice(1, -1);
+  }
+  return value;
+}
+
+function toPosixPath(path: string): string {
+  return path.replace(/\\/g, '/');
+}
+
+function collectFiles(rootPath: string): string[] {
+  const files: string[] = [];
+
+  function visit(currentPath: string) {
+    for (const entry of readdirSync(currentPath, { withFileTypes: true })) {
+      const fullPath = join(currentPath, entry.name);
+      if (entry.isDirectory()) {
+        visit(fullPath);
+      } else if (entry.isFile()) {
+        files.push(toPosixPath(relative(rootPath, fullPath)));
+      }
+    }
+  }
+
+  try {
+    const stat = statSync(rootPath);
+    if (stat.isFile()) return [rootPath.split(/[\\/]/).pop() || 'SKILL.md'];
+    if (stat.isDirectory()) visit(rootPath);
+  } catch {
+    return [];
+  }
+
+  return files.sort((a, b) => a.localeCompare(b));
+}
+
+function tryParse(content: string, files: string[] = ['SKILL.md']): SkillContentResult | null {
+  try {
+    const { metadata } = parseSkillMd(content);
+    if (metadata.description) {
+      metadata.description = stripSurroundingQuotes(String(metadata.description)).trim();
+    }
+    return { content, metadata, files };
+  } catch {
+    // Malformed frontmatter — still return raw content for display
+    return { content, metadata: { name: '' }, files };
+  }
+}
+
+/**
+ * Build a browser URL for a github/gitlab repo-string reference.
+ * Exact-path refs deep-link into the tree; search-form refs link to the repo root.
+ */
+function buildBrowseUrl(platform: 'github' | 'gitlab', repo: string): string | null {
+  try {
+    const parsed = parseRepoString(repo);
+    const ref = parsed.sha ?? parsed.version ?? 'main';
+    if (parsed.mode === 'exact') {
+      return platform === 'github'
+        ? `https://github.com/${parsed.ownerRepo}/tree/${ref}/${parsed.target}`
+        : `https://gitlab.com/${parsed.ownerRepo}/-/tree/${ref}/${parsed.target}`;
+    }
+    return platform === 'github'
+      ? `https://github.com/${parsed.ownerRepo}`
+      : `https://gitlab.com/${parsed.ownerRepo}`;
+  } catch {
+    return null;
+  }
+}
+
+function pluginRepository(
+  skill: Skill,
+  resolvedPlugins: ResolvedPluginInfo[] | undefined,
+): string | null {
+  if (!skill.sourcePlugin) return null;
+  const plugin = (resolvedPlugins ?? []).find(
+    (p) => p.id === skill.sourcePlugin!.id || p.name === skill.sourcePlugin!.name,
+  );
+  return plugin?.repository || null;
+}
+
+/**
+ * Resolve an external origin URL for a skill (github / gitlab / remote / plugin).
+ * Returns null for local / inline / installed skills with no external source.
+ */
+export function resolveSkillSourceUrl(
+  skill: Skill,
+  resolvedPlugins?: ResolvedPluginInfo[],
+): string | null {
+  if (skill.type === 'remote' && skill.def?.url) {
+    return skill.def.url;
+  }
+  if (skill.type === 'github' && skill.def?.repo) {
+    return buildBrowseUrl('github', skill.def.repo);
+  }
+  if (skill.type === 'gitlab' && skill.def?.repo) {
+    return buildBrowseUrl('gitlab', skill.def.repo);
+  }
+  if (skill.type === 'plugin' || skill.sourcePlugin) {
+    return pluginRepository(skill, resolvedPlugins);
+  }
+  return null;
+}
+
+/**
+ * Resolve SKILL.md content for a skill from inline content, a local path,
+ * or an installed copy under a provider's skillsDir.
+ */
+export function resolveSkillContent(
+  projectPath: string,
+  skill: Skill,
+  providers: string[],
+): SkillContentResult | null {
+  // Inline skills embed SKILL.md in def.content
+  if (skill.type === 'inline' && skill.def?.content) {
+    return tryParse(skill.def.content, ['SKILL.md']);
+  }
+
+  // Local skills point at a directory (or file) containing SKILL.md
+  if (skill.type === 'local' && skill.def?.path) {
+    const base = isAbsolute(skill.def.path)
+      ? skill.def.path
+      : join(projectPath, skill.def.path);
+    const isSkillFile = base.toLowerCase().endsWith('skill.md');
+    const skillMdPath = isSkillFile
+      ? base
+      : join(base, 'SKILL.md');
+    if (existsSync(skillMdPath)) {
+      try {
+        const files = collectFiles(isSkillFile ? skillMdPath : base);
+        return tryParse(readFileSync(skillMdPath, 'utf-8'), files);
+      } catch {
+        return null;
+      }
+    }
+  }
+
+  // Installed / github / gitlab / remote / plugin: look under provider skillsDirs
+  for (const pid of providers) {
+    const provider = getProvider(pid);
+    if (!provider) continue;
+    const skillMdPath = join(projectPath, provider.skillsDir, skill.id, 'SKILL.md');
+    if (!existsSync(skillMdPath)) continue;
+    try {
+      const skillRoot = join(projectPath, provider.skillsDir, skill.id);
+      return tryParse(readFileSync(skillMdPath, 'utf-8'), collectFiles(skillRoot));
+    } catch {
+      // Try next provider
+    }
+  }
+
+  return null;
+}
+
+/**
+ * Look up a skill by id in capabilities and resolve its SKILL.md content.
+ */
+export function resolveSkillContentById(
+  projectPath: string,
+  capabilities: Capabilities,
+  skillId: string,
+): SkillContentResult | null {
+  const skill = (capabilities.skills ?? []).find((s) => s.id === skillId);
+  if (!skill) return null;
+  const providers = capabilities.providers ?? [];
+  return resolveSkillContent(projectPath, skill, providers);
+}
+
+/**
+ * Get a display description for a skill: capabilities def.description first,
+ * then SKILL.md frontmatter description.
+ */
+export function resolveSkillDescription(
+  projectPath: string,
+  skill: Skill,
+  providers: string[],
+): { description: string | null; descriptionSource: 'capabilities' | 'frontmatter' | null } {
+  const fromCaps = skill.def?.description?.trim();
+  if (fromCaps) {
+    return { description: fromCaps, descriptionSource: 'capabilities' };
+  }
+
+  const resolved = resolveSkillContent(projectPath, skill, providers);
+  const fromFrontmatter = resolved?.metadata?.description?.trim();
+  if (fromFrontmatter) {
+    return { description: fromFrontmatter, descriptionSource: 'frontmatter' };
+  }
+
+  return { description: null, descriptionSource: null };
+}

--- a/web-ui/src/features/projects/api.ts
+++ b/web-ui/src/features/projects/api.ts
@@ -5,6 +5,7 @@ import type {
   VariablesResponse,
   OAuth2ServersResponse,
   ServerToolsResponse,
+  SkillContentResponse,
   OAuthStartResponse,
   ActionResponse,
 } from '../../types/api';
@@ -35,5 +36,10 @@ export const projectsApi = {
   getServerTools: (projectId: string, serverId: string) =>
     api.get<ServerToolsResponse>(
       `/api/projects/${encodeURIComponent(projectId)}/servers/${encodeURIComponent(serverId)}/tools`,
+    ),
+
+  getSkillContent: (projectId: string, skillId: string) =>
+    api.get<SkillContentResponse>(
+      `/api/projects/${encodeURIComponent(projectId)}/skills/${encodeURIComponent(skillId)}/content`,
     ),
 };

--- a/web-ui/src/features/projects/components/CapabilitiesSection.tsx
+++ b/web-ui/src/features/projects/components/CapabilitiesSection.tsx
@@ -107,7 +107,7 @@ export function CapabilitiesSection({ skills, tools, servers, subagents, rules, 
       {tokenSavings && <TokenSavingsBar stats={tokenSavings} />}
 
       <div className="grid grid-cols-1 gap-6 md:grid-cols-3">
-        <SkillsList skills={skills} search={search} />
+        <SkillsList skills={skills} search={search} projectId={projectId} />
         <ToolsList
           tools={tools as EnrichedTool[]}
           search={search}

--- a/web-ui/src/features/projects/components/HooksList.tsx
+++ b/web-ui/src/features/projects/components/HooksList.tsx
@@ -33,7 +33,7 @@ export function HooksList({ hooks, search = '' }: HooksListProps) {
           {search ? t('detail.noHooksMatch') : t('detail.noHooks')}
         </div>
       ) : (
-        <div className="space-y-1">
+        <div className="max-h-[520px] space-y-1 overflow-y-auto pr-1">
           {visible.map((hook) => (
             <HookItem key={hook.id} hook={hook} search={search} />
           ))}

--- a/web-ui/src/features/projects/components/RulesList.tsx
+++ b/web-ui/src/features/projects/components/RulesList.tsx
@@ -34,7 +34,7 @@ export function RulesList({ rules, search = '' }: RulesListProps) {
           {search ? t('detail.noRulesMatch') : t('detail.noRules')}
         </div>
       ) : (
-        <div className="space-y-1">
+        <div className="max-h-[520px] space-y-1 overflow-y-auto pr-1">
           {visible.map((rule) => (
             <RuleItem key={rule.id} rule={rule} search={search} />
           ))}

--- a/web-ui/src/features/projects/components/ServersList.tsx
+++ b/web-ui/src/features/projects/components/ServersList.tsx
@@ -58,7 +58,7 @@ export function ServersList({ servers, search, projectId, serverToolsMap }: Serv
           {search ? t('detail.noServersMatch') : t('detail.noServers')}
         </div>
       ) : (
-        <div className="space-y-1">
+        <div className="max-h-[520px] space-y-1 overflow-y-auto pr-1">
           {visible.map((server) => (
             <ServerItem
               key={server.id}

--- a/web-ui/src/features/projects/components/SkillDetailDialog.tsx
+++ b/web-ui/src/features/projects/components/SkillDetailDialog.tsx
@@ -1,0 +1,244 @@
+import { useMemo, useState } from 'react';
+import { useTranslation } from 'react-i18next';
+import * as Dialog from '@radix-ui/react-dialog';
+import { ChevronDown, ChevronRight, ExternalLink, File, Folder, X } from 'lucide-react';
+import { FaGithub, FaGitlab } from 'react-icons/fa';
+import { marked } from 'marked';
+import DOMPurify from 'dompurify';
+import type { Skill } from '../../../types/api';
+import { Spinner } from '../../../components/common/Spinner';
+import { SourceBadge } from '../../../components/common/ServerBadge';
+import { useSkillContent } from '../hooks';
+import { sourceTypeBadgeClasses } from './sourceTypeColors';
+
+interface SkillDetailDialogProps {
+  skill: Skill | null;
+  projectId: string;
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+}
+
+function stripFrontmatter(md: string): string {
+  return md.replace(/^---\s*\n[\s\S]*?\n---\s*\n?/, '');
+}
+
+function renderMarkdown(md: string): string {
+  const raw = marked.parse(stripFrontmatter(md), { async: false, gfm: true, breaks: true }) as string;
+  return DOMPurify.sanitize(raw);
+}
+
+function sourceHostKind(raw: string | null | undefined): 'github' | 'gitlab' | 'remote' {
+  if (!raw) return 'remote';
+  try {
+    const hostname = new URL(raw).hostname;
+    if (hostname === 'github.com' || hostname.endsWith('.github.com') || hostname === 'raw.githubusercontent.com') {
+      return 'github';
+    }
+    if (hostname === 'gitlab.com' || hostname.endsWith('.gitlab.com')) {
+      return 'gitlab';
+    }
+  } catch {
+    // fall through
+  }
+  return 'remote';
+}
+
+interface TreeNode {
+  name: string;
+  children: Map<string, TreeNode>;
+  isFile: boolean;
+}
+
+function buildTree(paths: string[]): TreeNode {
+  const root: TreeNode = { name: '', children: new Map(), isFile: false };
+  for (const p of paths) {
+    const segments = p.replace(/\\/g, '/').split('/').filter(Boolean);
+    let node = root;
+    for (let i = 0; i < segments.length; i++) {
+      const segment = segments[i];
+      if (!node.children.has(segment)) {
+        node.children.set(segment, {
+          name: segment,
+          children: new Map(),
+          isFile: i === segments.length - 1,
+        });
+      }
+      node = node.children.get(segment)!;
+    }
+  }
+  return root;
+}
+
+function FileTreeNode({ node, depth = 0 }: { node: TreeNode; depth?: number }) {
+  const [open, setOpen] = useState(depth === 0);
+  const hasChildren = node.children.size > 0;
+  const sorted = useMemo(
+    () =>
+      Array.from(node.children.values()).sort((a, b) => {
+        if (a.isFile !== b.isFile) return a.isFile ? 1 : -1;
+        return a.name.localeCompare(b.name);
+      }),
+    [node.children],
+  );
+
+  if (!node.name) {
+    return (
+      <>
+        {sorted.map((child) => (
+          <FileTreeNode key={child.name} node={child} depth={0} />
+        ))}
+      </>
+    );
+  }
+
+  return (
+    <div>
+      <button
+        type="button"
+        className="flex w-full items-center gap-1.5 rounded-sm px-1 py-0.5 text-left text-xs hover:bg-hover-bg"
+        style={{ paddingLeft: `${depth * 16 + 4}px` }}
+        onClick={() => hasChildren && setOpen((v) => !v)}
+      >
+        {hasChildren ? (
+          open ? (
+            <ChevronDown className="h-3 w-3 shrink-0 text-text-tertiary" />
+          ) : (
+            <ChevronRight className="h-3 w-3 shrink-0 text-text-tertiary" />
+          )
+        ) : (
+          <span className="inline-block w-3" />
+        )}
+        {node.isFile ? (
+          <File className="h-3.5 w-3.5 shrink-0 text-text-tertiary" />
+        ) : (
+          <Folder className="h-3.5 w-3.5 shrink-0 text-accent-primary" />
+        )}
+        <span className={`truncate ${node.isFile ? 'text-text-secondary' : 'font-medium text-text-primary'}`}>
+          {node.name}
+        </span>
+      </button>
+      {open &&
+        sorted.map((child) => (
+          <FileTreeNode key={child.name} node={child} depth={depth + 1} />
+        ))}
+    </div>
+  );
+}
+
+function FileTree({ files }: { files: string[] }) {
+  const tree = useMemo(() => buildTree(files), [files]);
+  if (files.length === 0) return null;
+  return (
+    <div className="rounded-lg border border-border-primary bg-bg-secondary p-3">
+      <FileTreeNode node={tree} />
+    </div>
+  );
+}
+
+export function SkillDetailDialog({ skill, projectId, open, onOpenChange }: SkillDetailDialogProps) {
+  const { t } = useTranslation('projects');
+  const { data, isLoading, isError } = useSkillContent(projectId, open && skill ? skill.id : null);
+
+  const previewHtml = useMemo(
+    () => (data?.content ? renderMarkdown(data.content) : ''),
+    [data?.content],
+  );
+
+  const sourceUrl = skill?.sourceUrl || null;
+  const sourceKind = sourceHostKind(sourceUrl);
+  const sourceTitle =
+    sourceKind === 'github'
+      ? t('openOnGitHub')
+      : sourceKind === 'gitlab'
+        ? t('openOnGitLab')
+        : t('skillDetail.viewSource');
+
+  return (
+    <Dialog.Root open={open} onOpenChange={onOpenChange}>
+      <Dialog.Portal>
+        <Dialog.Overlay className="fixed inset-0 z-50 bg-black/50 data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=open]:fade-in data-[state=closed]:fade-out" />
+        <Dialog.Content className="fixed left-1/2 top-1/2 z-50 flex max-h-[90vh] w-[min(90vw,720px)] -translate-x-1/2 -translate-y-1/2 flex-col overflow-hidden rounded-lg border border-border-primary bg-bg-secondary shadow-lg">
+          <div className="flex items-start justify-between border-b border-border-secondary px-6 py-4">
+            <div className="min-w-0 flex-1 pr-4">
+              <Dialog.Title className="truncate font-mono text-lg font-medium text-text-primary">
+                {skill?.id ?? t('skillDetail.title')}
+              </Dialog.Title>
+              {skill && (
+                <div className="mt-2 flex flex-wrap items-center gap-2">
+                  <span
+                    className={`shrink-0 rounded-sm px-1.5 py-0.5 text-[10px] font-medium uppercase ${sourceTypeBadgeClasses(skill.type)}`}
+                  >
+                    {skill.type}
+                  </span>
+                  {skill.sourcePlugin?.name && (
+                    <SourceBadge name={skill.sourcePlugin.name} kind="plugin" />
+                  )}
+                </div>
+              )}
+              <Dialog.Description className="sr-only">
+                {t('skillDetail.description')}
+              </Dialog.Description>
+            </div>
+            <div className="flex shrink-0 items-center gap-1">
+              {sourceUrl && (
+                <a
+                  href={sourceUrl}
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  className="inline-flex items-center gap-1.5 rounded-sm px-2 py-1 text-xs text-text-secondary transition-colors hover:bg-hover-bg hover:text-text-primary"
+                  title={sourceTitle}
+                  onClick={(e) => e.stopPropagation()}
+                >
+                  {sourceKind === 'github' ? (
+                    <FaGithub className="h-4 w-4" />
+                  ) : sourceKind === 'gitlab' ? (
+                    <FaGitlab className="h-4 w-4" />
+                  ) : (
+                    <ExternalLink className="h-3.5 w-3.5" />
+                  )}
+                  <span>{t('skillDetail.viewSource')}</span>
+                </a>
+              )}
+              <Dialog.Close
+                className="rounded-sm p-1 text-text-secondary transition-colors hover:bg-hover-bg"
+                aria-label="Close"
+              >
+                <X className="h-4 w-4" />
+              </Dialog.Close>
+            </div>
+          </div>
+
+          <div className="min-h-0 flex-1 overflow-y-auto px-6 py-5">
+            {isLoading && <Spinner label={t('skillDetail.loading')} />}
+            {!isLoading && isError && (
+              <div className="py-12 text-center text-sm text-text-tertiary">
+                {t('skillDetail.unavailable')}
+              </div>
+            )}
+            {!isLoading && !isError && previewHtml && (
+              <div className="space-y-5">
+                {data?.files && data.files.length > 0 && (
+                  <section>
+                    <h3 className="mb-2 text-xs font-medium uppercase tracking-wide text-text-tertiary">
+                      {t('skillDetail.files')}
+                    </h3>
+                    <FileTree files={data.files} />
+                  </section>
+                )}
+                <div
+                  className="registry-markdown overflow-hidden text-sm text-text-secondary"
+                  dangerouslySetInnerHTML={{ __html: previewHtml }}
+                />
+              </div>
+            )}
+            {!isLoading && !isError && !previewHtml && (
+              <div className="py-12 text-center text-sm text-text-tertiary">
+                {t('skillDetail.unavailable')}
+              </div>
+            )}
+          </div>
+        </Dialog.Content>
+      </Dialog.Portal>
+    </Dialog.Root>
+  );
+}

--- a/web-ui/src/features/projects/components/SkillsList.tsx
+++ b/web-ui/src/features/projects/components/SkillsList.tsx
@@ -1,16 +1,20 @@
+import { useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import type { Skill } from '../../../types/api';
 import { highlightText, matchesSearch } from '../../../lib/utils';
 import { SourceBadge } from '../../../components/common/ServerBadge';
 import { sourceTypeBadgeClasses } from './sourceTypeColors';
+import { SkillDetailDialog } from './SkillDetailDialog';
 
 interface SkillsListProps {
   skills: Skill[];
   search: string;
+  projectId: string;
 }
 
-export function SkillsList({ skills, search }: SkillsListProps) {
+export function SkillsList({ skills, search, projectId }: SkillsListProps) {
   const { t } = useTranslation('projects');
+  const [selectedSkill, setSelectedSkill] = useState<Skill | null>(null);
   const visible = skills.filter((s) => matchesSearch([s.id, s.description], search));
 
   return (
@@ -30,9 +34,14 @@ export function SkillsList({ skills, search }: SkillsListProps) {
           {search ? t('detail.noSkillsMatch') : t('detail.noSkills')}
         </div>
       ) : (
-        <div className="space-y-1">
+        <div className="max-h-[520px] space-y-1 overflow-y-auto pr-1">
           {visible.map((skill) => (
-            <div key={skill.id} className="rounded-sm border border-border-tertiary bg-bg-tertiary p-3">
+            <button
+              key={skill.id}
+              type="button"
+              onClick={() => setSelectedSkill(skill)}
+              className="w-full rounded-sm border border-border-tertiary bg-bg-tertiary p-3 text-left transition-colors hover:bg-hover-bg cursor-pointer"
+            >
               <div className="mb-1 flex items-center gap-2 min-w-0">
                 <span
                   className="truncate font-mono text-[13px] font-medium text-text-primary"
@@ -57,10 +66,19 @@ export function SkillsList({ skills, search }: SkillsListProps) {
                   <SourceBadge name={skill.sourcePlugin.name} kind="plugin" />
                 </div>
               )}
-            </div>
+            </button>
           ))}
         </div>
       )}
+
+      <SkillDetailDialog
+        skill={selectedSkill}
+        projectId={projectId}
+        open={!!selectedSkill}
+        onOpenChange={(open) => {
+          if (!open) setSelectedSkill(null);
+        }}
+      />
     </div>
   );
 }

--- a/web-ui/src/features/projects/components/SubagentsList.tsx
+++ b/web-ui/src/features/projects/components/SubagentsList.tsx
@@ -35,7 +35,7 @@ export function SubagentsList({ subagents, search = '' }: SubagentsListProps) {
           {search ? t('detail.noSubagentsMatch') : t('detail.noSubagents')}
         </div>
       ) : (
-        <div className="space-y-1">
+        <div className="max-h-[520px] space-y-1 overflow-y-auto pr-1">
           {visible.map((agent) => (
             <SubagentItem key={agent.id} agent={agent} search={search} />
           ))}

--- a/web-ui/src/features/projects/components/ToolsList.tsx
+++ b/web-ui/src/features/projects/components/ToolsList.tsx
@@ -1,4 +1,4 @@
-import { useState } from 'react';
+import { useMemo, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import { ChevronRight } from 'lucide-react';
 import type { EnrichedTool, ToolSchema } from '../../../types/api';
@@ -6,6 +6,7 @@ import { highlightText, matchesSearch } from '../../../lib/utils';
 import { SourceBadge } from '../../../components/common/ServerBadge';
 
 const DESC_PREVIEW_LENGTH = 80;
+const COMMANDS_GROUP_KEY = '__commands__';
 
 interface ToolsListProps {
   tools: EnrichedTool[];
@@ -30,6 +31,23 @@ function enrichTool(
   };
 }
 
+function getToolGroupKey(tool: EnrichedTool): string {
+  if (tool.type === 'mcp' && tool.mcpServer) {
+    return tool.mcpServer.replace(/^@/, '');
+  }
+  if (tool.type === 'command' && tool.group) {
+    return tool.group;
+  }
+  return COMMANDS_GROUP_KEY;
+}
+
+interface ToolGroup {
+  key: string;
+  label: string;
+  kind: 'server' | 'command';
+  tools: EnrichedTool[];
+}
+
 export function ToolsList({ tools, search, toolRequiredByMap, serverToolSchemaCache }: ToolsListProps) {
   const { t } = useTranslation('projects');
   const enriched = tools.map((tool) => enrichTool(tool, serverToolSchemaCache));
@@ -45,8 +63,39 @@ export function ToolsList({ tools, search, toolRequiredByMap, serverToolSchemaCa
         ? [tool.command || '', ...(tool.commandArgs || []).flatMap((a) => [a.name, a.description || ''])]
         : [];
     const requiredBy = toolRequiredByMap[tool.id] || [];
-    return matchesSearch([tool.id, desc, ...paramTexts, ...cmdTexts, ...requiredBy], search);
+    const groupKey = getToolGroupKey(tool);
+    return matchesSearch(
+      [tool.id, desc, groupKey === COMMANDS_GROUP_KEY ? '' : groupKey, ...paramTexts, ...cmdTexts, ...requiredBy],
+      search,
+    );
   });
+
+  const groups = useMemo((): ToolGroup[] => {
+    const map = new Map<string, ToolGroup>();
+    for (const tool of visible) {
+      const key = getToolGroupKey(tool);
+      let group = map.get(key);
+      if (!group) {
+        if (key === COMMANDS_GROUP_KEY) {
+          group = { key, label: t('tool.commandsGroup'), kind: 'command', tools: [] };
+        } else if (tool.type === 'mcp') {
+          group = { key, label: key, kind: 'server', tools: [] };
+        } else {
+          group = { key, label: key, kind: 'command', tools: [] };
+        }
+        map.set(key, group);
+      }
+      group.tools.push(tool);
+    }
+
+    // Stable order: MCP server groups first (alpha), then named command groups, then ungrouped Commands last
+    return Array.from(map.values()).sort((a, b) => {
+      if (a.key === COMMANDS_GROUP_KEY) return 1;
+      if (b.key === COMMANDS_GROUP_KEY) return -1;
+      if (a.kind !== b.kind) return a.kind === 'server' ? -1 : 1;
+      return a.label.localeCompare(b.label);
+    });
+  }, [visible, t]);
 
   return (
     <div>
@@ -64,14 +113,32 @@ export function ToolsList({ tools, search, toolRequiredByMap, serverToolSchemaCa
           {search ? t('detail.noToolsMatch') : t('detail.noTools')}
         </div>
       ) : (
-        <div className="space-y-1">
-          {visible.map((tool) => (
-            <ToolItem
-              key={tool.id}
-              tool={tool}
-              search={search}
-              requiredBy={toolRequiredByMap[tool.id] || []}
-            />
+        <div className="max-h-[520px] space-y-3 overflow-y-auto pr-1">
+          {groups.map((group) => (
+            <div key={group.key}>
+              <div className="mb-1.5 flex items-center gap-2">
+                {group.kind === 'server' ? (
+                  <SourceBadge name={group.label} kind="server" search={search} />
+                ) : (
+                  <span className="text-[11px] font-medium uppercase tracking-wide text-text-tertiary">
+                    {group.label}
+                  </span>
+                )}
+                <span className="rounded-sm bg-bg-tertiary px-1.5 py-0.5 text-[10px] text-text-tertiary">
+                  {group.tools.length}
+                </span>
+              </div>
+              <div className="space-y-1">
+                {group.tools.map((tool) => (
+                  <ToolItem
+                    key={tool.id}
+                    tool={tool}
+                    search={search}
+                    requiredBy={toolRequiredByMap[tool.id] || []}
+                  />
+                ))}
+              </div>
+            </div>
           ))}
         </div>
       )}

--- a/web-ui/src/features/projects/hooks.ts
+++ b/web-ui/src/features/projects/hooks.ts
@@ -69,3 +69,13 @@ export function useServerTools(projectId: string | null, serverId: string | null
     retry: false,
   });
 }
+
+export function useSkillContent(projectId: string | null, skillId: string | null) {
+  return useQuery({
+    queryKey: ['skill-content', projectId, skillId],
+    queryFn: () => projectsApi.getSkillContent(projectId!, skillId!),
+    enabled: !!projectId && !!skillId,
+    staleTime: 5 * 60_000,
+    retry: false,
+  });
+}

--- a/web-ui/src/locales/en/projects.json
+++ b/web-ui/src/locales/en/projects.json
@@ -82,7 +82,16 @@
     "cmd": "cmd",
     "requiredBy": "required by",
     "noToolsOnServer": "No tools found on this server",
-    "serverUnreachable": "Server unreachable"
+    "serverUnreachable": "Server unreachable",
+    "commandsGroup": "Commands"
+  },
+  "skillDetail": {
+    "title": "Skill details",
+    "description": "Rendered SKILL.md content for this skill",
+    "loading": "Loading skill…",
+    "unavailable": "Skill content is not available. Run capa install to install this skill.",
+    "files": "Files",
+    "viewSource": "View source"
   },
   "stat": {
     "skill": "skill",

--- a/web-ui/src/types/api.ts
+++ b/web-ui/src/types/api.ts
@@ -23,8 +23,11 @@ export interface Skill {
   id: string;
   type: string;
   description: string | null;
+  descriptionSource?: 'capabilities' | 'frontmatter' | null;
   requires: string[];
   sourcePlugin: SourcePlugin | null;
+  /** External origin URL for github / gitlab / remote / plugin skills. */
+  sourceUrl?: string | null;
 }
 
 export interface Tool {
@@ -35,6 +38,19 @@ export interface Tool {
   mcpTool?: string;
   command?: string;
   commandArgs?: CommandArg[];
+  /** Optional group name for command-type tools. */
+  group?: string;
+}
+
+export interface SkillContentResponse {
+  id: string;
+  content: string;
+  metadata: {
+    name: string;
+    description?: string;
+    [key: string]: unknown;
+  };
+  files: string[];
 }
 
 export interface CommandArg {


### PR DESCRIPTION
## Summary
- Fall back to SKILL.md frontmatter when a skill has no capabilities-file description, and expose skill content via a new API endpoint
- Add a skill detail dialog with rendered markdown, file tree, and View source links for github/gitlab/remote/plugin skills
- Group configured tools by MCP server / command group, and constrain capability lists to a scrollable max height

## Test plan
- [x] Open a project detail page with installed skills/tools/servers
- [x] Confirm skills without `def.description` show frontmatter descriptions
- [x] Click a skill and verify markdown, file tree, and View source (when applicable)
- [x] Confirm tools are grouped by server/group
- [x] Confirm long capability lists scroll within ~520px height