### PR TITLE
feat(mcp): expose server icons, metadata, and ping support

### DIFF
--- a/src/server/__tests__/mcp-handler.integration.test.ts
+++ b/src/server/__tests__/mcp-handler.integration.test.ts
@@ -662,3 +662,75 @@ describe('listServerTools (throwOnError pass-through)', () => {
     expect(tools).toEqual([]);
   });
 });
+
+// ─── initialize exposes server icons ─────────────────────────────────────────
+
+describe('handleMessage > initialize (server icons)', () => {
+  let h: Harness;
+
+  beforeEach(() => {
+    h = makeHarness({
+      providers: ['claude-code'],
+      options: {},
+      skills: [],
+      servers: [],
+      tools: [],
+    });
+  });
+
+  afterEach(() => destroyHarness(h));
+
+  it('returns capa favicon as SVG data-URI icons in serverInfo', async () => {
+    const resp = await h.mcp.handleMessage({
+      jsonrpc: '2.0',
+      id: 1,
+      method: 'initialize',
+    });
+
+    expect(resp.result.protocolVersion).toBe('2025-11-25');
+    expect(resp.result.serverInfo.name).toBe('capa-test-proj');
+    expect(resp.result.serverInfo.title).toBe('capa');
+    expect(resp.result.serverInfo.description).toBe(
+      'An agentic skills and tools package manager',
+    );
+    expect(resp.result.serverInfo.websiteUrl).toBe('https://capa.infragate.ai');
+
+    const icons = resp.result.serverInfo.icons;
+    expect(icons).toHaveLength(1);
+    expect(icons[0].mimeType).toBe('image/svg+xml');
+    expect(icons[0].sizes).toEqual(['any']);
+    expect(icons[0].src).toMatch(/^data:image\/svg\+xml;base64,/);
+  });
+});
+
+// ─── ping ────────────────────────────────────────────────────────────────────
+
+describe('handleMessage > ping', () => {
+  let h: Harness;
+
+  beforeEach(() => {
+    h = makeHarness({
+      providers: ['claude-code'],
+      options: {},
+      skills: [],
+      servers: [],
+      tools: [],
+    });
+  });
+
+  afterEach(() => destroyHarness(h));
+
+  it('returns an empty result', async () => {
+    const resp = await h.mcp.handleMessage({
+      jsonrpc: '2.0',
+      id: 42,
+      method: 'ping',
+    });
+
+    expect(resp).toEqual({
+      jsonrpc: '2.0',
+      id: 42,
+      result: {},
+    });
+  });
+});

--- a/src/server/mcp-handler.ts
+++ b/src/server/mcp-handler.ts
@@ -16,6 +16,8 @@ import { CommandToolExecutor } from './tool-executor';
 import { MCPProxy } from './mcp-proxy';
 import { buildToolCallText, extractCapaShellMeta } from './tool-formatter';
 import { VERSION } from '../version';
+import { CAPA_SERVER_ICONS } from '../shared/mcp-icons';
+import { projectNameFromId } from '../shared/paths';
 import { logger } from '../shared/logger';
 
 export interface ShellToolInfo {
@@ -217,8 +219,12 @@ export class CapaMCPServer {
 
     this.server = new Server(
       {
-        name: `capa-${projectId}`,
+        name: `capa-${projectNameFromId(projectId)}`,
         version: VERSION,
+        title: 'capa',
+        description: 'An agentic skills and tools package manager',
+        websiteUrl: 'https://capa.infragate.ai',
+        icons: CAPA_SERVER_ICONS,
       },
       {
         capabilities: {
@@ -1085,13 +1091,17 @@ export class CapaMCPServer {
         jsonrpc: '2.0',
         id: message.id,
         result: {
-          protocolVersion: '2024-11-05',
+          protocolVersion: '2025-11-25',
           capabilities: {
             tools: {},
           },
           serverInfo: {
-            name: `capa-${this.projectId}`,
+            name: `capa-${projectNameFromId(this.projectId)}`,
+            title: 'capa',
             version: VERSION,
+            description: 'An agentic skills and tools package manager',
+            websiteUrl: 'https://capa.infragate.ai',
+            icons: CAPA_SERVER_ICONS,
           },
         },
       };
@@ -1102,6 +1112,16 @@ export class CapaMCPServer {
       this.logger.debug('Initialized notification');
       return {
         jsonrpc: '2.0',
+        result: {},
+      };
+    }
+
+    // Handle ping (liveness check — https://modelcontextprotocol.io/specification/2025-11-25/basic/utilities/ping)
+    if (message.method === 'ping') {
+      this.logger.debug('Ping request');
+      return {
+        jsonrpc: '2.0',
+        id: message.id,
         result: {},
       };
     }

--- a/src/shared/__tests__/paths.test.ts
+++ b/src/shared/__tests__/paths.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'bun:test';
-import { generateProjectId, getCapabilitiesPath, detectCapabilitiesFile } from '../paths';
+import { generateProjectId, getCapabilitiesPath, detectCapabilitiesFile, projectNameFromId } from '../paths';
 import { resolve } from 'path';
 
 describe('paths', () => {
@@ -38,6 +38,16 @@ describe('paths', () => {
       const id2 = generateProjectId('/path/to/project2');
       
       expect(id1).not.toBe(id2);
+    });
+  });
+
+  describe('projectNameFromId', () => {
+    it('strips the trailing 4-char hash', () => {
+      expect(projectNameFromId('ontology-builder-a6a5')).toBe('ontology-builder');
+    });
+
+    it('leaves ids without a hash suffix unchanged', () => {
+      expect(projectNameFromId('test-proj')).toBe('test-proj');
     });
   });
 

--- a/src/shared/mcp-icons.ts
+++ b/src/shared/mcp-icons.ts
@@ -1,0 +1,10 @@
+import faviconSvg from '../../assets/favicon.svg' with { type: 'text' };
+
+/** MCP Implementation.icons for the capa server (spec 2025-11-25). */
+export const CAPA_SERVER_ICONS = [
+  {
+    src: `data:image/svg+xml;base64,${Buffer.from(faviconSvg).toString('base64')}`,
+    mimeType: 'image/svg+xml',
+    sizes: ['any'],
+  },
+];

--- a/src/shared/paths.ts
+++ b/src/shared/paths.ts
@@ -26,6 +26,14 @@ export function generateProjectId(projectPath: string): string {
 }
 
 /**
+ * Strip the trailing 4-char path hash from a project ID.
+ * `ontology-builder-a6a5` → `ontology-builder`
+ */
+export function projectNameFromId(projectId: string): string {
+  return projectId.replace(/-[a-f0-9]{4}$/i, '');
+}
+
+/**
  * Get the capabilities file path for a project
  */
 export function getCapabilitiesPath(projectPath: string, format: 'json' | 'yaml'): string {


### PR DESCRIPTION
## Summary

- Expose capa branding in the MCP `serverInfo`: `title`, `description`, `websiteUrl`, and `icons` (the favicon, inlined as an SVG `data:` URI).
- Bump the initialize `protocolVersion` to `2025-11-25`.
- Handle `ping` requests with an empty result (spec liveness check).
- Use the project name without the trailing path-hash for the server name via a new `projectNameFromId` helper.

## Notes

- The SVG is imported with `with { type: 'text' }`, which Bun **inlines at build time** into a string literal. Verified via a bundle test that the content is embedded, so the `--compile`d binary contains the icon (no runtime file dependency on `assets/favicon.svg`).

## Test plan

- [x] `bun test src/shared/__tests__/paths.test.ts src/server/__tests__/mcp-handler.integration.test.ts` — 31 pass
- [x] Verify icon/metadata render in an MCP client after a compiled build
