### PR TITLE
Enhance CLI wrap functionality and streamline install options

### DIFF
--- a/src/cli/commands/__tests__/add-install-flag.test.ts
+++ b/src/cli/commands/__tests__/add-install-flag.test.ts
@@ -1,0 +1,65 @@
+import { describe, it, expect, beforeEach, afterEach, mock } from 'bun:test';
+import { mkdtempSync, rmSync, writeFileSync, readFileSync } from 'fs';
+import { join } from 'path';
+import { tmpdir } from 'os';
+
+const installMock = mock(async () => {});
+
+mock.module('../install', () => ({
+  installCommand: installMock,
+}));
+
+const { addCommand } = await import('../add');
+
+function isolateHome(): { restore: () => void } {
+  const home = mkdtempSync(join(tmpdir(), 'capa-add-home-'));
+  const prevHome = process.env.HOME;
+  const prevUserProfile = process.env.USERPROFILE;
+  process.env.HOME = home;
+  process.env.USERPROFILE = home;
+  return {
+    restore: () => {
+      if (prevHome === undefined) delete process.env.HOME;
+      else process.env.HOME = prevHome;
+      if (prevUserProfile === undefined) delete process.env.USERPROFILE;
+      else process.env.USERPROFILE = prevUserProfile;
+      rmSync(home, { recursive: true, force: true });
+    },
+  };
+}
+
+describe('addCommand install flag (github skill)', () => {
+  let projectDir: string;
+  let homeCtx: { restore: () => void };
+  let originalCwd: string;
+
+  beforeEach(() => {
+    projectDir = mkdtempSync(join(tmpdir(), 'capa-add-proj-'));
+    homeCtx = isolateHome();
+    originalCwd = process.cwd();
+    process.chdir(projectDir);
+    writeFileSync(
+      join(projectDir, 'capabilities.yaml'),
+      'skills: []\nplugins: []\nservers: []\ntools: []\n',
+    );
+    installMock.mockClear();
+  });
+
+  afterEach(() => {
+    process.chdir(originalCwd);
+    homeCtx.restore();
+    rmSync(projectDir, { recursive: true, force: true });
+  });
+
+  it('does not call installCommand without --install', async () => {
+    await addCommand('owner/repo@my-skill', {});
+    expect(installMock).not.toHaveBeenCalled();
+    const yaml = readFileSync(join(projectDir, 'capabilities.yaml'), 'utf8');
+    expect(yaml).toContain('my-skill');
+  });
+
+  it('calls installCommand with --install', async () => {
+    await addCommand('owner/repo@my-skill', { install: true });
+    expect(installMock).toHaveBeenCalled();
+  });
+});

--- a/src/cli/commands/add.ts
+++ b/src/cli/commands/add.ts
@@ -396,10 +396,7 @@ export async function addCommand(
       return;
     }
     console.log(
-      '\nCapabilities file updated. Materialize with:\n' +
-        '  capa install              # write provider configs into this project\n' +
-        '  capa wrap <provider>      # shadow workspace (no in-repo .cursor/.claude writes)\n' +
-        '  capa add --install …      # one-shot add + install (legacy)\n',
+      '\nCapabilities file updated. Run capa install.\n',
     );
   }
 

--- a/src/cli/commands/add.ts
+++ b/src/cli/commands/add.ts
@@ -10,6 +10,7 @@ import { getAllGitProviders } from '../../shared/git-providers/registry';
 import { resolve, basename, join, relative } from 'path';
 import { access } from 'fs/promises';
 import { constants } from 'fs';
+import { refuseIfWrapWorkspace } from '../utils/wrap/marker';
 
 interface ParsedSkillSource {
   id: string;
@@ -373,13 +374,35 @@ export async function addCommand(
     provider?: string;
     envFile?: string | boolean;
     noCache?: boolean;
+    /** When true, run install after updating the capabilities file (legacy one-shot). */
+    install?: boolean;
   }
 ): Promise<void> {
+  if (await refuseIfWrapWorkspace('add')) {
+    process.exit(1);
+  }
+
   const installOpts = {
     envFile: options.envFile,
     provider: options.provider,
     noCache: options.noCache,
   };
+  const shouldInstall = options.install === true;
+
+  async function maybeInstall(): Promise<void> {
+    if (shouldInstall) {
+      console.log('\n📦 Running installation...\n');
+      await installCommand(installOpts);
+      return;
+    }
+    console.log(
+      '\nCapabilities file updated. Materialize with:\n' +
+        '  capa install              # write provider configs into this project\n' +
+        '  capa wrap <provider>      # shadow workspace (no in-repo .cursor/.claude writes)\n' +
+        '  capa add --install …      # one-shot add + install (legacy)\n',
+    );
+  }
+
   if (options.plugin && options.skill) {
     console.error('✗ Cannot pass both --skill and --plugin.');
     process.exit(1);
@@ -485,8 +508,7 @@ export async function addCommand(
       }
 
       console.log(`\u2713 Added ${resolvedCapability.slice(0, -1)} "${itemName}" from registry "${registryId}" to ${capabilitiesFile.path}`);
-      console.log('\n\u{1F4E6} Running installation...\n');
-      await installCommand(installOpts);
+      await maybeInstall();
       return;
     }
     // If no adapter matched, fall through to normal parsing
@@ -528,8 +550,7 @@ export async function addCommand(
     if (parsed.def.version) console.log(`  Version: ${parsed.def.version}`);
     if (parsed.def.ref) console.log(`  Ref: ${parsed.def.ref}`);
 
-    console.log('\n📦 Running installation...\n');
-    await installCommand(installOpts);
+    await maybeInstall();
     return;
   }
 
@@ -572,6 +593,5 @@ export async function addCommand(
     console.log(`  Path: ${skillDef.def.path}`);
   }
 
-  console.log('\n📦 Running installation...\n');
-  await installCommand(installOpts);
+  await maybeInstall();
 }

--- a/src/cli/commands/clean.ts
+++ b/src/cli/commands/clean.ts
@@ -11,8 +11,13 @@ import { getLockfilePath } from '../../shared/lockfile';
 import { resolveProvidersForClean } from '../../shared/providers/resolve';
 import { header, footer, info, warn, error, runTasks } from '../ui';
 import type { Task } from '../ui';
+import { refuseIfWrapWorkspace } from '../utils/wrap/marker';
 
 export async function cleanCommand(): Promise<void> {
+  if (await refuseIfWrapWorkspace('clean')) {
+    process.exit(1);
+  }
+
   const projectPath = process.cwd();
 
   header('Clean project');

--- a/src/cli/commands/install-tasks/context.ts
+++ b/src/cli/commands/install-tasks/context.ts
@@ -39,6 +39,18 @@ export interface InstallOptions {
   provider?: string;
   /** When true, ignore lockfile + on-disk cache and re-resolve every remote source. */
   noCache?: boolean;
+  /** Write root for provider configs (default: process.cwd()). */
+  projectPath?: string;
+  /**
+   * Path used for generateProjectId + db.upsertProject path (default: projectPath).
+   * Wrap uses the real project here while writing into a shadow workspace.
+   */
+  identityPath?: string;
+  /**
+   * When false, throw on failure instead of process.exit (for wrap live re-apply).
+   * Default true.
+   */
+  exitProcess?: boolean;
 }
 
 export type GetRepoSnapshotFn = (

--- a/src/cli/commands/install-tasks/context.ts
+++ b/src/cli/commands/install-tasks/context.ts
@@ -51,6 +51,11 @@ export interface InstallOptions {
    * Default true.
    */
   exitProcess?: boolean;
+  /**
+   * Suppress install UI output (for wrap capabilities live re-apply).
+   * Default false.
+   */
+  quiet?: boolean;
 }
 
 export type GetRepoSnapshotFn = (

--- a/src/cli/commands/install.ts
+++ b/src/cli/commands/install.ts
@@ -1,3 +1,4 @@
+import { resolve } from 'path';
 import { detectCapabilitiesFile, generateProjectId } from '../../shared/paths';
 import { parseCapabilitiesFile } from '../../shared/capabilities';
 import { ensureServer } from '../utils/server-manager';
@@ -9,8 +10,15 @@ import { LockfileBuilder, loadLockfile } from '../../shared/lockfile';
 import { runTasks, summary, info, warn, error } from '../ui';
 import { buildInstallTasks } from './install-tasks';
 import type { InstallCtx, InstallOptions } from './install-tasks';
+import { refuseIfWrapWorkspace } from '../utils/wrap/marker';
 
 export type { InstallOptions, GetRepoSnapshotFn } from './install-tasks';
+
+function failExit(message: string, exitProcess: boolean): never {
+  console.error(`✗ ${message}`);
+  if (exitProcess) process.exit(1);
+  throw new Error(message);
+}
 
 export async function installCommand(
   envFileOrOptions?: string | boolean | InstallOptions,
@@ -20,20 +28,35 @@ export async function installCommand(
   let envFile: string | boolean | undefined;
   let flagProvider: string | undefined;
   let noCache = false;
+  let projectPath = process.cwd();
+  let identityPath: string | undefined;
+  let exitProcess = true;
   if (typeof envFileOrOptions === 'object' && envFileOrOptions !== null) {
     envFile = envFileOrOptions.envFile;
     flagProvider = envFileOrOptions.provider;
     noCache = !!envFileOrOptions.noCache;
+    if (envFileOrOptions.projectPath) projectPath = resolve(envFileOrOptions.projectPath);
+    identityPath = envFileOrOptions.identityPath
+      ? resolve(envFileOrOptions.identityPath)
+      : undefined;
+    if (envFileOrOptions.exitProcess === false) exitProcess = false;
   } else {
     envFile = envFileOrOptions;
   }
 
-  const projectPath = process.cwd();
+  const idPath = identityPath ?? projectPath;
+
+  // Only refuse when installing into the current cwd wrap workspace (not when
+  // wrap itself installs into a workspace via explicit projectPath).
+  if (!envFileOrOptions || typeof envFileOrOptions !== 'object' || !envFileOrOptions.projectPath) {
+    if (await refuseIfWrapWorkspace('install')) {
+      failExit('Refusing to install inside a wrap workspace.', exitProcess);
+    }
+  }
 
   const capabilitiesFile = await detectCapabilitiesFile(projectPath);
   if (!capabilitiesFile) {
-    console.error('✗ No capabilities file found. Run "capa init" first.');
-    process.exit(1);
+    failExit('No capabilities file found. Run "capa init" first.', exitProcess);
   }
 
   const capabilities = await parseCapabilitiesFile(
@@ -42,12 +65,11 @@ export async function installCommand(
   );
 
   const reqCmds = capabilities.options?.requiresCommands;
-  const projectId = generateProjectId(projectPath);
+  const projectId = generateProjectId(idPath);
   const serverStatus = await ensureServer(VERSION);
 
   if (!serverStatus.running || !serverStatus.url) {
-    console.error('✗ Failed to start server');
-    process.exit(1);
+    failExit('Failed to start server', exitProcess);
   }
 
   const startedAt = Date.now();
@@ -60,7 +82,8 @@ export async function installCommand(
 
   let resolvedProviders: string[];
   try {
-    db.upsertProject({ id: projectId, path: projectPath });
+    // Always store the real project path for MCP tool cwd / identity.
+    db.upsertProject({ id: projectId, path: idPath });
     resolvedProviders = await resolveProvidersForInstall({
       flagProvider,
       capabilitiesProviders: capabilities.providers,
@@ -75,7 +98,7 @@ export async function installCommand(
     try {
       db.close();
     } catch {}
-    process.exit(1);
+    failExit(message, exitProcess);
   }
 
   // Hoisted so the catch block can surface ctx.errors accumulated before the throw.
@@ -116,7 +139,7 @@ export async function installCommand(
     });
     // Exit non-zero on accumulated per-task failures (continue-on-error mode).
     if (initialCtx.failed > 0) {
-      process.exit(1);
+      failExit(`Install completed with ${initialCtx.failed} failure(s).`, exitProcess);
     }
   } catch (err: unknown) {
     for (const e of initialCtx.errors) error(e);
@@ -128,8 +151,11 @@ export async function installCommand(
       elapsedMs: Date.now() - startedAt,
     });
     if (err instanceof Error) {
-      console.error(`✗ ${err.message}`);
-      process.exit(1);
+      if (exitProcess) {
+        console.error(`✗ ${err.message}`);
+        process.exit(1);
+      }
+      throw err;
     }
     throw err;
   } finally {

--- a/src/cli/commands/install.ts
+++ b/src/cli/commands/install.ts
@@ -7,7 +7,7 @@ import { CapaDatabase } from '../../db/database';
 import { VERSION } from '../../version';
 import { resolveProvidersForInstall } from '../../shared/providers/resolve';
 import { LockfileBuilder, loadLockfile } from '../../shared/lockfile';
-import { runTasks, summary, info, warn, error } from '../ui';
+import { runTasks, summary, info, warn, error, setFlags, getFlags } from '../ui';
 import { buildInstallTasks } from './install-tasks';
 import type { InstallCtx, InstallOptions } from './install-tasks';
 import { refuseIfWrapWorkspace } from '../utils/wrap/marker';
@@ -31,6 +31,7 @@ export async function installCommand(
   let projectPath = process.cwd();
   let identityPath: string | undefined;
   let exitProcess = true;
+  let quiet = false;
   if (typeof envFileOrOptions === 'object' && envFileOrOptions !== null) {
     envFile = envFileOrOptions.envFile;
     flagProvider = envFileOrOptions.provider;
@@ -40,15 +41,48 @@ export async function installCommand(
       ? resolve(envFileOrOptions.identityPath)
       : undefined;
     if (envFileOrOptions.exitProcess === false) exitProcess = false;
+    quiet = !!envFileOrOptions.quiet;
   } else {
     envFile = envFileOrOptions;
   }
 
+  const prevQuiet = getFlags().quiet;
+  if (quiet) setFlags({ quiet: true });
+  try {
+    await installCommandBody({
+      envFile,
+      flagProvider,
+      noCache,
+      projectPath,
+      identityPath,
+      exitProcess,
+      // Only refuse wrap cwd when the caller did not pass an explicit projectPath
+      // (wrap itself always passes one).
+      refuseWrapCwd:
+        typeof envFileOrOptions !== 'object' ||
+        envFileOrOptions === null ||
+        !envFileOrOptions.projectPath,
+    });
+  } finally {
+    if (quiet) setFlags({ quiet: prevQuiet });
+  }
+}
+
+async function installCommandBody(opts: {
+  envFile: string | boolean | undefined;
+  flagProvider: string | undefined;
+  noCache: boolean;
+  projectPath: string;
+  identityPath: string | undefined;
+  exitProcess: boolean;
+  refuseWrapCwd: boolean;
+}): Promise<void> {
+  const { envFile, flagProvider, noCache, exitProcess, refuseWrapCwd } = opts;
+  const projectPath = opts.projectPath;
+  const identityPath = opts.identityPath;
   const idPath = identityPath ?? projectPath;
 
-  // Only refuse when installing into the current cwd wrap workspace (not when
-  // wrap itself installs into a workspace via explicit projectPath).
-  if (!envFileOrOptions || typeof envFileOrOptions !== 'object' || !envFileOrOptions.projectPath) {
+  if (refuseWrapCwd) {
     if (await refuseIfWrapWorkspace('install')) {
       failExit('Refusing to install inside a wrap workspace.', exitProcess);
     }

--- a/src/cli/commands/wrap.ts
+++ b/src/cli/commands/wrap.ts
@@ -15,6 +15,50 @@ export interface WrapOptions {
   prune?: boolean;
 }
 
+function startDetachedWatchWorker(opts: {
+  realProjectPath: string;
+  workspacePath: string;
+  providerId: string;
+  capabilitiesPath: string;
+  exclusionProviderIds: string[];
+}): { pid?: number; stop: () => void } {
+  const proc = Bun.spawn(
+    [
+      process.execPath,
+      '__wrap_watch__',
+      opts.realProjectPath,
+      opts.workspacePath,
+      opts.providerId,
+      opts.capabilitiesPath,
+      JSON.stringify(opts.exclusionProviderIds),
+    ],
+    {
+      stdin: 'ignore',
+      stdout: 'ignore',
+      stderr: 'ignore',
+      detached: true,
+      windowsHide: true,
+    },
+  );
+  proc.unref();
+
+  return {
+    pid: proc.pid,
+    stop: () => {
+      if (proc.pid == null) return;
+      try {
+        process.kill(proc.pid, 'SIGTERM');
+      } catch {
+        try {
+          process.kill(proc.pid, 'SIGKILL');
+        } catch {
+          // already gone
+        }
+      }
+    },
+  };
+}
+
 export async function wrapCommand(
   providerArg: string | undefined,
   args: string[],
@@ -69,34 +113,34 @@ export async function wrapCommand(
   );
   info(prepared.workspacePath);
 
-  const watchers = startWrapWatchers({
-    realProjectPath: prepared.realProjectPath,
-    workspacePath: prepared.workspacePath,
-    providerId: provider.id,
-    capabilitiesPath: prepared.capabilitiesPath,
-    exclusionProviderIds: prepared.exclusionProviderIds,
-  });
-
-  let cleaned = false;
-  const cleanup = () => {
-    if (cleaned) return;
-    cleaned = true;
-    watchers.exitSweep();
-    watchers.stop();
-  };
-
-  const onStopSignal = () => {
-    cleanup();
-    process.exit(0);
-  };
-  process.once('SIGTERM', onStopSignal);
-  try {
-    process.once('SIGHUP', onStopSignal);
-  } catch {
-    // Windows
-  }
-
   if (provider.wrap.kind === 'gui') {
+    const watchers = startWrapWatchers({
+      realProjectPath: prepared.realProjectPath,
+      workspacePath: prepared.workspacePath,
+      providerId: provider.id,
+      capabilitiesPath: prepared.capabilitiesPath,
+      exclusionProviderIds: prepared.exclusionProviderIds,
+    });
+
+    let cleaned = false;
+    const cleanup = () => {
+      if (cleaned) return;
+      cleaned = true;
+      watchers.exitSweep();
+      watchers.stop();
+    };
+
+    const onStopSignal = () => {
+      cleanup();
+      process.exit(0);
+    };
+    process.once('SIGTERM', onStopSignal);
+    try {
+      process.once('SIGHUP', onStopSignal);
+    } catch {
+      // Windows
+    }
+
     info(
       `Launching ${provider.wrap.binary} (wrap stops when the window closes, or Ctrl+C / q)`,
     );
@@ -129,15 +173,35 @@ export async function wrapCommand(
     process.exit(0);
   }
 
-  // CLI: blocking
+  // CLI: watchers run in a detached process so this process can spawnSync the
+  // TUI without Bun's event-loop stdin reader stealing keystrokes.
+  const watchWorker = startDetachedWatchWorker({
+    realProjectPath: prepared.realProjectPath,
+    workspacePath: prepared.workspacePath,
+    providerId: provider.id,
+    capabilitiesPath: prepared.capabilitiesPath,
+    exclusionProviderIds: prepared.exclusionProviderIds,
+  });
+
+  const onStopSignal = () => {
+    watchWorker.stop();
+    process.exit(0);
+  };
+  process.once('SIGTERM', onStopSignal);
+  try {
+    process.once('SIGHUP', onStopSignal);
+  } catch {
+    // Windows
+  }
+
   try {
     const result = await launchProvider(provider, prepared.workspacePath, args);
-    cleanup();
+    watchWorker.stop();
     if (result.exitCode != null && result.exitCode !== 0) {
       process.exit(result.exitCode);
     }
   } catch (err) {
-    cleanup();
+    watchWorker.stop();
     error(
       `Failed to launch ${provider.wrap.binary}: ${
         err instanceof Error ? err.message : String(err)

--- a/src/cli/commands/wrap.ts
+++ b/src/cli/commands/wrap.ts
@@ -1,0 +1,148 @@
+import { resolve } from 'path';
+import {
+  getWrappableProvider,
+  getWrappableProviders,
+} from '../../shared/providers';
+import { prepareWorkspace, pruneWorkspaces } from '../utils/wrap/workspace';
+import { startWrapWatchers } from '../utils/wrap/watch-project';
+import { launchProvider } from '../utils/wrap/launch';
+import { waitForInterrupt } from '../utils/wrap/wait-for-interrupt';
+import { info, error } from '../ui';
+
+export interface WrapOptions {
+  project?: string;
+  printDir?: boolean;
+  prune?: boolean;
+}
+
+export async function wrapCommand(
+  providerArg: string | undefined,
+  args: string[],
+  options: WrapOptions = {},
+): Promise<void> {
+  if (options.prune) {
+    const n = await pruneWorkspaces();
+    info(`Pruned ${n} wrap workspace(s).`);
+    return;
+  }
+
+  if (!providerArg) {
+    const available = getWrappableProviders()
+      .map((p) => p.id)
+      .sort()
+      .join(', ');
+    error(`Missing provider. Wrappable providers: ${available || '(none)'}`);
+    process.exit(1);
+  }
+
+  const provider = getWrappableProvider(providerArg);
+  if (!provider || !provider.wrap) {
+    const available = getWrappableProviders()
+      .map((p) => `${p.id}${p.pluginProviderId ? ` (alias: ${p.pluginProviderId})` : ''}`)
+      .sort()
+      .join(', ');
+    error(
+      `Unknown or non-wrappable provider "${providerArg}".\n` +
+        `  Available: ${available || '(none)'}`,
+    );
+    process.exit(1);
+  }
+
+  const realProjectPath = resolve(options.project ?? process.cwd());
+
+  let prepared;
+  try {
+    prepared = await prepareWorkspace(realProjectPath, provider);
+  } catch (err) {
+    error(err instanceof Error ? err.message : String(err));
+    process.exit(1);
+  }
+
+  if (options.printDir) {
+    console.log(prepared.workspacePath);
+  }
+
+  info(
+    prepared.cold
+      ? `Created wrap workspace for ${provider.displayName}`
+      : `Reusing wrap workspace for ${provider.displayName}`,
+  );
+  info(prepared.workspacePath);
+
+  const watchers = startWrapWatchers({
+    realProjectPath: prepared.realProjectPath,
+    workspacePath: prepared.workspacePath,
+    providerId: provider.id,
+    capabilitiesPath: prepared.capabilitiesPath,
+    exclusionProviderIds: prepared.exclusionProviderIds,
+  });
+
+  let cleaned = false;
+  const cleanup = () => {
+    if (cleaned) return;
+    cleaned = true;
+    watchers.exitSweep();
+    watchers.stop();
+  };
+
+  const onStopSignal = () => {
+    cleanup();
+    process.exit(0);
+  };
+  process.once('SIGTERM', onStopSignal);
+  try {
+    process.once('SIGHUP', onStopSignal);
+  } catch {
+    // Windows
+  }
+
+  if (provider.wrap.kind === 'gui') {
+    info(
+      `Launching ${provider.wrap.binary} (wrap stops when the window closes, or Ctrl+C / q)`,
+    );
+    let launch;
+    try {
+      launch = await launchProvider(provider, prepared.workspacePath, args);
+    } catch (err) {
+      cleanup();
+      error(
+        `Failed to launch ${provider.wrap.binary}: ${
+          err instanceof Error ? err.message : String(err)
+        }`,
+      );
+      process.exit(1);
+    }
+
+    const abortInterrupt = new AbortController();
+    const reason = await Promise.race([
+      (launch.closed ?? Promise.resolve(0)).then(() => 'closed' as const),
+      waitForInterrupt(abortInterrupt.signal).then(() => 'interrupt' as const),
+    ]);
+    abortInterrupt.abort();
+
+    if (reason === 'interrupt') {
+      launch.kill?.();
+    }
+
+    cleanup();
+    info(reason === 'closed' ? 'Provider window closed — stopped watching.' : 'Stopped watching.');
+    process.exit(0);
+  }
+
+  // CLI: blocking
+  try {
+    const result = await launchProvider(provider, prepared.workspacePath, args);
+    cleanup();
+    if (result.exitCode != null && result.exitCode !== 0) {
+      process.exit(result.exitCode);
+    }
+  } catch (err) {
+    cleanup();
+    error(
+      `Failed to launch ${provider.wrap.binary}: ${
+        err instanceof Error ? err.message : String(err)
+      }`,
+    );
+    process.exit(1);
+  }
+}

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -8,6 +8,7 @@ import { statusCommand } from './commands/status';
 import { installCommand } from './commands/install';
 import { cleanCommand } from './commands/clean';
 import { addCommand } from './commands/add';
+import { wrapCommand } from './commands/wrap';
 import { authCommand } from './commands/auth';
 import { upgradeCommand } from './commands/upgrade';
 import { shellCommand } from './commands/sh';
@@ -90,6 +91,7 @@ if (process.argv[2] === '__server__') {
       .description('Add a skill or plugin from various sources (GitHub, GitLab, registry, local path, or remote URL)')
       .option('--plugin', 'Treat <source> as a plugin (default is skill)')
       .option('--skill', 'Treat <source> as a skill (default; flag exists for explicitness)')
+      .option('--install', 'Also run capa install after updating the capabilities file')
       .option('-e, --env [file]', 'Load variables from .env file (defaults to .env if no file specified)')
       .option('-p, --provider <id>', 'Install for a single provider (e.g. "cursor", "claude-code")')
       .option('--no-cache', 'Bypass the on-disk cache and lockfile; re-resolve every remote source')
@@ -100,6 +102,22 @@ if (process.argv[2] === '__server__') {
           envFile: options.env,
           provider: options.provider,
           noCache: options.cache === false,
+          install: options.install === true,
+        });
+      });
+
+    program
+      .command('wrap [provider] [args...]')
+      .description('Run a provider from a CAPA shadow workspace without modifying in-repo provider configs')
+      .option('--project <dir>', 'Source project directory (default: cwd)')
+      .option('--print-dir', 'Print the workspace path before launching')
+      .option('--prune', 'Remove wrap workspaces under ~/.capa/workspaces and exit')
+      .allowUnknownOption()
+      .action(async (provider: string | undefined, args: string[], options) => {
+        await wrapCommand(provider, args ?? [], {
+          project: options.project,
+          printDir: options.printDir === true,
+          prune: options.prune === true,
         });
       });
 
@@ -120,7 +138,7 @@ if (process.argv[2] === '__server__') {
 
     program
       .command('stop')
-      .description('Stop the capa server')
+      .description('Stop the capa server and any active wrap sessions')
       .action(async () => {
         await stopCommand();
       });

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -35,6 +35,13 @@ if (process.argv[2] === '__server__') {
     console.error('Failed to start server:', error);
     process.exit(1);
   });
+} else if (process.argv[2] === '__wrap_watch__') {
+  import('./utils/wrap/watch-worker')
+    .then(({ runWrapWatchWorker }) => runWrapWatchWorker(process.argv.slice(3)))
+    .catch((err) => {
+      console.error('Failed to start wrap watcher:', err);
+      process.exit(1);
+    });
 } else {
   (async () => {
     try {

--- a/src/cli/utils/server-manager.ts
+++ b/src/cli/utils/server-manager.ts
@@ -1,6 +1,7 @@
 import { existsSync, readFileSync, unlinkSync } from 'fs';
 import { getPidFilePath, loadSettings } from '../../shared/config';
 import { stopAllWrapSessions } from './wrap/sessions';
+import { isQuiet } from '../ui';
 
 export interface ServerStatus {
   running: boolean;
@@ -89,12 +90,15 @@ export async function startServer(background: boolean = true): Promise<void> {
   const status = await getServerStatus();
   
   if (status.running) {
-    console.log(`Server already running (PID: ${status.pid})`);
+    if (!isQuiet()) {
+      console.log(`Server already running (PID: ${status.pid})`);
+    }
     return;
   }
-  
-  console.log('Starting capa server...');
-  
+
+  if (!isQuiet()) {
+    console.log('Starting capa server...');
+  } 
   // Get the path to the current executable
   const exePath = process.execPath;
   
@@ -114,7 +118,9 @@ export async function startServer(background: boolean = true): Promise<void> {
     
     const newStatus = await getServerStatus();
     if (newStatus.running) {
-      console.log(`✓ Server started at ${newStatus.url}`);
+      if (!isQuiet()) {
+        console.log(`✓ Server started at ${newStatus.url}`);
+      }
     } else {
       console.error('✗ Failed to start server');
       process.exit(1);

--- a/src/cli/utils/server-manager.ts
+++ b/src/cli/utils/server-manager.ts
@@ -1,5 +1,6 @@
 import { existsSync, readFileSync, unlinkSync } from 'fs';
 import { getPidFilePath, loadSettings } from '../../shared/config';
+import { stopAllWrapSessions } from './wrap/sessions';
 
 export interface ServerStatus {
   running: boolean;
@@ -131,41 +132,48 @@ export async function startServer(background: boolean = true): Promise<void> {
 }
 
 /**
- * Stop the capa server
+ * Stop the capa server and any active `capa wrap` sessions.
  */
 export async function stopServer(): Promise<void> {
+  const wrapCount = await stopAllWrapSessions();
+  if (wrapCount > 0) {
+    console.log(`✓ Stopped ${wrapCount} wrap session(s)`);
+  }
+
   const status = await getServerStatus();
-  
+
   if (!status.running || !status.pid) {
-    console.log('Server is not running');
+    if (wrapCount === 0) {
+      console.log('Server is not running');
+    }
     return;
   }
-  
+
   console.log(`Stopping server (PID: ${status.pid})...`);
-  
+
   try {
     process.kill(status.pid, 'SIGTERM');
-    
+
     // Wait for process to exit
     for (let i = 0; i < 50; i++) {
-      await new Promise(resolve => setTimeout(resolve, 100));
+      await new Promise((resolve) => setTimeout(resolve, 100));
       if (!isProcessRunning(status.pid)) {
         break;
       }
     }
-    
+
     // Force kill if still running
     if (isProcessRunning(status.pid)) {
       console.log('Force stopping server...');
       process.kill(status.pid, 'SIGKILL');
     }
-    
+
     // Clean up PID file
     const pidFile = getPidFilePath();
     if (existsSync(pidFile)) {
       unlinkSync(pidFile);
     }
-    
+
     console.log('✓ Server stopped');
   } catch (error) {
     console.error('Failed to stop server:', error);

--- a/src/cli/utils/wrap/__tests__/launch.test.ts
+++ b/src/cli/utils/wrap/__tests__/launch.test.ts
@@ -1,0 +1,50 @@
+import { describe, expect, mock, test, beforeEach, afterEach } from 'bun:test';
+import { EventEmitter } from 'node:events';
+
+const spawnCalls: Array<{ cmd: string; args: string[]; opts: Record<string, unknown> }> = [];
+
+class FakeChild extends EventEmitter {
+  kill() {
+    this.emit('close', 0, null);
+  }
+}
+
+mock.module('node:child_process', () => ({
+  spawn: (cmd: string, args: string[], opts: Record<string, unknown>) => {
+    spawnCalls.push({ cmd, args, opts });
+    const child = new FakeChild();
+    queueMicrotask(() => child.emit('close', 0, null));
+    return child;
+  },
+}));
+
+import { launchProvider } from '../launch';
+import type { ProviderIntegration } from '../../../../types/providers';
+
+const claude: ProviderIntegration = {
+  id: 'claude-code',
+  displayName: 'Claude Code',
+  wrap: { binary: 'claude', kind: 'cli' },
+} as ProviderIntegration;
+
+describe('launchProvider CLI', () => {
+  beforeEach(() => {
+    spawnCalls.length = 0;
+  });
+
+  afterEach(() => {
+    mock.restore();
+  });
+
+  test('spawns with inherited stdio and visible Windows console', async () => {
+    const result = await launchProvider(claude, 'C:\\ws\\proj', ['--help']);
+    expect(result.exitCode).toBe(0);
+    expect(spawnCalls).toHaveLength(1);
+    expect(spawnCalls[0]?.cmd).toBe('claude');
+    expect(spawnCalls[0]?.args).toEqual(['--help']);
+    expect(spawnCalls[0]?.opts.stdio).toBe('inherit');
+    expect(spawnCalls[0]?.opts.cwd).toBe('C:\\ws\\proj');
+    expect(spawnCalls[0]?.opts.windowsHide).toBe(false);
+    expect(spawnCalls[0]?.opts.shell).toBe(false);
+  });
+});

--- a/src/cli/utils/wrap/__tests__/launch.test.ts
+++ b/src/cli/utils/wrap/__tests__/launch.test.ts
@@ -1,20 +1,14 @@
 import { describe, expect, mock, test, beforeEach, afterEach } from 'bun:test';
-import { EventEmitter } from 'node:events';
 
-const spawnCalls: Array<{ cmd: string; args: string[]; opts: Record<string, unknown> }> = [];
-
-class FakeChild extends EventEmitter {
-  kill() {
-    this.emit('close', 0, null);
-  }
-}
+const spawnSyncCalls: Array<{ cmd: string; args: string[]; opts: Record<string, unknown> }> = [];
 
 mock.module('node:child_process', () => ({
-  spawn: (cmd: string, args: string[], opts: Record<string, unknown>) => {
-    spawnCalls.push({ cmd, args, opts });
-    const child = new FakeChild();
-    queueMicrotask(() => child.emit('close', 0, null));
-    return child;
+  spawnSync: (cmd: string, args: string[], opts: Record<string, unknown>) => {
+    spawnSyncCalls.push({ cmd, args, opts });
+    return { status: 0, signal: null, error: undefined };
+  },
+  spawn: () => {
+    throw new Error('async spawn should not be used for CLI wrap launch');
   },
 }));
 
@@ -29,22 +23,22 @@ const claude: ProviderIntegration = {
 
 describe('launchProvider CLI', () => {
   beforeEach(() => {
-    spawnCalls.length = 0;
+    spawnSyncCalls.length = 0;
   });
 
   afterEach(() => {
     mock.restore();
   });
 
-  test('spawns with inherited stdio and visible Windows console', async () => {
+  test('uses spawnSync with inherited stdio for a real TTY', async () => {
     const result = await launchProvider(claude, 'C:\\ws\\proj', ['--help']);
     expect(result.exitCode).toBe(0);
-    expect(spawnCalls).toHaveLength(1);
-    expect(spawnCalls[0]?.cmd).toBe('claude');
-    expect(spawnCalls[0]?.args).toEqual(['--help']);
-    expect(spawnCalls[0]?.opts.stdio).toBe('inherit');
-    expect(spawnCalls[0]?.opts.cwd).toBe('C:\\ws\\proj');
-    expect(spawnCalls[0]?.opts.windowsHide).toBe(false);
-    expect(spawnCalls[0]?.opts.shell).toBe(false);
+    expect(spawnSyncCalls).toHaveLength(1);
+    expect(spawnSyncCalls[0]?.cmd).toBe('claude');
+    expect(spawnSyncCalls[0]?.args).toEqual(['--help']);
+    expect(spawnSyncCalls[0]?.opts.stdio).toBe('inherit');
+    expect(spawnSyncCalls[0]?.opts.cwd).toBe('C:\\ws\\proj');
+    expect(spawnSyncCalls[0]?.opts.windowsHide).toBe(false);
+    expect(spawnSyncCalls[0]?.opts.shell).toBe(false);
   });
 });

--- a/src/cli/utils/wrap/__tests__/marker.test.ts
+++ b/src/cli/utils/wrap/__tests__/marker.test.ts
@@ -1,0 +1,73 @@
+import { describe, it, expect, beforeEach, afterEach } from 'bun:test';
+import { mkdirSync, mkdtempSync, writeFileSync, rmSync } from 'fs';
+import { join } from 'path';
+import { tmpdir } from 'os';
+import { readWorkspaceMarker, refuseIfWrapWorkspace } from '../marker';
+import { WORKSPACE_MARKER } from '../../../../shared/workspaces/paths';
+
+describe('readWorkspaceMarker', () => {
+  let homeish: string;
+  let cacheRoot: string;
+  let workingDir: string;
+
+  beforeEach(() => {
+    homeish = mkdtempSync(join(tmpdir(), 'capa-marker-'));
+    cacheRoot = join(homeish, 'proj-cursor-abc');
+    workingDir = join(cacheRoot, 'proj');
+    mkdirSync(workingDir, { recursive: true });
+    writeFileSync(
+      join(cacheRoot, WORKSPACE_MARKER),
+      JSON.stringify({
+        realProjectPath: '/real/proj',
+        providerId: 'cursor',
+        createdAt: new Date().toISOString(),
+        cachePath: cacheRoot,
+        workingDir: 'proj',
+      }) + '\n',
+    );
+  });
+
+  afterEach(() => {
+    rmSync(homeish, { recursive: true, force: true });
+  });
+
+  it('detects the nested working directory', async () => {
+    const marker = await readWorkspaceMarker(workingDir);
+    expect(marker?.providerId).toBe('cursor');
+    expect(marker?.workingDir).toBe('proj');
+  });
+
+  it('detects a subdirectory inside the nested working directory', async () => {
+    const nested = join(workingDir, 'src', 'lib');
+    mkdirSync(nested, { recursive: true });
+    const marker = await readWorkspaceMarker(nested);
+    expect(marker?.providerId).toBe('cursor');
+    expect(marker?.realProjectPath).toBe('/real/proj');
+  });
+
+  it('detects the cache root itself', async () => {
+    const marker = await readWorkspaceMarker(cacheRoot);
+    expect(marker?.providerId).toBe('cursor');
+  });
+
+  it('returns null outside a wrap workspace', async () => {
+    const outside = mkdtempSync(join(tmpdir(), 'capa-outside-'));
+    try {
+      expect(await readWorkspaceMarker(outside)).toBeNull();
+    } finally {
+      rmSync(outside, { recursive: true, force: true });
+    }
+  });
+
+  it('refuseIfWrapWorkspace returns true from a subdirectory', async () => {
+    const nested = join(workingDir, 'deep');
+    mkdirSync(nested, { recursive: true });
+    const prev = process.cwd();
+    try {
+      process.chdir(nested);
+      expect(await refuseIfWrapWorkspace('install')).toBe(true);
+    } finally {
+      process.chdir(prev);
+    }
+  });
+});

--- a/src/cli/utils/wrap/__tests__/sessions.test.ts
+++ b/src/cli/utils/wrap/__tests__/sessions.test.ts
@@ -1,0 +1,21 @@
+import { describe, it, expect } from 'bun:test';
+import { findWrapPids, isPidRunning, stopAllWrapSessions } from '../sessions';
+
+describe('wrap process discovery', () => {
+  it('isPidRunning reports the current process', () => {
+    expect(isPidRunning(process.pid)).toBe(true);
+    expect(isPidRunning(99999999)).toBe(false);
+  });
+
+  it('findWrapPids does not include the current (non-wrap) process', async () => {
+    const pids = await findWrapPids();
+    expect(pids.includes(process.pid)).toBe(false);
+  });
+
+  it('stopAllWrapSessions is a no-op when nothing is wrapping', async () => {
+    // May still find unrelated wraps on the machine; just ensure it resolves.
+    const n = await stopAllWrapSessions();
+    expect(typeof n).toBe('number');
+    expect(n).toBeGreaterThanOrEqual(0);
+  });
+});

--- a/src/cli/utils/wrap/__tests__/symlink-workspace.test.ts
+++ b/src/cli/utils/wrap/__tests__/symlink-workspace.test.ts
@@ -1,0 +1,162 @@
+import { describe, it, expect, beforeEach, afterEach } from 'bun:test';
+import {
+  existsSync,
+  mkdirSync,
+  mkdtempSync,
+  writeFileSync,
+  rmSync,
+  lstatSync,
+  readlinkSync,
+  realpathSync,
+  readFileSync,
+} from 'fs';
+import { join } from 'path';
+import { tmpdir, platform } from 'os';
+import {
+  buildSymlinkWorkspace,
+  syncTopLevelSymlinks,
+  promoteToRealProject,
+  getWrapExclusionSet,
+  removeTopLevelEntry,
+} from '../symlink-workspace';
+import { WORKSPACE_MARKER } from '../../../../shared/workspaces/paths';
+import { LOCKFILE_NAME } from '../../../../shared/lockfile';
+
+/** Cursor wrap with capabilities.providers: [cursor] — does not pull in openclaw/claude. */
+const CURSOR_ONLY = ['cursor'];
+/** Wrap that also installs for claude-code from capabilities. */
+const CURSOR_AND_CLAUDE = ['cursor', 'claude-code'];
+
+describe('symlink-workspace', () => {
+  let realDir: string;
+  let wsDir: string;
+
+  beforeEach(() => {
+    realDir = mkdtempSync(join(tmpdir(), 'capa-wrap-real-'));
+    wsDir = mkdtempSync(join(tmpdir(), 'capa-wrap-ws-'));
+    mkdirSync(join(realDir, 'src'));
+    writeFileSync(join(realDir, 'src', 'a.ts'), 'export {}');
+    writeFileSync(join(realDir, 'capabilities.yaml'), 'skills: []\n');
+    writeFileSync(join(realDir, LOCKFILE_NAME), 'version: 1\nskills: []\nplugins: []\n');
+    mkdirSync(join(realDir, '.git'));
+    mkdirSync(join(realDir, '.cursor'));
+    writeFileSync(join(realDir, '.cursor', 'x'), 'nope');
+    mkdirSync(join(realDir, '.claude'));
+    writeFileSync(join(realDir, 'CLAUDE.md'), 'x');
+    writeFileSync(join(realDir, 'AGENTS.md'), 'y');
+    mkdirSync(join(realDir, 'skills'));
+    writeFileSync(join(realDir, 'skills', 'SKILL.md'), 'local');
+  });
+
+  afterEach(() => {
+    rmSync(realDir, { recursive: true, force: true });
+    rmSync(wsDir, { recursive: true, force: true });
+  });
+
+  it('exclusion set is scoped to listed providers (not the full registry)', () => {
+    const cursorOnly = getWrapExclusionSet(CURSOR_ONLY);
+    expect(cursorOnly.has('.cursor')).toBe(true);
+    expect(cursorOnly.has('AGENTS.md')).toBe(true);
+    expect(cursorOnly.has('.claude')).toBe(false);
+    expect(cursorOnly.has('CLAUDE.md')).toBe(false);
+    expect(cursorOnly.has('skills')).toBe(false);
+    expect(cursorOnly.has(LOCKFILE_NAME)).toBe(true);
+    expect(cursorOnly.has(WORKSPACE_MARKER)).toBe(true);
+
+    const both = getWrapExclusionSet(CURSOR_AND_CLAUDE);
+    expect(both.has('.cursor')).toBe(true);
+    expect(both.has('.claude')).toBe(true);
+    expect(both.has('CLAUDE.md')).toBe(true);
+    expect(both.has('skills')).toBe(false);
+  });
+
+  it('symlinks src and skills for cursor-only; skips .cursor and AGENTS.md', () => {
+    buildSymlinkWorkspace(realDir, wsDir, CURSOR_ONLY);
+
+    expect(lstatSync(join(wsDir, 'src')).isDirectory() || lstatSync(join(wsDir, 'src')).isSymbolicLink()).toBe(true);
+    expect(existsSync(join(wsDir, 'src', 'a.ts'))).toBe(true);
+    expect(existsSync(join(wsDir, 'capabilities.yaml'))).toBe(true);
+    expect(readFileSync(join(wsDir, 'capabilities.yaml'), 'utf8')).toContain('skills');
+    expect(existsSync(join(wsDir, 'skills'))).toBe(true);
+
+    expect(existsSync(join(wsDir, '.cursor'))).toBe(false);
+    expect(existsSync(join(wsDir, 'AGENTS.md'))).toBe(false);
+    // Not in capabilities providers → still symlinked
+    expect(existsSync(join(wsDir, '.claude'))).toBe(true);
+    expect(existsSync(join(wsDir, 'CLAUDE.md'))).toBe(true);
+    expect(existsSync(join(wsDir, LOCKFILE_NAME))).toBe(false);
+
+    if (platform() !== 'win32') {
+      expect(lstatSync(join(wsDir, 'src')).isSymbolicLink()).toBe(true);
+      expect(readlinkSync(join(wsDir, 'capabilities.yaml'))).toContain('capabilities.yaml');
+    } else {
+      expect(realpathSync(join(wsDir, 'src'))).toBe(realpathSync(join(realDir, 'src')));
+    }
+  });
+
+  it('skips .claude when capabilities also lists claude-code', () => {
+    buildSymlinkWorkspace(realDir, wsDir, CURSOR_AND_CLAUDE);
+    expect(existsSync(join(wsDir, '.cursor'))).toBe(false);
+    expect(existsSync(join(wsDir, '.claude'))).toBe(false);
+    expect(existsSync(join(wsDir, 'CLAUDE.md'))).toBe(false);
+    expect(existsSync(join(wsDir, 'skills'))).toBe(true);
+  });
+
+  it('sync adds a link for a new top-level file', () => {
+    buildSymlinkWorkspace(realDir, wsDir, CURSOR_ONLY);
+    writeFileSync(join(realDir, 'NEW.md'), 'hello');
+    const linked = syncTopLevelSymlinks(realDir, wsDir, CURSOR_ONLY);
+    expect(linked).toContain('NEW.md');
+    expect(existsSync(join(wsDir, 'NEW.md'))).toBe(true);
+    expect(readFileSync(join(wsDir, 'NEW.md'), 'utf8')).toBe('hello');
+  });
+
+  it('sync ignores newly created dirs owned by the wrap providers', () => {
+    buildSymlinkWorkspace(realDir, wsDir, CURSOR_ONLY);
+    mkdirSync(join(realDir, '.cursor', 'rules'), { recursive: true });
+    // .cursor already excluded; a brand-new excluded top-level shouldn't link
+    // (recreate exclusion target as a sibling that is still owned — AGENTS.md)
+    writeFileSync(join(realDir, 'AGENTS.md'), 'updated');
+    syncTopLevelSymlinks(realDir, wsDir, CURSOR_ONLY);
+    expect(existsSync(join(wsDir, 'AGENTS.md'))).toBe(false);
+  });
+
+  it('sync does link unrelated provider dirs that are not in the exclusion set', () => {
+    buildSymlinkWorkspace(realDir, wsDir, CURSOR_ONLY);
+    mkdirSync(join(realDir, '.opencode'), { recursive: true });
+    syncTopLevelSymlinks(realDir, wsDir, CURSOR_ONLY);
+    expect(existsSync(join(wsDir, '.opencode'))).toBe(true);
+  });
+
+  it('promote moves a workspace-only file into the real project and leaves a link', () => {
+    buildSymlinkWorkspace(realDir, wsDir, CURSOR_ONLY);
+    writeFileSync(join(wsDir, 'NOTES.md'), 'from agent');
+    promoteToRealProject(realDir, wsDir, 'NOTES.md', CURSOR_ONLY);
+
+    expect(existsSync(join(realDir, 'NOTES.md'))).toBe(true);
+    expect(existsSync(join(wsDir, 'NOTES.md'))).toBe(true);
+    expect(readFileSync(join(realDir, 'NOTES.md'), 'utf8')).toBe('from agent');
+  });
+
+  it('promote overwrites real with workspace content when both exist separately', () => {
+    buildSymlinkWorkspace(realDir, wsDir, CURSOR_ONLY);
+    writeFileSync(join(realDir, 'SHARED.md'), 'old');
+    writeFileSync(join(wsDir, 'SHARED.md'), 'new from agent');
+    promoteToRealProject(realDir, wsDir, 'SHARED.md', CURSOR_ONLY);
+    expect(readFileSync(join(realDir, 'SHARED.md'), 'utf8')).toBe('new from agent');
+  });
+
+  it('removeTopLevelEntry deletes a file', () => {
+    writeFileSync(join(realDir, 'GONE.md'), 'x');
+    removeTopLevelEntry(realDir, 'GONE.md');
+    expect(existsSync(join(realDir, 'GONE.md'))).toBe(false);
+  });
+
+  it('promote does not move provider-owned paths', () => {
+    buildSymlinkWorkspace(realDir, wsDir, CURSOR_ONLY);
+    mkdirSync(join(wsDir, '.cursor'));
+    writeFileSync(join(wsDir, '.cursor', 'settings.json'), '{}');
+    promoteToRealProject(realDir, wsDir, '.cursor', CURSOR_ONLY);
+    expect(lstatSync(join(wsDir, '.cursor')).isSymbolicLink()).toBe(false);
+  });
+});

--- a/src/cli/utils/wrap/__tests__/workspace.test.ts
+++ b/src/cli/utils/wrap/__tests__/workspace.test.ts
@@ -1,0 +1,130 @@
+import { describe, it, expect, beforeEach, afterEach, mock } from 'bun:test';
+import {
+  existsSync,
+  mkdtempSync,
+  mkdirSync,
+  writeFileSync,
+  rmSync,
+  readFileSync,
+} from 'fs';
+import { join, basename } from 'path';
+import { tmpdir } from 'os';
+import { getWrappableProvider } from '../../../../shared/providers';
+import { WORKSPACE_MARKER } from '../../../../shared/workspaces/paths';
+
+const installMock = mock(async () => {});
+
+mock.module('../../../commands/install', () => ({
+  installCommand: installMock,
+}));
+
+const { prepareWorkspace, computeCapabilitiesFingerprint, workspaceDirName, workingDirName } =
+  await import('../workspace');
+
+function isolateHome(): { home: string; restore: () => void } {
+  const home = mkdtempSync(join(tmpdir(), 'capa-ws-home-'));
+  const prevHome = process.env.HOME;
+  const prevUserProfile = process.env.USERPROFILE;
+  process.env.HOME = home;
+  process.env.USERPROFILE = home;
+  return {
+    home,
+    restore: () => {
+      if (prevHome === undefined) delete process.env.HOME;
+      else process.env.HOME = prevHome;
+      if (prevUserProfile === undefined) delete process.env.USERPROFILE;
+      else process.env.USERPROFILE = prevUserProfile;
+      rmSync(home, { recursive: true, force: true });
+    },
+  };
+}
+
+describe('prepareWorkspace', () => {
+  let realDir: string;
+  let homeCtx: { home: string; restore: () => void };
+
+  beforeEach(() => {
+    realDir = mkdtempSync(join(tmpdir(), 'capa-ws-real-'));
+    homeCtx = isolateHome();
+    writeFileSync(
+      join(realDir, 'capabilities.yaml'),
+      'skills: []\nproviders:\n  - claude-code\n',
+    );
+    mkdirSync(join(realDir, 'src'));
+    writeFileSync(join(realDir, 'src', 'x.ts'), '');
+    installMock.mockClear();
+    installMock.mockImplementation(async () => {});
+  });
+
+  afterEach(() => {
+    homeCtx.restore();
+    rmSync(realDir, { recursive: true, force: true });
+  });
+
+  it('cold prepare nests the original project name under the cache slug', async () => {
+    const provider = getWrappableProvider('claude-code')!;
+    const prepared = await prepareWorkspace(realDir, provider);
+
+    expect(prepared.cold).toBe(true);
+    expect(basename(prepared.workspacePath)).toBe(workingDirName(realDir));
+    expect(basename(prepared.workspacePath)).toBe(basename(realDir));
+    expect(prepared.cachePath).toBe(join(prepared.workspacePath, '..'));
+    expect(existsSync(join(prepared.cachePath, WORKSPACE_MARKER))).toBe(true);
+    expect(existsSync(join(prepared.workspacePath, WORKSPACE_MARKER))).toBe(false);
+    const marker = JSON.parse(
+      readFileSync(join(prepared.cachePath, WORKSPACE_MARKER), 'utf8'),
+    );
+    expect(marker.providerId).toBe('claude-code');
+    expect(marker.cachePath).toBe(prepared.cachePath);
+    expect(marker.workingDir).toBe(basename(realDir));
+    // Marker must not appear inside the IDE-visible working directory.
+    expect(existsSync(join(prepared.workspacePath, WORKSPACE_MARKER))).toBe(false);
+    expect(existsSync(join(prepared.cachePath, WORKSPACE_MARKER))).toBe(true);
+    expect(installMock).toHaveBeenCalledTimes(1);
+    const args = installMock.mock.calls.at(0) as unknown as [
+      { projectPath: string; identityPath: string; provider: string },
+    ];
+    expect(args[0].projectPath).toBe(prepared.workspacePath);
+    expect(args[0].identityPath).toBe(realDir);
+    expect(args[0].provider).toBe('claude-code');
+  });
+
+  it('second prepare with same fingerprint skips install when DB has project', async () => {
+    const provider = getWrappableProvider('claude-code')!;
+
+    const { CapaDatabase } = await import('../../../../db/database');
+    const { loadSettings, getDatabasePath, ensureCapaDir } = await import(
+      '../../../../shared/config'
+    );
+    const { generateProjectId } = await import('../../../../shared/paths');
+    await ensureCapaDir();
+    const settings = await loadSettings();
+    const db = new CapaDatabase(getDatabasePath(settings));
+    db.upsertProject({ id: generateProjectId(realDir), path: realDir });
+    db.close();
+
+    const first = await prepareWorkspace(realDir, provider);
+    expect(first.cold).toBe(true);
+    expect(installMock).toHaveBeenCalledTimes(1);
+
+    installMock.mockClear();
+    const second = await prepareWorkspace(realDir, provider);
+    expect(second.cold).toBe(false);
+    expect(second.workspacePath).toBe(first.workspacePath);
+    expect(second.cachePath).toBe(first.cachePath);
+    expect(installMock).not.toHaveBeenCalled();
+  });
+
+  it('fingerprint changes when capabilities.yaml changes', async () => {
+    const a = await computeCapabilitiesFingerprint(realDir);
+    writeFileSync(
+      join(realDir, 'capabilities.yaml'),
+      'skills:\n  - id: x\n    type: inline\n    def:\n      content: hi\n',
+    );
+    const b = await computeCapabilitiesFingerprint(realDir);
+    expect(a).not.toBe(b);
+    expect(workspaceDirName(realDir, 'claude-code', a)).not.toBe(
+      workspaceDirName(realDir, 'claude-code', b),
+    );
+  });
+});

--- a/src/cli/utils/wrap/launch.ts
+++ b/src/cli/utils/wrap/launch.ts
@@ -1,0 +1,148 @@
+import { spawn } from 'node:child_process';
+import type { ProviderIntegration } from '../../../types/providers';
+
+export interface LaunchResult {
+  /** Exit code for CLI providers after they exit. */
+  exitCode?: number;
+  /**
+   * GUI: resolves when the app process exits (e.g. Cursor with `--wait`
+   * after the window is closed).
+   */
+  closed?: Promise<number>;
+  /** GUI: terminate the launcher/app process (e.g. on Ctrl+C). */
+  kill?: () => void;
+}
+
+/**
+ * Stop capa from competing with the child for console input.
+ *
+ * Bun keeps polling fd 0 after anything touches `process.stdin` (e.g. clack
+ * spinners during cold install). A child spawned with stdio inherit then races
+ * the parent for keystrokes — Claude's TUI looks "broken". Pause/unref first.
+ */
+function releaseStdinForChild(): void {
+  const stdin = process.stdin;
+  try {
+    if (typeof stdin.setRawMode === 'function' && stdin.isTTY) {
+      stdin.setRawMode(false);
+    }
+  } catch {
+    // ignore
+  }
+  try {
+    stdin.pause();
+  } catch {
+    // ignore
+  }
+  try {
+    stdin.removeAllListeners('data');
+    stdin.removeAllListeners('readable');
+    stdin.removeAllListeners('keypress');
+  } catch {
+    // ignore
+  }
+  try {
+    stdin.unref();
+  } catch {
+    // ignore
+  }
+
+  // Spinner may have hidden the cursor; restore before handing off the TTY.
+  if (process.stdout.isTTY) {
+    try {
+      process.stdout.write('\x1b[?25h');
+    } catch {
+      // ignore
+    }
+  }
+}
+
+/**
+ * Headroom's wrap pattern: parent ignores SIGINT so Ctrl+C is for the child
+ * CLI, not the wrap process (watchers stay alive until the child exits).
+ */
+function ignoreParentSigint(): () => void {
+  const noop = () => {
+    // Child owns the console; do not exit wrap on Ctrl+C.
+  };
+  process.on('SIGINT', noop);
+  return () => {
+    process.off('SIGINT', noop);
+  };
+}
+
+/**
+ * Launch the provider binary according to wrap.kind.
+ * CLI: blocking, cwd = workspace.
+ * GUI: returns immediately with `closed`/`kill` so wrap can race window-close vs interrupt.
+ */
+export async function launchProvider(
+  provider: ProviderIntegration,
+  workspacePath: string,
+  args: string[],
+): Promise<LaunchResult> {
+  const wrap = provider.wrap;
+  if (!wrap) {
+    throw new Error(`Provider "${provider.id}" is not wrappable.`);
+  }
+
+  const wrapArgs = wrap.args ?? [];
+
+  if (wrap.kind === 'gui') {
+    // Prefer awaiting the GUI launcher (Cursor/VS Code `--wait`) so closing the
+    // window ends wrap. Not detached — we need the process lifetime.
+    const proc = Bun.spawn([wrap.binary, ...wrapArgs, workspacePath, ...args], {
+      cwd: workspacePath,
+      stdin: 'ignore',
+      stdout: 'ignore',
+      stderr: 'ignore',
+      windowsHide: true,
+    });
+
+    return {
+      closed: proc.exited.then((code) => code ?? 0),
+      kill: () => {
+        try {
+          proc.kill();
+        } catch {
+          // already exited
+        }
+      },
+    };
+  }
+
+  // CLI: mirror Headroom (`subprocess.run(..., inherit stdio)`), not Bun.spawn.
+  // node:child_process + released stdin is far more reliable for interactive TUIs
+  // under a Bun-compiled parent (Claude Code, Codex, etc.).
+  releaseStdinForChild();
+  const restoreSigint = ignoreParentSigint();
+
+  try {
+    const exitCode = await new Promise<number>((resolve, reject) => {
+      const child = spawn(wrap.binary, [...wrapArgs, ...args], {
+        cwd: workspacePath,
+        env: process.env,
+        stdio: 'inherit',
+        windowsHide: false,
+        shell: false,
+      });
+
+      child.on('error', (err) => {
+        reject(err);
+      });
+
+      child.on('close', (code, signal) => {
+        if (code != null) {
+          resolve(code);
+          return;
+        }
+        // Signal exit without a code (POSIX); map roughly like a shell would.
+        resolve(signal ? 128 : 1);
+      });
+    });
+
+    return { exitCode };
+  } finally {
+    restoreSigint();
+  }
+}

--- a/src/cli/utils/wrap/launch.ts
+++ b/src/cli/utils/wrap/launch.ts
@@ -1,4 +1,4 @@
-import { spawn } from 'node:child_process';
+import { spawnSync } from 'node:child_process';
 import type { ProviderIntegration } from '../../../types/providers';
 
 export interface LaunchResult {
@@ -14,11 +14,10 @@ export interface LaunchResult {
 }
 
 /**
- * Stop capa from competing with the child for console input.
+ * Quiesce parent stdin so Bun races the child less for console keystrokes.
  *
- * Bun keeps polling fd 0 after anything touches `process.stdin` (e.g. clack
- * spinners during cold install). A child spawned with stdio inherit then races
- * the parent for keystrokes — Claude's TUI looks "broken". Pause/unref first.
+ * Do NOT destroy/close fd 0 — that breaks `stdio: 'inherit'` and makes Claude
+ * see a non-TTY (it then demands `--print` + a prompt).
  */
 function releaseStdinForChild(): void {
   const stdin = process.stdin;
@@ -47,7 +46,6 @@ function releaseStdinForChild(): void {
     // ignore
   }
 
-  // Spinner may have hidden the cursor; restore before handing off the TTY.
   if (process.stdout.isTTY) {
     try {
       process.stdout.write('\x1b[?25h');
@@ -59,7 +57,7 @@ function releaseStdinForChild(): void {
 
 /**
  * Headroom's wrap pattern: parent ignores SIGINT so Ctrl+C is for the child
- * CLI, not the wrap process (watchers stay alive until the child exits).
+ * CLI, not the wrap process.
  */
 function ignoreParentSigint(): () => void {
   const noop = () => {
@@ -73,7 +71,7 @@ function ignoreParentSigint(): () => void {
 
 /**
  * Launch the provider binary according to wrap.kind.
- * CLI: blocking, cwd = workspace.
+ * CLI: blocking spawnSync with inherited console (real TTY for Claude).
  * GUI: returns immediately with `closed`/`kill` so wrap can race window-close vs interrupt.
  */
 export async function launchProvider(
@@ -89,8 +87,6 @@ export async function launchProvider(
   const wrapArgs = wrap.args ?? [];
 
   if (wrap.kind === 'gui') {
-    // Prefer awaiting the GUI launcher (Cursor/VS Code `--wait`) so closing the
-    // window ends wrap. Not detached — we need the process lifetime.
     const proc = Bun.spawn([wrap.binary, ...wrapArgs, workspacePath, ...args], {
       cwd: workspacePath,
       stdin: 'ignore',
@@ -111,36 +107,27 @@ export async function launchProvider(
     };
   }
 
-  // CLI: mirror Headroom (`subprocess.run(..., inherit stdio)`), not Bun.spawn.
-  // node:child_process + released stdin is far more reliable for interactive TUIs
-  // under a Bun-compiled parent (Claude Code, Codex, etc.).
+  // CLI interactive TUI: inherit the real console so isTTY stays true.
+  // spawnSync blocks this thread; watchers run in a detached __wrap_watch__
+  // process so we are not also polling stdin from an in-process event loop.
   releaseStdinForChild();
   const restoreSigint = ignoreParentSigint();
 
   try {
-    const exitCode = await new Promise<number>((resolve, reject) => {
-      const child = spawn(wrap.binary, [...wrapArgs, ...args], {
-        cwd: workspacePath,
-        env: process.env,
-        stdio: 'inherit',
-        windowsHide: false,
-        shell: false,
-      });
-
-      child.on('error', (err) => {
-        reject(err);
-      });
-
-      child.on('close', (code, signal) => {
-        if (code != null) {
-          resolve(code);
-          return;
-        }
-        // Signal exit without a code (POSIX); map roughly like a shell would.
-        resolve(signal ? 128 : 1);
-      });
+    const result = spawnSync(wrap.binary, [...wrapArgs, ...args], {
+      cwd: workspacePath,
+      env: process.env,
+      stdio: 'inherit',
+      windowsHide: false,
+      shell: false,
     });
 
+    if (result.error) {
+      throw result.error;
+    }
+
+    const exitCode =
+      result.status != null ? result.status : result.signal != null ? 128 : 1;
     return { exitCode };
   } finally {
     restoreSigint();

--- a/src/cli/utils/wrap/marker.ts
+++ b/src/cli/utils/wrap/marker.ts
@@ -1,0 +1,54 @@
+import { existsSync } from 'fs';
+import { basename, join, resolve } from 'path';
+import { WORKSPACE_MARKER, type WorkspaceMarker } from '../../../shared/workspaces/paths';
+
+async function tryReadMarker(markerPath: string): Promise<WorkspaceMarker | null> {
+  if (!existsSync(markerPath)) return null;
+  try {
+    const data = (await Bun.file(markerPath).json()) as WorkspaceMarker;
+    if (!data?.realProjectPath || !data?.providerId) return null;
+    return data;
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * If cwd (or `dir`) is inside a capa wrap shadow workspace, return its marker.
+ *
+ * The marker lives on the **cache root** (parent of the nested project-named
+ * working dir), so IDE users never see `.capa-workspace.json` in the tree.
+ */
+export async function readWorkspaceMarker(
+  dir: string = process.cwd(),
+): Promise<WorkspaceMarker | null> {
+  const abs = resolve(dir);
+
+  // Primary: parent cache root (marker is one level above the working dir).
+  const parentMarker = await tryReadMarker(join(abs, '..', WORKSPACE_MARKER));
+  if (parentMarker) {
+    const expected =
+      parentMarker.workingDir ?? basename(resolve(parentMarker.realProjectPath));
+    if (basename(abs) === expected || !parentMarker.workingDir) {
+      return parentMarker;
+    }
+  }
+
+  // Legacy / direct open of the cache root itself.
+  return tryReadMarker(join(abs, WORKSPACE_MARKER));
+}
+
+/**
+ * Refuse to run project-mutating commands inside a wrap workspace.
+ * Returns true and prints an error if the current directory is a wrap workspace.
+ */
+export async function refuseIfWrapWorkspace(command: string): Promise<boolean> {
+  const marker = await readWorkspaceMarker();
+  if (!marker) return false;
+  console.error(
+    `✗ Cannot run "capa ${command}" inside a wrap workspace.\n` +
+      `  Run it from the real project instead:\n` +
+      `  ${marker.realProjectPath}`,
+  );
+  return true;
+}

--- a/src/cli/utils/wrap/marker.ts
+++ b/src/cli/utils/wrap/marker.ts
@@ -1,5 +1,5 @@
 import { existsSync } from 'fs';
-import { basename, join, resolve } from 'path';
+import { dirname, join, relative, resolve, sep } from 'path';
 import { WORKSPACE_MARKER, type WorkspaceMarker } from '../../../shared/workspaces/paths';
 
 async function tryReadMarker(markerPath: string): Promise<WorkspaceMarker | null> {
@@ -13,29 +13,48 @@ async function tryReadMarker(markerPath: string): Promise<WorkspaceMarker | null
   }
 }
 
+function isPathInside(child: string, parent: string): boolean {
+  const rel = relative(resolve(parent), resolve(child));
+  return rel === '' || (!rel.startsWith('..') && !rel.startsWith(`..${sep}`));
+}
+
 /**
  * If cwd (or `dir`) is inside a capa wrap shadow workspace, return its marker.
  *
  * The marker lives on the **cache root** (parent of the nested project-named
  * working dir), so IDE users never see `.capa-workspace.json` in the tree.
+ * Walks ancestors so `capa install/add/clean` from a subdirectory still refuse.
  */
 export async function readWorkspaceMarker(
   dir: string = process.cwd(),
 ): Promise<WorkspaceMarker | null> {
-  const abs = resolve(dir);
+  let abs = resolve(dir);
+  const seen = new Set<string>();
 
-  // Primary: parent cache root (marker is one level above the working dir).
-  const parentMarker = await tryReadMarker(join(abs, '..', WORKSPACE_MARKER));
-  if (parentMarker) {
-    const expected =
-      parentMarker.workingDir ?? basename(resolve(parentMarker.realProjectPath));
-    if (basename(abs) === expected || !parentMarker.workingDir) {
-      return parentMarker;
+  while (!seen.has(abs)) {
+    seen.add(abs);
+
+    const marker = await tryReadMarker(join(abs, WORKSPACE_MARKER));
+    if (marker) {
+      const workingDir = marker.workingDir;
+      if (!workingDir) {
+        // Legacy flat layout: marker dir is the workspace root.
+        if (isPathInside(resolve(dir), abs)) return marker;
+      } else {
+        const nestedRoot = join(abs, workingDir);
+        // Current dir is the cache root, the nested working dir, or inside it.
+        if (abs === resolve(dir) || isPathInside(resolve(dir), nestedRoot)) {
+          return marker;
+        }
+      }
     }
+
+    const parent = dirname(abs);
+    if (parent === abs) break;
+    abs = parent;
   }
 
-  // Legacy / direct open of the cache root itself.
-  return tryReadMarker(join(abs, WORKSPACE_MARKER));
+  return null;
 }
 
 /**

--- a/src/cli/utils/wrap/sessions.ts
+++ b/src/cli/utils/wrap/sessions.ts
@@ -1,0 +1,107 @@
+/**
+ * Discover and stop live `capa wrap` processes without a PID registry.
+ * `capa stop` scans the process table for capa binaries whose argv includes `wrap`.
+ */
+
+export function isPidRunning(pid: number): boolean {
+  if (!Number.isFinite(pid) || pid <= 0) return false;
+  try {
+    process.kill(pid, 0);
+    return true;
+  } catch (err: unknown) {
+    const code =
+      err && typeof err === 'object' && 'code' in err
+        ? String((err as { code: unknown }).code)
+        : '';
+    return code === 'EPERM';
+  }
+}
+
+function tryKill(pid: number, signal: NodeJS.Signals): boolean {
+  try {
+    process.kill(pid, signal);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+/**
+ * Find capa processes whose argv includes `wrap`.
+ */
+export async function findWrapPids(): Promise<number[]> {
+  const self = process.pid;
+  const pids: number[] = [];
+
+  if (process.platform === 'win32') {
+    try {
+      const proc = Bun.spawn(
+        [
+          'powershell',
+          '-NoProfile',
+          '-Command',
+          `Get-CimInstance Win32_Process -Filter "Name = 'capa.exe'" | ` +
+            `Where-Object { $_.CommandLine -match '\\swrap(\\s|$)' -and $_.ProcessId -ne ${self} } | ` +
+            `Select-Object -ExpandProperty ProcessId`,
+        ],
+        { stdout: 'pipe', stderr: 'ignore' },
+      );
+      const out = await new Response(proc.stdout).text();
+      await proc.exited;
+      for (const line of out.split(/\r?\n/)) {
+        const n = parseInt(line.trim(), 10);
+        if (Number.isFinite(n) && n > 0) pids.push(n);
+      }
+    } catch {
+      // ignore
+    }
+    return [...new Set(pids)];
+  }
+
+  try {
+    const proc = Bun.spawn(['ps', '-ax', '-o', 'pid=,command='], {
+      stdout: 'pipe',
+      stderr: 'ignore',
+    });
+    const out = await new Response(proc.stdout).text();
+    await proc.exited;
+    for (const line of out.split('\n')) {
+      const m = line.trim().match(/^(\d+)\s+(.+)$/);
+      if (!m) continue;
+      const pid = parseInt(m[1]!, 10);
+      const cmd = m[2]!;
+      if (pid === self) continue;
+      // e.g. `capa wrap cursor`, `./dist/capa wrap …`, `bun src/cli/index.ts wrap …`
+      if (!/\bwrap\b/.test(cmd)) continue;
+      if (!/\bcapa(?:\.exe)?\b/i.test(cmd) && !/src\/cli\/index\.ts\b/.test(cmd)) continue;
+      pids.push(pid);
+    }
+  } catch {
+    // ignore
+  }
+  return [...new Set(pids)];
+}
+
+async function terminatePids(pids: number[]): Promise<void> {
+  const unique = [...new Set(pids)].filter((pid) => pid !== process.pid && isPidRunning(pid));
+  for (const pid of unique) {
+    tryKill(pid, 'SIGTERM');
+  }
+  for (let i = 0; i < 50; i++) {
+    await new Promise((r) => setTimeout(r, 100));
+    if (unique.every((pid) => !isPidRunning(pid))) break;
+  }
+  for (const pid of unique) {
+    if (isPidRunning(pid)) tryKill(pid, 'SIGKILL');
+  }
+}
+
+/**
+ * Stop every live `capa wrap` process. Returns how many PIDs were targeted.
+ */
+export async function stopAllWrapSessions(): Promise<number> {
+  const pids = await findWrapPids();
+  if (pids.length === 0) return 0;
+  await terminatePids(pids);
+  return pids.length;
+}

--- a/src/cli/utils/wrap/sessions.ts
+++ b/src/cli/utils/wrap/sessions.ts
@@ -41,7 +41,7 @@ export async function findWrapPids(): Promise<number[]> {
           '-NoProfile',
           '-Command',
           `Get-CimInstance Win32_Process -Filter "Name = 'capa.exe'" | ` +
-            `Where-Object { $_.CommandLine -match '\\swrap(\\s|$)' -and $_.ProcessId -ne ${self} } | ` +
+            `Where-Object { ($_.CommandLine -match '\\swrap(\\s|$)' -or $_.CommandLine -match '__wrap_watch__') -and $_.ProcessId -ne ${self} } | ` +
             `Select-Object -ExpandProperty ProcessId`,
         ],
         { stdout: 'pipe', stderr: 'ignore' },
@@ -72,7 +72,7 @@ export async function findWrapPids(): Promise<number[]> {
       const cmd = m[2]!;
       if (pid === self) continue;
       // e.g. `capa wrap cursor`, `./dist/capa wrap …`, `bun src/cli/index.ts wrap …`
-      if (!/\bwrap\b/.test(cmd)) continue;
+      if (!/\bwrap\b/.test(cmd) && !/__wrap_watch__/.test(cmd)) continue;
       if (!/\bcapa(?:\.exe)?\b/i.test(cmd) && !/src\/cli\/index\.ts\b/.test(cmd)) continue;
       pids.push(pid);
     }

--- a/src/cli/utils/wrap/symlink-workspace.ts
+++ b/src/cli/utils/wrap/symlink-workspace.ts
@@ -170,17 +170,49 @@ export function isLinkedToReal(
 
 /**
  * Try to replace a workspace path with a symlink/junction/hardlink to `realEntry`.
- * Returns true on success. On failure the workspace entry is left as-is (caller may mirror).
+ * Returns true on success. On failure the workspace entry is left as-is.
  */
 function tryRelink(realEntry: string, wsEntry: string): boolean {
   try {
-    if (existsSync(wsEntry)) {
-      // Only remove if not already the link we want
-      if (isAlreadyLinked(wsEntry, realEntry)) return true;
-      rmSync(wsEntry, { recursive: true, force: true });
+    if (existsSync(wsEntry) && isAlreadyLinked(wsEntry, realEntry)) {
+      return true;
     }
-    createWorkspaceSymlink(realEntry, wsEntry);
-    return true;
+
+    // Move the existing entry aside first so a failed link can restore it.
+    const backup = `${wsEntry}.capa-relink-bak`;
+    try {
+      rmSync(backup, { recursive: true, force: true });
+    } catch {
+      // ignore
+    }
+
+    let hadOriginal = false;
+    if (existsSync(wsEntry)) {
+      renameSync(wsEntry, backup);
+      hadOriginal = true;
+    }
+
+    try {
+      createWorkspaceSymlink(realEntry, wsEntry);
+      if (hadOriginal) {
+        rmSync(backup, { recursive: true, force: true });
+      }
+      return true;
+    } catch {
+      try {
+        rmSync(wsEntry, { recursive: true, force: true });
+      } catch {
+        // ignore
+      }
+      if (hadOriginal) {
+        try {
+          renameSync(backup, wsEntry);
+        } catch {
+          // ignore
+        }
+      }
+      return false;
+    }
   } catch {
     return false;
   }

--- a/src/cli/utils/wrap/symlink-workspace.ts
+++ b/src/cli/utils/wrap/symlink-workspace.ts
@@ -1,0 +1,296 @@
+import {
+  existsSync,
+  lstatSync,
+  mkdirSync,
+  readdirSync,
+  renameSync,
+  rmSync,
+  symlinkSync,
+  linkSync,
+  copyFileSync,
+  cpSync,
+  statSync,
+} from 'fs';
+import { join, resolve } from 'path';
+import { platform } from 'os';
+import { getProviderOwnedTopLevelNames } from '../../../shared/providers';
+import { LOCKFILE_NAME } from '../../../shared/lockfile';
+import { WORKSPACE_MARKER } from '../../../shared/workspaces/paths';
+
+const isWin = platform() === 'win32';
+
+/** Always excluded from the symlink tree (in addition to provider-owned names). */
+export const ALWAYS_EXCLUDE = new Set([
+  LOCKFILE_NAME,
+  '.capa',
+  WORKSPACE_MARKER,
+]);
+
+/**
+ * Exclusion set for wrap symlink/sync: always-exclude names plus owned paths of
+ * the wrap provider and any providers listed in capabilities.yaml.
+ */
+export function getWrapExclusionSet(providerIds: Iterable<string>): Set<string> {
+  const names = getProviderOwnedTopLevelNames(providerIds);
+  for (const n of ALWAYS_EXCLUDE) names.add(n);
+  return names;
+}
+
+function symlinkErrorMessage(err: unknown): string {
+  const code = err && typeof err === 'object' && 'code' in err ? String((err as { code: unknown }).code) : '';
+  if (code === 'EPERM' || code === 'EACCES') {
+    return (
+      'Failed to create symlink (permission denied). ' +
+      (isWin
+        ? 'Enable Windows Developer Mode or run with elevated privileges for symlink creation.'
+        : 'Check filesystem permissions.')
+    );
+  }
+  return err instanceof Error ? err.message : String(err);
+}
+
+/**
+ * Create a symlink (Windows: directory junction; file symlink with hard-link fallback)
+ * from `linkPath` to `targetPath`.
+ */
+export function createWorkspaceSymlink(targetPath: string, linkPath: string): void {
+  const targetIsDir = existsSync(targetPath) && statSync(targetPath).isDirectory();
+  try {
+    if (isWin) {
+      if (targetIsDir) {
+        symlinkSync(targetPath, linkPath, 'junction');
+      } else {
+        try {
+          symlinkSync(targetPath, linkPath, 'file');
+        } catch {
+          // File symlinks need Developer Mode; hard links work on the same volume.
+          linkSync(targetPath, linkPath);
+        }
+      }
+    } else {
+      symlinkSync(targetPath, linkPath);
+    }
+  } catch (err) {
+    throw new Error(symlinkErrorMessage(err));
+  }
+}
+
+/**
+ * Build (or refresh) top-level symlinks from real project → workspace.
+ * Skips excluded names and entries that already exist in the workspace.
+ */
+export function syncTopLevelSymlinks(
+  realProjectPath: string,
+  workspacePath: string,
+  providerIds: Iterable<string>,
+): string[] {
+  const excluded = getWrapExclusionSet(providerIds);
+  const realRoot = resolve(realProjectPath);
+  const wsRoot = resolve(workspacePath);
+  mkdirSync(wsRoot, { recursive: true });
+
+  const linked: string[] = [];
+  let entries: string[];
+  try {
+    entries = readdirSync(realRoot);
+  } catch (err) {
+    throw new Error(
+      `Cannot read project directory: ${err instanceof Error ? err.message : String(err)}`,
+    );
+  }
+
+  for (const name of entries) {
+    if (excluded.has(name)) continue;
+    const target = join(realRoot, name);
+    const link = join(wsRoot, name);
+    try {
+      lstatSync(link);
+      // Already present — still count as synced if it links to real (or is our mirror).
+      linked.push(name);
+      continue;
+    } catch {
+      // does not exist
+    }
+    createWorkspaceSymlink(target, link);
+    linked.push(name);
+  }
+  return linked;
+}
+
+/**
+ * Remove a top-level entry from a root (file, dir, symlink, or junction).
+ */
+export function removeTopLevelEntry(root: string, name: string): void {
+  const target = join(resolve(root), name);
+  try {
+    rmSync(target, { recursive: true, force: true });
+  } catch {
+    // best-effort
+  }
+}
+
+/**
+ * Full cold build: ensure workspace dir, sync all top-level symlinks.
+ */
+export function buildSymlinkWorkspace(
+  realProjectPath: string,
+  workspacePath: string,
+  providerIds: Iterable<string>,
+): void {
+  mkdirSync(workspacePath, { recursive: true });
+  syncTopLevelSymlinks(realProjectPath, workspacePath, providerIds);
+}
+
+function isAlreadyLinked(wsEntry: string, realEntry: string): boolean {
+  try {
+    if (lstatSync(wsEntry).isSymbolicLink()) return true;
+  } catch {
+    return false;
+  }
+  try {
+    if (!existsSync(realEntry)) return false;
+    const a = statSync(wsEntry);
+    const b = statSync(realEntry);
+    return a.ino === b.ino && a.dev === b.dev;
+  } catch {
+    return false;
+  }
+}
+
+/** True when the workspace entry already shares storage with the real path. */
+export function isLinkedToReal(
+  realProjectPath: string,
+  workspacePath: string,
+  name: string,
+): boolean {
+  const wsEntry = join(resolve(workspacePath), name);
+  const realEntry = join(resolve(realProjectPath), name);
+  return isAlreadyLinked(wsEntry, realEntry);
+}
+
+/**
+ * Try to replace a workspace path with a symlink/junction/hardlink to `realEntry`.
+ * Returns true on success. On failure the workspace entry is left as-is (caller may mirror).
+ */
+function tryRelink(realEntry: string, wsEntry: string): boolean {
+  try {
+    if (existsSync(wsEntry)) {
+      // Only remove if not already the link we want
+      if (isAlreadyLinked(wsEntry, realEntry)) return true;
+      rmSync(wsEntry, { recursive: true, force: true });
+    }
+    createWorkspaceSymlink(realEntry, wsEntry);
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+/**
+ * Push a workspace top-level entry into the real project immediately, then prefer
+ * replacing the workspace copy with a link so further edits are shared in place.
+ *
+ * If linking fails (e.g. cross-volume hardlink on Windows), content is still
+ * copied to the real project so the original stays up to date; the next change
+ * will mirror again.
+ */
+export function promoteToRealProject(
+  realProjectPath: string,
+  workspacePath: string,
+  name: string,
+  providerIds: Iterable<string>,
+): void {
+  const excluded = getWrapExclusionSet(providerIds);
+  if (excluded.has(name)) return;
+
+  const wsEntry = join(resolve(workspacePath), name);
+  const realEntry = join(resolve(realProjectPath), name);
+
+  let st;
+  try {
+    st = lstatSync(wsEntry);
+  } catch {
+    return;
+  }
+  if (st.isSymbolicLink()) return;
+  if (isAlreadyLinked(wsEntry, realEntry)) return;
+
+  if (st.isDirectory()) {
+    if (!existsSync(realEntry)) {
+      try {
+        renameSync(wsEntry, realEntry);
+      } catch {
+        cpSync(wsEntry, realEntry, { recursive: true });
+        rmSync(wsEntry, { recursive: true, force: true });
+      }
+      tryRelink(realEntry, wsEntry);
+      return;
+    }
+    // Both dirs exist separately — prefer linking workspace to real (real wins structure).
+    // Do not delete workspace content without linking; try junction/symlink only.
+    tryRelink(realEntry, wsEntry);
+    return;
+  }
+
+  // File: always push workspace bytes to real first (agent edits win).
+  try {
+    if (!existsSync(realEntry)) {
+      try {
+        renameSync(wsEntry, realEntry);
+      } catch {
+        copyFileSync(wsEntry, realEntry);
+        rmSync(wsEntry, { force: true });
+      }
+      if (!tryRelink(realEntry, wsEntry)) {
+        // Cross-device / no symlink privilege: put a regular copy back in workspace
+        // and keep mirroring on subsequent events.
+        if (!existsSync(wsEntry)) {
+          copyFileSync(realEntry, wsEntry);
+        }
+      }
+      return;
+    }
+
+    // Real exists as a separate file — overwrite with workspace content, then link.
+    copyFileSync(wsEntry, realEntry);
+    if (!tryRelink(realEntry, wsEntry)) {
+      // Keep workspace file; content already mirrored to real.
+    }
+  } catch {
+    // best-effort
+  }
+}
+
+/**
+ * Mirror every unlinked top-level workspace entry into the real project.
+ * Safe to call frequently (poll / watch / exit).
+ */
+export function promotePendingEntries(
+  realProjectPath: string,
+  workspacePath: string,
+  providerIds: Iterable<string>,
+): void {
+  const excluded = getWrapExclusionSet(providerIds);
+  const wsRoot = resolve(workspacePath);
+  let entries: string[];
+  try {
+    entries = readdirSync(wsRoot);
+  } catch {
+    return;
+  }
+  for (const name of entries) {
+    if (excluded.has(name)) continue;
+    try {
+      const st = lstatSync(join(wsRoot, name));
+      if (st.isSymbolicLink()) continue;
+      if (isLinkedToReal(realProjectPath, workspacePath, name)) continue;
+    } catch {
+      continue;
+    }
+    try {
+      promoteToRealProject(realProjectPath, workspacePath, name, providerIds);
+    } catch {
+      // best-effort
+    }
+  }
+}

--- a/src/cli/utils/wrap/wait-for-interrupt.ts
+++ b/src/cli/utils/wrap/wait-for-interrupt.ts
@@ -1,0 +1,73 @@
+import * as readline from 'readline';
+
+/**
+ * Block until the user interrupts the wrap watcher, or `signal` aborts
+ * (e.g. GUI window closed).
+ *
+ * On Windows (especially Bun-compiled exes), `process.on('SIGINT')` alone is
+ * unreliable. We also listen via readline's SIGINT and a simple `q`+Enter.
+ */
+export function waitForInterrupt(signal?: AbortSignal): Promise<void> {
+  return new Promise<void>((resolve) => {
+    let settled = false;
+    let rl: readline.Interface | null = null;
+
+    const done = () => {
+      if (settled) return;
+      settled = true;
+      try {
+        process.off('SIGINT', done);
+        process.off('SIGTERM', done);
+        process.off('SIGHUP', done);
+      } catch {
+        // SIGHUP may not exist on Windows
+      }
+      try {
+        signal?.removeEventListener('abort', done);
+      } catch {
+        // ignore
+      }
+      if (rl) {
+        try {
+          rl.removeListener('SIGINT', done);
+          rl.removeListener('line', onLine);
+          rl.close();
+        } catch {
+          // ignore
+        }
+        rl = null;
+      }
+      resolve();
+    };
+
+    const onLine = (line: string) => {
+      const t = line.trim().toLowerCase();
+      if (t === 'q' || t === 'quit' || t === 'exit') done();
+    };
+
+    if (signal?.aborted) {
+      done();
+      return;
+    }
+
+    process.on('SIGINT', done);
+    process.on('SIGTERM', done);
+    try {
+      process.on('SIGHUP', done);
+    } catch {
+      // Windows
+    }
+    signal?.addEventListener('abort', done, { once: true });
+
+    if (process.stdin.isTTY) {
+      rl = readline.createInterface({
+        input: process.stdin,
+        output: process.stdout,
+        terminal: true,
+      });
+      // readline fires SIGINT on Ctrl+C more reliably on Windows than process alone
+      rl.on('SIGINT', done);
+      rl.on('line', onLine);
+    }
+  });
+}

--- a/src/cli/utils/wrap/watch-project.ts
+++ b/src/cli/utils/wrap/watch-project.ts
@@ -34,6 +34,11 @@ interface WatchOpts {
   capabilitiesPath: string;
   /** Wrap target + capabilities.providers — drives symlink exclusions. */
   exclusionProviderIds: string[];
+  /**
+   * When false, keep the poll timer referenced so a detached watch worker
+   * cannot exit if fs.watch() failed to register. Default true (GUI in-process).
+   */
+  unrefPoll?: boolean;
 }
 
 function entryExists(root: string, name: string): boolean {
@@ -362,7 +367,12 @@ export function startWrapWatchers(opts: WatchOpts): WrapWatchers {
   }
 
   pollTimer = setInterval(reconcile, POLL_MS);
-  if (typeof pollTimer === 'object' && pollTimer && 'unref' in pollTimer) {
+  if (
+    opts.unrefPoll !== false &&
+    typeof pollTimer === 'object' &&
+    pollTimer &&
+    'unref' in pollTimer
+  ) {
     (pollTimer as NodeJS.Timeout).unref?.();
   }
 

--- a/src/cli/utils/wrap/watch-project.ts
+++ b/src/cli/utils/wrap/watch-project.ts
@@ -1,0 +1,389 @@
+import { watch, type FSWatcher, existsSync, lstatSync, readdirSync } from 'fs';
+import { join, resolve, basename } from 'path';
+import {
+  createWorkspaceSymlink,
+  getWrapExclusionSet,
+  isLinkedToReal,
+  promotePendingEntries,
+  promoteToRealProject,
+  removeTopLevelEntry,
+  syncTopLevelSymlinks,
+} from './symlink-workspace';
+import { installCommand } from '../../commands/install';
+import { parseCapabilitiesFile } from '../../../shared/capabilities';
+import { collectWrapExclusionProviderIds } from '../../../shared/providers';
+import { isVerbose } from '../../ui';
+
+/** Coalesce burst writes only — keep sync as close to real-time as possible. */
+const PROMOTE_COALESCE_MS = 16;
+/** Backup poll for platforms where fs.watch drops events (notably Windows). */
+const POLL_MS = 200;
+const CAPABILITIES_DEBOUNCE_MS = 400;
+
+export interface WrapWatchers {
+  stop: () => void;
+  /** Promote any pending workspace-only top-level entries (call on exit). */
+  exitSweep: () => void;
+}
+
+interface WatchOpts {
+  realProjectPath: string;
+  workspacePath: string;
+  providerId: string;
+  capabilitiesPath: string;
+  /** Wrap target + capabilities.providers — drives symlink exclusions. */
+  exclusionProviderIds: string[];
+}
+
+function entryExists(root: string, name: string): boolean {
+  try {
+    lstatSync(join(root, name));
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+/**
+ * Start bidirectional top-level watchers + capabilities live re-apply.
+ * Handles creates, updates, and deletions in both directions.
+ */
+export function startWrapWatchers(opts: WatchOpts): WrapWatchers {
+  const realRoot = resolve(opts.realProjectPath);
+  const wsRoot = resolve(opts.workspacePath);
+  let providerIds = [...opts.exclusionProviderIds];
+  let excluded = getWrapExclusionSet(providerIds);
+  const ignoreReal = new Set<string>();
+  const ignoreWs = new Set<string>();
+  const promoteTimers = new Map<string, ReturnType<typeof setTimeout>>();
+  /** Names we keep in sync both ways — do not resurrect after a delete. */
+  const synced = new Set<string>();
+
+  let capsTimer: ReturnType<typeof setTimeout> | null = null;
+  let pollTimer: ReturnType<typeof setInterval> | null = null;
+  let reapplyRunning = false;
+  let reapplyQueued = false;
+  let stopped = false;
+
+  const watchers: FSWatcher[] = [];
+
+  function brieflyIgnore(name: string): void {
+    ignoreReal.add(name);
+    ignoreWs.add(name);
+    setTimeout(() => {
+      ignoreReal.delete(name);
+      ignoreWs.delete(name);
+    }, 50);
+  }
+
+  function flushPromote(name: string): void {
+    if (excluded.has(name) || stopped) return;
+    if (!entryExists(wsRoot, name)) return;
+    if (isLinkedToReal(realRoot, wsRoot, name)) {
+      synced.add(name);
+      return;
+    }
+
+    brieflyIgnore(name);
+    try {
+      promoteToRealProject(realRoot, wsRoot, name, providerIds);
+      if (entryExists(realRoot, name)) synced.add(name);
+    } catch {
+      // quiet
+    }
+  }
+
+  function schedulePromote(name: string): void {
+    if (excluded.has(name) || stopped || ignoreWs.has(name)) return;
+    if (isLinkedToReal(realRoot, wsRoot, name)) {
+      synced.add(name);
+      return;
+    }
+
+    const existing = promoteTimers.get(name);
+    if (existing) clearTimeout(existing);
+
+    promoteTimers.set(
+      name,
+      setTimeout(() => {
+        promoteTimers.delete(name);
+        flushPromote(name);
+      }, PROMOTE_COALESCE_MS),
+    );
+  }
+
+  /** Real deleted → drop workspace copy (do not let poll resurrect it). */
+  function syncDeleteFromReal(name: string): void {
+    if (excluded.has(name) || stopped || ignoreReal.has(name)) return;
+    brieflyIgnore(name);
+    removeTopLevelEntry(wsRoot, name);
+    synced.delete(name);
+  }
+
+  /** Workspace deleted → drop real copy. */
+  function syncDeleteFromWorkspace(name: string): void {
+    if (excluded.has(name) || stopped || ignoreWs.has(name)) return;
+    brieflyIgnore(name);
+    removeTopLevelEntry(realRoot, name);
+    synced.delete(name);
+  }
+
+  function reconcile(): void {
+    if (stopped) return;
+
+    let realNames: string[] = [];
+    let wsNames: string[] = [];
+    try {
+      realNames = readdirSync(realRoot).filter((n) => !excluded.has(n));
+    } catch {
+      return;
+    }
+    try {
+      wsNames = readdirSync(wsRoot).filter((n) => !excluded.has(n));
+    } catch {
+      return;
+    }
+
+    const realSet = new Set(realNames);
+    const wsSet = new Set(wsNames);
+
+    // Synced name missing on real → remove from workspace (deletion sync).
+    for (const name of [...synced]) {
+      if (excluded.has(name)) {
+        synced.delete(name);
+        continue;
+      }
+      const onReal = realSet.has(name);
+      const onWs = wsSet.has(name);
+      if (!onReal && onWs) {
+        syncDeleteFromReal(name);
+      } else if (onReal && !onWs) {
+        syncDeleteFromWorkspace(name);
+      } else if (!onReal && !onWs) {
+        synced.delete(name);
+      }
+    }
+
+    // Real has it, workspace missing → link into workspace.
+    for (const name of realNames) {
+      if (ignoreReal.has(name)) continue;
+      if (!wsSet.has(name)) {
+        brieflyIgnore(name);
+        try {
+          createWorkspaceSymlink(join(realRoot, name), join(wsRoot, name));
+          synced.add(name);
+        } catch {
+          // quiet
+        }
+      } else if (isLinkedToReal(realRoot, wsRoot, name) || entryExists(wsRoot, name)) {
+        synced.add(name);
+      }
+    }
+
+    // Workspace-only: new agent file → promote. Broken symlink / leftover after
+    // real delete that's still in synced was handled above.
+    for (const name of wsNames) {
+      if (ignoreWs.has(name) || realSet.has(name)) continue;
+      if (synced.has(name)) {
+        // Real gone but still marked synced — remove workspace copy.
+        syncDeleteFromReal(name);
+        continue;
+      }
+      try {
+        const st = lstatSync(join(wsRoot, name));
+        if (st.isSymbolicLink()) {
+          // Dangling link to deleted real path.
+          syncDeleteFromReal(name);
+          continue;
+        }
+      } catch {
+        continue;
+      }
+      flushPromote(name);
+    }
+  }
+
+  async function refreshExclusionProviders(): Promise<void> {
+    try {
+      const capsPath = resolve(opts.capabilitiesPath);
+      const format = capsPath.endsWith('.json') ? 'json' : 'yaml';
+      const capabilities = await parseCapabilitiesFile(capsPath, format);
+      providerIds = collectWrapExclusionProviderIds(opts.providerId, capabilities.providers);
+      excluded = getWrapExclusionSet(providerIds);
+    } catch {
+      // Keep last good exclusion set.
+    }
+  }
+
+  async function reapplyCapabilities(): Promise<void> {
+    if (stopped) return;
+    if (reapplyRunning) {
+      reapplyQueued = true;
+      return;
+    }
+    reapplyRunning = true;
+    try {
+      await refreshExclusionProviders();
+      await installCommand({
+        projectPath: wsRoot,
+        identityPath: realRoot,
+        provider: opts.providerId,
+        exitProcess: false,
+      });
+      try {
+        const linked = syncTopLevelSymlinks(realRoot, wsRoot, providerIds);
+        for (const name of linked) synced.add(name);
+      } catch {
+        // ignore
+      }
+    } catch (err) {
+      if (isVerbose()) {
+        console.warn(
+          `[wrap] capabilities re-apply failed (keeping last good): ${
+            err instanceof Error ? err.message : String(err)
+          }`,
+        );
+      }
+    } finally {
+      reapplyRunning = false;
+      if (reapplyQueued) {
+        reapplyQueued = false;
+        void reapplyCapabilities();
+      }
+    }
+  }
+
+  function onRealChange(filename: string | null): void {
+    if (!filename || stopped) return;
+    const name = filename.split(/[/\\]/)[0];
+    if (!name || excluded.has(name) || ignoreReal.has(name)) return;
+
+    if (!entryExists(realRoot, name)) {
+      syncDeleteFromReal(name);
+      return;
+    }
+
+    const link = join(wsRoot, name);
+    if (entryExists(wsRoot, name)) {
+      synced.add(name);
+      return;
+    }
+    try {
+      brieflyIgnore(name);
+      createWorkspaceSymlink(join(realRoot, name), link);
+      synced.add(name);
+    } catch {
+      // quiet
+    }
+  }
+
+  function onWsChange(filename: string | null): void {
+    if (!filename || stopped) return;
+    const name = filename.split(/[/\\]/)[0];
+    if (!name || excluded.has(name) || ignoreWs.has(name)) return;
+
+    if (!entryExists(wsRoot, name)) {
+      syncDeleteFromWorkspace(name);
+      return;
+    }
+
+    schedulePromote(name);
+  }
+
+  function onCapsChange(): void {
+    if (stopped) return;
+    if (capsTimer) clearTimeout(capsTimer);
+    capsTimer = setTimeout(() => {
+      capsTimer = null;
+      void reapplyCapabilities();
+    }, CAPABILITIES_DEBOUNCE_MS);
+  }
+
+  try {
+    watchers.push(
+      watch(realRoot, { persistent: true }, (_event, filename) => {
+        onRealChange(filename != null ? String(filename) : null);
+      }),
+    );
+  } catch {
+    // fs.watch may fail on some platforms
+  }
+
+  try {
+    watchers.push(
+      watch(wsRoot, { persistent: true }, (_event, filename) => {
+        onWsChange(filename != null ? String(filename) : null);
+      }),
+    );
+  } catch {
+    // ignore
+  }
+
+  const capsFile = resolve(opts.capabilitiesPath);
+  const capsDir = resolve(capsFile, '..');
+  const capsBase = basename(capsFile);
+  try {
+    watchers.push(
+      watch(capsDir, { persistent: true }, (_event, filename) => {
+        if (filename != null && String(filename) === capsBase) onCapsChange();
+      }),
+    );
+  } catch {
+    // ignore
+  }
+
+  try {
+    const linked = syncTopLevelSymlinks(realRoot, wsRoot, providerIds);
+    for (const name of linked) synced.add(name);
+  } catch {
+    // ignore
+  }
+
+  pollTimer = setInterval(reconcile, POLL_MS);
+  if (typeof pollTimer === 'object' && pollTimer && 'unref' in pollTimer) {
+    (pollTimer as NodeJS.Timeout).unref?.();
+  }
+
+  return {
+    stop() {
+      stopped = true;
+      if (capsTimer) clearTimeout(capsTimer);
+      if (pollTimer) clearInterval(pollTimer);
+      for (const t of promoteTimers.values()) clearTimeout(t);
+      promoteTimers.clear();
+      for (const w of watchers) {
+        try {
+          w.close();
+        } catch {}
+      }
+    },
+    exitSweep() {
+      for (const name of [...promoteTimers.keys()]) {
+        const t = promoteTimers.get(name);
+        if (t) clearTimeout(t);
+        promoteTimers.delete(name);
+        flushPromote(name);
+      }
+      try {
+        // Only promote genuinely new workspace-only files (not resurrected deletes).
+        const realSet = new Set(readdirSync(realRoot));
+        for (const name of readdirSync(wsRoot)) {
+          if (excluded.has(name) || realSet.has(name) || synced.has(name)) continue;
+          try {
+            if (lstatSync(join(wsRoot, name)).isSymbolicLink()) {
+              removeTopLevelEntry(wsRoot, name);
+              continue;
+            }
+          } catch {
+            continue;
+          }
+          promoteToRealProject(realRoot, wsRoot, name, providerIds);
+        }
+      } catch {
+        try {
+          promotePendingEntries(realRoot, wsRoot, providerIds);
+        } catch {}
+      }
+    },
+  };
+}

--- a/src/cli/utils/wrap/watch-project.ts
+++ b/src/cli/utils/wrap/watch-project.ts
@@ -18,7 +18,8 @@ import { isVerbose } from '../../ui';
 const PROMOTE_COALESCE_MS = 16;
 /** Backup poll for platforms where fs.watch drops events (notably Windows). */
 const POLL_MS = 200;
-const CAPABILITIES_DEBOUNCE_MS = 400;
+/** Wait after the last capabilities edit before re-installing. */
+const CAPABILITIES_DEBOUNCE_MS = 2000;
 
 export interface WrapWatchers {
   stop: () => void;
@@ -42,6 +43,19 @@ function entryExists(root: string, name: string): boolean {
   } catch {
     return false;
   }
+}
+
+/** Single in-place status line for capabilities re-apply (avoids log spam). */
+function writeReapplyStatus(message: string | null): void {
+  if (!process.stderr.isTTY) {
+    if (message) process.stderr.write(`[wrap] ${message}\n`);
+    return;
+  }
+  if (message == null) {
+    process.stderr.write('\r\x1b[K');
+    return;
+  }
+  process.stderr.write(`\r\x1b[K[wrap] ${message}`);
 }
 
 /**
@@ -222,6 +236,7 @@ export function startWrapWatchers(opts: WatchOpts): WrapWatchers {
       return;
     }
     reapplyRunning = true;
+    writeReapplyStatus('Re-applying capabilities…');
     try {
       await refreshExclusionProviders();
       await installCommand({
@@ -229,6 +244,7 @@ export function startWrapWatchers(opts: WatchOpts): WrapWatchers {
         identityPath: realRoot,
         provider: opts.providerId,
         exitProcess: false,
+        quiet: true,
       });
       try {
         const linked = syncTopLevelSymlinks(realRoot, wsRoot, providerIds);
@@ -236,19 +252,25 @@ export function startWrapWatchers(opts: WatchOpts): WrapWatchers {
       } catch {
         // ignore
       }
+      writeReapplyStatus('Capabilities re-applied');
     } catch (err) {
-      if (isVerbose()) {
-        console.warn(
-          `[wrap] capabilities re-apply failed (keeping last good): ${
-            err instanceof Error ? err.message : String(err)
-          }`,
-        );
-      }
+      writeReapplyStatus(
+        `Capabilities re-apply failed (keeping last good)${
+          isVerbose()
+            ? `: ${err instanceof Error ? err.message : String(err)}`
+            : ''
+        }`,
+      );
     } finally {
       reapplyRunning = false;
       if (reapplyQueued) {
         reapplyQueued = false;
         void reapplyCapabilities();
+      } else {
+        // Clear the status line after a short beat so it doesn't linger forever.
+        setTimeout(() => {
+          if (!reapplyRunning) writeReapplyStatus(null);
+        }, 1500);
       }
     }
   }
@@ -347,6 +369,7 @@ export function startWrapWatchers(opts: WatchOpts): WrapWatchers {
   return {
     stop() {
       stopped = true;
+      writeReapplyStatus(null);
       if (capsTimer) clearTimeout(capsTimer);
       if (pollTimer) clearInterval(pollTimer);
       for (const t of promoteTimers.values()) clearTimeout(t);

--- a/src/cli/utils/wrap/watch-worker.ts
+++ b/src/cli/utils/wrap/watch-worker.ts
@@ -35,6 +35,9 @@ export async function runWrapWatchWorker(argv: string[]): Promise<void> {
     providerId,
     capabilitiesPath,
     exclusionProviderIds,
+    // Detached worker must keep a referenced handle or it can exit when
+    // fs.watch fails and the forever-await alone does not pin the event loop.
+    unrefPoll: false,
   });
 
   const shutdown = () => {

--- a/src/cli/utils/wrap/watch-worker.ts
+++ b/src/cli/utils/wrap/watch-worker.ts
@@ -1,0 +1,59 @@
+/**
+ * Detached wrap watcher entrypoint.
+ *
+ * CLI wrap runs the interactive provider via spawnSync (so Bun cannot race it
+ * for console input). Live symlink/capabilities sync therefore runs in this
+ * separate process: `capa __wrap_watch__ <real> <ws> <providerId> <caps> <exclJson>`
+ */
+import { startWrapWatchers } from './watch-project';
+
+export async function runWrapWatchWorker(argv: string[]): Promise<void> {
+  // argv: [realProjectPath, workspacePath, providerId, capabilitiesPath, exclusionJson]
+  const [realProjectPath, workspacePath, providerId, capabilitiesPath, exclusionJson] = argv;
+  if (!realProjectPath || !workspacePath || !providerId || !capabilitiesPath) {
+    console.error(
+      'usage: capa __wrap_watch__ <realPath> <workspacePath> <providerId> <capabilitiesPath> <exclusionJson>',
+    );
+    process.exit(1);
+  }
+
+  let exclusionProviderIds: string[] = [providerId];
+  if (exclusionJson) {
+    try {
+      const parsed = JSON.parse(exclusionJson) as unknown;
+      if (Array.isArray(parsed) && parsed.every((x) => typeof x === 'string')) {
+        exclusionProviderIds = parsed;
+      }
+    } catch {
+      // keep default
+    }
+  }
+
+  const watchers = startWrapWatchers({
+    realProjectPath,
+    workspacePath,
+    providerId,
+    capabilitiesPath,
+    exclusionProviderIds,
+  });
+
+  const shutdown = () => {
+    try {
+      watchers.exitSweep();
+      watchers.stop();
+    } finally {
+      process.exit(0);
+    }
+  };
+
+  process.on('SIGTERM', shutdown);
+  process.on('SIGINT', shutdown);
+  try {
+    process.on('SIGHUP', shutdown);
+  } catch {
+    // Windows
+  }
+
+  // Stay alive until signaled.
+  await new Promise<void>(() => {});
+}

--- a/src/cli/utils/wrap/workspace.ts
+++ b/src/cli/utils/wrap/workspace.ts
@@ -1,0 +1,262 @@
+import { createHash } from 'crypto';
+import { basename, join, resolve } from 'path';
+import { existsSync, mkdirSync, readdirSync, rmSync, statSync, writeFileSync } from 'fs';
+import { detectCapabilitiesFile, generateProjectId } from '../../../shared/paths';
+import { LOCKFILE_NAME } from '../../../shared/lockfile';
+import { loadSettings, getDatabasePath, ensureCapaDir } from '../../../shared/config';
+import { CapaDatabase } from '../../../db/database';
+import {
+  getWorkspacesDir,
+  WORKSPACE_MARKER,
+  type WorkspaceMarker,
+} from '../../../shared/workspaces/paths';
+import { parseCapabilitiesFile } from '../../../shared/capabilities';
+import { collectWrapExclusionProviderIds } from '../../../shared/providers';
+import { buildSymlinkWorkspace, syncTopLevelSymlinks } from './symlink-workspace';
+import { installCommand } from '../../commands/install';
+import type { ProviderIntegration } from '../../../types/providers';
+
+export interface PreparedWorkspace {
+  /** Fingerprinted cache root under ~/.capa/workspaces/<slug>/. */
+  cachePath: string;
+  /**
+   * Nested dir named after the real project basename — what IDEs/agents open
+   * so the window title stays the original project name.
+   */
+  workspacePath: string;
+  realProjectPath: string;
+  capabilitiesPath: string;
+  /**
+   * Provider ids whose owned paths are excluded from the symlink tree:
+   * wrap target + capabilities.providers.
+   */
+  exclusionProviderIds: string[];
+  cold: boolean;
+}
+
+function sanitizeName(name: string): string {
+  return name
+    .toLowerCase()
+    .replace(/[^a-z0-9-]/g, '-')
+    .replace(/-+/g, '-')
+    .replace(/^-|-$/g, '') || 'project';
+}
+
+/**
+ * Short fingerprint of capabilities.yaml + capabilities.lock for workspace cache keys.
+ */
+export async function computeCapabilitiesFingerprint(realProjectPath: string): Promise<string> {
+  const caps = await detectCapabilitiesFile(realProjectPath);
+  const parts: string[] = [];
+  if (caps) {
+    try {
+      parts.push(await Bun.file(caps.path).text());
+    } catch {
+      parts.push('');
+    }
+  } else {
+    parts.push('');
+  }
+  const lockPath = join(realProjectPath, LOCKFILE_NAME);
+  if (existsSync(lockPath)) {
+    try {
+      parts.push(await Bun.file(lockPath).text());
+    } catch {
+      parts.push('nolock');
+    }
+  } else {
+    parts.push('nolock');
+  }
+  return createHash('sha256').update(parts.join('\0')).digest('hex').slice(0, 12);
+}
+
+export function workspaceDirName(
+  realProjectPath: string,
+  providerId: string,
+  fingerprint: string,
+): string {
+  const projectName = sanitizeName(basename(resolve(realProjectPath)));
+  const provider = sanitizeName(providerId);
+  return `${projectName}-${provider}-${fingerprint}`;
+}
+
+/** Original project folder name preserved for the nested working directory. */
+export function workingDirName(realProjectPath: string): string {
+  return basename(resolve(realProjectPath)) || 'project';
+}
+
+async function writeMarker(
+  cachePath: string,
+  realProjectPath: string,
+  providerId: string,
+  workingDir: string,
+): Promise<void> {
+  const marker: WorkspaceMarker = {
+    realProjectPath: resolve(realProjectPath),
+    providerId,
+    createdAt: new Date().toISOString(),
+    cachePath: resolve(cachePath),
+    workingDir,
+  };
+  writeFileSync(join(cachePath, WORKSPACE_MARKER), JSON.stringify(marker, null, 2) + '\n');
+}
+
+async function markerValid(
+  cachePath: string,
+  realProjectPath: string,
+  providerId: string,
+  workingDir: string,
+): Promise<boolean> {
+  const markerPath = join(cachePath, WORKSPACE_MARKER);
+  if (!existsSync(markerPath)) return false;
+  try {
+    const data = (await Bun.file(markerPath).json()) as WorkspaceMarker;
+    // Reject legacy flat layouts (marker without workingDir, or project files at cache root).
+    if (!data.workingDir || data.workingDir !== workingDir) return false;
+    return (
+      data.providerId === providerId &&
+      resolve(data.realProjectPath) === resolve(realProjectPath)
+    );
+  } catch {
+    return false;
+  }
+}
+
+/**
+ * Old wrap builds put symlinks + marker directly in the slug folder.
+ * Those must be rebuilt into the nested layout.
+ */
+function isLegacyFlatCache(cachePath: string, workingDir: string): boolean {
+  if (!existsSync(cachePath)) return false;
+  const nested = join(cachePath, workingDir);
+  // Flat = marker (or capabilities.yaml) at cache root and no nested working dir.
+  if (existsSync(nested)) return false;
+  return (
+    existsSync(join(cachePath, WORKSPACE_MARKER)) ||
+    existsSync(join(cachePath, 'capabilities.yaml')) ||
+    existsSync(join(cachePath, 'capabilities.json'))
+  );
+}
+
+
+async function dbHasProject(realProjectPath: string): Promise<boolean> {
+  try {
+    const settings = await loadSettings();
+    const db = new CapaDatabase(getDatabasePath(settings));
+    try {
+      const id = generateProjectId(realProjectPath);
+      return db.getProject(id) != null;
+    } finally {
+      db.close();
+    }
+  } catch {
+    return false;
+  }
+}
+
+function cacheLooksLikeWrap(cachePath: string): boolean {
+  // Marker lives on the cache root (above the nested working dir).
+  return existsSync(join(cachePath, WORKSPACE_MARKER));
+}
+
+/**
+ * Resolve/create the persistent wrap workspace. Cold = rebuild + install;
+ * warm = sync symlinks only (skip install).
+ *
+ * Layout:
+ *   ~/.capa/workspaces/<slug>/           ← cache identity + .capa-workspace.json
+ *     <originalProjectName>/             ← IDE/agent cwd (original name)
+ *       src/ -> …                        ← symlinks + CAPA provider configs
+ */
+export async function prepareWorkspace(
+  realProjectPath: string,
+  provider: ProviderIntegration,
+): Promise<PreparedWorkspace> {
+  const real = resolve(realProjectPath);
+  const caps = await detectCapabilitiesFile(real);
+  if (!caps) {
+    throw new Error('No capabilities file found. Run "capa init" first.');
+  }
+
+  await ensureCapaDir();
+  const workspacesDir = getWorkspacesDir();
+  mkdirSync(workspacesDir, { recursive: true });
+
+  const fingerprint = await computeCapabilitiesFingerprint(real);
+  const dirName = workspaceDirName(real, provider.id, fingerprint);
+  const cachePath = join(workspacesDir, dirName);
+  const workName = workingDirName(real);
+  const workspacePath = join(cachePath, workName);
+
+  const capabilities = await parseCapabilitiesFile(caps.path, caps.format);
+  const exclusionProviderIds = collectWrapExclusionProviderIds(
+    provider.id,
+    capabilities.providers,
+  );
+
+  const warm =
+    !isLegacyFlatCache(cachePath, workName) &&
+    existsSync(workspacePath) &&
+    (await markerValid(cachePath, real, provider.id, workName)) &&
+    (await dbHasProject(real));
+
+  if (warm) {
+    syncTopLevelSymlinks(real, workspacePath, exclusionProviderIds);
+    return {
+      cachePath,
+      workspacePath,
+      realProjectPath: real,
+      capabilitiesPath: caps.path,
+      exclusionProviderIds,
+      cold: false,
+    };
+  }
+
+  // Cold: remove partial/stale/legacy-flat cache dir if present, rebuild nested
+  if (existsSync(cachePath)) {
+    rmSync(cachePath, { recursive: true, force: true });
+  }
+  mkdirSync(workspacePath, { recursive: true });
+  buildSymlinkWorkspace(real, workspacePath, exclusionProviderIds);
+  await writeMarker(cachePath, real, provider.id, workName);
+
+  await installCommand({
+    projectPath: workspacePath,
+    identityPath: real,
+    provider: provider.id,
+  });
+
+  return {
+    cachePath,
+    workspacePath,
+    realProjectPath: real,
+    capabilitiesPath: caps.path,
+    exclusionProviderIds,
+    cold: true,
+  };
+}
+
+/**
+ * Remove wrap cache dirs under ~/.capa/workspaces.
+ * Returns the number of cache roots removed.
+ */
+export async function pruneWorkspaces(): Promise<number> {
+  await ensureCapaDir();
+  const dir = getWorkspacesDir();
+  if (!existsSync(dir)) return 0;
+
+  let removed = 0;
+  for (const name of readdirSync(dir)) {
+    const full = join(dir, name);
+    try {
+      if (!statSync(full).isDirectory()) continue;
+      if (cacheLooksLikeWrap(full)) {
+        rmSync(full, { recursive: true, force: true });
+        removed++;
+      }
+    } catch {
+      // skip
+    }
+  }
+  return removed;
+}

--- a/src/shared/providers/__tests__/wrap.test.ts
+++ b/src/shared/providers/__tests__/wrap.test.ts
@@ -1,0 +1,66 @@
+import { describe, it, expect } from 'bun:test';
+import {
+  getWrappableProvider,
+  getWrappableProviders,
+  getProviderOwnedTopLevelNames,
+  collectWrapExclusionProviderIds,
+} from '../index';
+
+describe('wrap provider helpers', () => {
+  it('lists wrappable providers that declare wrap', () => {
+    const ids = getWrappableProviders().map((p) => p.id).sort();
+    expect(ids).toContain('claude-code');
+    expect(ids).toContain('codex');
+    expect(ids).toContain('cursor');
+  });
+
+  it('resolves by registry id', () => {
+    const p = getWrappableProvider('claude-code');
+    expect(p?.id).toBe('claude-code');
+    expect(p?.wrap?.binary).toBe('claude');
+    expect(p?.wrap?.kind).toBe('cli');
+  });
+
+  it('resolves claude alias via pluginProviderId', () => {
+    const p = getWrappableProvider('claude');
+    expect(p?.id).toBe('claude-code');
+    expect(p?.wrap).toBeDefined();
+  });
+
+  it('returns undefined for non-wrappable providers', () => {
+    expect(getWrappableProvider('amp')).toBeUndefined();
+    expect(getWrappableProvider('not-a-provider')).toBeUndefined();
+  });
+
+  it('cursor wrap is gui with wait-until-close args', () => {
+    const wrap = getWrappableProvider('cursor')?.wrap;
+    expect(wrap?.kind).toBe('gui');
+    expect(wrap?.args).toEqual(['--new-window', '--wait']);
+  });
+
+  it('collectWrapExclusionProviderIds unions wrap target with capabilities providers', () => {
+    expect(collectWrapExclusionProviderIds('cursor', ['cursor']).sort()).toEqual(['cursor']);
+    expect(collectWrapExclusionProviderIds('claude', ['cursor']).sort()).toEqual([
+      'claude-code',
+      'cursor',
+    ]);
+    expect(collectWrapExclusionProviderIds('cursor', undefined)).toEqual(['cursor']);
+  });
+
+  it('getProviderOwnedTopLevelNames is scoped to the given providers', () => {
+    const cursor = getProviderOwnedTopLevelNames(['cursor']);
+    expect(cursor.has('.cursor')).toBe(true);
+    expect(cursor.has('AGENTS.md')).toBe(true);
+    expect(cursor.has('.claude')).toBe(false);
+    expect(cursor.has('skills')).toBe(false);
+
+    const openclaw = getProviderOwnedTopLevelNames(['openclaw']);
+    expect(openclaw.has('skills')).toBe(true);
+
+    const both = getProviderOwnedTopLevelNames(['cursor', 'claude-code']);
+    expect(both.has('.cursor')).toBe(true);
+    expect(both.has('.claude')).toBe(true);
+    expect(both.has('CLAUDE.md')).toBe(true);
+    expect(both.has('.mcp.json')).toBe(true);
+  });
+});

--- a/src/shared/providers/index.ts
+++ b/src/shared/providers/index.ts
@@ -37,10 +37,105 @@ export function getProviderByPluginProviderId(id: string): ProviderIntegration |
   return getAllProviders().find((p) => p.pluginProviderId?.toLowerCase() === needle);
 }
 
+/**
+ * Providers that declare `wrap` and can be launched via `capa wrap`.
+ */
+export function getWrappableProviders(): ProviderIntegration[] {
+  return getAllProviders().filter((p) => p.wrap !== undefined);
+}
+
+/**
+ * Resolve a wrappable provider by registry id or pluginProviderId alias
+ * (e.g. `claude` → `claude-code`). Returns undefined if unknown or not wrappable.
+ */
+export function getWrappableProvider(id: string): ProviderIntegration | undefined {
+  const needle = id.toLowerCase();
+  const byId = getProvider(needle);
+  if (byId?.wrap) return byId;
+  const byPlugin = getProviderByPluginProviderId(needle);
+  if (byPlugin?.wrap) return byPlugin;
+  return undefined;
+}
+
+/**
+ * Top-level path segment of a project-relative path (e.g. `.cursor/skills` → `.cursor`).
+ */
+function topLevelName(relPath: string): string {
+  const normalized = relPath.replace(/\\/g, '/').replace(/^\.\//, '');
+  const slash = normalized.indexOf('/');
+  return slash === -1 ? normalized : normalized.slice(0, slash);
+}
+
+function addProviderOwnedTopLevelNames(p: ProviderIntegration, names: Set<string>): void {
+  if (p.skillsDir) names.add(topLevelName(p.skillsDir));
+  if (p.instructions?.filename) names.add(topLevelName(p.instructions.filename));
+  if (p.mcp?.configPath) names.add(topLevelName(p.mcp.configPath));
+  if (p.mcp?.defaultMcpFallbackPath) names.add(topLevelName(p.mcp.defaultMcpFallbackPath));
+  if (p.rules?.dir) names.add(topLevelName(p.rules.dir));
+  if (p.subagents?.dir) names.add(topLevelName(p.subagents.dir));
+  if (p.hooks?.storage) {
+    const storage = p.hooks.storage;
+    if (storage.kind === 'directory') {
+      names.add(topLevelName(storage.dir));
+    } else if ('configPath' in storage) {
+      names.add(topLevelName(storage.configPath));
+    }
+  }
+  for (const manifest of p.pluginManifestPaths ?? []) {
+    names.add(topLevelName(manifest));
+  }
+}
+
+/**
+ * Resolve a capabilities/wrap provider token to a registry id when possible
+ * (e.g. `claude` → `claude-code`).
+ */
+export function resolveProviderId(raw: string): string | undefined {
+  const needle = raw.trim().toLowerCase();
+  if (!needle) return undefined;
+  return (getProvider(needle) ?? getProviderByPluginProviderId(needle))?.id;
+}
+
+/**
+ * Provider ids whose owned paths wrap should shadow (not symlink):
+ * the launched wrap provider plus every entry in `capabilities.providers`.
+ */
+export function collectWrapExclusionProviderIds(
+  wrapProviderId: string,
+  capabilitiesProviders?: string[] | null,
+): string[] {
+  const ids = new Set<string>();
+  const wrapId = resolveProviderId(wrapProviderId) ?? wrapProviderId.toLowerCase();
+  ids.add(wrapId);
+  for (const raw of capabilitiesProviders ?? []) {
+    if (typeof raw !== 'string') continue;
+    const id = resolveProviderId(raw);
+    if (id) ids.add(id);
+  }
+  return [...ids];
+}
+
+/**
+ * Top-level names owned by the given providers (registry id or plugin alias).
+ * Used by `capa wrap` so the shadow workspace skips configs that install will
+ * write for the launched provider and any providers listed in capabilities.
+ */
+export function getProviderOwnedTopLevelNames(providerIds: Iterable<string>): Set<string> {
+  const names = new Set<string>();
+  for (const raw of providerIds) {
+    const id = resolveProviderId(raw) ?? raw.trim().toLowerCase();
+    const p = getProvider(id);
+    if (!p) continue;
+    addProviderOwnedTopLevelNames(p, names);
+  }
+  return names;
+}
+
 export type { ProviderIntegration } from '../../types/providers';
 export type {
   McpIntegration,
   InstructionsIntegration,
   RulesIntegration,
   SubagentsIntegration,
+  WrapIntegration,
 } from '../../types/providers';

--- a/src/shared/providers/registry.ts
+++ b/src/shared/providers/registry.ts
@@ -95,6 +95,7 @@ export const providers: Record<string, ProviderIntegration> = {
     },
     pluginManifestPaths: ['.claude-plugin/plugin.json'],
     pluginProviderId: 'claude',
+    wrap: { binary: 'claude', kind: 'cli' },
     hooks: {
       // Claude Code reads hooks from the project-local .claude/settings.json.
       // Docs: https://docs.claude.com/en/docs/claude-code/hooks
@@ -240,6 +241,7 @@ export const providers: Record<string, ProviderIntegration> = {
         stop: { event: 'Stop' },
       },
     },
+    wrap: { binary: 'codex', kind: 'cli' },
   },
   'command-code': {
     id: 'command-code',
@@ -341,6 +343,7 @@ export const providers: Record<string, ProviderIntegration> = {
         stop: { event: 'stop' },
       },
     },
+    wrap: { binary: 'cursor', kind: 'gui', args: ['--new-window', '--wait'] },
   },
   droid: {
     id: 'droid',

--- a/src/shared/workspaces/paths.ts
+++ b/src/shared/workspaces/paths.ts
@@ -1,0 +1,19 @@
+import { join } from 'path';
+import { getCapaDir } from '../config';
+
+/** Marker filename written into every wrap shadow workspace. */
+export const WORKSPACE_MARKER = '.capa-workspace.json';
+
+export function getWorkspacesDir(): string {
+  return join(getCapaDir(), 'workspaces');
+}
+
+export interface WorkspaceMarker {
+  realProjectPath: string;
+  providerId: string;
+  createdAt: string;
+  /** Fingerprinted cache root that holds this marker (same directory as the file). */
+  cachePath?: string;
+  /** Nested working directory name under the cache root (IDE/agent cwd). */
+  workingDir?: string;
+}

--- a/src/types/providers.ts
+++ b/src/types/providers.ts
@@ -49,6 +49,23 @@ export interface McpIntegration {
 }
 
 /**
+ * How `capa wrap <provider>` launches this provider from a shadow workspace.
+ * Undefined when the provider is not wrappable.
+ */
+export interface WrapIntegration {
+  /** Executable to spawn (must be on PATH). */
+  binary: string;
+  /** CLI = blocking foreground; GUI = wait for app window (or interrupt). */
+  kind: 'cli' | 'gui';
+  /**
+   * Extra args always passed to the binary.
+   * GUI: inserted before the workspace path (e.g. Cursor `--new-window --wait`).
+   * CLI: inserted before user passthrough args.
+   */
+  args?: string[];
+}
+
+/**
  * Where the provider reads its agent-instructions file (AGENTS.md, CLAUDE.md, etc.).
  */
 export interface InstructionsIntegration {
@@ -233,4 +250,6 @@ export interface ProviderIntegration {
   purgeStaleSubAgentMcp?: boolean;
   /** When true, sub-agent text is folded into the `instructions.filename` file instead of separate sub-agent files. */
   foldSubAgentsIntoInstructions?: boolean;
+  /** When set, `capa wrap <id>` can launch this provider from a shadow workspace. */
+  wrap?: WrapIntegration;
 }


### PR DESCRIPTION
This pull request introduces several improvements and new features to the CLI, focusing on enhanced workspace handling, better process control, and improved testability. The main highlights are the addition of a new `wrap` command for workspace management, more flexible and testable install logic, and new tests for the `add` command's install behavior.

**Key changes include:**

### New Features: Wrap Workspace Support

* Added a new `wrapCommand` in `wrap.ts` to manage provider-specific wrap workspaces, including workspace preparation, watcher management, and launching providers in both GUI and CLI modes. This includes robust process and signal handling for cleanup and user interrupts.
* Integrated wrap workspace support into the CLI entrypoint (`index.ts`), including a new `__wrap_watch__` mode for detached watcher processes. [[1]](diffhunk://#diff-2304ffbbb1cb4987906a47b08b7c3b590fc542f4247b733844049776fd8591f2R11) [[2]](diffhunk://#diff-2304ffbbb1cb4987906a47b08b7c3b590fc542f4247b733844049776fd8591f2R38-R44)

### Install Command Refactoring and Options

* Refactored `installCommand` to accept additional options (`projectPath`, `identityPath`, `exitProcess`, `quiet`) for improved testability and better integration with wrap workspaces. The install logic is now encapsulated in a helper function for clearer process control and error handling. [[1]](diffhunk://#diff-9d7adcca5f47eca20859c2a649219f9db7e7f42d4bf23a92eae392a4e8cdf4fcR1) [[2]](diffhunk://#diff-9d7adcca5f47eca20859c2a649219f9db7e7f42d4bf23a92eae392a4e8cdf4fcL9-R22) [[3]](diffhunk://#diff-9d7adcca5f47eca20859c2a649219f9db7e7f42d4bf23a92eae392a4e8cdf4fcR31-R93) [[4]](diffhunk://#diff-9d7adcca5f47eca20859c2a649219f9db7e7f42d4bf23a92eae392a4e8cdf4fcL45-R106) [[5]](diffhunk://#diff-9d7adcca5f47eca20859c2a649219f9db7e7f42d4bf23a92eae392a4e8cdf4fcL63-R120) [[6]](diffhunk://#diff-9d7adcca5f47eca20859c2a649219f9db7e7f42d4bf23a92eae392a4e8cdf4fcL78-R135) [[7]](diffhunk://#diff-9d7adcca5f47eca20859c2a649219f9db7e7f42d4bf23a92eae392a4e8cdf4fcL119-R176) [[8]](diffhunk://#diff-9d7adcca5f47eca20859c2a649219f9db7e7f42d4bf23a92eae392a4e8cdf4fcR188-R194) [[9]](diffhunk://#diff-c5ee4a84fb911ad628890270ea6fafb98da486b63ff57441cf9bfcf8a0cfad20R42-R58)
* Added a check to refuse running install and clean commands inside a wrap workspace, improving safety and preventing accidental modifications. [[1]](diffhunk://#diff-9d7adcca5f47eca20859c2a649219f9db7e7f42d4bf23a92eae392a4e8cdf4fcR31-R93) [[2]](diffhunk://#diff-af3148c70ee3d5e4ba56bc4589a50089379f4199a80758cd36ec01261fb20fa4R13) [[3]](diffhunk://#diff-532a809a1017d5b45b820547bcab7325dff2ffbd4d4a93e01513dd5da678d8c9R14-R20)

### Add Command Enhancements

* Updated the `addCommand` to support an `--install` flag, allowing users to optionally trigger installation after updating the capabilities file. The install step is now conditional and provides user feedback. [[1]](diffhunk://#diff-af3148c70ee3d5e4ba56bc4589a50089379f4199a80758cd36ec01261fb20fa4R377-R402) [[2]](diffhunk://#diff-af3148c70ee3d5e4ba56bc4589a50089379f4199a80758cd36ec01261fb20fa4L488-R508) [[3]](diffhunk://#diff-af3148c70ee3d5e4ba56bc4589a50089379f4199a80758cd36ec01261fb20fa4L531-R550) [[4]](diffhunk://#diff-af3148c70ee3d5e4ba56bc4589a50089379f4199a80758cd36ec01261fb20fa4L575-R593) [[5]](diffhunk://#diff-2304ffbbb1cb4987906a47b08b7c3b590fc542f4247b733844049776fd8591f2R101)

### Test Coverage

* Added a new test suite for the `addCommand` to verify the correct behavior of the `--install` flag, ensuring that installation is only triggered when requested.

These changes collectively improve the CLI's robustness, extensibility, and testability, especially around workspace management and install workflows.