### PR TITLE
fix: capa sh / install identity in wrap shadow workspaces

### DIFF
--- a/src/cli/commands/install.ts
+++ b/src/cli/commands/install.ts
@@ -11,6 +11,7 @@ import { runTasks, summary, info, warn, error, setFlags, getFlags } from '../ui'
 import { buildInstallTasks } from './install-tasks';
 import type { InstallCtx, InstallOptions } from './install-tasks';
 import { refuseIfWrapWorkspace } from '../utils/wrap/marker';
+import { isUnderWrapWorkspacesDir } from '../../shared/workspaces/paths';
 
 export type { InstallOptions, GetRepoSnapshotFn } from './install-tasks';
 
@@ -102,6 +103,15 @@ async function installCommandBody(opts: {
     if (await refuseIfWrapWorkspace('install')) {
       failExit('Refusing to install inside a wrap workspace.', exitProcess);
     }
+  }
+
+  // Never register a shadow workspace path as the project identity (even when
+  // wrap itself installs into the workspace with identityPath = real project).
+  if (isUnderWrapWorkspacesDir(idPath)) {
+    failExit(
+      'Refusing to register a wrap workspace path as a project. Use the real project path.',
+      exitProcess,
+    );
   }
 
   const capabilitiesFile = await detectCapabilitiesFile(projectPath);

--- a/src/cli/commands/sh.ts
+++ b/src/cli/commands/sh.ts
@@ -5,6 +5,7 @@ import type { Capabilities } from '../../types/capabilities';
 import { getQualifiedToolName } from '../../types/capabilities';
 import { slugify } from '../../shared/slug';
 import { CAPA_RAW_ARG } from '../../server/tool-formatter';
+import { resolveProjectIdentityPath } from '../utils/wrap/marker';
 
 interface ShellToolInfo {
   id: string;
@@ -679,7 +680,10 @@ export async function shellCommand(args: string[]): Promise<void> {
 
   const serverUrl = status.url;
   const capabilities = await parseCapabilitiesFile(capFile.path, capFile.format);
-  const projectId = generateProjectId(cwd);
+  // Wrap installs register the real project path; resolve identity so `capa sh`
+  // from the shadow workspace hits the same project id / MCP tools.
+  const identityPath = await resolveProjectIdentityPath(cwd);
+  const projectId = generateProjectId(identityPath);
 
   let tools: ShellToolInfo[];
   try {

--- a/src/cli/commands/sh.ts
+++ b/src/cli/commands/sh.ts
@@ -1,3 +1,4 @@
+import { resolve } from 'path';
 import { detectCapabilitiesFile, generateProjectId } from '../../shared/paths';
 import { parseCapabilitiesFile } from '../../shared/capabilities';
 import { getDatabasePath, loadSettings } from '../../shared/config';
@@ -306,7 +307,25 @@ async function ensureProjectConfigured(
   const settings = await loadSettings();
   const db = new CapaDatabase(getDatabasePath(settings));
   try {
-    db.upsertProject({ id: projectId, path: identityPath });
+    const existing = db.getProject(projectId);
+    if (existing) {
+      const existingPath = resolve(existing.path);
+      const wantPath = resolve(identityPath);
+      const samePath =
+        process.platform === 'win32'
+          ? existingPath.toLowerCase() === wantPath.toLowerCase()
+          : existingPath === wantPath;
+      if (!samePath) {
+        throw new Error(
+          `Project id "${projectId}" is already registered at a different path:\n` +
+            `  existing: ${existing.path}\n` +
+            `  this:     ${identityPath}\n` +
+            `Remove the conflicting project or reinstall from the correct directory.`,
+        );
+      }
+    } else {
+      db.upsertProject({ id: projectId, path: identityPath });
+    }
   } finally {
     db.close();
   }

--- a/src/cli/commands/sh.ts
+++ b/src/cli/commands/sh.ts
@@ -8,6 +8,7 @@ import { getQualifiedToolName } from '../../types/capabilities';
 import { slugify } from '../../shared/slug';
 import { CAPA_RAW_ARG } from '../../server/tool-formatter';
 import { resolveProjectIdentityPath } from '../utils/wrap/marker';
+import { isUnderWrapWorkspacesDir } from '../../shared/workspaces/paths';
 
 interface ShellToolInfo {
   id: string;
@@ -296,6 +297,12 @@ async function ensureProjectConfigured(
   identityPath: string,
   capabilities: Capabilities,
 ): Promise<void> {
+  if (isUnderWrapWorkspacesDir(identityPath)) {
+    throw new Error(
+      `Refusing to register wrap workspace path as a project: ${identityPath}`,
+    );
+  }
+
   const settings = await loadSettings();
   const db = new CapaDatabase(getDatabasePath(settings));
   try {
@@ -737,10 +744,23 @@ export async function shellCommand(args: string[]): Promise<void> {
   }
 
   const serverUrl = status.url;
-  const capabilities = await parseCapabilitiesFile(capFile.path, capFile.format);
+  let capabilities;
+  try {
+    capabilities = await parseCapabilitiesFile(capFile.path, capFile.format);
+  } catch (err: any) {
+    console.error(`Failed to parse capabilities: ${err.message}`);
+    process.exit(1);
+  }
+
   // Wrap installs register the real project path; resolve identity so `capa sh`
   // from the shadow workspace hits the same project id / MCP tools.
-  const identityPath = await resolveProjectIdentityPath(cwd);
+  let identityPath: string;
+  try {
+    identityPath = await resolveProjectIdentityPath(cwd);
+  } catch (err: any) {
+    console.error(err.message || String(err));
+    process.exit(1);
+  }
   const projectId = generateProjectId(identityPath);
 
   let tools: ShellToolInfo[];

--- a/src/cli/commands/sh.ts
+++ b/src/cli/commands/sh.ts
@@ -1,5 +1,7 @@
 import { detectCapabilitiesFile, generateProjectId } from '../../shared/paths';
 import { parseCapabilitiesFile } from '../../shared/capabilities';
+import { getDatabasePath, loadSettings } from '../../shared/config';
+import { CapaDatabase } from '../../db/database';
 import { getServerStatus } from '../utils/server-manager';
 import type { Capabilities } from '../../types/capabilities';
 import { getQualifiedToolName } from '../../types/capabilities';
@@ -275,8 +277,64 @@ async function fetchShellTools(serverUrl: string, projectId: string): Promise<Sh
     const body = await response.text().catch(() => '');
     throw new Error(`Failed to fetch shell tools (${response.status}): ${body}`);
   }
-  const data = await response.json() as { tools: ShellToolInfo[] };
+  const data = (await response.json()) as { tools: ShellToolInfo[] };
   return data.tools;
+}
+
+function isProjectNotReadyError(message: string): boolean {
+  return /Project not configured|Project not found/i.test(message);
+}
+
+/**
+ * Ensure the project exists in the DB and has capabilities loaded on the server.
+ * Needed when `capa sh` runs from a wrap workspace after a partial install, or
+ * before any successful configure for this identity path.
+ */
+async function ensureProjectConfigured(
+  serverUrl: string,
+  projectId: string,
+  identityPath: string,
+  capabilities: Capabilities,
+): Promise<void> {
+  const settings = await loadSettings();
+  const db = new CapaDatabase(getDatabasePath(settings));
+  try {
+    db.upsertProject({ id: projectId, path: identityPath });
+  } finally {
+    db.close();
+  }
+
+  const response = await fetch(`${serverUrl}/api/projects/${encodeURIComponent(projectId)}/configure`, {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json',
+      Accept: 'application/json',
+    },
+    body: JSON.stringify(capabilities),
+    signal: AbortSignal.timeout(120000),
+  });
+  if (!response.ok) {
+    const text = await response.text().catch(() => response.statusText);
+    throw new Error(`Failed to configure project: ${text}`);
+  }
+  // Drain body (JSON or NDJSON) so the connection can close cleanly.
+  await response.text().catch(() => '');
+}
+
+async function fetchShellToolsWithConfigure(
+  serverUrl: string,
+  projectId: string,
+  identityPath: string,
+  capabilities: Capabilities,
+): Promise<ShellToolInfo[]> {
+  try {
+    return await fetchShellTools(serverUrl, projectId);
+  } catch (err) {
+    const message = err instanceof Error ? err.message : String(err);
+    if (!isProjectNotReadyError(message)) throw err;
+    await ensureProjectConfigured(serverUrl, projectId, identityPath, capabilities);
+    return await fetchShellTools(serverUrl, projectId);
+  }
 }
 
 /**
@@ -687,7 +745,7 @@ export async function shellCommand(args: string[]): Promise<void> {
 
   let tools: ShellToolInfo[];
   try {
-    tools = await fetchShellTools(serverUrl, projectId);
+    tools = await fetchShellToolsWithConfigure(serverUrl, projectId, identityPath, capabilities);
   } catch (err: any) {
     console.error(`Failed to load tools: ${err.message}`);
     console.error('Make sure the project has been installed ("capa install").');

--- a/src/cli/utils/wrap/__tests__/marker.test.ts
+++ b/src/cli/utils/wrap/__tests__/marker.test.ts
@@ -85,4 +85,18 @@ describe('readWorkspaceMarker', () => {
       rmSync(outside, { recursive: true, force: true });
     }
   });
+
+  it('refuseIfWrapWorkspace returns true under workspaces dir even without a marker', async () => {
+    const { getWorkspacesDir } = await import('../../../../shared/workspaces/paths');
+    const orphan = join(getWorkspacesDir(), `orphan-test-${Date.now()}`);
+    mkdirSync(orphan, { recursive: true });
+    const prev = process.cwd();
+    try {
+      process.chdir(orphan);
+      expect(await refuseIfWrapWorkspace('install')).toBe(true);
+    } finally {
+      process.chdir(prev);
+      rmSync(orphan, { recursive: true, force: true });
+    }
+  });
 });

--- a/src/cli/utils/wrap/__tests__/marker.test.ts
+++ b/src/cli/utils/wrap/__tests__/marker.test.ts
@@ -1,8 +1,8 @@
 import { describe, it, expect, beforeEach, afterEach } from 'bun:test';
 import { mkdirSync, mkdtempSync, writeFileSync, rmSync } from 'fs';
-import { join } from 'path';
+import { join, resolve } from 'path';
 import { tmpdir } from 'os';
-import { readWorkspaceMarker, refuseIfWrapWorkspace } from '../marker';
+import { readWorkspaceMarker, refuseIfWrapWorkspace, resolveProjectIdentityPath } from '../marker';
 import { WORKSPACE_MARKER } from '../../../../shared/workspaces/paths';
 
 describe('readWorkspaceMarker', () => {
@@ -68,6 +68,21 @@ describe('readWorkspaceMarker', () => {
       expect(await refuseIfWrapWorkspace('install')).toBe(true);
     } finally {
       process.chdir(prev);
+    }
+  });
+
+  it('resolveProjectIdentityPath returns the real project inside a wrap workspace', async () => {
+    expect(await resolveProjectIdentityPath(workingDir)).toBe(resolve('/real/proj'));
+    expect(await resolveProjectIdentityPath(join(workingDir, 'src'))).toBe(resolve('/real/proj'));
+  });
+
+  it('resolveProjectIdentityPath returns the dir outside a wrap workspace', async () => {
+    const outside = mkdtempSync(join(tmpdir(), 'capa-outside-'));
+    try {
+      const resolved = await resolveProjectIdentityPath(outside);
+      expect(resolved).toBe(resolve(outside));
+    } finally {
+      rmSync(outside, { recursive: true, force: true });
     }
   });
 });

--- a/src/cli/utils/wrap/marker.ts
+++ b/src/cli/utils/wrap/marker.ts
@@ -1,6 +1,11 @@
 import { existsSync } from 'fs';
 import { dirname, join, relative, resolve, sep } from 'path';
-import { WORKSPACE_MARKER, type WorkspaceMarker } from '../../../shared/workspaces/paths';
+import {
+  WORKSPACE_MARKER,
+  getWorkspacesDir,
+  isUnderWrapWorkspacesDir,
+  type WorkspaceMarker,
+} from '../../../shared/workspaces/paths';
 
 async function tryReadMarker(markerPath: string): Promise<WorkspaceMarker | null> {
   if (!existsSync(markerPath)) return null;
@@ -63,23 +68,50 @@ export async function readWorkspaceMarker(
  */
 export async function refuseIfWrapWorkspace(command: string): Promise<boolean> {
   const marker = await readWorkspaceMarker();
-  if (!marker) return false;
-  console.error(
-    `✗ Cannot run "capa ${command}" inside a wrap workspace.\n` +
-      `  Run it from the real project instead:\n` +
-      `  ${marker.realProjectPath}`,
-  );
-  return true;
+  if (marker) {
+    console.error(
+      `✗ Cannot run "capa ${command}" inside a wrap workspace.\n` +
+        `  Run it from the real project instead:\n` +
+        `  ${marker.realProjectPath}`,
+    );
+    return true;
+  }
+  if (isUnderWrapWorkspacesDir(process.cwd())) {
+    console.error(
+      `✗ Cannot run "capa ${command}" inside a wrap workspace under:\n` +
+        `  ${getWorkspacesDir()}\n` +
+        `  Run it from the real project instead.`,
+    );
+    return true;
+  }
+  return false;
 }
 
 /**
  * Path used for project identity (DB id / MCP endpoint).
  * Inside a wrap workspace this is the real project path; otherwise `dir`.
+ * Never returns a path under `~/.capa/workspaces`.
  */
 export async function resolveProjectIdentityPath(
   dir: string = process.cwd(),
 ): Promise<string> {
   const marker = await readWorkspaceMarker(dir);
-  if (marker?.realProjectPath) return resolve(marker.realProjectPath);
-  return resolve(dir);
+  if (marker?.realProjectPath) {
+    const real = resolve(marker.realProjectPath);
+    if (isUnderWrapWorkspacesDir(real)) {
+      throw new Error(
+        `Wrap workspace marker has an invalid realProjectPath under ${getWorkspacesDir()}: ${real}`,
+      );
+    }
+    return real;
+  }
+
+  const abs = resolve(dir);
+  if (isUnderWrapWorkspacesDir(abs)) {
+    throw new Error(
+      `Inside a wrap workspace (${abs}) but ${WORKSPACE_MARKER} was not found. ` +
+        `Re-run "capa wrap <provider>" or run capa from the real project.`,
+    );
+  }
+  return abs;
 }

--- a/src/cli/utils/wrap/marker.ts
+++ b/src/cli/utils/wrap/marker.ts
@@ -71,3 +71,15 @@ export async function refuseIfWrapWorkspace(command: string): Promise<boolean> {
   );
   return true;
 }
+
+/**
+ * Path used for project identity (DB id / MCP endpoint).
+ * Inside a wrap workspace this is the real project path; otherwise `dir`.
+ */
+export async function resolveProjectIdentityPath(
+  dir: string = process.cwd(),
+): Promise<string> {
+  const marker = await readWorkspaceMarker(dir);
+  if (marker?.realProjectPath) return resolve(marker.realProjectPath);
+  return resolve(dir);
+}

--- a/src/server/index.ts
+++ b/src/server/index.ts
@@ -13,6 +13,7 @@ import type { Capabilities, MCPServer, ToolMCPDefinition, ToolCommandDefinition 
 import type { OAuth2Config } from '../types/oauth';
 import { extractAllVariables } from '../shared/variable-resolver';
 import { detectCapabilitiesFile } from '../shared/paths';
+import { isUnderWrapWorkspacesDir } from '../shared/workspaces/paths';
 import { parseCapabilitiesFile } from '../shared/capabilities';
 import { RegistryManager } from '../shared/registries/manager';
 import { seedDefaultRegistries } from '../shared/registries/seed';
@@ -199,6 +200,14 @@ class CapaServer {
     const projects = this.db.getAllProjects();
     let removed = 0;
     for (const project of projects) {
+      if (isUnderWrapWorkspacesDir(project.path)) {
+        this.logger.warn(
+          `Removing shadow wrap workspace project "${project.id}" at path: ${project.path}`,
+        );
+        this.db.deleteProject(project.id);
+        removed++;
+        continue;
+      }
       if (!existsSync(project.path)) {
         this.logger.warn(`Project directory not found, removing project "${project.id}" at path: ${project.path}`);
         this.db.deleteProject(project.id);
@@ -206,7 +215,7 @@ class CapaServer {
       }
     }
     if (removed > 0) {
-      this.logger.info(`Removed ${removed} project(s) with missing directories`);
+      this.logger.info(`Removed ${removed} invalid project(s) (missing dirs or wrap shadows)`);
     } else {
       this.logger.debug('All configured projects have valid directories');
     }
@@ -593,7 +602,9 @@ class CapaServer {
     const apiLogger = this.logger.child('API');
     apiLogger.info('Get all projects');
     try {
-      const projects = this.db.getAllProjects();
+      const projects = this.db
+        .getAllProjects()
+        .filter((project) => !isUnderWrapWorkspacesDir(project.path));
       
       // Enrich projects with additional data
       const enrichedProjects = projects.map((project) => {

--- a/src/shared/workspaces/__tests__/paths.test.ts
+++ b/src/shared/workspaces/__tests__/paths.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'bun:test';
-import { join } from 'path';
+import { join, resolve } from 'path';
 import { tmpdir } from 'os';
 import { getWorkspacesDir, isUnderWrapWorkspacesDir } from '../paths';
 
@@ -13,5 +13,20 @@ describe('isUnderWrapWorkspacesDir', () => {
   it('returns false for unrelated paths', () => {
     expect(isUnderWrapWorkspacesDir(tmpdir())).toBe(false);
     expect(isUnderWrapWorkspacesDir(join(tmpdir(), 'some-project'))).toBe(false);
+  });
+
+  it('returns false for a sibling path that only shares a prefix', () => {
+    const root = getWorkspacesDir();
+    expect(isUnderWrapWorkspacesDir(`${root}2`)).toBe(false);
+    expect(isUnderWrapWorkspacesDir(`${root}-other`)).toBe(false);
+  });
+
+  it('treats Windows drive-letter casing as the same location', () => {
+    if (process.platform !== 'win32') return;
+    const root = resolve(getWorkspacesDir());
+    const flipped = root.replace(/^([A-Za-z]):/, (_, d: string) =>
+      d === d.toUpperCase() ? `${d.toLowerCase()}:` : `${d.toUpperCase()}:`,
+    );
+    expect(isUnderWrapWorkspacesDir(join(flipped, 'shadow', 'proj'))).toBe(true);
   });
 });

--- a/src/shared/workspaces/__tests__/paths.test.ts
+++ b/src/shared/workspaces/__tests__/paths.test.ts
@@ -1,0 +1,17 @@
+import { describe, it, expect } from 'bun:test';
+import { join } from 'path';
+import { tmpdir } from 'os';
+import { getWorkspacesDir, isUnderWrapWorkspacesDir } from '../paths';
+
+describe('isUnderWrapWorkspacesDir', () => {
+  it('returns true for the workspaces root and nested paths', () => {
+    const root = getWorkspacesDir();
+    expect(isUnderWrapWorkspacesDir(root)).toBe(true);
+    expect(isUnderWrapWorkspacesDir(join(root, 'proj-claude-abc', 'proj'))).toBe(true);
+  });
+
+  it('returns false for unrelated paths', () => {
+    expect(isUnderWrapWorkspacesDir(tmpdir())).toBe(false);
+    expect(isUnderWrapWorkspacesDir(join(tmpdir(), 'some-project'))).toBe(false);
+  });
+});

--- a/src/shared/workspaces/paths.ts
+++ b/src/shared/workspaces/paths.ts
@@ -1,4 +1,4 @@
-import { join } from 'path';
+import { join, resolve, sep } from 'path';
 import { getCapaDir } from '../config';
 
 /** Marker filename written into every wrap shadow workspace. */
@@ -6,6 +6,18 @@ export const WORKSPACE_MARKER = '.capa-workspace.json';
 
 export function getWorkspacesDir(): string {
   return join(getCapaDir(), 'workspaces');
+}
+
+/**
+ * True when `dir` is under `~/.capa/workspaces` (wrap shadow cache tree).
+ * Used as a belt-and-suspenders guard when the workspace marker is missing.
+ */
+export function isUnderWrapWorkspacesDir(dir: string): boolean {
+  const workspaces = resolve(getWorkspacesDir());
+  const abs = resolve(dir);
+  if (abs === workspaces) return true;
+  const rootWithSep = workspaces.endsWith(sep) ? workspaces : workspaces + sep;
+  return abs.startsWith(rootWithSep);
 }
 
 export interface WorkspaceMarker {

--- a/src/shared/workspaces/paths.ts
+++ b/src/shared/workspaces/paths.ts
@@ -1,4 +1,4 @@
-import { join, resolve, sep } from 'path';
+import { isAbsolute, join, relative, resolve } from 'path';
 import { getCapaDir } from '../config';
 
 /** Marker filename written into every wrap shadow workspace. */
@@ -11,13 +11,15 @@ export function getWorkspacesDir(): string {
 /**
  * True when `dir` is under `~/.capa/workspaces` (wrap shadow cache tree).
  * Used as a belt-and-suspenders guard when the workspace marker is missing.
+ *
+ * Uses `path.relative` (case-insensitive on Windows) rather than string
+ * `startsWith`, so `C:\...` vs `c:\...` cannot bypass the guard.
  */
 export function isUnderWrapWorkspacesDir(dir: string): boolean {
   const workspaces = resolve(getWorkspacesDir());
   const abs = resolve(dir);
-  if (abs === workspaces) return true;
-  const rootWithSep = workspaces.endsWith(sep) ? workspaces : workspaces + sep;
-  return abs.startsWith(rootWithSep);
+  const rel = relative(workspaces, abs);
+  return rel === '' || (!rel.startsWith('..') && !isAbsolute(rel));
 }
 
 export interface WorkspaceMarker {


### PR DESCRIPTION
## Summary
- Resolve `capa sh` project identity from the wrap marker’s real project path (not the shadow cwd under `~/.capa/workspaces`)
- Auto-configure the real project when shell tools return “Project not configured” / “Project not found”
- Refuse registering wrap shadow paths as projects (`install` / identity guards), and prune/filter shadow duplicates from the server project list

## Test plan
- [x] From a real project: `capa wrap claude` (or another CLI provider), then in the shadow workspace run `capa sh` with a build that includes these commits — tools list against the real project id
- [x] Confirm `capa install` inside the shadow workspace is refused and points at the real project path
- [x] Restart `capa start` with a DB that had a shadow-path project; confirm it is removed and no longer listed in the UI
- [x] `bun test src/cli/utils/wrap/__tests__/marker.test.ts src/shared/workspaces/__tests__/paths.test.ts`
