### PR TITLE
feat: register projects on init and delete from UI

### DIFF
--- a/src/cli/commands/__tests__/init-command.test.ts
+++ b/src/cli/commands/__tests__/init-command.test.ts
@@ -47,7 +47,11 @@ function isolateHome(): { restore: () => void } {
       else process.env.HOME = prevHome;
       if (prevUserProfile === undefined) delete process.env.USERPROFILE;
       else process.env.USERPROFILE = prevUserProfile;
-      rmSync(home, { recursive: true, force: true });
+      try {
+        rmSync(home, { recursive: true, force: true });
+      } catch {
+        // Windows can briefly lock capa.db after close
+      }
     },
   };
 }
@@ -127,6 +131,34 @@ describe('initCommand', () => {
       expect(db.getProject(projectId)).not.toBeNull();
     } finally {
       db.close();
+    }
+  });
+
+  it('rolls back a newly inserted project when configure fails', async () => {
+    fetchMock.mockImplementationOnce(async () => ({
+      ok: false,
+      statusText: 'Internal Server Error',
+      text: async () => 'configure failed',
+    }));
+
+    const originalExit = process.exit;
+    process.exit = ((code?: number) => {
+      throw new Error(`process.exit(${code})`);
+    }) as typeof process.exit;
+
+    try {
+      await expect(initCommand('yaml')).rejects.toThrow(/process\.exit\(1\)/);
+
+      const projectId = generateProjectId(projectDir);
+      const settings = await loadSettings();
+      const db = new CapaDatabase(getDatabasePath(settings));
+      try {
+        expect(db.getProject(projectId)).toBeNull();
+      } finally {
+        db.close();
+      }
+    } finally {
+      process.exit = originalExit;
     }
   });
 

--- a/src/cli/commands/__tests__/init-command.test.ts
+++ b/src/cli/commands/__tests__/init-command.test.ts
@@ -5,11 +5,21 @@ import { tmpdir } from 'os';
 import {
   createDefaultCapabilities,
   parseCapabilitiesFile,
+  writeCapabilitiesFile,
 } from '../../../shared/capabilities';
+import { generateProjectId } from '../../../shared/paths';
+import { getDatabasePath, loadSettings } from '../../../shared/config';
+import { CapaDatabase } from '../../../db/database';
 
 const ensureServerMock = mock(async () => ({
   running: true,
   url: 'http://127.0.0.1:5912',
+}));
+
+const fetchMock = mock(async () => ({
+  ok: true,
+  statusText: 'OK',
+  text: async () => '{}',
 }));
 
 mock.module('../../utils/server-manager', () => ({
@@ -19,6 +29,9 @@ mock.module('../../utils/server-manager', () => ({
   getServerStatus: mock(async () => ({ running: false, url: undefined, pid: undefined })),
   restartServer: mock(async () => {}),
 }));
+
+const originalFetch = globalThis.fetch;
+globalThis.fetch = fetchMock as unknown as typeof fetch;
 
 const { initCommand } = await import('../init');
 
@@ -50,6 +63,7 @@ describe('initCommand', () => {
     originalCwd = process.cwd();
     process.chdir(projectDir);
     ensureServerMock.mockClear();
+    fetchMock.mockClear();
   });
 
   afterEach(() => {
@@ -62,7 +76,7 @@ describe('initCommand', () => {
     expect(typeof initCommand).toBe('function');
   });
 
-  it('writes a default capabilities.yaml with the expected shape', async () => {
+  it('writes a default capabilities.yaml and registers the project', async () => {
     const capabilitiesPath = join(projectDir, 'capabilities.yaml');
     expect(existsSync(capabilitiesPath)).toBe(false);
 
@@ -77,9 +91,47 @@ describe('initCommand', () => {
     expect(parsed.servers).toEqual([]);
     expect(parsed.tools).toEqual([]);
     expect(ensureServerMock).toHaveBeenCalled();
+    expect(fetchMock).toHaveBeenCalled();
+
+    const projectId = generateProjectId(projectDir);
+    const settings = await loadSettings();
+    const db = new CapaDatabase(getDatabasePath(settings));
+    try {
+      const project = db.getProject(projectId);
+      expect(project).not.toBeNull();
+      expect(project!.path).toBe(projectDir);
+    } finally {
+      db.close();
+    }
+  });
+
+  it('registers an existing capabilities file without recreating it', async () => {
+    const capabilitiesPath = join(projectDir, 'capabilities.yaml');
+    const custom = createDefaultCapabilities();
+    custom.skills = [
+      { id: 'custom-skill', type: 'inline', def: { content: '# Custom\n', description: 'test' } },
+    ];
+    await writeCapabilitiesFile(capabilitiesPath, 'yaml', custom);
+    const before = await Bun.file(capabilitiesPath).text();
+
+    await initCommand('yaml');
+
+    const after = await Bun.file(capabilitiesPath).text();
+    expect(after).toBe(before);
+    expect(ensureServerMock).toHaveBeenCalled();
+
+    const projectId = generateProjectId(projectDir);
+    const settings = await loadSettings();
+    const db = new CapaDatabase(getDatabasePath(settings));
+    try {
+      expect(db.getProject(projectId)).not.toBeNull();
+    } finally {
+      db.close();
+    }
   });
 
   afterAll(() => {
+    globalThis.fetch = originalFetch;
     mock.restore();
   });
 });

--- a/src/cli/commands/clean-project.ts
+++ b/src/cli/commands/clean-project.ts
@@ -1,0 +1,153 @@
+import { existsSync, rmSync, statSync } from 'fs';
+import { resolve } from 'path';
+import { detectCapabilitiesFile } from '../../shared/paths';
+import { parseCapabilitiesFile } from '../../shared/capabilities';
+import { getLockfilePath } from '../../shared/lockfile';
+import { resolveProvidersForClean } from '../../shared/providers/resolve';
+import type { CapaDatabase } from '../../db/database';
+import type { Capabilities } from '../../types/capabilities';
+import { unregisterMCPServer, unregisterSubAgentMCPServer } from '../utils/mcp-client-manager';
+import { cleanAgentsFile, removeSubAgentInstructions } from '../utils/agents-file';
+import { cleanRules } from '../utils/rules-installer';
+import { cleanHooks } from '../utils/hooks-installer';
+import { stopWrapSessionsForProject } from '../utils/wrap/sessions';
+import { pruneWorkspacesForProject } from '../utils/wrap/workspace';
+
+export interface CleanProjectOptions {
+  projectPath: string;
+  projectId: string;
+  db: CapaDatabase;
+  /** When omitted, capabilities are loaded from the project path if present. */
+  capabilities?: Capabilities;
+}
+
+export interface CleanProjectResult {
+  warnings: string[];
+  wrapSessionsStopped: number;
+  workspacesPruned: number;
+  managedFilesRemoved: number;
+}
+
+/**
+ * Tear down capa-managed state for a project: stop wrap sessions, remove
+ * managed artifacts / MCP wiring, prune wrap workspaces, delete DB rows.
+ * Does not delete capabilities.yaml / capabilities.json.
+ */
+export async function cleanProject(opts: CleanProjectOptions): Promise<CleanProjectResult> {
+  const projectPath = resolve(opts.projectPath);
+  const { projectId, db } = opts;
+  const warnings: string[] = [];
+
+  const wrapSessionsStopped = await stopWrapSessionsForProject(projectPath);
+
+  let capabilities = opts.capabilities;
+  if (!capabilities) {
+    const capabilitiesFile = await detectCapabilitiesFile(projectPath);
+    if (capabilitiesFile) {
+      try {
+        capabilities = await parseCapabilitiesFile(
+          capabilitiesFile.path,
+          capabilitiesFile.format,
+        );
+      } catch (err) {
+        warnings.push(
+          `Failed to parse capabilities file: ${err instanceof Error ? err.message : String(err)}`,
+        );
+      }
+    }
+  }
+
+  const providers: string[] = resolveProvidersForClean({
+    capabilitiesProviders: capabilities?.providers,
+    db,
+    projectId,
+  });
+
+  const managedFiles = db.getManagedFiles(projectId);
+  let managedFilesRemoved = 0;
+  for (const filePath of managedFiles) {
+    if (existsSync(filePath)) {
+      try {
+        const stats = statSync(filePath);
+        if (stats.isDirectory()) {
+          rmSync(filePath, { recursive: true, force: true });
+        } else {
+          rmSync(filePath);
+        }
+        managedFilesRemoved++;
+      } catch (err) {
+        warnings.push(`Failed to remove ${filePath}: ${err}`);
+      }
+    }
+    db.removeManagedFile(projectId, filePath);
+  }
+
+  if (providers.length > 0) {
+    try {
+      cleanAgentsFile(projectPath, providers);
+    } catch (err) {
+      warnings.push(
+        `Failed to clean agent instructions: ${err instanceof Error ? err.message : String(err)}`,
+      );
+    }
+
+    try {
+      const ruleIds = (capabilities?.rules ?? []).map((r) => r.id);
+      cleanRules(projectPath, providers, ruleIds);
+    } catch (err) {
+      warnings.push(
+        `Failed to clean rules: ${err instanceof Error ? err.message : String(err)}`,
+      );
+    }
+  }
+
+  if (db.getManagedHooks(projectId).length > 0) {
+    const { warnings: hookWarnings } = cleanHooks(projectPath, projectId, db);
+    warnings.push(...hookWarnings);
+  }
+
+  const lockfilePath = getLockfilePath(projectPath);
+  if (existsSync(lockfilePath)) {
+    try {
+      rmSync(lockfilePath, { force: true });
+    } catch (err: unknown) {
+      const message = err instanceof Error ? err.message : String(err);
+      warnings.push(`Failed to remove lockfile ${lockfilePath}: ${message}`);
+    }
+  }
+
+  if (providers.length > 0) {
+    const installedSubAgents = db.getSubAgents(projectId);
+    for (const { agent_id } of installedSubAgents) {
+      try {
+        await unregisterSubAgentMCPServer(projectPath, agent_id, providers);
+        removeSubAgentInstructions(projectPath, agent_id, providers);
+      } catch (err) {
+        warnings.push(
+          `Failed to unregister sub-agent ${agent_id}: ${
+            err instanceof Error ? err.message : String(err)
+          }`,
+        );
+      }
+    }
+
+    try {
+      await unregisterMCPServer(projectPath, projectId, providers);
+    } catch (err) {
+      warnings.push(
+        `Failed to unregister MCP server: ${err instanceof Error ? err.message : String(err)}`,
+      );
+    }
+  }
+
+  const workspacesPruned = await pruneWorkspacesForProject(projectPath);
+
+  db.deleteProject(projectId);
+
+  return {
+    warnings,
+    wrapSessionsStopped,
+    workspacesPruned,
+    managedFilesRemoved,
+  };
+}

--- a/src/cli/commands/clean-project.ts
+++ b/src/cli/commands/clean-project.ts
@@ -1,4 +1,5 @@
-import { existsSync, rmSync, statSync } from 'fs';
+import { existsSync } from 'fs';
+import { rm } from 'fs/promises';
 import { resolve } from 'path';
 import { detectCapabilitiesFile } from '../../shared/paths';
 import { parseCapabilitiesFile } from '../../shared/capabilities';
@@ -68,12 +69,7 @@ export async function cleanProject(opts: CleanProjectOptions): Promise<CleanProj
   for (const filePath of managedFiles) {
     if (existsSync(filePath)) {
       try {
-        const stats = statSync(filePath);
-        if (stats.isDirectory()) {
-          rmSync(filePath, { recursive: true, force: true });
-        } else {
-          rmSync(filePath);
-        }
+        await rm(filePath, { recursive: true, force: true });
         managedFilesRemoved++;
       } catch (err) {
         warnings.push(`Failed to remove ${filePath}: ${err}`);
@@ -109,7 +105,7 @@ export async function cleanProject(opts: CleanProjectOptions): Promise<CleanProj
   const lockfilePath = getLockfilePath(projectPath);
   if (existsSync(lockfilePath)) {
     try {
-      rmSync(lockfilePath, { force: true });
+      await rm(lockfilePath, { force: true });
     } catch (err: unknown) {
       const message = err instanceof Error ? err.message : String(err);
       warnings.push(`Failed to remove lockfile ${lockfilePath}: ${message}`);

--- a/src/cli/commands/clean.ts
+++ b/src/cli/commands/clean.ts
@@ -1,17 +1,10 @@
-import { existsSync, rmSync, statSync } from 'fs';
 import { detectCapabilitiesFile, generateProjectId } from '../../shared/paths';
 import { loadSettings, getDatabasePath } from '../../shared/config';
 import { CapaDatabase } from '../../db/database';
 import { parseCapabilitiesFile } from '../../shared/capabilities';
-import { unregisterMCPServer, unregisterSubAgentMCPServer } from '../utils/mcp-client-manager';
-import { cleanAgentsFile, removeSubAgentInstructions } from '../utils/agents-file';
-import { cleanRules } from '../utils/rules-installer';
-import { cleanHooks } from '../utils/hooks-installer';
-import { getLockfilePath } from '../../shared/lockfile';
-import { resolveProvidersForClean } from '../../shared/providers/resolve';
-import { header, footer, info, warn, error, runTasks } from '../ui';
-import type { Task } from '../ui';
+import { header, footer, info, warn, error } from '../ui';
 import { refuseIfWrapWorkspace } from '../utils/wrap/marker';
+import { cleanProject } from './clean-project';
 
 export async function cleanCommand(): Promise<void> {
   if (await refuseIfWrapWorkspace('clean')) {
@@ -40,124 +33,41 @@ export async function cleanCommand(): Promise<void> {
   const dbPath = getDatabasePath(settings);
   const db = new CapaDatabase(dbPath);
 
-  const providers = resolveProvidersForClean({
-    capabilitiesProviders: capabilities.providers,
-    db,
-    projectId,
-  });
-  if (providers.length === 0) {
-    warn('No providers found. Skipping provider-specific cleanup.');
-  }
-
-  const managedFiles = db.getManagedFiles(projectId);
-
-  // Collected from inside tasks; flushed after the spinner clears.
-  const deferredErrors: string[] = [];
-
-  const tasks: Task[] = [
-    {
-      title: 'Remove managed files',
-      task: async (_, task) => {
-        if (managedFiles.length === 0) {
-          task.skip('No files to clean.');
-          return;
-        }
-        const total = managedFiles.length;
-        for (let i = 0; i < total; i++) {
-          const filePath = managedFiles[i];
-          task.output = `[${i + 1}/${total}] ${filePath}`;
-          if (existsSync(filePath)) {
-            try {
-              const stats = statSync(filePath);
-              if (stats.isDirectory()) {
-                rmSync(filePath, { recursive: true, force: true });
-              } else {
-                rmSync(filePath);
-              }
-            } catch (err) {
-              deferredErrors.push(`Failed to remove ${filePath}: ${err}`);
-            }
-          }
-          db.removeManagedFile(projectId, filePath);
-        }
-        task.title = `Removed ${total} managed file${total === 1 ? '' : 's'}`;
-      },
-    },
-    {
-      // Sub-agent integrations write capa snippets independently of the top-level
-      // `agents:` block, so gate only on providers — not on `capabilities.agents`.
-      title: 'Clean agent instructions',
-      enabled: () => providers.length > 0,
-      task: async () => {
-        cleanAgentsFile(projectPath, providers);
-      },
-    },
-    {
-      title: 'Clean rules',
-      enabled: () => providers.length > 0,
-      task: async () => {
-        const ruleIds = (capabilities.rules ?? []).map((r) => r.id);
-        cleanRules(projectPath, providers, ruleIds);
-      },
-    },
-    {
-      title: 'Clean hooks',
-      enabled: () => db.getManagedHooks(projectId).length > 0,
-      task: async (_, task) => {
-        const { removed, warnings } = cleanHooks(projectPath, projectId, db);
-        for (const w of warnings) deferredErrors.push(w);
-        task.title = removed > 0
-          ? `Removed ${removed} hook entr${removed === 1 ? 'y' : 'ies'}`
-          : 'No hooks to clean';
-      },
-    },
-    {
-      title: 'Remove lockfile',
-      task: async () => {
-        const lockfilePath = getLockfilePath(projectPath);
-        if (existsSync(lockfilePath)) {
-          try {
-            rmSync(lockfilePath, { force: true });
-          } catch (err: unknown) {
-            const message = err instanceof Error ? err.message : String(err);
-            deferredErrors.push(`Failed to remove lockfile ${lockfilePath}: ${message}`);
-          }
-        }
-      },
-    },
-    {
-      title: 'Unregister sub-agents',
-      enabled: () => providers.length > 0 && db.getSubAgents(projectId).length > 0,
-      task: async (_, task) => {
-        const installedSubAgents = db.getSubAgents(projectId);
-        const total = installedSubAgents.length;
-        for (let i = 0; i < total; i++) {
-          const { agent_id } = installedSubAgents[i];
-          task.output = `[${i + 1}/${total}] ${agent_id}`;
-          await unregisterSubAgentMCPServer(projectPath, agent_id, providers);
-          removeSubAgentInstructions(projectPath, agent_id, providers);
-        }
-        task.title = `Unregistered ${total} sub-agent${total === 1 ? '' : 's'}`;
-      },
-    },
-    {
-      title: 'Unregister MCP server from clients',
-      enabled: () => providers.length > 0,
-      task: async () => {
-        await unregisterMCPServer(projectPath, projectId, providers);
-      },
-    },
-    {
-      title: 'Remove project data',
-      task: async () => {
-        db.deleteProject(projectId);
-      },
-    },
-  ];
-
   try {
-    await runTasks(tasks);
-    for (const e of deferredErrors) error(e);
+    const result = await cleanProject({
+      projectPath,
+      projectId,
+      db,
+      capabilities,
+    });
+
+    if (result.wrapSessionsStopped > 0) {
+      info(
+        `Stopped ${result.wrapSessionsStopped} wrap session process${
+          result.wrapSessionsStopped === 1 ? '' : 'es'
+        }`,
+      );
+    }
+    if (result.managedFilesRemoved > 0) {
+      info(
+        `Removed ${result.managedFilesRemoved} managed file${
+          result.managedFilesRemoved === 1 ? '' : 's'
+        }`,
+      );
+    }
+    if (result.workspacesPruned > 0) {
+      info(
+        `Pruned ${result.workspacesPruned} wrap workspace${
+          result.workspacesPruned === 1 ? '' : 's'
+        }`,
+      );
+    }
+    if (result.warnings.length === 0 && result.managedFilesRemoved === 0) {
+      // Providers may still have been cleaned; keep messaging light.
+    }
+    for (const w of result.warnings) {
+      warn(w);
+    }
     footer('Cleanup complete!');
   } finally {
     db.close();

--- a/src/cli/commands/init.ts
+++ b/src/cli/commands/init.ts
@@ -33,6 +33,8 @@ async function registerProject(
   const projectId = generateProjectId(identityPath);
   const settings = await loadSettings();
   const db = new CapaDatabase(getDatabasePath(settings));
+  let newlyInserted = false;
+
   try {
     const existing = db.getProject(projectId);
     if (existing) {
@@ -51,29 +53,44 @@ async function registerProject(
       }
     } else {
       db.upsertProject({ id: projectId, path: identityPath });
+      newlyInserted = true;
     }
+
+    try {
+      const response = await fetch(
+        `${serverUrl}/api/projects/${encodeURIComponent(projectId)}/configure`,
+        {
+          method: 'POST',
+          headers: {
+            'Content-Type': 'application/json',
+            Accept: 'application/json',
+          },
+          body: JSON.stringify(capabilities),
+          signal: AbortSignal.timeout(120000),
+        },
+      );
+      if (!response.ok) {
+        const text = await response.text().catch(() => response.statusText);
+        throw new Error(`Failed to configure project: ${text}`);
+      }
+      await response.text().catch(() => '');
+    } catch (err) {
+      // Roll back only newly created rows so a failed configure does not leave
+      // a stale empty project in the UI. Pre-existing projects are left alone.
+      if (newlyInserted) {
+        try {
+          db.deleteProject(projectId);
+        } catch {
+          // ignore rollback errors
+        }
+      }
+      throw err;
+    }
+
+    return projectId;
   } finally {
     db.close();
   }
-
-  const response = await fetch(
-    `${serverUrl}/api/projects/${encodeURIComponent(projectId)}/configure`,
-    {
-      method: 'POST',
-      headers: {
-        'Content-Type': 'application/json',
-        Accept: 'application/json',
-      },
-      body: JSON.stringify(capabilities),
-      signal: AbortSignal.timeout(120000),
-    },
-  );
-  if (!response.ok) {
-    const text = await response.text().catch(() => response.statusText);
-    throw new Error(`Failed to configure project: ${text}`);
-  }
-  await response.text().catch(() => '');
-  return projectId;
 }
 
 export async function initCommand(format: CapabilitiesFormat): Promise<void> {

--- a/src/cli/commands/init.ts
+++ b/src/cli/commands/init.ts
@@ -1,30 +1,125 @@
 import { existsSync } from 'fs';
 import { resolve } from 'path';
-import { getCapabilitiesPath } from '../../shared/paths';
-import { createDefaultCapabilities, writeCapabilitiesFile } from '../../shared/capabilities';
-import type { CapabilitiesFormat } from '../../types/capabilities';
-import { ensureCapaDir } from '../../shared/config';
+import {
+  detectCapabilitiesFile,
+  generateProjectId,
+  getCapabilitiesPath,
+} from '../../shared/paths';
+import {
+  createDefaultCapabilities,
+  parseCapabilitiesFile,
+  writeCapabilitiesFile,
+} from '../../shared/capabilities';
+import type { Capabilities, CapabilitiesFormat } from '../../types/capabilities';
+import { ensureCapaDir, loadSettings, getDatabasePath } from '../../shared/config';
+import { CapaDatabase } from '../../db/database';
+import { isUnderWrapWorkspacesDir } from '../../shared/workspaces/paths';
 import { ensureServer } from '../utils/server-manager';
+import { refuseIfWrapWorkspace } from '../utils/wrap/marker';
 import { VERSION } from '../../version';
 
+async function registerProject(
+  projectPath: string,
+  capabilities: Capabilities,
+  serverUrl: string,
+): Promise<string> {
+  const identityPath = resolve(projectPath);
+  if (isUnderWrapWorkspacesDir(identityPath)) {
+    throw new Error(
+      `Refusing to register wrap workspace path as a project: ${identityPath}`,
+    );
+  }
+
+  const projectId = generateProjectId(identityPath);
+  const settings = await loadSettings();
+  const db = new CapaDatabase(getDatabasePath(settings));
+  try {
+    const existing = db.getProject(projectId);
+    if (existing) {
+      const existingPath = resolve(existing.path);
+      const samePath =
+        process.platform === 'win32'
+          ? existingPath.toLowerCase() === identityPath.toLowerCase()
+          : existingPath === identityPath;
+      if (!samePath) {
+        throw new Error(
+          `Project id "${projectId}" is already registered at a different path:\n` +
+            `  existing: ${existing.path}\n` +
+            `  this:     ${identityPath}\n` +
+            `Remove the conflicting project or reinstall from the correct directory.`,
+        );
+      }
+    } else {
+      db.upsertProject({ id: projectId, path: identityPath });
+    }
+  } finally {
+    db.close();
+  }
+
+  const response = await fetch(
+    `${serverUrl}/api/projects/${encodeURIComponent(projectId)}/configure`,
+    {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        Accept: 'application/json',
+      },
+      body: JSON.stringify(capabilities),
+      signal: AbortSignal.timeout(120000),
+    },
+  );
+  if (!response.ok) {
+    const text = await response.text().catch(() => response.statusText);
+    throw new Error(`Failed to configure project: ${text}`);
+  }
+  await response.text().catch(() => '');
+  return projectId;
+}
+
 export async function initCommand(format: CapabilitiesFormat): Promise<void> {
+  if (await refuseIfWrapWorkspace('init')) {
+    process.exit(1);
+  }
+
   const projectPath = process.cwd();
   const capabilitiesPath = getCapabilitiesPath(projectPath, format);
-  
-  if (existsSync(capabilitiesPath)) {
-    console.warn(`⚠ ${capabilitiesPath} already exists. Skipping initialization.`);
-    return;
-  }
-  
-  // Ensure .capa directory exists
+
   await ensureCapaDir();
-  
-  // Create default capabilities file
-  const capabilities = createDefaultCapabilities();
-  await writeCapabilitiesFile(capabilitiesPath, format, capabilities);
-  
-  console.log(`✓ Created ${capabilitiesPath}`);
-  
-  // Ensure server is running
-  await ensureServer(VERSION);
+
+  let capabilities: Capabilities;
+  let created = false;
+
+  if (existsSync(capabilitiesPath)) {
+    console.warn(`⚠ ${capabilitiesPath} already exists. Skipping file creation.`);
+    const detected = await detectCapabilitiesFile(projectPath);
+    if (!detected) {
+      // File exists at the requested format path but detect failed — parse directly.
+      capabilities = await parseCapabilitiesFile(capabilitiesPath, format);
+    } else {
+      capabilities = await parseCapabilitiesFile(detected.path, detected.format);
+    }
+  } else {
+    capabilities = createDefaultCapabilities();
+    await writeCapabilitiesFile(capabilitiesPath, format, capabilities);
+    console.log(`✓ Created ${capabilitiesPath}`);
+    created = true;
+  }
+
+  const serverStatus = await ensureServer(VERSION);
+  if (!serverStatus.running || !serverStatus.url) {
+    console.error('✗ Failed to start capa server');
+    process.exit(1);
+  }
+
+  try {
+    const projectId = await registerProject(projectPath, capabilities, serverStatus.url);
+    console.log(
+      created
+        ? `✓ Registered project ${projectId}`
+        : `✓ Registered project ${projectId} (capabilities file unchanged)`,
+    );
+  } catch (err) {
+    console.error(`✗ ${err instanceof Error ? err.message : String(err)}`);
+    process.exit(1);
+  }
 }

--- a/src/cli/commands/wrap.ts
+++ b/src/cli/commands/wrap.ts
@@ -114,11 +114,13 @@ export async function wrapCommand(
   );
   info(prepared.workspacePath);
 
-  writeWrapSession(prepared.cachePath, {
+  if (!writeWrapSession(prepared.cachePath, {
     pid: process.pid,
     realProjectPath: prepared.realProjectPath,
     workspacePath: prepared.workspacePath,
-  });
+  })) {
+    console.warn('⚠ Could not write wrap session file; clean/delete may not stop this session.');
+  }
 
   if (provider.wrap.kind === 'gui') {
     const watchers = startWrapWatchers({
@@ -191,12 +193,14 @@ export async function wrapCommand(
     exclusionProviderIds: prepared.exclusionProviderIds,
   });
 
-  writeWrapSession(prepared.cachePath, {
+  if (!writeWrapSession(prepared.cachePath, {
     pid: process.pid,
     watchPid: watchWorker.pid,
     realProjectPath: prepared.realProjectPath,
     workspacePath: prepared.workspacePath,
-  });
+  })) {
+    console.warn('⚠ Could not write wrap session file; clean/delete may not stop this session.');
+  }
 
   const cleanupCli = () => {
     watchWorker.stop();

--- a/src/cli/commands/wrap.ts
+++ b/src/cli/commands/wrap.ts
@@ -7,6 +7,7 @@ import { prepareWorkspace, pruneWorkspaces } from '../utils/wrap/workspace';
 import { startWrapWatchers } from '../utils/wrap/watch-project';
 import { launchProvider } from '../utils/wrap/launch';
 import { waitForInterrupt } from '../utils/wrap/wait-for-interrupt';
+import { clearWrapSession, writeWrapSession } from '../utils/wrap/session-file';
 import { info, error } from '../ui';
 
 export interface WrapOptions {
@@ -113,6 +114,12 @@ export async function wrapCommand(
   );
   info(prepared.workspacePath);
 
+  writeWrapSession(prepared.cachePath, {
+    pid: process.pid,
+    realProjectPath: prepared.realProjectPath,
+    workspacePath: prepared.workspacePath,
+  });
+
   if (provider.wrap.kind === 'gui') {
     const watchers = startWrapWatchers({
       realProjectPath: prepared.realProjectPath,
@@ -128,6 +135,7 @@ export async function wrapCommand(
       cleaned = true;
       watchers.exitSweep();
       watchers.stop();
+      clearWrapSession(prepared.cachePath);
     };
 
     const onStopSignal = () => {
@@ -183,8 +191,20 @@ export async function wrapCommand(
     exclusionProviderIds: prepared.exclusionProviderIds,
   });
 
-  const onStopSignal = () => {
+  writeWrapSession(prepared.cachePath, {
+    pid: process.pid,
+    watchPid: watchWorker.pid,
+    realProjectPath: prepared.realProjectPath,
+    workspacePath: prepared.workspacePath,
+  });
+
+  const cleanupCli = () => {
     watchWorker.stop();
+    clearWrapSession(prepared.cachePath);
+  };
+
+  const onStopSignal = () => {
+    cleanupCli();
     process.exit(0);
   };
   process.once('SIGTERM', onStopSignal);
@@ -196,12 +216,12 @@ export async function wrapCommand(
 
   try {
     const result = await launchProvider(provider, prepared.workspacePath, args);
-    watchWorker.stop();
+    cleanupCli();
     if (result.exitCode != null && result.exitCode !== 0) {
       process.exit(result.exitCode);
     }
   } catch (err) {
-    watchWorker.stop();
+    cleanupCli();
     error(
       `Failed to launch ${provider.wrap.binary}: ${
         err instanceof Error ? err.message : String(err)

--- a/src/cli/utils/wrap/__tests__/sessions.test.ts
+++ b/src/cli/utils/wrap/__tests__/sessions.test.ts
@@ -43,6 +43,23 @@ describe('wrap process discovery', () => {
     expect(commandLineMatchesProject(projectFlag, real)).toBe(true);
   });
 
+  it('commandLineMatchesProject does not match path prefixes (proj vs proj2)', () => {
+    const real =
+      process.platform === 'win32' ? 'C:\\Users\\me\\proj' : '/Users/me/proj';
+    const other =
+      process.platform === 'win32' ? 'C:\\Users\\me\\proj2' : '/Users/me/proj2';
+
+    const otherWatch = `capa __wrap_watch__ ${other} ${other}\\ws cursor caps.yaml []`;
+    expect(commandLineMatchesProject(otherWatch, real)).toBe(false);
+
+    const otherProject = `capa wrap cursor --project ${other}`;
+    expect(commandLineMatchesProject(otherProject, real)).toBe(false);
+
+    // Substring would match; token equality must not.
+    const substrish = `capa wrap cursor --project ${real}2`;
+    expect(commandLineMatchesProject(substrish, real)).toBe(false);
+  });
+
   it('normalizePathForMatch produces absolute paths', () => {
     const n = normalizePathForMatch('.');
     expect(n.length).toBeGreaterThan(1);

--- a/src/cli/utils/wrap/__tests__/sessions.test.ts
+++ b/src/cli/utils/wrap/__tests__/sessions.test.ts
@@ -1,5 +1,11 @@
 import { describe, it, expect } from 'bun:test';
-import { findWrapPids, isPidRunning, stopAllWrapSessions } from '../sessions';
+import {
+  findWrapPids,
+  isPidRunning,
+  stopAllWrapSessions,
+  commandLineMatchesProject,
+  normalizePathForMatch,
+} from '../sessions';
 
 describe('wrap process discovery', () => {
   it('isPidRunning reports the current process', () => {
@@ -17,5 +23,32 @@ describe('wrap process discovery', () => {
     const n = await stopAllWrapSessions();
     expect(typeof n).toBe('number');
     expect(n).toBeGreaterThanOrEqual(0);
+  });
+
+  it('commandLineMatchesProject matches real path and workspace paths', () => {
+    const real =
+      process.platform === 'win32' ? 'C:\\Users\\me\\proj' : '/Users/me/proj';
+    const workspace =
+      process.platform === 'win32'
+        ? 'C:\\Users\\me\\.capa\\workspaces\\proj-cursor-abc\\proj'
+        : '/Users/me/.capa/workspaces/proj-cursor-abc/proj';
+
+    const watchCmd = `capa __wrap_watch__ ${real} ${workspace} cursor ${real}\\capabilities.yaml []`;
+    expect(commandLineMatchesProject(watchCmd, real, [workspace])).toBe(true);
+
+    const otherCmd = 'capa wrap cursor --project /other/path';
+    expect(commandLineMatchesProject(otherCmd, real, [workspace])).toBe(false);
+
+    const projectFlag = `capa wrap cursor --project ${real}`;
+    expect(commandLineMatchesProject(projectFlag, real)).toBe(true);
+  });
+
+  it('normalizePathForMatch produces absolute paths', () => {
+    const n = normalizePathForMatch('.');
+    expect(n.length).toBeGreaterThan(1);
+    if (process.platform === 'win32') {
+      expect(n).toBe(n.toLowerCase());
+      expect(n.includes('/')).toBe(false);
+    }
   });
 });

--- a/src/cli/utils/wrap/session-file.ts
+++ b/src/cli/utils/wrap/session-file.ts
@@ -19,15 +19,21 @@ export function wrapSessionPath(cachePath: string): string {
 export function writeWrapSession(
   cachePath: string,
   session: Omit<WrapSessionFile, 'startedAt'> & { startedAt?: string },
-): void {
-  const data: WrapSessionFile = {
-    pid: session.pid,
-    watchPid: session.watchPid,
-    realProjectPath: resolve(session.realProjectPath),
-    workspacePath: resolve(session.workspacePath),
-    startedAt: session.startedAt ?? new Date().toISOString(),
-  };
-  writeFileSync(wrapSessionPath(cachePath), JSON.stringify(data, null, 2) + '\n');
+): boolean {
+  try {
+    const data: WrapSessionFile = {
+      pid: session.pid,
+      watchPid: session.watchPid,
+      realProjectPath: resolve(session.realProjectPath),
+      workspacePath: resolve(session.workspacePath),
+      startedAt: session.startedAt ?? new Date().toISOString(),
+    };
+    writeFileSync(wrapSessionPath(cachePath), JSON.stringify(data, null, 2) + '\n');
+    return true;
+  } catch {
+    // Session file is auxiliary for clean/stop discovery; never fail wrap startup.
+    return false;
+  }
 }
 
 export function clearWrapSession(cachePath: string): void {

--- a/src/cli/utils/wrap/session-file.ts
+++ b/src/cli/utils/wrap/session-file.ts
@@ -1,0 +1,61 @@
+import { existsSync, unlinkSync, writeFileSync } from 'fs';
+import { join, resolve } from 'path';
+
+/** Written into each wrap cache root so clean/delete can stop live sessions. */
+export const WRAP_SESSION_FILE = 'wrap-session.json';
+
+export interface WrapSessionFile {
+  pid: number;
+  watchPid?: number;
+  realProjectPath: string;
+  workspacePath: string;
+  startedAt: string;
+}
+
+export function wrapSessionPath(cachePath: string): string {
+  return join(cachePath, WRAP_SESSION_FILE);
+}
+
+export function writeWrapSession(
+  cachePath: string,
+  session: Omit<WrapSessionFile, 'startedAt'> & { startedAt?: string },
+): void {
+  const data: WrapSessionFile = {
+    pid: session.pid,
+    watchPid: session.watchPid,
+    realProjectPath: resolve(session.realProjectPath),
+    workspacePath: resolve(session.workspacePath),
+    startedAt: session.startedAt ?? new Date().toISOString(),
+  };
+  writeFileSync(wrapSessionPath(cachePath), JSON.stringify(data, null, 2) + '\n');
+}
+
+export function clearWrapSession(cachePath: string): void {
+  const path = wrapSessionPath(cachePath);
+  if (!existsSync(path)) return;
+  try {
+    unlinkSync(path);
+  } catch {
+    // ignore
+  }
+}
+
+export async function readWrapSession(cachePath: string): Promise<WrapSessionFile | null> {
+  const path = wrapSessionPath(cachePath);
+  if (!existsSync(path)) return null;
+  try {
+    const data = (await Bun.file(path).json()) as WrapSessionFile;
+    if (!data?.pid || !data?.realProjectPath) return null;
+    return data;
+  } catch {
+    return null;
+  }
+}
+
+export function pathsEqual(a: string, b: string): boolean {
+  const left = resolve(a);
+  const right = resolve(b);
+  return process.platform === 'win32'
+    ? left.toLowerCase() === right.toLowerCase()
+    : left === right;
+}

--- a/src/cli/utils/wrap/sessions.ts
+++ b/src/cli/utils/wrap/sessions.ts
@@ -1,7 +1,13 @@
 /**
  * Discover and stop live `capa wrap` processes without a PID registry.
  * `capa stop` scans the process table for capa binaries whose argv includes `wrap`.
+ * Project-scoped stop also reads wrap-session.json files under ~/.capa/workspaces.
  */
+
+import { readdirSync, existsSync, statSync } from 'fs';
+import { join, resolve } from 'path';
+import { getWorkspacesDir, WORKSPACE_MARKER } from '../../../shared/workspaces/paths';
+import { pathsEqual, readWrapSession, WRAP_SESSION_FILE } from './session-file';
 
 export function isPidRunning(pid: number): boolean {
   if (!Number.isFinite(pid) || pid <= 0) return false;
@@ -26,12 +32,43 @@ function tryKill(pid: number, signal: NodeJS.Signals): boolean {
   }
 }
 
+export interface WrapProcess {
+  pid: number;
+  commandLine: string;
+}
+
 /**
- * Find capa processes whose argv includes `wrap`.
+ * Normalize a path for substring matching inside process command lines.
  */
-export async function findWrapPids(): Promise<number[]> {
+export function normalizePathForMatch(p: string): string {
+  const abs = resolve(p);
+  if (process.platform === 'win32') {
+    return abs.replace(/\//g, '\\').toLowerCase();
+  }
+  return abs;
+}
+
+/**
+ * True when a process command line belongs to a wrap session for `realProjectPath`
+ * (or one of its wrap workspace/cache paths).
+ */
+export function commandLineMatchesProject(
+  commandLine: string,
+  realProjectPath: string,
+  extraPaths: string[] = [],
+): boolean {
+  const haystack =
+    process.platform === 'win32' ? commandLine.replace(/\//g, '\\').toLowerCase() : commandLine;
+  const needles = [realProjectPath, ...extraPaths].map(normalizePathForMatch).filter(Boolean);
+  return needles.some((needle) => needle.length > 1 && haystack.includes(needle));
+}
+
+/**
+ * List capa processes whose argv includes `wrap` or `__wrap_watch__`.
+ */
+export async function listWrapProcesses(): Promise<WrapProcess[]> {
   const self = process.pid;
-  const pids: number[] = [];
+  const procs: WrapProcess[] = [];
 
   if (process.platform === 'win32') {
     try {
@@ -42,20 +79,25 @@ export async function findWrapPids(): Promise<number[]> {
           '-Command',
           `Get-CimInstance Win32_Process -Filter "Name = 'capa.exe'" | ` +
             `Where-Object { ($_.CommandLine -match '\\swrap(\\s|$)' -or $_.CommandLine -match '__wrap_watch__') -and $_.ProcessId -ne ${self} } | ` +
-            `Select-Object -ExpandProperty ProcessId`,
+            `ForEach-Object { "{0}\t{1}" -f $_.ProcessId, $_.CommandLine }`,
         ],
         { stdout: 'pipe', stderr: 'ignore' },
       );
       const out = await new Response(proc.stdout).text();
       await proc.exited;
       for (const line of out.split(/\r?\n/)) {
-        const n = parseInt(line.trim(), 10);
-        if (Number.isFinite(n) && n > 0) pids.push(n);
+        const tab = line.indexOf('\t');
+        if (tab < 0) continue;
+        const n = parseInt(line.slice(0, tab).trim(), 10);
+        const cmd = line.slice(tab + 1);
+        if (Number.isFinite(n) && n > 0 && cmd) {
+          procs.push({ pid: n, commandLine: cmd });
+        }
       }
     } catch {
       // ignore
     }
-    return [...new Set(pids)];
+    return procs;
   }
 
   try {
@@ -71,15 +113,89 @@ export async function findWrapPids(): Promise<number[]> {
       const pid = parseInt(m[1]!, 10);
       const cmd = m[2]!;
       if (pid === self) continue;
-      // e.g. `capa wrap cursor`, `./dist/capa wrap …`, `bun src/cli/index.ts wrap …`
       if (!/\bwrap\b/.test(cmd) && !/__wrap_watch__/.test(cmd)) continue;
       if (!/\bcapa(?:\.exe)?\b/i.test(cmd) && !/src\/cli\/index\.ts\b/.test(cmd)) continue;
-      pids.push(pid);
+      procs.push({ pid, commandLine: cmd });
     }
   } catch {
     // ignore
   }
-  return [...new Set(pids)];
+  return procs;
+}
+
+/**
+ * Find capa processes whose argv includes `wrap`.
+ */
+export async function findWrapPids(): Promise<number[]> {
+  const procs = await listWrapProcesses();
+  return [...new Set(procs.map((p) => p.pid))];
+}
+
+async function listWorkspacePathsForProject(realProjectPath: string): Promise<string[]> {
+  const real = resolve(realProjectPath);
+  const dir = getWorkspacesDir();
+  if (!existsSync(dir)) return [];
+
+  const paths: string[] = [];
+  for (const name of readdirSync(dir)) {
+    const cachePath = join(dir, name);
+    try {
+      if (!statSync(cachePath).isDirectory()) continue;
+      const markerPath = join(cachePath, WORKSPACE_MARKER);
+      if (!existsSync(markerPath)) continue;
+      const marker = (await Bun.file(markerPath).json()) as { realProjectPath?: string; workingDir?: string; cachePath?: string };
+      if (!marker?.realProjectPath || !pathsEqual(marker.realProjectPath, real)) continue;
+      paths.push(cachePath);
+      if (marker.workingDir) {
+        paths.push(join(cachePath, marker.workingDir));
+      }
+      if (marker.cachePath) {
+        paths.push(marker.cachePath);
+      }
+    } catch {
+      // skip
+    }
+  }
+  return paths;
+}
+
+async function pidsFromSessionFiles(realProjectPath: string): Promise<number[]> {
+  const real = resolve(realProjectPath);
+  const dir = getWorkspacesDir();
+  if (!existsSync(dir)) return [];
+
+  const pids: number[] = [];
+  for (const name of readdirSync(dir)) {
+    const cachePath = join(dir, name);
+    try {
+      if (!statSync(cachePath).isDirectory()) continue;
+      if (!existsSync(join(cachePath, WRAP_SESSION_FILE))) continue;
+      const session = await readWrapSession(cachePath);
+      if (!session || !pathsEqual(session.realProjectPath, real)) continue;
+      pids.push(session.pid);
+      if (session.watchPid) pids.push(session.watchPid);
+    } catch {
+      // skip
+    }
+  }
+  return pids;
+}
+
+/**
+ * Find wrap / __wrap_watch__ PIDs belonging to a specific real project path.
+ */
+export async function findWrapPidsForProject(realProjectPath: string): Promise<number[]> {
+  const real = resolve(realProjectPath);
+  const workspacePaths = await listWorkspacePathsForProject(real);
+  const fromSessions = await pidsFromSessionFiles(real);
+  const procs = await listWrapProcesses();
+  const fromArgv = procs
+    .filter((p) => commandLineMatchesProject(p.commandLine, real, workspacePaths))
+    .map((p) => p.pid);
+
+  return [...new Set([...fromSessions, ...fromArgv])].filter(
+    (pid) => pid !== process.pid && Number.isFinite(pid) && pid > 0,
+  );
 }
 
 async function terminatePids(pids: number[]): Promise<void> {
@@ -101,6 +217,16 @@ async function terminatePids(pids: number[]): Promise<void> {
  */
 export async function stopAllWrapSessions(): Promise<number> {
   const pids = await findWrapPids();
+  if (pids.length === 0) return 0;
+  await terminatePids(pids);
+  return pids.length;
+}
+
+/**
+ * Stop wrap sessions for one real project. Returns how many PIDs were targeted.
+ */
+export async function stopWrapSessionsForProject(realProjectPath: string): Promise<number> {
+  const pids = await findWrapPidsForProject(realProjectPath);
   if (pids.length === 0) return 0;
   await terminatePids(pids);
   return pids.length;

--- a/src/cli/utils/wrap/sessions.ts
+++ b/src/cli/utils/wrap/sessions.ts
@@ -38,7 +38,7 @@ export interface WrapProcess {
 }
 
 /**
- * Normalize a path for substring matching inside process command lines.
+ * Normalize a path for display / tests (absolute; lowercase + backslashes on Windows).
  */
 export function normalizePathForMatch(p: string): string {
   const abs = resolve(p);
@@ -48,19 +48,60 @@ export function normalizePathForMatch(p: string): string {
   return abs;
 }
 
+/** Split a process command line into argv-like tokens (handles simple quotes). */
+export function tokenizeCommandLine(commandLine: string): string[] {
+  const tokens: string[] = [];
+  const re = /"([^"]*)"|'([^']*)'|(\S+)/g;
+  let m: RegExpExecArray | null;
+  while ((m = re.exec(commandLine)) !== null) {
+    tokens.push(m[1] ?? m[2] ?? m[3] ?? '');
+  }
+  return tokens;
+}
+
+function tokenMatchesAnyPath(token: string, paths: string[]): boolean {
+  if (!token || token.length < 2) return false;
+  // Skip flags / bare words that aren't path-like.
+  if (!/[\\/]/.test(token) && !/^[A-Za-z]:/.test(token)) return false;
+  try {
+    return paths.some((p) => pathsEqual(token, p));
+  } catch {
+    return false;
+  }
+}
+
 /**
  * True when a process command line belongs to a wrap session for `realProjectPath`
  * (or one of its wrap workspace/cache paths).
+ *
+ * Uses argv-shaped matching (not substring includes) so `/proj` does not match `/proj2`.
  */
 export function commandLineMatchesProject(
   commandLine: string,
   realProjectPath: string,
   extraPaths: string[] = [],
 ): boolean {
-  const haystack =
-    process.platform === 'win32' ? commandLine.replace(/\//g, '\\').toLowerCase() : commandLine;
-  const needles = [realProjectPath, ...extraPaths].map(normalizePathForMatch).filter(Boolean);
-  return needles.some((needle) => needle.length > 1 && haystack.includes(needle));
+  const targets = [realProjectPath, ...extraPaths].map((p) => resolve(p));
+  const tokens = tokenizeCommandLine(commandLine);
+
+  const watchIdx = tokens.findIndex(
+    (t) => t === '__wrap_watch__' || t.endsWith('/__wrap_watch__') || t.endsWith('\\__wrap_watch__'),
+  );
+  if (watchIdx >= 0) {
+    const realArg = tokens[watchIdx + 1];
+    const wsArg = tokens[watchIdx + 2];
+    if (realArg && tokenMatchesAnyPath(realArg, targets)) return true;
+    if (wsArg && tokenMatchesAnyPath(wsArg, targets)) return true;
+  }
+
+  const projectFlagIdx = tokens.findIndex((t) => t === '--project');
+  if (projectFlagIdx >= 0) {
+    const arg = tokens[projectFlagIdx + 1];
+    if (arg && tokenMatchesAnyPath(arg, targets)) return true;
+  }
+
+  // Exact argv token equality only (boundary-safe).
+  return tokens.some((token) => tokenMatchesAnyPath(token, targets));
 }
 
 /**
@@ -143,7 +184,11 @@ async function listWorkspacePathsForProject(realProjectPath: string): Promise<st
       if (!statSync(cachePath).isDirectory()) continue;
       const markerPath = join(cachePath, WORKSPACE_MARKER);
       if (!existsSync(markerPath)) continue;
-      const marker = (await Bun.file(markerPath).json()) as { realProjectPath?: string; workingDir?: string; cachePath?: string };
+      const marker = (await Bun.file(markerPath).json()) as {
+        realProjectPath?: string;
+        workingDir?: string;
+        cachePath?: string;
+      };
       if (!marker?.realProjectPath || !pathsEqual(marker.realProjectPath, real)) continue;
       paths.push(cachePath);
       if (marker.workingDir) {
@@ -183,11 +228,12 @@ async function pidsFromSessionFiles(realProjectPath: string): Promise<number[]> 
 
 /**
  * Find wrap / __wrap_watch__ PIDs belonging to a specific real project path.
+ * Session files are authoritative; argv matching is a fallback.
  */
 export async function findWrapPidsForProject(realProjectPath: string): Promise<number[]> {
   const real = resolve(realProjectPath);
-  const workspacePaths = await listWorkspacePathsForProject(real);
   const fromSessions = await pidsFromSessionFiles(real);
+  const workspacePaths = await listWorkspacePathsForProject(real);
   const procs = await listWrapProcesses();
   const fromArgv = procs
     .filter((p) => commandLineMatchesProject(p.commandLine, real, workspacePaths))

--- a/src/cli/utils/wrap/workspace.ts
+++ b/src/cli/utils/wrap/workspace.ts
@@ -1,6 +1,7 @@
 import { createHash } from 'crypto';
 import { basename, join, resolve } from 'path';
 import { existsSync, mkdirSync, readdirSync, rmSync, statSync, writeFileSync } from 'fs';
+import { rm } from 'fs/promises';
 import { detectCapabilitiesFile, generateProjectId } from '../../../shared/paths';
 import { LOCKFILE_NAME } from '../../../shared/lockfile';
 import { loadSettings, getDatabasePath, ensureCapaDir } from '../../../shared/config';
@@ -284,7 +285,7 @@ export async function pruneWorkspacesForProject(realProjectPath: string): Promis
           ? resolve(data.realProjectPath).toLowerCase() === real.toLowerCase()
           : resolve(data.realProjectPath) === real;
       if (!same) continue;
-      rmSync(full, { recursive: true, force: true });
+      await rm(full, { recursive: true, force: true });
       removed++;
     } catch {
       // skip

--- a/src/cli/utils/wrap/workspace.ts
+++ b/src/cli/utils/wrap/workspace.ts
@@ -260,3 +260,35 @@ export async function pruneWorkspaces(): Promise<number> {
   }
   return removed;
 }
+
+/**
+ * Remove wrap cache dirs whose marker realProjectPath matches `realProjectPath`.
+ */
+export async function pruneWorkspacesForProject(realProjectPath: string): Promise<number> {
+  await ensureCapaDir();
+  const dir = getWorkspacesDir();
+  if (!existsSync(dir)) return 0;
+
+  const real = resolve(realProjectPath);
+  let removed = 0;
+  for (const name of readdirSync(dir)) {
+    const full = join(dir, name);
+    try {
+      if (!statSync(full).isDirectory()) continue;
+      const markerPath = join(full, WORKSPACE_MARKER);
+      if (!existsSync(markerPath)) continue;
+      const data = (await Bun.file(markerPath).json()) as WorkspaceMarker;
+      if (!data?.realProjectPath) continue;
+      const same =
+        process.platform === 'win32'
+          ? resolve(data.realProjectPath).toLowerCase() === real.toLowerCase()
+          : resolve(data.realProjectPath) === real;
+      if (!same) continue;
+      rmSync(full, { recursive: true, force: true });
+      removed++;
+    } catch {
+      // skip
+    }
+  }
+  return removed;
+}

--- a/src/server/index.ts
+++ b/src/server/index.ts
@@ -27,6 +27,7 @@ import {
   listProjectFs,
   writeProjectImport,
 } from './project-fs';
+import { cleanProject } from '../cli/commands/clean-project';
 import {
   listRegistriesHandler,
   createRegistryHandler,
@@ -355,6 +356,12 @@ class CapaServer {
       return this.handleGetProject(projectId);
     }
 
+    // Delete / clean project (keeps capabilities file)
+    if (projectGetMatch && request.method === 'DELETE') {
+      const projectId = projectGetMatch[1];
+      return this.handleDeleteProject(projectId);
+    }
+
     // Live capabilities file change stream (SSE)
     const projectEventsMatch = path.match(/^\/api\/projects\/([^/]+)\/events$/);
     if (projectEventsMatch && request.method === 'GET') {
@@ -630,6 +637,62 @@ class CapaServer {
       return new Response(
         JSON.stringify({ error: error.message }),
         { status: 500, headers: { 'Content-Type': 'application/json' } }
+      );
+    }
+  }
+
+  private async handleDeleteProject(projectId: string): Promise<Response> {
+    const apiLogger = this.logger.child('API');
+    apiLogger.info(`Delete project: ${projectId}`);
+    try {
+      const project = this.db.getProject(projectId);
+      if (!project) {
+        return new Response(
+          JSON.stringify({ error: 'Project not found' }),
+          { status: 404, headers: { 'Content-Type': 'application/json' } },
+        );
+      }
+
+      if (isUnderWrapWorkspacesDir(project.path)) {
+        return new Response(
+          JSON.stringify({ error: 'Refusing to delete a wrap workspace shadow path' }),
+          { status: 400, headers: { 'Content-Type': 'application/json' } },
+        );
+      }
+
+      const result = await cleanProject({
+        projectPath: project.path,
+        projectId,
+        db: this.db,
+      });
+
+      this.capsWatcher.unwatchProject(projectId);
+      this.sessionManager.clearProjectCapabilities(projectId);
+      this.effectiveCapsCache.delete(projectId);
+
+      apiLogger.info(
+        `Deleted project ${projectId} (wrap stopped: ${result.wrapSessionsStopped}, workspaces pruned: ${result.workspacesPruned})`,
+      );
+      if (result.warnings.length > 0) {
+        for (const w of result.warnings) {
+          apiLogger.warn(w);
+        }
+      }
+
+      return new Response(
+        JSON.stringify({
+          success: true,
+          wrapSessionsStopped: result.wrapSessionsStopped,
+          workspacesPruned: result.workspacesPruned,
+          warnings: result.warnings,
+        }),
+        { headers: { 'Content-Type': 'application/json' } },
+      );
+    } catch (error: any) {
+      apiLogger.failure(`Error: ${error.message}`);
+      return new Response(
+        JSON.stringify({ error: error.message }),
+        { status: 500, headers: { 'Content-Type': 'application/json' } },
       );
     }
   }

--- a/src/server/session-manager.ts
+++ b/src/server/session-manager.ts
@@ -235,6 +235,14 @@ export class SessionManager {
   }
 
   /**
+   * Drop in-memory capabilities for a project (e.g. after delete/clean).
+   */
+  clearProjectCapabilities(projectId: string): void {
+    this.projectCapabilities.delete(projectId);
+    this.capabilitiesLoadInflight.delete(projectId);
+  }
+
+  /**
    * Get capabilities for a project (loads from DB on cache miss, e.g. after server restart)
    */
   getProjectCapabilities(projectId: string): Capabilities | null {

--- a/web-ui/src/features/projects/api.ts
+++ b/web-ui/src/features/projects/api.ts
@@ -21,6 +21,9 @@ export const projectsApi = {
   get: (projectId: string) =>
     api.get<ProjectDetail>(`/api/projects/${encodeURIComponent(projectId)}`),
 
+  delete: (projectId: string) =>
+    api.delete<ActionResponse>(`/api/projects/${encodeURIComponent(projectId)}`),
+
   getVariables: (projectId: string) =>
     api.get<VariablesResponse>(`/api/projects/${encodeURIComponent(projectId)}/variables`),
 

--- a/web-ui/src/features/projects/components/ProjectsTable.tsx
+++ b/web-ui/src/features/projects/components/ProjectsTable.tsx
@@ -1,7 +1,9 @@
 import { Link } from 'react-router-dom';
 import { useTranslation } from 'react-i18next';
+import { Trash2 } from 'lucide-react';
 import type { ProjectSummary } from '../../../types/api';
 import { projectDisplayName, formatDate } from '../../../lib/utils';
+import { useDeleteProject } from '../hooks';
 
 interface ProjectsTableProps {
   projects: ProjectSummary[];
@@ -12,12 +14,13 @@ export function ProjectsTable({ projects }: ProjectsTableProps) {
 
   return (
     <div className="overflow-hidden rounded-lg border border-border-primary bg-bg-secondary">
-      <div className="grid grid-cols-[1fr_80px_80px_80px_140px] items-center border-b border-border-secondary px-5 py-3 text-xs font-medium uppercase tracking-wider text-text-tertiary max-md:hidden">
+      <div className="grid grid-cols-[1fr_80px_80px_80px_140px_72px] items-center border-b border-border-secondary px-5 py-3 text-xs font-medium uppercase tracking-wider text-text-tertiary max-md:hidden">
         <div>{t('columns.project')}</div>
         <div className="text-center">{t('columns.skills')}</div>
         <div className="text-center">{t('columns.tools')}</div>
         <div className="text-center">{t('columns.servers')}</div>
         <div className="text-right">{t('columns.lastUpdated')}</div>
+        <div className="text-right">{t('columns.actions')}</div>
       </div>
       <div>
         {projects.map((project) => (
@@ -29,17 +32,28 @@ export function ProjectsTable({ projects }: ProjectsTableProps) {
 }
 
 function ProjectRow({ project }: { project: ProjectSummary }) {
+  const { t } = useTranslation('projects');
+  const deleteProject = useDeleteProject();
   const name = projectDisplayName(project.path, project.id);
 
+  const handleDelete = (e: React.MouseEvent) => {
+    e.preventDefault();
+    e.stopPropagation();
+    if (!confirm(t('actions.confirmDeleteProject', { name }))) return;
+    deleteProject.mutate(project.id);
+  };
+
   return (
-    <Link
-      to={`/ui/project?id=${encodeURIComponent(project.id)}`}
-      className="grid grid-cols-[1fr_80px_80px_80px_140px] items-center border-b border-border-tertiary px-5 py-4 text-text-primary no-underline transition-colors hover:bg-hover-bg max-md:grid-cols-1 max-md:gap-2"
-    >
-      <div>
+    <div className="grid grid-cols-[1fr_80px_80px_80px_140px_72px] items-center border-b border-border-tertiary px-5 py-4 text-text-primary transition-colors hover:bg-hover-bg max-md:grid-cols-[1fr_auto] max-md:gap-2">
+      <Link
+        to={`/ui/project?id=${encodeURIComponent(project.id)}`}
+        className="min-w-0 no-underline text-inherit max-md:col-span-1"
+      >
         <div className="mb-1 text-sm font-medium">{name}</div>
-        <div className="truncate font-mono text-xs text-text-tertiary" title={project.path}>{project.path}</div>
-      </div>
+        <div className="truncate font-mono text-xs text-text-tertiary" title={project.path}>
+          {project.path}
+        </div>
+      </Link>
       <div className="text-center text-sm text-text-secondary max-md:hidden">
         {project.skills_count}
       </div>
@@ -49,14 +63,27 @@ function ProjectRow({ project }: { project: ProjectSummary }) {
       <div className="text-center text-sm text-text-secondary max-md:hidden">
         {project.servers_count}
       </div>
-      <div className="text-right text-xs text-text-tertiary max-md:text-left">
+      <div className="text-right text-xs text-text-tertiary max-md:hidden">
         {formatDate(project.updated_at)}
       </div>
-      <div className="hidden max-md:flex max-md:gap-4 max-md:text-xs max-md:text-text-tertiary">
+      <div className="flex justify-end max-md:row-start-1 max-md:col-start-2">
+        <button
+          type="button"
+          onClick={handleDelete}
+          disabled={deleteProject.isPending}
+          title={t('actions.deleteProject')}
+          aria-label={t('actions.deleteProject')}
+          className="inline-flex h-8 w-8 items-center justify-center rounded-sm text-text-tertiary transition-colors hover:bg-error-bg hover:text-error-text cursor-pointer disabled:opacity-50"
+        >
+          <Trash2 size={16} />
+        </button>
+      </div>
+      <div className="hidden max-md:col-span-2 max-md:flex max-md:gap-4 max-md:text-xs max-md:text-text-tertiary">
         <span>{project.skills_count} skills</span>
         <span>{project.tools_count} tools</span>
         <span>{project.servers_count} servers</span>
+        <span>{formatDate(project.updated_at)}</span>
       </div>
-    </Link>
+    </div>
   );
 }

--- a/web-ui/src/features/projects/hooks.ts
+++ b/web-ui/src/features/projects/hooks.ts
@@ -38,6 +38,18 @@ export function useProjects() {
   });
 }
 
+export function useDeleteProject() {
+  const qc = useQueryClient();
+  return useMutation({
+    mutationFn: (projectId: string) => projectsApi.delete(projectId),
+    onSuccess: (_data, projectId) => {
+      qc.invalidateQueries({ queryKey: ['projects'] });
+      qc.removeQueries({ queryKey: ['project', projectId] });
+      invalidateProjectQueries(qc, projectId);
+    },
+  });
+}
+
 export function useProject(projectId: string | null) {
   return useQuery({
     queryKey: ['project', projectId],

--- a/web-ui/src/locales/en/projects.json
+++ b/web-ui/src/locales/en/projects.json
@@ -7,11 +7,12 @@
     "skills": "Skills",
     "tools": "Tools",
     "servers": "Servers",
-    "lastUpdated": "Last Updated"
+    "lastUpdated": "Last Updated",
+    "actions": "Actions"
   },
   "empty": {
     "title": "No projects configured",
-    "description": "Projects are automatically registered when you run capa install in a directory containing a capabilities.json or capabilities.yaml file."
+    "description": "Projects appear here after you run capa init, capa install, or capa wrap in a directory with a capabilities file."
   },
   "noResults": {
     "title": "No projects found",
@@ -73,6 +74,8 @@
     "edit": "Edit",
     "cancel": "Cancel",
     "delete": "Delete",
+    "deleteProject": "Delete project",
+    "confirmDeleteProject": "Remove \"{{name}}\" from capa? This stops any wrap sessions for the project and clears capa-managed data. The capabilities file is kept.",
     "dragToReorder": "Drag to reorder",
     "editSkill": "Edit skill",
     "editServer": "Edit server",

--- a/web-ui/src/pages/ProjectDetailPage.tsx
+++ b/web-ui/src/pages/ProjectDetailPage.tsx
@@ -1,7 +1,7 @@
 import { useState, useEffect, useCallback } from 'react';
-import { useSearchParams } from 'react-router-dom';
+import { useSearchParams, useNavigate } from 'react-router-dom';
 import { useTranslation } from 'react-i18next';
-import { AlertTriangle, ArrowDown } from 'lucide-react';
+import { AlertTriangle, ArrowDown, Trash2 } from 'lucide-react';
 import { TopBar } from '../components/layout/TopBar';
 import { Page } from '../components/layout/Page';
 import { Alert } from '../components/common/Alert';
@@ -11,11 +11,18 @@ import { CapabilitiesSection } from '../features/projects/components/Capabilitie
 import { ProvidersSection } from '../features/projects/components/ProvidersSection';
 import { OptionsSection } from '../features/projects/components/OptionsSection';
 import { VariablesForm } from '../features/projects/components/VariablesForm';
-import { useProject, useProjectCapabilitiesLiveSync, useVariables, useOAuth2Servers } from '../features/projects/hooks';
+import {
+  useProject,
+  useProjectCapabilitiesLiveSync,
+  useVariables,
+  useOAuth2Servers,
+  useDeleteProject,
+} from '../features/projects/hooks';
 import { projectDisplayName, safeDecode } from '../lib/utils';
 
 export function ProjectDetailPage() {
   const { t } = useTranslation();
+  const navigate = useNavigate();
   const [searchParams] = useSearchParams();
   const projectId = searchParams.get('id') || searchParams.get('project');
   const returnUrl = searchParams.get('return');
@@ -28,6 +35,7 @@ export function ProjectDetailPage() {
   const { data: project, isLoading, error } = useProject(projectId);
   const { data: variables } = useVariables(projectId);
   const { data: oauth2Servers } = useOAuth2Servers(projectId);
+  const deleteProject = useDeleteProject();
   useProjectCapabilitiesLiveSync(projectId);
 
   useEffect(() => {
@@ -48,6 +56,20 @@ export function ProjectDetailPage() {
   const caps = project?.capabilities;
   const hasProviders = (caps?.providers?.length ?? 0) > 0;
   const showNoConfig = !isLoading && !caps && !error;
+
+  const handleDeleteProject = () => {
+    if (!projectId) return;
+    if (!confirm(t('projects:actions.confirmDeleteProject', { name: displayName }))) return;
+    deleteProject.mutate(projectId, {
+      onSuccess: () => navigate('/'),
+      onError: (err) => {
+        setMessage({
+          text: err instanceof Error ? err.message : String(err),
+          type: 'error',
+        });
+      },
+    });
+  };
 
   const missingVarCount = variables?.required
     ? variables.required.filter((v) => !variables.values?.[v]).length
@@ -126,6 +148,18 @@ export function ProjectDetailPage() {
           <Alert type="error">{(error as Error).message}</Alert>
         ) : (
           <>
+            <div className="mb-6 flex justify-end">
+              <button
+                type="button"
+                onClick={handleDeleteProject}
+                disabled={deleteProject.isPending}
+                className="inline-flex items-center gap-1.5 rounded-sm border border-border-primary bg-bg-secondary px-3 py-1.5 text-xs font-medium text-text-secondary transition-colors hover:bg-error-bg hover:text-error-text hover:border-transparent cursor-pointer disabled:opacity-50"
+              >
+                <Trash2 size={14} />
+                {t('projects:actions.deleteProject')}
+              </button>
+            </div>
+
             {hasProviders && <ProvidersSection providers={caps!.providers} />}
 
             <div id="capabilities-section">

--- a/web-ui/src/pages/ProjectsListPage.tsx
+++ b/web-ui/src/pages/ProjectsListPage.tsx
@@ -43,18 +43,19 @@ export function ProjectsListPage() {
             title={t('empty.title')}
             description={
               <p>
-                {t('empty.description').split('capa install').map((part, i, arr) =>
-                  i < arr.length - 1 ? (
-                    <span key={i}>
-                      {part}
-                      <code className="rounded-sm bg-code-bg px-1.5 py-0.5 font-mono text-xs">
-                        capa install
-                      </code>
-                    </span>
-                  ) : (
-                    <span key={i}>{part}</span>
-                  ),
-                )}
+                Projects appear here after you run{' '}
+                <code className="rounded-sm bg-code-bg px-1.5 py-0.5 font-mono text-xs">
+                  capa init
+                </code>
+                ,{' '}
+                <code className="rounded-sm bg-code-bg px-1.5 py-0.5 font-mono text-xs">
+                  capa install
+                </code>
+                , or{' '}
+                <code className="rounded-sm bg-code-bg px-1.5 py-0.5 font-mono text-xs">
+                  capa wrap
+                </code>
+                .
               </p>
             }
           />


### PR DESCRIPTION
## Summary
- `capa init` now registers the project in the capa DB and configures the server so it appears in the UI before `install`/`wrap`; existing capabilities files are left unchanged
- UI delete (list + detail) runs the same cleanup as `capa clean` via `DELETE /api/projects/:id`, including stopping wrap sessions for that project and pruning its wrap workspaces, while keeping the capabilities file
- Shared `cleanProject` is used by both CLI clean and the API; wrap sessions write `wrap-session.json` for reliable project-scoped stop

## Test plan
- [x] Run `capa init` in a new directory — capabilities file created and project appears in UI
- [x] Run `capa init` again (or after deleting from UI) — file not recreated, project re-registered
- [x] Delete a project from the UI list and from the detail page — confirms wrap stop warning; project disappears; capabilities file remains
- [x] With `capa wrap` running for a project, delete that project from the UI — wrap process is stopped
- [x] `capa clean` still works from the CLI on an installed project
- [x] `bun test src/cli/commands/__tests__/init-command.test.ts src/cli/utils/wrap/__tests__/sessions.test.ts`

Made with [Cursor](https://cursor.com)