### PR TITLE
feat: expand capa add kinds and add --passthrough mode

### DIFF
--- a/src/cli/commands/__tests__/add-builders.test.ts
+++ b/src/cli/commands/__tests__/add-builders.test.ts
@@ -1,0 +1,138 @@
+import { describe, it, expect } from 'bun:test';
+import {
+  buildServerEntry,
+  buildToolEntry,
+  buildHookEntry,
+  buildRuleEntry,
+  resolveAddKind,
+  parseKeyValueList,
+} from '../add-builders';
+
+describe('resolveAddKind', () => {
+  it('defaults to skill', () => {
+    expect(resolveAddKind({})).toBe('skill');
+  });
+
+  it('rejects multiple kinds', () => {
+    expect(() => resolveAddKind({ server: true, tool: true })).toThrow(/Cannot combine/);
+  });
+});
+
+describe('buildServerEntry', () => {
+  it('builds stdio owl-style server', () => {
+    const entry = buildServerEntry({
+      id: 'owl',
+      cmd: 'npx',
+      arg: ['-y', 'owl-mcp@1.0.14', 'serve'],
+    });
+    expect(entry).toEqual({
+      id: 'owl',
+      type: 'mcp',
+      def: {
+        cmd: 'npx',
+        args: ['-y', 'owl-mcp@1.0.14', 'serve'],
+      },
+    });
+  });
+
+  it('builds remote URL server', () => {
+    const entry = buildServerEntry({
+      id: 'aws-knowledge',
+      type: 'mcp',
+      url: 'https://knowledge-mcp.global.api.aws',
+      description: 'AWS docs',
+    });
+    expect(entry.id).toBe('aws-knowledge');
+    expect(entry.type).toBe('mcp');
+    expect((entry.def as any).url).toBe('https://knowledge-mcp.global.api.aws');
+    expect(entry.description).toBe('AWS docs');
+  });
+
+  it('rejects unknown server type', () => {
+    expect(() =>
+      buildServerEntry({ id: 'x', type: 'openapi', url: 'https://example.com' }),
+    ).toThrow(/Unsupported server type/);
+  });
+
+  it('requires cmd or url xor', () => {
+    expect(() => buildServerEntry({ id: 'x' })).toThrow(/exactly one/);
+    expect(() =>
+      buildServerEntry({ id: 'x', cmd: 'npx', url: 'https://x' }),
+    ).toThrow(/exactly one/);
+  });
+});
+
+describe('buildToolEntry', () => {
+  it('builds MCP tool with defaults', () => {
+    const entry = buildToolEntry({
+      id: 'search',
+      mcpServer: 'atlassian',
+      mcpTool: 'search',
+      default: ['cloudId=4cb87cf8-test'],
+    });
+    expect(entry).toEqual({
+      id: 'search',
+      type: 'mcp',
+      def: {
+        server: '@atlassian',
+        tool: 'search',
+        defaults: { cloudId: '4cb87cf8-test' },
+      },
+    });
+  });
+
+  it('builds command tool', () => {
+    const entry = buildToolEntry({
+      id: 'greet',
+      command: 'echo Hello',
+    });
+    expect(entry.type).toBe('command');
+    expect((entry.def as any).run.cmd).toBe('echo Hello');
+  });
+});
+
+describe('buildHookEntry', () => {
+  it('builds meta-style sessionStart hook', () => {
+    const entry = buildHookEntry({
+      id: 'update-projects',
+      on: 'sessionStart',
+      command: 'node scripts/update-projects.mjs',
+      timeout: '120',
+    });
+    expect(entry).toEqual({
+      id: 'update-projects',
+      on: 'sessionStart',
+      type: 'command',
+      command: 'node scripts/update-projects.mjs',
+      timeout: 120,
+    });
+  });
+
+  it('rejects invalid events', () => {
+    expect(() =>
+      buildHookEntry({ id: 'x', on: 'not-an-event', command: 'echo' }),
+    ).toThrow(/Invalid hook event/);
+  });
+});
+
+describe('buildRuleEntry', () => {
+  it('builds inline always-apply rule', async () => {
+    const entry = await buildRuleEntry({
+      id: 'code-style',
+      inline: 'Prefer const',
+      alwaysApply: true,
+    });
+    expect(entry).toEqual({
+      id: 'code-style',
+      type: 'inline',
+      content: 'Prefer const',
+      alwaysApply: true,
+    });
+  });
+});
+
+describe('parseKeyValueList', () => {
+  it('parses KEY=VALUE pairs', () => {
+    expect(parseKeyValueList(['A=1', 'B=two=parts'])).toEqual({ A: '1', B: 'two=parts' });
+  });
+});

--- a/src/cli/commands/__tests__/add-kinds-passthrough.test.ts
+++ b/src/cli/commands/__tests__/add-kinds-passthrough.test.ts
@@ -1,0 +1,128 @@
+import { describe, it, expect, beforeEach, afterEach } from 'bun:test';
+import { mkdtempSync, rmSync, writeFileSync, readFileSync, existsSync } from 'fs';
+import { join } from 'path';
+import { tmpdir } from 'os';
+import { addCommand } from '../add';
+import { upsertNativeMcpServer } from '../../utils/passthrough/native-mcp';
+import { CapaDatabase } from '../../../db/database';
+import { cleanProject } from '../clean-project';
+
+describe('capa add --server (capabilities file)', () => {
+  let tempDir: string;
+  let prevCwd: string;
+
+  beforeEach(() => {
+    tempDir = mkdtempSync(join(tmpdir(), 'capa-add-server-'));
+    prevCwd = process.cwd();
+    process.chdir(tempDir);
+    writeFileSync(
+      join(tempDir, 'capabilities.yaml'),
+      'skills: []\nservers: []\ntools: []\n',
+      'utf-8',
+    );
+  });
+
+  afterEach(() => {
+    process.chdir(prevCwd);
+    try {
+      rmSync(tempDir, { recursive: true, force: true });
+    } catch {}
+  });
+
+  it('appends an owl-style stdio server', async () => {
+    await addCommand(undefined, {
+      server: true,
+      id: 'owl',
+      cmd: 'npx',
+      arg: ['-y', 'owl-mcp@1.0.14', 'serve'],
+    });
+    const yaml = readFileSync(join(tempDir, 'capabilities.yaml'), 'utf-8');
+    expect(yaml).toContain('id: owl');
+    expect(yaml).toContain('cmd: npx');
+    expect(yaml).toContain('owl-mcp@1.0.14');
+  });
+
+  it('appends a remote URL server', async () => {
+    await addCommand(undefined, {
+      server: true,
+      id: 'aws-knowledge',
+      url: 'https://knowledge-mcp.global.api.aws',
+    });
+    const yaml = readFileSync(join(tempDir, 'capabilities.yaml'), 'utf-8');
+    expect(yaml).toContain('id: aws-knowledge');
+    expect(yaml).toContain('url: https://knowledge-mcp.global.api.aws');
+  });
+
+  it('appends a hook matching meta shape', async () => {
+    await addCommand(undefined, {
+      hook: true,
+      id: 'update-projects',
+      on: 'sessionStart',
+      command: 'node scripts/update-projects.mjs',
+      timeout: '120',
+    });
+    const yaml = readFileSync(join(tempDir, 'capabilities.yaml'), 'utf-8');
+    expect(yaml).toContain('id: update-projects');
+    expect(yaml).toContain('on: sessionStart');
+    expect(yaml).toContain('timeout: 120');
+  });
+
+  it('appends a tool with defaults', async () => {
+    await addCommand(undefined, {
+      tool: true,
+      id: 'search',
+      mcpServer: '@atlassian',
+      mcpTool: 'search',
+      default: ['cloudId=abc'],
+    });
+    const yaml = readFileSync(join(tempDir, 'capabilities.yaml'), 'utf-8');
+    expect(yaml).toContain('id: search');
+    expect(yaml).toContain('server: "@atlassian"');
+    expect(yaml).toContain('cloudId: abc');
+  });
+});
+
+describe('passthrough MCP is not cleaned by capa clean', () => {
+  let tempDir: string;
+  let dbPath: string;
+
+  beforeEach(() => {
+    tempDir = mkdtempSync(join(tmpdir(), 'capa-passthrough-clean-'));
+    dbPath = join(tempDir, 'capa.db');
+  });
+
+  afterEach(() => {
+    try {
+      rmSync(tempDir, { recursive: true, force: true });
+    } catch {}
+  });
+
+  it('leaves passthrough MCP entries after cleanProject', async () => {
+    await upsertNativeMcpServer(
+      tempDir,
+      'owl',
+      { cmd: 'npx', args: ['-y', 'owl-mcp@1.0.14', 'serve'] },
+      ['cursor'],
+    );
+    const mcpPath = join(tempDir, '.cursor', 'mcp.json');
+    expect(existsSync(mcpPath)).toBe(true);
+
+    writeFileSync(
+      join(tempDir, 'capabilities.yaml'),
+      'providers:\n  - cursor\nskills: []\nservers: []\ntools: []\n',
+      'utf-8',
+    );
+
+    const db = new CapaDatabase(dbPath);
+    const projectId = 'test-passthrough-0001';
+    db.upsertProject({ id: projectId, path: tempDir });
+    db.setProjectProviders(projectId, ['cursor']);
+    // Do NOT add managed_files for the mcp config — passthrough owns nothing.
+    await cleanProject({ projectPath: tempDir, projectId, db });
+    db.close();
+
+    expect(existsSync(mcpPath)).toBe(true);
+    const config = JSON.parse(readFileSync(mcpPath, 'utf-8'));
+    expect(config.mcpServers.owl).toBeDefined();
+  });
+});

--- a/src/cli/commands/add-builders.ts
+++ b/src/cli/commands/add-builders.ts
@@ -1,0 +1,446 @@
+/**
+ * Builders that turn `capa add` CLI flags into capabilities-file entries.
+ * Exported for unit tests.
+ */
+
+import { basename, resolve, relative, join } from 'path';
+import { access } from 'fs/promises';
+import { constants } from 'fs';
+import { CANONICAL_HOOK_EVENTS, type CanonicalHookEvent, type Hook, type HookSource } from '../../types/hooks';
+import type { Rule } from '../../types/rules';
+import type { MCPServer, Tool } from '../../types/capabilities';
+
+export function parseKeyValue(raw: string): { key: string; value: string } {
+  const eq = raw.indexOf('=');
+  if (eq <= 0) {
+    throw new Error(`Expected KEY=VALUE, got: ${raw}`);
+  }
+  return { key: raw.slice(0, eq), value: raw.slice(eq + 1) };
+}
+
+export function parseKeyValueList(items: string[] | undefined): Record<string, string> | undefined {
+  if (!items || items.length === 0) return undefined;
+  const out: Record<string, string> = {};
+  for (const item of items) {
+    const { key, value } = parseKeyValue(item);
+    out[key] = value;
+  }
+  return out;
+}
+
+export interface BuildServerOptions {
+  id?: string;
+  type?: string;
+  cmd?: string;
+  arg?: string[];
+  env?: string[];
+  url?: string;
+  header?: string[];
+  cwd?: string;
+  description?: string;
+}
+
+export function buildServerEntry(opts: BuildServerOptions): Record<string, unknown> {
+  const serverType = (opts.type ?? 'mcp').trim().toLowerCase();
+  if (serverType !== 'mcp') {
+    throw new Error(
+      `Unsupported server type "${opts.type}". Only "mcp" is supported today.\n` +
+        `  Example: capa add --server --type mcp --id my-server --url https://…`,
+    );
+  }
+  const id = opts.id?.trim();
+  if (!id) {
+    throw new Error('Server requires --id <id>.');
+  }
+
+  const hasCmd = !!opts.cmd?.trim();
+  const hasUrl = !!opts.url?.trim();
+  if (hasCmd === hasUrl) {
+    throw new Error('Server requires exactly one of --cmd or --url.');
+  }
+
+  const def: Record<string, unknown> = {};
+  if (hasCmd) {
+    def.cmd = opts.cmd!.trim();
+    if (opts.arg && opts.arg.length > 0) def.args = opts.arg;
+    const env = parseKeyValueList(opts.env);
+    if (env) def.env = env;
+    if (opts.cwd?.trim()) def.cwd = opts.cwd.trim();
+  } else {
+    def.url = opts.url!.trim();
+    const headers = parseKeyValueList(opts.header);
+    if (headers) def.headers = headers;
+  }
+
+  const entry: Record<string, unknown> = {
+    id,
+    type: 'mcp',
+    def,
+  };
+  if (opts.description?.trim()) entry.description = opts.description.trim();
+  return entry;
+}
+
+/** Narrow helper for typed tests / callers. */
+export function buildServerEntryAsMcp(opts: BuildServerOptions): MCPServer {
+  return buildServerEntry(opts) as unknown as MCPServer;
+}
+
+export interface BuildToolOptions {
+  id?: string;
+  mcpServer?: string;
+  mcpTool?: string;
+  default?: string[];
+  command?: string;
+  description?: string;
+  group?: string;
+}
+
+export function buildToolEntry(opts: BuildToolOptions): Record<string, unknown> {
+  const id = opts.id?.trim();
+  if (!id) {
+    throw new Error('Tool requires --id <id>.');
+  }
+
+  const hasMcp = !!(opts.mcpServer || opts.mcpTool);
+  const hasCommand = !!opts.command?.trim();
+  if (hasMcp && hasCommand) {
+    throw new Error('Tool cannot combine --mcp-server/--mcp-tool with --command.');
+  }
+  if (!hasMcp && !hasCommand) {
+    throw new Error('Tool requires either --mcp-server + --mcp-tool, or --command.');
+  }
+
+  if (hasCommand) {
+    const entry: Record<string, unknown> = {
+      id,
+      type: 'command',
+      def: { run: { cmd: opts.command!.trim() } },
+    };
+    if (opts.description?.trim()) entry.description = opts.description.trim();
+    if (opts.group?.trim()) entry.group = opts.group.trim();
+    return entry;
+  }
+
+  if (!opts.mcpServer?.trim() || !opts.mcpTool?.trim()) {
+    throw new Error('MCP tool requires both --mcp-server <@id> and --mcp-tool <name>.');
+  }
+  let server = opts.mcpServer.trim();
+  if (!server.startsWith('@')) server = `@${server}`;
+
+  const def: Record<string, unknown> = {
+    server,
+    tool: opts.mcpTool.trim(),
+  };
+  const defaults = parseKeyValueList(opts.default);
+  if (defaults) def.defaults = defaults;
+
+  const entry: Record<string, unknown> = {
+    id,
+    type: 'mcp',
+    def,
+  };
+  if (opts.description?.trim()) entry.description = opts.description.trim();
+  if (opts.group?.trim()) entry.group = opts.group.trim();
+  return entry;
+}
+
+export function buildToolEntryAsTool(opts: BuildToolOptions): Tool {
+  return buildToolEntry(opts) as unknown as Tool;
+}
+
+export interface ParsedRuleSource {
+  id: string;
+  type: 'inline' | 'remote' | 'github' | 'gitlab' | 'local';
+  content?: string;
+  url?: string;
+  path?: string;
+  def?: { repo: string };
+}
+
+/**
+ * Parse a rule source. Unlike skills, local paths point at a markdown *file*
+ * (or any readable file), not a directory with SKILL.md.
+ */
+export async function parseRuleSource(source: string): Promise<ParsedRuleSource> {
+  const githubExactMatch = source.match(
+    /^([\w.-]+\/[\w.-]+)::([\w./-]+?)(?::([\w.-]+)|#([a-f0-9]{7,40}))?$/i,
+  );
+  if (githubExactMatch) {
+    const [, repo, path, version, ref] = githubExactMatch;
+    return {
+      id: basename(path).replace(/\.md$/i, ''),
+      type: 'github',
+      def: {
+        repo: `${repo}::${path}${version ? ':' + version : ''}${ref ? '#' + ref : ''}`,
+      },
+    };
+  }
+
+  const githubAtMatch = source.match(
+    /^([\w.-]+\/[\w.-]+)@([\w.-]+)(?::([\w.-]+)|#([a-f0-9]{7,40}))?$/i,
+  );
+  if (githubAtMatch) {
+    const [, repo, name, version, ref] = githubAtMatch;
+    return {
+      id: name.replace(/\.md$/i, ''),
+      type: 'github',
+      def: {
+        repo: `${repo}@${name}${version ? ':' + version : ''}${ref ? '#' + ref : ''}`,
+      },
+    };
+  }
+
+  const gitlabExactMatch = source.match(
+    /^gitlab:([\w.-]+(?:\/[\w.-]+)+)::([\w./-]+?)(?::([\w.-]+)|#([a-f0-9]{7,40}))?$/i,
+  );
+  if (gitlabExactMatch) {
+    const [, repo, path, version, ref] = gitlabExactMatch;
+    return {
+      id: basename(path).replace(/\.md$/i, ''),
+      type: 'gitlab',
+      def: {
+        repo: `${repo}::${path}${version ? ':' + version : ''}${ref ? '#' + ref : ''}`,
+      },
+    };
+  }
+
+  const gitlabAtMatch = source.match(
+    /^gitlab:([\w.-]+(?:\/[\w.-]+)+)@([\w.-]+)(?::([\w.-]+)|#([a-f0-9]{7,40}))?$/i,
+  );
+  if (gitlabAtMatch) {
+    const [, repo, name, version, ref] = gitlabAtMatch;
+    return {
+      id: name.replace(/\.md$/i, ''),
+      type: 'gitlab',
+      def: {
+        repo: `${repo}@${name}${version ? ':' + version : ''}${ref ? '#' + ref : ''}`,
+      },
+    };
+  }
+
+  if (
+    source.startsWith('./') ||
+    source.startsWith('../') ||
+    source.startsWith('/') ||
+    /^[A-Za-z]:/.test(source)
+  ) {
+    const absPath = resolve(process.cwd(), source);
+    try {
+      await access(absPath, constants.R_OK);
+    } catch {
+      throw new Error(`Rule file not found or unreadable: ${absPath}`);
+    }
+    const projectRoot = process.cwd();
+    const pathToStore = absPath.startsWith(projectRoot)
+      ? relative(projectRoot, absPath)
+      : absPath;
+    return {
+      id: basename(absPath).replace(/\.md$/i, ''),
+      type: 'local',
+      path: pathToStore,
+    };
+  }
+
+  if (source.startsWith('http://') || source.startsWith('https://')) {
+    return {
+      id: basename(source).replace(/\.md$/i, '') || 'custom-rule',
+      type: 'remote',
+      url: source,
+    };
+  }
+
+  throw new Error(
+    `Unable to parse rule source: ${source}\n\n` +
+      `Supported formats:\n` +
+      `  GitHub:  owner/repo@rule-name  or  owner/repo::path/to/rule.md\n` +
+      `  GitLab:  gitlab:group/repo@rule-name\n` +
+      `  Local:   ./path/to/rule.md\n` +
+      `  Remote:  https://example.com/rule.md\n` +
+      `  Inline:  capa add --rule --id my-rule --inline "…"`,
+  );
+}
+
+export interface BuildRuleOptions {
+  id?: string;
+  source?: string;
+  inline?: string;
+  appliesTo?: string[];
+  alwaysApply?: boolean;
+  description?: string;
+}
+
+export async function buildRuleEntry(opts: BuildRuleOptions): Promise<Record<string, unknown>> {
+  if (opts.inline !== undefined && opts.source) {
+    throw new Error('Rule cannot combine --inline with a positional source.');
+  }
+
+  let parsed: ParsedRuleSource;
+  if (opts.inline !== undefined) {
+    const id = opts.id?.trim();
+    if (!id) {
+      throw new Error('Inline rule requires --id <id>.');
+    }
+    parsed = { id, type: 'inline', content: opts.inline };
+  } else if (opts.source) {
+    parsed = await parseRuleSource(opts.source);
+    if (opts.id?.trim()) parsed.id = opts.id.trim();
+  } else {
+    throw new Error('Rule requires a positional <source> or --inline <content>.');
+  }
+
+  const entry: Record<string, unknown> = {
+    id: parsed.id,
+    type: parsed.type,
+  };
+  if (parsed.type === 'inline') entry.content = parsed.content ?? '';
+  if (parsed.type === 'remote') entry.url = parsed.url;
+  if (parsed.type === 'local') entry.path = parsed.path;
+  if (parsed.type === 'github' || parsed.type === 'gitlab') entry.def = parsed.def;
+  if (opts.appliesTo && opts.appliesTo.length > 0) entry.appliesTo = opts.appliesTo;
+  if (opts.alwaysApply) entry.alwaysApply = true;
+  if (opts.description?.trim()) entry.description = opts.description.trim();
+  return entry;
+}
+
+export function buildRuleEntryAsRule(entry: Record<string, unknown>): Rule {
+  return entry as unknown as Rule;
+}
+
+export interface BuildHookOptions {
+  id?: string;
+  on?: string;
+  type?: string;
+  command?: string;
+  prompt?: string;
+  source?: string;
+  matcher?: string;
+  timeout?: string | number;
+  failClosed?: boolean;
+  sequential?: boolean;
+  description?: string;
+}
+
+function parseHookSource(raw: string): HookSource {
+  const trimmed = raw.trim();
+  if (
+    trimmed.startsWith('./') ||
+    trimmed.startsWith('../') ||
+    trimmed.startsWith('/') ||
+    /^[A-Za-z]:/.test(trimmed)
+  ) {
+    const absPath = resolve(process.cwd(), trimmed);
+    const projectRoot = process.cwd();
+    const pathToStore = absPath.startsWith(projectRoot)
+      ? relative(projectRoot, absPath)
+      : absPath;
+    return { type: 'local', path: pathToStore };
+  }
+  if (trimmed.startsWith('http://') || trimmed.startsWith('https://')) {
+    return { type: 'remote', url: trimmed };
+  }
+  if (trimmed.toLowerCase().startsWith('gitlab:')) {
+    return { type: 'gitlab', def: { repo: trimmed.replace(/^gitlab:/i, '') } };
+  }
+  // Treat owner/repo… as github
+  if (/^[\w.-]+\/[\w.-]+/.test(trimmed)) {
+    return { type: 'github', def: { repo: trimmed } };
+  }
+  throw new Error(
+    `Unable to parse hook --source: ${raw}\n` +
+      `  Use a local path, http(s) URL, github owner/repo…, or gitlab:group/repo…`,
+  );
+}
+
+export function buildHookEntry(opts: BuildHookOptions): Record<string, unknown> {
+  const id = opts.id?.trim();
+  if (!id) {
+    throw new Error('Hook requires --id <id>.');
+  }
+  const on = opts.on?.trim();
+  if (!on) {
+    throw new Error('Hook requires --on <event> (e.g. sessionStart, beforeShell, cursor:beforeShellExecution).');
+  }
+
+  const isCanonical = (CANONICAL_HOOK_EVENTS as readonly string[]).includes(on);
+  const isProviderScoped = /^[a-zA-Z][\w-]*:.+/.test(on);
+  if (!isCanonical && !isProviderScoped) {
+    throw new Error(
+      `Invalid hook event "${on}".\n` +
+        `  Use a canonical event (${CANONICAL_HOOK_EVENTS.join(', ')})\n` +
+        `  or a provider-scoped event like "cursor:beforeShellExecution".`,
+    );
+  }
+
+  const hookType = (opts.type ?? 'command').trim().toLowerCase();
+  if (hookType !== 'command' && hookType !== 'prompt') {
+    throw new Error('Hook --type must be "command" or "prompt".');
+  }
+
+  const hasCommand = !!opts.command?.trim();
+  const hasPrompt = !!opts.prompt?.trim();
+  const hasSource = !!opts.source?.trim();
+
+  if (hookType === 'command') {
+    if (hasPrompt) throw new Error('Command hooks cannot use --prompt (use --command or --source).');
+    if (!hasCommand && !hasSource) {
+      throw new Error('Command hook requires --command <shell> or --source <path|url|repo>.');
+    }
+  } else {
+    if (hasCommand) throw new Error('Prompt hooks cannot use --command (use --prompt or --source).');
+    if (!hasPrompt && !hasSource) {
+      throw new Error('Prompt hook requires --prompt <text> or --source <path|url|repo>.');
+    }
+  }
+
+  const entry: Record<string, unknown> = {
+    id,
+    on: isCanonical ? (on as CanonicalHookEvent) : on,
+    type: hookType,
+  };
+  if (hasCommand) entry.command = opts.command!.trim();
+  if (hasPrompt) entry.prompt = opts.prompt!.trim();
+  if (hasSource) entry.source = parseHookSource(opts.source!);
+  if (opts.matcher?.trim()) entry.matcher = opts.matcher.trim();
+  if (opts.description?.trim()) entry.description = opts.description.trim();
+  if (opts.failClosed) entry.failClosed = true;
+  if (opts.sequential) entry.sequential = true;
+  if (opts.timeout !== undefined && opts.timeout !== '') {
+    const n = typeof opts.timeout === 'number' ? opts.timeout : Number(opts.timeout);
+    if (!Number.isFinite(n) || n <= 0) {
+      throw new Error(`Invalid --timeout: ${opts.timeout}`);
+    }
+    entry.timeout = n;
+  }
+  return entry;
+}
+
+export function buildHookEntryAsHook(opts: BuildHookOptions): Hook {
+  return buildHookEntry(opts) as unknown as Hook;
+}
+
+/** Kind flags that are mutually exclusive on `capa add`. */
+export type AddKind = 'skill' | 'plugin' | 'server' | 'tool' | 'rule' | 'hook';
+
+export function resolveAddKind(flags: {
+  skill?: boolean;
+  plugin?: boolean;
+  server?: boolean;
+  tool?: boolean;
+  rule?: boolean;
+  hook?: boolean;
+}): AddKind {
+  const kinds: AddKind[] = [];
+  if (flags.skill) kinds.push('skill');
+  if (flags.plugin) kinds.push('plugin');
+  if (flags.server) kinds.push('server');
+  if (flags.tool) kinds.push('tool');
+  if (flags.rule) kinds.push('rule');
+  if (flags.hook) kinds.push('hook');
+  if (kinds.length > 1) {
+    throw new Error(
+      `Cannot combine kind flags: ${kinds.map((k) => `--${k}`).join(', ')}. Pass exactly one.`,
+    );
+  }
+  return kinds[0] ?? 'skill';
+}

--- a/src/cli/commands/add.ts
+++ b/src/cli/commands/add.ts
@@ -1,10 +1,8 @@
 import { detectCapabilitiesFile } from '../../shared/paths';
 import { parseCapabilitiesFile, appendCapabilityEntry } from '../../shared/capabilities';
 import { installCommand } from './install';
-import { RegistryManager } from '../../shared/registries/manager';
 import type { Skill, Capabilities } from '../../types/capabilities';
 import type { Plugin, PluginDefinition } from '../../types/plugin';
-import type { RegistryCapability } from '../../types/registry';
 import type { CapabilitiesFormat } from '../../types/capabilities';
 import { validatePluginDef } from '../../shared/plugin-source';
 import { getAllGitProviders } from '../../shared/git-providers/registry';
@@ -20,6 +18,7 @@ import {
   resolveAddKind,
   type AddKind,
 } from './add-builders';
+import { tryResolveRegistryItem } from './resolve-registry-source';
 
 interface ParsedSkillSource {
   id: string;
@@ -495,78 +494,53 @@ export async function addCommand(
   }
 
   // --- Registry route (runs before --plugin / --skill branches) ---
-  const RESERVED_PREFIXES = /^(github|gitlab|bitbucket|npm|file|http|https):/i;
-  const registryMatch = source.match(/^([a-zA-Z][\w-]*):([\s\S]+)$/);
-  if (registryMatch && !RESERVED_PREFIXES.test(source) && !source.startsWith('.') && !source.startsWith('/') && !/^[A-Za-z]:[\\/]/.test(source)) {
-    const [, registryId, itemId] = registryMatch;
-    const { CapaDatabase } = await import('../../db/database');
-    const { loadSettings, getDatabasePath } = await import('../../shared/config');
-    const settings = await loadSettings();
-    const dbForRegistry = new CapaDatabase(getDatabasePath(settings));
-    const manager = new RegistryManager(dbForRegistry);
-    let adapter;
-    let detail: Awaited<ReturnType<typeof manager.view>> | undefined;
-    let resolvedCapability: RegistryCapability | undefined;
+  {
+    let resolved;
     try {
-      adapter = await manager.getAdapter(registryId);
-      if (adapter) {
-        for (const cap of adapter.manifest.capabilities) {
-          try {
-            detail = await manager.view(registryId, { capability: cap, id: itemId });
-            resolvedCapability = cap;
-            break;
-          } catch {
-            // item not found under this capability, try next
-          }
-        }
-      }
-    } finally {
-      try { dbForRegistry.close(); } catch {}
+      resolved = source ? await tryResolveRegistryItem(source) : null;
+    } catch (err) {
+      console.error(`✗ ${err instanceof Error ? err.message : String(err)}`);
+      process.exit(1);
     }
-    if (adapter) {
-      console.log(`Resolving from registry "${adapter.manifest.name}"...`);
-      if (!detail || !resolvedCapability) {
-        throw new Error(
-          `Item "${itemId}" not found in registry "${registryId}" under any capability ` +
-          `(tried: ${adapter.manifest.capabilities.join(', ')}).`
+    if (resolved) {
+      console.log(`Resolving from registry "${resolved.registryName}"...`);
+
+      if (options.plugin && resolved.capability !== 'plugins') {
+        console.warn(
+          `  ⚠ --plugin ignored: registry "${resolved.registryId}" resolved "${resolved.itemId}" as a ${resolved.capability.slice(0, -1)}.`,
+        );
+      }
+      if (options.skill && resolved.capability !== 'skills') {
+        console.warn(
+          `  ⚠ --skill ignored: registry "${resolved.registryId}" resolved "${resolved.itemId}" as a ${resolved.capability.slice(0, -1)}.`,
         );
       }
 
-      // Warn when a manual --plugin/--skill flag disagrees with the registry's verdict
-      if (options.plugin && resolvedCapability !== 'plugins') {
-        console.warn(`  ⚠ --plugin ignored: registry "${registryId}" resolved "${itemId}" as a ${resolvedCapability.slice(0, -1)}.`);
-      }
-      if (options.skill && resolvedCapability !== 'skills') {
-        console.warn(`  ⚠ --skill ignored: registry "${registryId}" resolved "${itemId}" as a ${resolvedCapability.slice(0, -1)}.`);
-      }
-
-      const snippet = detail.installSnippet;
-      const itemName = (snippet as any).id ?? itemId.split('/').pop() ?? 'registry-item';
-
-      if (resolvedCapability === 'skills') {
-        const existing = capabilities.skills.find(s => s.id === itemName);
+      if (resolved.capability === 'skills' && resolved.skill) {
+        const existing = capabilities.skills.find((s) => s.id === resolved.itemName);
         if (existing) {
-          console.error(`\u2717 Skill with id "${itemName}" already exists in capabilities file.`);
+          console.error(`\u2717 Skill with id "${resolved.itemName}" already exists in capabilities file.`);
           console.error(`  Rename or remove the existing entry in ${capabilitiesFile.path} and try again.`);
           process.exit(1);
         }
-        const newSkill: Skill = { ...(snippet as Skill), id: itemName };
         await appendCapabilityEntry(
           capabilitiesFile.path,
           capabilitiesFile.format,
           'skills',
-          newSkill as unknown as Record<string, unknown>
+          resolved.skill as unknown as Record<string, unknown>,
         );
-      } else if (resolvedCapability === 'plugins') {
+      } else if (resolved.capability === 'plugins' && resolved.plugin) {
         if (!capabilities.plugins) capabilities.plugins = [];
-        const newPlugin = snippet as Plugin;
-        const existing = capabilities.plugins.find(p =>
-          (p as any).id === itemName ||
-          (p.type === newPlugin.type
-            && p.def.repo === newPlugin.def.repo
-            && (p.def.subpath ?? '') === (newPlugin.def.subpath ?? '')));
+        const newPlugin = resolved.plugin;
+        const existing = capabilities.plugins.find(
+          (p) =>
+            (p as { id?: string }).id === resolved.itemName ||
+            (p.type === newPlugin.type &&
+              p.def.repo === newPlugin.def.repo &&
+              (p.def.subpath ?? '') === (newPlugin.def.subpath ?? '')),
+        );
         if (existing) {
-          console.error(`\u2717 Plugin "${itemName}" already exists in capabilities file.`);
+          console.error(`\u2717 Plugin "${resolved.itemName}" already exists in capabilities file.`);
           console.error(`  Rename or remove the existing entry in ${capabilitiesFile.path} and try again.`);
           process.exit(1);
         }
@@ -574,15 +548,16 @@ export async function addCommand(
           capabilitiesFile.path,
           capabilitiesFile.format,
           'plugins',
-          { ...newPlugin, id: itemName } as unknown as Record<string, unknown>
+          { ...newPlugin, id: resolved.itemName } as unknown as Record<string, unknown>,
         );
       }
 
-      console.log(`\u2713 Added ${resolvedCapability.slice(0, -1)} "${itemName}" from registry "${registryId}" to ${capabilitiesFile.path}`);
+      console.log(
+        `\u2713 Added ${resolved.capability.slice(0, -1)} "${resolved.itemName}" from registry "${resolved.registryId}" to ${capabilitiesFile.path}`,
+      );
       await maybeInstall();
       return;
     }
-    // If no adapter matched, fall through to normal parsing
   }
 
   // --- Plugin mode (--plugin flag) ---

--- a/src/cli/commands/add.ts
+++ b/src/cli/commands/add.ts
@@ -2,15 +2,24 @@ import { detectCapabilitiesFile } from '../../shared/paths';
 import { parseCapabilitiesFile, appendCapabilityEntry } from '../../shared/capabilities';
 import { installCommand } from './install';
 import { RegistryManager } from '../../shared/registries/manager';
-import type { Skill } from '../../types/capabilities';
+import type { Skill, Capabilities } from '../../types/capabilities';
 import type { Plugin, PluginDefinition } from '../../types/plugin';
 import type { RegistryCapability } from '../../types/registry';
+import type { CapabilitiesFormat } from '../../types/capabilities';
 import { validatePluginDef } from '../../shared/plugin-source';
 import { getAllGitProviders } from '../../shared/git-providers/registry';
 import { resolve, basename, join, relative } from 'path';
 import { access } from 'fs/promises';
 import { constants } from 'fs';
 import { refuseIfWrapWorkspace } from '../utils/wrap/marker';
+import {
+  buildServerEntry,
+  buildToolEntry,
+  buildRuleEntry,
+  buildHookEntry,
+  resolveAddKind,
+  type AddKind,
+} from './add-builders';
 
 interface ParsedSkillSource {
   id: string;
@@ -366,20 +375,74 @@ export function parsePluginSource(source: string): ParsedPluginSource {
   );
 }
 
+export interface AddCommandOptions {
+  plugin?: boolean;
+  skill?: boolean;
+  server?: boolean;
+  tool?: boolean;
+  rule?: boolean;
+  hook?: boolean;
+  provider?: string;
+  envFile?: string | boolean;
+  noCache?: boolean;
+  /** When true, run install after updating the capabilities file (legacy one-shot). */
+  install?: boolean;
+  /** Write provider-native files; skip capabilities file / capa server / DB tracking. */
+  passthrough?: boolean;
+  // Server flags
+  id?: string;
+  type?: string;
+  cmd?: string;
+  arg?: string[];
+  env?: string[];
+  url?: string;
+  header?: string[];
+  cwd?: string;
+  description?: string;
+  // Tool flags
+  mcpServer?: string;
+  mcpTool?: string;
+  default?: string[];
+  command?: string;
+  group?: string;
+  // Rule flags
+  inline?: string;
+  appliesTo?: string[];
+  alwaysApply?: boolean;
+  // Hook flags
+  on?: string;
+  prompt?: string;
+  source?: string;
+  matcher?: string;
+  timeout?: string;
+  failClosed?: boolean;
+  sequential?: boolean;
+}
+
 export async function addCommand(
-  source: string,
-  options: {
-    plugin?: boolean;
-    skill?: boolean;
-    provider?: string;
-    envFile?: string | boolean;
-    noCache?: boolean;
-    /** When true, run install after updating the capabilities file (legacy one-shot). */
-    install?: boolean;
-  }
+  source: string | undefined,
+  options: AddCommandOptions
 ): Promise<void> {
   if (await refuseIfWrapWorkspace('add')) {
     process.exit(1);
+  }
+
+  let kind: AddKind;
+  try {
+    kind = resolveAddKind(options);
+  } catch (err) {
+    console.error(`✗ ${err instanceof Error ? err.message : String(err)}`);
+    process.exit(1);
+  }
+
+  if (options.passthrough && options.install) {
+    console.log('Note: --install is ignored with --passthrough (files are written immediately).\n');
+  }
+
+  if (options.passthrough) {
+    const { passthroughAdd } = await import('../utils/passthrough');
+    await passthroughAdd(source, kind, options);
+    return;
   }
 
   const installOpts = {
@@ -400,11 +463,6 @@ export async function addCommand(
     );
   }
 
-  if (options.plugin && options.skill) {
-    console.error('✗ Cannot pass both --skill and --plugin.');
-    process.exit(1);
-  }
-
   const projectPath = process.cwd();
 
   const capabilitiesFile = await detectCapabilitiesFile(projectPath);
@@ -419,6 +477,22 @@ export async function addCommand(
     capabilitiesFile.path,
     capabilitiesFile.format
   );
+
+  // --- Server / tool / rule / hook (no registry route) ---
+  if (kind === 'server' || kind === 'tool' || kind === 'rule' || kind === 'hook') {
+    try {
+      await appendTypedEntry(kind, source, options, capabilities, capabilitiesFile, maybeInstall);
+    } catch (err) {
+      console.error(`✗ ${err instanceof Error ? err.message : String(err)}`);
+      process.exit(1);
+    }
+    return;
+  }
+
+  if (!source) {
+    console.error('✗ Missing <source>. Example: capa add owner/repo@skill-name');
+    process.exit(1);
+  }
 
   // --- Registry route (runs before --plugin / --skill branches) ---
   const RESERVED_PREFIXES = /^(github|gitlab|bitbucket|npm|file|http|https):/i;
@@ -512,7 +586,7 @@ export async function addCommand(
   }
 
   // --- Plugin mode (--plugin flag) ---
-  if (options.plugin) {
+  if (kind === 'plugin') {
     let parsed: ParsedPluginSource;
     try {
       parsed = parsePluginSource(source);
@@ -592,3 +666,107 @@ export async function addCommand(
 
   await maybeInstall();
 }
+
+async function appendTypedEntry(
+  kind: 'server' | 'tool' | 'rule' | 'hook',
+  source: string | undefined,
+  options: AddCommandOptions,
+  capabilities: Capabilities,
+  capabilitiesFile: { path: string; format: CapabilitiesFormat },
+  maybeInstall: () => Promise<void>,
+): Promise<void> {
+  let entry: Record<string, unknown>;
+  let section: 'servers' | 'tools' | 'rules' | 'hooks';
+  let label: string;
+
+  if (kind === 'server') {
+    if (source) {
+      throw new Error('Server mode does not take a positional <source>; use --id/--cmd/--url flags.');
+    }
+    entry = buildServerEntry({
+      id: options.id,
+      type: options.type,
+      cmd: options.cmd,
+      arg: options.arg,
+      env: options.env,
+      url: options.url,
+      header: options.header,
+      cwd: options.cwd,
+      description: options.description,
+    });
+    section = 'servers';
+    label = 'server';
+    const existing = (capabilities.servers ?? []).find((s) => s.id === entry.id);
+    if (existing) {
+      throw new Error(`Server with id "${entry.id}" already exists in capabilities file.`);
+    }
+  } else if (kind === 'tool') {
+    if (source) {
+      throw new Error('Tool mode does not take a positional <source>; use --id and MCP/command flags.');
+    }
+    entry = buildToolEntry({
+      id: options.id,
+      mcpServer: options.mcpServer,
+      mcpTool: options.mcpTool,
+      default: options.default,
+      command: options.command,
+      description: options.description,
+      group: options.group,
+    });
+    section = 'tools';
+    label = 'tool';
+    const existing = (capabilities.tools ?? []).find((t) => t.id === entry.id);
+    if (existing) {
+      throw new Error(`Tool with id "${entry.id}" already exists in capabilities file.`);
+    }
+  } else if (kind === 'rule') {
+    entry = await buildRuleEntry({
+      id: options.id,
+      source,
+      inline: options.inline,
+      appliesTo: options.appliesTo,
+      alwaysApply: options.alwaysApply,
+      description: options.description,
+    });
+    section = 'rules';
+    label = 'rule';
+    const existing = (capabilities.rules ?? []).find((r) => r.id === entry.id);
+    if (existing) {
+      throw new Error(`Rule with id "${entry.id}" already exists in capabilities file.`);
+    }
+  } else {
+    if (source) {
+      throw new Error('Hook mode does not take a positional <source>; use --id/--on/--command flags.');
+    }
+    entry = buildHookEntry({
+      id: options.id,
+      on: options.on,
+      type: options.type,
+      command: options.command,
+      prompt: options.prompt,
+      source: options.source,
+      matcher: options.matcher,
+      timeout: options.timeout,
+      failClosed: options.failClosed,
+      sequential: options.sequential,
+      description: options.description,
+    });
+    section = 'hooks';
+    label = 'hook';
+    const existing = (capabilities.hooks ?? []).find((h) => h.id === entry.id);
+    if (existing) {
+      throw new Error(`Hook with id "${entry.id}" already exists in capabilities file.`);
+    }
+  }
+
+  await appendCapabilityEntry(
+    capabilitiesFile.path,
+    capabilitiesFile.format,
+    section,
+    entry,
+  );
+
+  console.log(`✓ Added ${label} "${entry.id}" to ${capabilitiesFile.path}`);
+  await maybeInstall();
+}
+

--- a/src/cli/commands/install-tasks/context.ts
+++ b/src/cli/commands/install-tasks/context.ts
@@ -66,6 +66,11 @@ export interface InstallOptions {
    * Warnings about missing credentials are still recorded.
    */
   skipCredentialOpen?: boolean;
+  /**
+   * Write provider-native files from the capabilities file without starting
+   * the capa server or registering a capa MCP proxy entry.
+   */
+  passthrough?: boolean;
 }
 
 export type GetRepoSnapshotFn = (

--- a/src/cli/commands/install-tasks/helpers/install-one-skill.ts
+++ b/src/cli/commands/install-tasks/helpers/install-one-skill.ts
@@ -60,7 +60,9 @@ export async function installOneSkill(
   lockBuilder: LockfileBuilder,
   noCache: boolean,
   resolvedRepos: Map<string, GetSnapshotResult>,
+  opts?: { trackManaged?: boolean },
 ): Promise<SkillInstallOutcome> {
+  const trackManaged = opts?.trackManaged !== false;
   const authFetch = createAuthenticatedFetch(db);
 
   let skillMarkdown: string;
@@ -304,14 +306,16 @@ export async function installOneSkill(
     const skillMdPath = join(skillDir, 'SKILL.md');
 
     if (existsSync(skillDir)) {
-      const managedFiles = db.getManagedFiles(projectId);
-      if (!managedFiles.includes(skillDir)) {
-        console.error(
-          `  ✗ Directory already exists and is not managed by capa: ${skillDir}`
-        );
-        console.error('    Please delete it manually and run "capa install" again.');
-        try { db.close(); } catch {}
-        process.exit(1);
+      if (trackManaged) {
+        const managedFiles = db.getManagedFiles(projectId);
+        if (!managedFiles.includes(skillDir)) {
+          console.error(
+            `  ✗ Directory already exists and is not managed by capa: ${skillDir}`
+          );
+          console.error('    Please delete it manually and run "capa install" again.');
+          try { db.close(); } catch {}
+          process.exit(1);
+        }
       }
       rmSync(skillDir, { recursive: true, force: true });
     }
@@ -338,7 +342,9 @@ export async function installOneSkill(
       }
     }
 
-    db.addManagedFile(projectId, skillDir);
+    if (trackManaged) {
+      db.addManagedFile(projectId, skillDir);
+    }
   }
 
   return 'installed';

--- a/src/cli/commands/install-tasks/helpers/install-one-skill.ts
+++ b/src/cli/commands/install-tasks/helpers/install-one-skill.ts
@@ -316,8 +316,18 @@ export async function installOneSkill(
           try { db.close(); } catch {}
           process.exit(1);
         }
+        rmSync(skillDir, { recursive: true, force: true });
+      } else {
+        // Passthrough must not delete directories capa does not own.
+        console.error(
+          `  ✗ Directory already exists: ${skillDir}`
+        );
+        console.error(
+          '    Passthrough will not overwrite existing skill directories. Delete it manually and retry.',
+        );
+        try { db.close(); } catch {}
+        process.exit(1);
       }
-      rmSync(skillDir, { recursive: true, force: true });
     }
 
     if (skillSourceDir) {

--- a/src/cli/commands/install.ts
+++ b/src/cli/commands/install.ts
@@ -35,6 +35,7 @@ export async function installCommand(
   let quiet = false;
   let skipPrerequisites = false;
   let skipCredentialOpen = false;
+  let passthrough = false;
   if (typeof envFileOrOptions === 'object' && envFileOrOptions !== null) {
     envFile = envFileOrOptions.envFile;
     flagProvider = envFileOrOptions.provider;
@@ -47,8 +48,21 @@ export async function installCommand(
     quiet = !!envFileOrOptions.quiet;
     skipPrerequisites = !!envFileOrOptions.skipPrerequisites;
     skipCredentialOpen = !!envFileOrOptions.skipCredentialOpen;
+    passthrough = !!envFileOrOptions.passthrough;
   } else {
     envFile = envFileOrOptions;
+  }
+
+  if (passthrough) {
+    const { passthroughInstall } = await import('../utils/passthrough');
+    await passthroughInstall({
+      envFile,
+      provider: flagProvider,
+      noCache,
+      projectPath,
+      exitProcess,
+    });
+    return;
   }
 
   const prevQuiet = getFlags().quiet;

--- a/src/cli/commands/plugin-install.ts
+++ b/src/cli/commands/plugin-install.ts
@@ -315,7 +315,16 @@ export async function resolvePlugins(
         const skillsBaseDir = join(projectPath, providerEntry.skillsDir);
         const destSkillDir = join(skillsBaseDir, entry.id);
         try {
-          if (existsSync(destSkillDir)) rmSync(destSkillDir, { recursive: true, force: true });
+          if (existsSync(destSkillDir)) {
+            if (!trackManaged) {
+              warnings.push(
+                `Skill "${entry.id}" for ${client}: directory already exists at ${destSkillDir}; ` +
+                  `passthrough will not overwrite it. Delete it manually and retry.`,
+              );
+              continue;
+            }
+            rmSync(destSkillDir, { recursive: true, force: true });
+          }
           mkdirSync(resolve(destSkillDir, '..'), { recursive: true });
           if (hasSecurity) {
             copySkillDirWithSecurity(

--- a/src/cli/commands/plugin-install.ts
+++ b/src/cli/commands/plugin-install.ts
@@ -128,9 +128,10 @@ export async function resolvePlugins(
   getRepoSnapshot: GetRepoSnapshotFn,
   capabilitiesFilePath: string,
   lockBuilder: LockfileBuilder,
-  options: { noCache?: boolean } = {}
+  options: { noCache?: boolean; trackManaged?: boolean; pluginsBaseDir?: string } = {}
 ): Promise<ResolvePluginsResult> {
   const noCache = !!options.noCache;
+  const trackManaged = options.trackManaged !== false;
   const plugins = capabilities.plugins ?? [];
   const mergedSkills: Skill[] = Array.isArray(capabilities.skills) ? [...capabilities.skills] : [];
   // Preserve all explicitly defined servers from the capabilities file; never drop them when merging plugin servers
@@ -143,7 +144,7 @@ export async function resolvePlugins(
     throw new Error('No providers configured. Resolve providers before calling resolvePlugins.');
   }
 
-  const pluginsBase = getPluginsTempBase(projectId);
+  const pluginsBase = options.pluginsBaseDir ?? getPluginsTempBase(projectId);
   const currentPluginIds = new Set<string>();
   const warnings: string[] = [];
 
@@ -332,7 +333,9 @@ export async function resolvePlugins(
               copySkillTree({ src: srcSkillDir, dst: destSkillDir });
             }
           }
-          db.addManagedFile(projectId, destSkillDir);
+          if (trackManaged) {
+            db.addManagedFile(projectId, destSkillDir);
+          }
         } catch (err: any) {
           if (err instanceof BlockedPhraseError) {
             throw err;

--- a/src/cli/commands/resolve-registry-source.ts
+++ b/src/cli/commands/resolve-registry-source.ts
@@ -9,6 +9,10 @@ import { loadSettings, getDatabasePath } from '../../shared/config';
 import type { RegistryCapability } from '../../types/registry';
 import type { Skill } from '../../types/capabilities';
 import type { Plugin } from '../../types/plugin';
+import {
+  claudePluginsNativeInstall,
+  type NativePluginInstall,
+} from '../utils/passthrough/native-plugin-install';
 
 const RESERVED_PREFIXES = /^(github|gitlab|bitbucket|npm|file|http|https):/i;
 
@@ -28,6 +32,11 @@ export interface ResolvedRegistryItem {
   itemName: string;
   skill?: Skill;
   plugin?: Plugin;
+  /**
+   * When set, passthrough can invoke the provider's own plugin installer
+   * for matching provider ids instead of unpacking the plugin tree.
+   */
+  nativeInstall?: NativePluginInstall;
 }
 
 /**
@@ -97,6 +106,10 @@ export async function tryResolveRegistryItem(source: string): Promise<ResolvedRe
     result.skill = { ...(snippet as Skill), id: itemName };
   } else if (resolvedCapability === 'plugins') {
     result.plugin = { ...(snippet as Plugin), id: itemName };
+    // Claude marketplace plugins can be installed natively into Claude Code.
+    if (registryId === 'claude-plugins') {
+      result.nativeInstall = claudePluginsNativeInstall(itemName, result.plugin.def);
+    }
   }
 
   return result;

--- a/src/cli/commands/resolve-registry-source.ts
+++ b/src/cli/commands/resolve-registry-source.ts
@@ -1,0 +1,103 @@
+/**
+ * Resolve `registryId:itemId` sources via RegistryManager.
+ * Returns null when the source is not a registry form or no adapter matches.
+ */
+
+import { RegistryManager } from '../../shared/registries/manager';
+import { CapaDatabase } from '../../db/database';
+import { loadSettings, getDatabasePath } from '../../shared/config';
+import type { RegistryCapability } from '../../types/registry';
+import type { Skill } from '../../types/capabilities';
+import type { Plugin } from '../../types/plugin';
+
+const RESERVED_PREFIXES = /^(github|gitlab|bitbucket|npm|file|http|https):/i;
+
+export function looksLikeRegistrySource(source: string): boolean {
+  if (RESERVED_PREFIXES.test(source)) return false;
+  if (source.startsWith('.') || source.startsWith('/') || /^[A-Za-z]:[\\/]/.test(source)) {
+    return false;
+  }
+  return /^([a-zA-Z][\w-]*):([\s\S]+)$/.test(source);
+}
+
+export interface ResolvedRegistryItem {
+  registryId: string;
+  registryName: string;
+  itemId: string;
+  capability: RegistryCapability;
+  itemName: string;
+  skill?: Skill;
+  plugin?: Plugin;
+}
+
+/**
+ * Try to resolve a `slug:itemId` source against configured registry adapters.
+ * Returns null when the source is not registry-shaped or no adapter exists for the slug.
+ * Throws when an adapter exists but the item is not found.
+ */
+export async function tryResolveRegistryItem(source: string): Promise<ResolvedRegistryItem | null> {
+  if (!looksLikeRegistrySource(source)) return null;
+
+  const match = source.match(/^([a-zA-Z][\w-]*):([\s\S]+)$/);
+  if (!match) return null;
+  const [, registryId, itemId] = match;
+
+  const settings = await loadSettings();
+  const db = new CapaDatabase(getDatabasePath(settings));
+  const manager = new RegistryManager(db);
+  let adapter;
+  let detail: Awaited<ReturnType<typeof manager.view>> | undefined;
+  let resolvedCapability: RegistryCapability | undefined;
+
+  try {
+    adapter = await manager.getAdapter(registryId);
+    if (!adapter) return null;
+
+    for (const cap of adapter.manifest.capabilities) {
+      try {
+        detail = await manager.view(registryId, { capability: cap, id: itemId });
+        resolvedCapability = cap;
+        break;
+      } catch {
+        // try next capability
+      }
+    }
+  } finally {
+    try {
+      db.close();
+    } catch {}
+  }
+
+  if (!adapter) return null;
+
+  if (!detail || !resolvedCapability) {
+    throw new Error(
+      `Item "${itemId}" not found in registry "${registryId}" under any capability ` +
+        `(tried: ${adapter.manifest.capabilities.join(', ')}).`,
+    );
+  }
+
+  const snippet = detail.installSnippet;
+  const itemName =
+    (typeof (snippet as { id?: unknown }).id === 'string'
+      ? (snippet as { id: string }).id
+      : null) ??
+    itemId.split('/').pop() ??
+    'registry-item';
+
+  const result: ResolvedRegistryItem = {
+    registryId,
+    registryName: adapter.manifest.name,
+    itemId,
+    capability: resolvedCapability,
+    itemName,
+  };
+
+  if (resolvedCapability === 'skills') {
+    result.skill = { ...(snippet as Skill), id: itemName };
+  } else if (resolvedCapability === 'plugins') {
+    result.plugin = { ...(snippet as Plugin), id: itemName };
+  }
+
+  return result;
+}

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -28,6 +28,12 @@ import { checkForUpdates } from './utils/version-check';
 import { VERSION } from '../version';
 import { setFlags, ExitCode, error } from './ui';
 
+/** Commander accumulator for repeatable options. */
+function collectRepeatable(value: string, previous: string[]): string[] {
+  previous.push(value);
+  return previous;
+}
+
 // Check if running as server
 if (process.argv[2] === '__server__') {
   // Import and start server
@@ -82,34 +88,102 @@ if (process.argv[2] === '__server__') {
       });
 
     program
+      .command('add [source]')
+      .description(
+        'Add a skill, plugin, server, tool, rule, or hook (writes capabilities file, or native files with --passthrough)',
+      )
+      .option('--plugin', 'Treat as a plugin')
+      .option('--skill', 'Treat as a skill (default when no other kind flag is set)')
+      .option('--server', 'Add an MCP (or future) server entry')
+      .option('--tool', 'Add a tool entry')
+      .option('--rule', 'Add a rule entry')
+      .option('--hook', 'Add a hook entry')
+      .option('--passthrough', 'Write provider-native files; skip capabilities file and capa management')
+      .option('--install', 'Also run capa install after updating the capabilities file')
+      .option('-e, --env [file]', 'Load variables from .env file (defaults to .env if no file specified)')
+      .option('-p, --provider <id>', 'Provider id (install follow-up, or required for --passthrough in non-TTY)')
+      .option('--no-cache', 'Bypass the on-disk cache and lockfile; re-resolve every remote source')
+      // Shared / server / tool / rule / hook metadata
+      .option('--id <id>', 'Entry id (required for --server/--tool/--hook; optional override for --rule)')
+      .option('--type <name>', 'Server type (default mcp) or hook type (command|prompt)')
+      .option('--cmd <bin>', 'Server stdio command')
+      .option('--arg <token>', 'Server stdio arg (repeatable)', collectRepeatable, [])
+      .option('--env-var <KEY=VAL>', 'Server env var (repeatable)', collectRepeatable, [])
+      .option('--url <url>', 'Remote MCP server URL')
+      .option('--header <KEY=VAL>', 'Remote MCP header (repeatable)', collectRepeatable, [])
+      .option('--cwd <path>', 'Server working directory')
+      .option('--description <text>', 'Optional description')
+      .option('--mcp-server <id>', 'Tool: MCP server reference (@id or id)')
+      .option('--mcp-tool <name>', 'Tool: upstream MCP tool name')
+      .option('--default <KEY=VAL>', 'Tool default arg (repeatable)', collectRepeatable, [])
+      .option('--command <cmd>', 'Tool command body, or hook shell command')
+      .option('--group <name>', 'Tool group name')
+      .option('--inline <text>', 'Rule inline content')
+      .option('--applies-to <glob>', 'Rule appliesTo glob (repeatable)', collectRepeatable, [])
+      .option('--always-apply', 'Rule alwaysApply')
+      .option('--on <event>', 'Hook event (sessionStart, beforeShell, …)')
+      .option('--prompt <text>', 'Hook prompt body')
+      .option('--source <path>', 'Hook alternate body source (path, URL, or repo)')
+      .option('--matcher <pattern>', 'Hook matcher/pattern')
+      .option('--timeout <seconds>', 'Hook timeout in seconds')
+      .option('--fail-closed', 'Hook failClosed')
+      .option('--sequential', 'Hook sequential')
+      .action(async (source: string | undefined, options) => {
+        await addCommand(source, {
+          plugin: options.plugin,
+          skill: options.skill,
+          server: options.server,
+          tool: options.tool,
+          rule: options.rule,
+          hook: options.hook,
+          passthrough: options.passthrough === true,
+          envFile: options.env,
+          provider: options.provider,
+          noCache: options.cache === false,
+          install: options.install === true,
+          id: options.id,
+          type: options.type,
+          cmd: options.cmd,
+          arg: options.arg,
+          // Commander --env is already used for .env file; server env uses --env-var
+          env: options.envVar,
+          url: options.url,
+          header: options.header,
+          cwd: options.cwd,
+          description: options.description,
+          mcpServer: options.mcpServer,
+          mcpTool: options.mcpTool,
+          default: options.default,
+          command: options.command,
+          group: options.group,
+          inline: options.inline,
+          appliesTo: options.appliesTo,
+          alwaysApply: options.alwaysApply === true,
+          on: options.on,
+          prompt: options.prompt,
+          source: options.source,
+          matcher: options.matcher,
+          timeout: options.timeout,
+          failClosed: options.failClosed === true,
+          sequential: options.sequential === true,
+        });
+      });
+
+    program
       .command('install')
       .description('Install skills and configure tools')
       .option('-e, --env [file]', 'Load variables from .env file (defaults to .env if no file specified)')
       .option('-p, --provider <id>', 'Install for a single provider (e.g. "cursor", "claude-code")')
       .option('--no-cache', 'Bypass the on-disk cache and lockfile; re-resolve every remote source')
+      .option('--passthrough', 'Write provider-native files from the capabilities file (no capa server/proxy)')
       .action(async (options) => {
         // Commander inverts --no-* flags: `options.cache` is true by default and
         // false when --no-cache is passed. Convert to the explicit noCache flag.
-        await installCommand({ envFile: options.env, provider: options.provider, noCache: options.cache === false });
-      });
-
-    program
-      .command('add <source>')
-      .description('Add a skill or plugin from various sources (GitHub, GitLab, registry, local path, or remote URL)')
-      .option('--plugin', 'Treat <source> as a plugin (default is skill)')
-      .option('--skill', 'Treat <source> as a skill (default; flag exists for explicitness)')
-      .option('--install', 'Also run capa install after updating the capabilities file')
-      .option('-e, --env [file]', 'Load variables from .env file (defaults to .env if no file specified)')
-      .option('-p, --provider <id>', 'Install for a single provider (e.g. "cursor", "claude-code")')
-      .option('--no-cache', 'Bypass the on-disk cache and lockfile; re-resolve every remote source')
-      .action(async (source: string, options) => {
-        await addCommand(source, {
-          plugin: options.plugin,
-          skill: options.skill,
+        await installCommand({
           envFile: options.env,
           provider: options.provider,
           noCache: options.cache === false,
-          install: options.install === true,
+          passthrough: options.passthrough === true,
         });
       });
 

--- a/src/cli/utils/hooks-installer.ts
+++ b/src/cli/utils/hooks-installer.ts
@@ -71,6 +71,16 @@ export interface InstallHooksOptions {
   noCache?: boolean;
   /** When set, hook lockfile entries are recorded for `github`/`gitlab`/`remote` sources. */
   lockBuilder?: LockfileBuilder;
+  /**
+   * When false, skip writing `managed_hooks` rows (passthrough mode).
+   * @default true
+   */
+  trackManaged?: boolean;
+  /**
+   * Prefix for provider entry `name` tags. Default `'capa:'`.
+   * Pass `''` for passthrough so `capa clean` will not remove these entries.
+   */
+  nameTagPrefix?: string;
 }
 
 export interface InstallHooksResult {
@@ -85,6 +95,8 @@ export interface InstallHooksResult {
  */
 export async function installHooks(opts: InstallHooksOptions): Promise<InstallHooksResult> {
   const { projectPath, projectId, hooks, providers, db } = opts;
+  const trackManaged = opts.trackManaged !== false;
+  const nameTagPrefix = opts.nameTagPrefix;
   const warnings: string[] = [];
   let installed = 0;
 
@@ -190,6 +202,7 @@ export async function installHooks(opts: InstallHooksOptions): Promise<InstallHo
           hook,
           mapping,
           runReference,
+          ...(nameTagPrefix !== undefined ? { nameTagPrefix } : {}),
         });
 
         const { configPath, locator } = applyHookEntryToConfig({
@@ -201,17 +214,19 @@ export async function installHooks(opts: InstallHooksOptions): Promise<InstallHo
         // Only track scriptPath for files capa wrote under ~/.capa, so
         // prune/clean delete what they own and never touch user-authored
         // local scripts referenced via `source.type=local`.
-        const scriptPath = body.needsMaterialisation
-          ? hookScriptPaths.get(hook.id) ?? null
-          : null;
-        db.upsertManagedHook({
-          projectId,
-          providerId,
-          hookId: hook.id,
-          configPath,
-          locator: JSON.stringify(locator),
-          scriptPath,
-        });
+        if (trackManaged) {
+          const scriptPath = body.needsMaterialisation
+            ? hookScriptPaths.get(hook.id) ?? null
+            : null;
+          db.upsertManagedHook({
+            projectId,
+            providerId,
+            hookId: hook.id,
+            configPath,
+            locator: JSON.stringify(locator),
+            scriptPath,
+          });
+        }
         installed++;
         taskLog(`  ✓ Installed hook "${hook.id}" → ${provider.displayName} (${eventName})`);
       } catch (err: unknown) {

--- a/src/cli/utils/passthrough/__tests__/native-mcp.test.ts
+++ b/src/cli/utils/passthrough/__tests__/native-mcp.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, beforeEach, afterEach } from 'bun:test';
-import { mkdtempSync, rmSync, readFileSync, existsSync } from 'fs';
+import { mkdtempSync, rmSync, readFileSync, existsSync, mkdirSync, writeFileSync } from 'fs';
 import { join } from 'path';
 import { tmpdir } from 'os';
 import { buildNativeMcpEntry, upsertNativeMcpServer } from '../native-mcp';
@@ -103,5 +103,22 @@ describe('upsertNativeMcpServer', () => {
     await expect(
       upsertNativeMcpServer(tempDir, 'capa', { url: 'https://x' }, ['cursor']),
     ).rejects.toThrow(/reserved key/);
+  });
+
+  it('refuses to overwrite malformed MCP JSON', async () => {
+    const configDir = join(tempDir, '.cursor');
+    mkdirSync(configDir, { recursive: true });
+    const configPath = join(configDir, 'mcp.json');
+    writeFileSync(configPath, '{ not valid json', 'utf-8');
+
+    const result = await upsertNativeMcpServer(
+      tempDir,
+      'owl',
+      { cmd: 'npx', args: ['-y', 'owl-mcp'] },
+      ['cursor'],
+    );
+    expect(result.written.length).toBe(0);
+    expect(result.warnings.some((w) => /Failed to parse existing MCP config/.test(w))).toBe(true);
+    expect(readFileSync(configPath, 'utf-8')).toBe('{ not valid json');
   });
 });

--- a/src/cli/utils/passthrough/__tests__/native-mcp.test.ts
+++ b/src/cli/utils/passthrough/__tests__/native-mcp.test.ts
@@ -1,0 +1,107 @@
+import { describe, it, expect, beforeEach, afterEach } from 'bun:test';
+import { mkdtempSync, rmSync, readFileSync, existsSync } from 'fs';
+import { join } from 'path';
+import { tmpdir } from 'os';
+import { buildNativeMcpEntry, upsertNativeMcpServer } from '../native-mcp';
+import type { McpIntegration } from '../../../types/providers';
+
+const cursorMcp: McpIntegration = {
+  configPath: '.cursor/mcp.json',
+  format: 'json',
+  serversKey: 'mcpServers',
+  serverKey: 'capa',
+  entryUrlKey: 'url',
+  supportsSubAgentEntries: false,
+};
+
+const claudeMcp: McpIntegration = {
+  configPath: '.mcp.json',
+  format: 'json',
+  serversKey: 'mcpServers',
+  serverKey: 'capa',
+  entryUrlKey: 'url',
+  entryType: 'http',
+  supportsSubAgentEntries: true,
+};
+
+describe('buildNativeMcpEntry', () => {
+  it('builds URL entry for cursor', () => {
+    const entry = buildNativeMcpEntry(cursorMcp, {
+      url: 'https://knowledge-mcp.global.api.aws',
+    });
+    expect(entry).toEqual({ url: 'https://knowledge-mcp.global.api.aws' });
+  });
+
+  it('builds URL entry with type for claude-code', () => {
+    const entry = buildNativeMcpEntry(claudeMcp, {
+      url: 'https://mcp.example.com',
+    });
+    expect(entry).toEqual({ type: 'http', url: 'https://mcp.example.com' });
+  });
+
+  it('builds stdio command entry', () => {
+    const entry = buildNativeMcpEntry(cursorMcp, {
+      cmd: 'npx',
+      args: ['-y', 'owl-mcp@1.0.14', 'serve'],
+      env: { FOO: 'bar' },
+    });
+    expect(entry).toEqual({
+      command: 'npx',
+      args: ['-y', 'owl-mcp@1.0.14', 'serve'],
+      env: { FOO: 'bar' },
+    });
+  });
+});
+
+describe('upsertNativeMcpServer', () => {
+  let tempDir: string;
+
+  beforeEach(() => {
+    tempDir = mkdtempSync(join(tmpdir(), 'capa-native-mcp-'));
+  });
+
+  afterEach(() => {
+    try {
+      rmSync(tempDir, { recursive: true, force: true });
+    } catch {}
+  });
+
+  it('writes owl stdio server into .cursor/mcp.json', async () => {
+    const result = await upsertNativeMcpServer(
+      tempDir,
+      'owl',
+      { cmd: 'npx', args: ['-y', 'owl-mcp@1.0.14', 'serve'] },
+      ['cursor'],
+    );
+    expect(result.written.length).toBe(1);
+    expect(result.written[0].serverKey).toBe('owl');
+    const configPath = join(tempDir, '.cursor', 'mcp.json');
+    expect(existsSync(configPath)).toBe(true);
+    const config = JSON.parse(readFileSync(configPath, 'utf-8'));
+    expect(config.mcpServers.owl).toEqual({
+      command: 'npx',
+      args: ['-y', 'owl-mcp@1.0.14', 'serve'],
+    });
+    expect(config.mcpServers.capa).toBeUndefined();
+  });
+
+  it('writes remote URL server into .mcp.json for claude-code', async () => {
+    await upsertNativeMcpServer(
+      tempDir,
+      'aws-knowledge',
+      { url: 'https://knowledge-mcp.global.api.aws' },
+      ['claude-code'],
+    );
+    const config = JSON.parse(readFileSync(join(tempDir, '.mcp.json'), 'utf-8'));
+    expect(config.mcpServers['aws-knowledge']).toEqual({
+      type: 'http',
+      url: 'https://knowledge-mcp.global.api.aws',
+    });
+  });
+
+  it('refuses reserved capa key', async () => {
+    await expect(
+      upsertNativeMcpServer(tempDir, 'capa', { url: 'https://x' }, ['cursor']),
+    ).rejects.toThrow(/reserved key/);
+  });
+});

--- a/src/cli/utils/passthrough/__tests__/native-plugin-install.test.ts
+++ b/src/cli/utils/passthrough/__tests__/native-plugin-install.test.ts
@@ -1,0 +1,30 @@
+import { describe, expect, it } from 'bun:test';
+import { claudePluginsNativeInstall, runNativePluginInstall } from '../native-plugin-install';
+
+describe('claudePluginsNativeInstall', () => {
+  it('synthesizes claude plugin install from item name', () => {
+    expect(claudePluginsNativeInstall('frontend-design')).toEqual({
+      providerIds: ['claude-code'],
+      command: 'claude plugin install frontend-design@claude-plugins-official',
+    });
+  });
+
+  it('prefers snippet def fields when present', () => {
+    expect(
+      claudePluginsNativeInstall('ignored', {
+        plugin: 'code-review',
+        marketplace: 'my-marketplace',
+        command: 'claude plugin install code-review@my-marketplace',
+      }),
+    ).toEqual({
+      providerIds: ['claude-code'],
+      command: 'claude plugin install code-review@my-marketplace',
+    });
+  });
+});
+
+describe('runNativePluginInstall', () => {
+  it('rejects empty commands', () => {
+    expect(() => runNativePluginInstall('   ')).toThrow(/empty/i);
+  });
+});

--- a/src/cli/utils/passthrough/index.ts
+++ b/src/cli/utils/passthrough/index.ts
@@ -1,0 +1,490 @@
+/**
+ * Passthrough mode: resolve capa sources and write provider-native files
+ * without a capa server, proxy MCP entry, or managed DB tracking.
+ */
+
+import { join, resolve } from 'path';
+import { existsSync } from 'fs';
+import { resolveProviders } from '../../../shared/providers/resolve';
+import { loadSettings, getDatabasePath } from '../../../shared/config';
+import { CapaDatabase } from '../../../db/database';
+import { createAuthenticatedFetch } from '../../../shared/authenticated-fetch';
+import { LockfileBuilder } from '../../../shared/lockfile';
+import { generateProjectId } from '../../../shared/paths';
+import { getRepoSnapshot } from '../../commands/install-tasks/helpers/repo-snapshot';
+import { installOneSkill } from '../../commands/install-tasks/helpers/install-one-skill';
+import { resolveRuleBody } from '../../commands/install-tasks/install-rules';
+import { installRules } from '../rules-installer';
+import { installHooks } from '../hooks-installer';
+import { resolvePlugins } from '../../commands/plugin-install';
+import { parseSkillSource, parsePluginSource, type AddCommandOptions } from '../../commands/add';
+import {
+  buildServerEntry,
+  buildRuleEntry,
+  buildHookEntry,
+  type AddKind,
+} from '../../commands/add-builders';
+import { upsertNativeMcpServer } from './native-mcp';
+import type { Capabilities, Skill, MCPServer, Plugin } from '../../../types/capabilities';
+import type { Rule } from '../../../types/rules';
+import type { Hook } from '../../../types/hooks';
+import type { GetSnapshotResult } from '../../../shared/cache';
+import { getProvider } from '../../../shared/providers';
+
+function expandEnvInRecord(
+  record: Record<string, string> | undefined,
+): Record<string, string> | undefined {
+  if (!record) return undefined;
+  const out: Record<string, string> = {};
+  for (const [k, v] of Object.entries(record)) {
+    out[k] = v.replace(/\$\{([A-Za-z_][A-Za-z0-9_]*)\}/g, (_, name: string) => {
+      return process.env[name] ?? '';
+    });
+  }
+  return out;
+}
+
+async function loadEnvFileOptional(envFile: string | boolean | undefined): Promise<void> {
+  if (envFile === undefined || envFile === false) return;
+  const { parseEnvFile } = await import('../../../shared/env-parser');
+  const path = envFile === true ? resolve(process.cwd(), '.env') : resolve(process.cwd(), String(envFile));
+  if (!existsSync(path)) {
+    throw new Error(`Environment file not found: ${path}`);
+  }
+  const vars = parseEnvFile(path);
+  for (const [k, v] of Object.entries(vars)) {
+    if (process.env[k] === undefined) process.env[k] = v;
+  }
+}
+
+async function openAuthDb(): Promise<{ db: CapaDatabase; settings: Awaited<ReturnType<typeof loadSettings>> }> {
+  const settings = await loadSettings();
+  const db = new CapaDatabase(getDatabasePath(settings));
+  return { db, settings };
+}
+
+async function resolvePassthroughProviders(flagProvider?: string): Promise<string[]> {
+  return resolveProviders({
+    flagProvider,
+    promptMessage: 'Which provider do you want to write files for?',
+    missingHint:
+      'No provider specified. Pass --provider <id> (required in non-interactive mode).\n\n' +
+      '  Example: capa add … --passthrough -p cursor',
+  });
+}
+
+function emptyCapabilities(providers: string[]): Capabilities {
+  return {
+    providers,
+    skills: [],
+    servers: [],
+    tools: [],
+  };
+}
+
+export async function passthroughAdd(
+  source: string | undefined,
+  kind: AddKind,
+  options: AddCommandOptions,
+): Promise<void> {
+  if (kind === 'tool') {
+    console.error(
+      '✗ Tools cannot be added with --passthrough.\n' +
+        '  Provider-native MCP exposes whole servers; capa tool aliases/defaults require managed mode.\n' +
+        '  Use: capa add --tool …   (without --passthrough)\n' +
+        '  Or:  capa add --server/--plugin … --passthrough',
+    );
+    process.exit(1);
+  }
+
+  await loadEnvFileOptional(options.envFile);
+  const providers = await resolvePassthroughProviders(options.provider);
+  const projectPath = process.cwd();
+  const projectId = generateProjectId(projectPath);
+  const written: string[] = [];
+  const warnings: string[] = [];
+
+  const { db, settings } = await openAuthDb();
+  try {
+    if (kind === 'skill') {
+      if (!source) {
+        throw new Error('Missing <source>. Example: capa add owner/repo@skill --passthrough');
+      }
+      const skillDef = await parseSkillSource(source);
+      const skill: Skill = { id: skillDef.id, type: skillDef.type, def: skillDef.def };
+      const caps = emptyCapabilities(providers);
+      const lockBuilder = new LockfileBuilder(null);
+      const outcome = await installOneSkill(
+        skill,
+        projectPath,
+        projectId,
+        providers,
+        db,
+        settings,
+        caps,
+        join(projectPath, 'capabilities.yaml'),
+        lockBuilder,
+        !!options.noCache,
+        new Map(),
+        { trackManaged: false },
+      );
+      if (outcome === 'installed') {
+        for (const pid of providers) {
+          const prov = getProvider(pid);
+          if (prov) written.push(join(projectPath, prov.skillsDir, skill.id));
+        }
+        console.log(`✓ Passthrough: installed skill "${skill.id}"`);
+      } else {
+        console.log(`⚠ Skill "${skill.id}" was skipped (${outcome})`);
+      }
+    } else if (kind === 'plugin') {
+      if (!source) {
+        throw new Error('Missing <source>. Example: capa add --plugin owner/repo --passthrough');
+      }
+      const parsed = parsePluginSource(source);
+      const plugin: Plugin = { id: parsed.idHint, type: parsed.type, def: parsed.def };
+      const caps = emptyCapabilities(providers);
+      caps.plugins = [plugin];
+      const authFetch = createAuthenticatedFetch(db);
+      const lockBuilder = new LockfileBuilder(null);
+      const pluginsBaseDir = join(projectPath, '.capa-passthrough', 'plugins');
+      const result = await resolvePlugins(
+        caps,
+        projectPath,
+        projectId,
+        authFetch,
+        db,
+        getRepoSnapshot,
+        join(projectPath, 'capabilities.yaml'),
+        lockBuilder,
+        { noCache: !!options.noCache, trackManaged: false, pluginsBaseDir },
+      );
+      warnings.push(...result.warnings);
+      for (const skill of result.mergedCapabilities.skills ?? []) {
+        if (skill.type !== 'plugin' && skill.type !== 'installed') continue;
+        for (const pid of providers) {
+          const prov = getProvider(pid);
+          if (prov) written.push(join(projectPath, prov.skillsDir, skill.id));
+        }
+      }
+      // Native MCP for plugin servers
+      for (const server of result.mergedCapabilities.servers ?? []) {
+        if (server.type !== 'mcp') continue;
+        const def = {
+          ...server.def,
+          env: expandEnvInRecord(server.def.env),
+          headers: expandEnvInRecord(server.def.headers),
+        };
+        const mcpResult = await upsertNativeMcpServer(projectPath, server.id, def, providers);
+        warnings.push(...mcpResult.warnings);
+        for (const w of mcpResult.written) written.push(`${w.configPath}#${w.serverKey}`);
+        if (server.def.url) {
+          warnings.push(
+            `Server "${server.id}" uses a remote URL — complete OAuth/auth in your provider if required.`,
+          );
+        }
+      }
+      console.log(`✓ Passthrough: installed plugin "${plugin.id}"`);
+    } else if (kind === 'server') {
+      if (source) {
+        throw new Error('Server mode does not take a positional <source>; use --id/--cmd/--url flags.');
+      }
+      const entry = buildServerEntry({
+        id: options.id,
+        type: options.type,
+        cmd: options.cmd,
+        arg: options.arg,
+        env: options.env,
+        url: options.url,
+        header: options.header,
+        cwd: options.cwd,
+        description: options.description,
+      }) as unknown as MCPServer;
+      const def = {
+        ...entry.def,
+        env: expandEnvInRecord(entry.def.env),
+        headers: expandEnvInRecord(entry.def.headers),
+      };
+      const mcpResult = await upsertNativeMcpServer(projectPath, entry.id, def, providers);
+      warnings.push(...mcpResult.warnings);
+      for (const w of mcpResult.written) {
+        written.push(`${w.configPath}#${w.serverKey}`);
+        console.log(`✓ Wrote MCP server "${w.serverKey}" → ${w.configPath} (${w.provider})`);
+      }
+      if (entry.def.url) {
+        console.log('  Note: complete OAuth/auth in your provider if this remote server requires it.');
+      }
+    } else if (kind === 'rule') {
+      const entry = (await buildRuleEntry({
+        id: options.id,
+        source,
+        inline: options.inline,
+        appliesTo: options.appliesTo,
+        alwaysApply: options.alwaysApply,
+        description: options.description,
+      })) as unknown as Rule;
+      const authFetch = createAuthenticatedFetch(db);
+      const body = await resolveRuleBody(entry, {
+        capabilitiesFilePath: join(projectPath, 'capabilities.yaml'),
+        authFetch,
+        getRepoSnapshot,
+        noCache: !!options.noCache,
+      });
+      const bodies = new Map([[entry.id, body]]);
+      installRules(projectPath, [entry], providers, bodies);
+      console.log(`✓ Passthrough: installed rule "${entry.id}"`);
+      written.push(`rule:${entry.id}`);
+    } else if (kind === 'hook') {
+      if (source) {
+        throw new Error('Hook mode does not take a positional <source>; use --id/--on/--command flags.');
+      }
+      const entry = buildHookEntry({
+        id: options.id,
+        on: options.on,
+        type: options.type,
+        command: options.command,
+        prompt: options.prompt,
+        source: options.source,
+        matcher: options.matcher,
+        timeout: options.timeout,
+        failClosed: options.failClosed,
+        sequential: options.sequential,
+        description: options.description,
+      }) as unknown as Hook;
+      const authFetch = createAuthenticatedFetch(db);
+      const result = await installHooks({
+        projectPath,
+        projectId,
+        capabilitiesFilePath: join(projectPath, 'capabilities.yaml'),
+        hooks: [entry],
+        providers,
+        db,
+        authFetch,
+        getRepoSnapshot,
+        noCache: !!options.noCache,
+        trackManaged: false,
+        nameTagPrefix: '',
+      });
+      warnings.push(...result.warnings);
+      console.log(`✓ Passthrough: installed hook "${entry.id}" (${result.installed} provider entr${result.installed === 1 ? 'y' : 'ies'})`);
+      written.push(`hook:${entry.id}`);
+    }
+  } catch (err) {
+    console.error(`✗ ${err instanceof Error ? err.message : String(err)}`);
+    process.exit(1);
+  } finally {
+    try {
+      db.close();
+    } catch {}
+  }
+
+  for (const w of warnings) console.warn(`  ⚠ ${w}`);
+  console.log(
+    '\nPassthrough write complete. capa clean will not remove these files (no managed state).\n',
+  );
+  if (written.length > 0) {
+    console.log('Paths / keys touched:');
+    for (const p of [...new Set(written)].filter(Boolean)) {
+      console.log(`  - ${p}`);
+    }
+    console.log('');
+  }
+}
+
+export async function passthroughInstall(opts: {
+  envFile?: string | boolean;
+  provider?: string;
+  noCache?: boolean;
+  projectPath?: string;
+  exitProcess?: boolean;
+}): Promise<void> {
+  const exitProcess = opts.exitProcess !== false;
+  const projectPath = opts.projectPath ? resolve(opts.projectPath) : process.cwd();
+  const projectId = generateProjectId(projectPath);
+
+  const { detectCapabilitiesFile } = await import('../../../shared/paths');
+  const { parseCapabilitiesFile } = await import('../../../shared/capabilities');
+
+  const capabilitiesFile = await detectCapabilitiesFile(projectPath);
+  if (!capabilitiesFile) {
+    const msg = 'No capabilities file found. Run "capa init" first.';
+    console.error(`✗ ${msg}`);
+    if (exitProcess) process.exit(1);
+    throw new Error(msg);
+  }
+
+  await loadEnvFileOptional(opts.envFile);
+  let capabilities = await parseCapabilitiesFile(capabilitiesFile.path, capabilitiesFile.format);
+
+  let providers: string[];
+  try {
+    providers = await resolveProviders({
+      flagProvider: opts.provider,
+      capabilitiesProviders: capabilities.providers,
+      promptMessage: 'Which provider do you want to write files for?',
+      missingHint:
+        'No provider specified. Pass --provider <id> or add a "providers" section to your capabilities file.',
+    });
+  } catch (err) {
+    const msg = err instanceof Error ? err.message : String(err);
+    console.error(`✗ ${msg}`);
+    if (exitProcess) process.exit(1);
+    throw err;
+  }
+  capabilities.providers = providers;
+
+  const { db, settings } = await openAuthDb();
+  const authFetch = createAuthenticatedFetch(db);
+  const lockBuilder = new LockfileBuilder(null);
+  const warnings: string[] = [];
+  let added = 0;
+  let skipped = 0;
+  let failed = 0;
+
+  try {
+    const pluginsBaseDir = join(projectPath, '.capa-passthrough', 'plugins');
+    const pluginResult = await resolvePlugins(
+      capabilities,
+      projectPath,
+      projectId,
+      authFetch,
+      db,
+      getRepoSnapshot,
+      capabilitiesFile.path,
+      lockBuilder,
+      { noCache: !!opts.noCache, trackManaged: false, pluginsBaseDir },
+    );
+    warnings.push(...pluginResult.warnings);
+    capabilities = pluginResult.mergedCapabilities;
+    capabilities.providers = providers;
+
+    const resolvedRepos = new Map<string, GetSnapshotResult>();
+
+    // Skills (non-plugin; plugin skills already copied)
+    for (const skill of capabilities.skills ?? []) {
+      if (skill.type === 'plugin' || skill.type === 'installed') {
+        skipped++;
+        continue;
+      }
+      try {
+        const outcome = await installOneSkill(
+          skill,
+          projectPath,
+          projectId,
+          providers,
+          db,
+          settings,
+          capabilities,
+          capabilitiesFile.path,
+          lockBuilder,
+          !!opts.noCache,
+          resolvedRepos,
+          { trackManaged: false },
+        );
+        if (outcome === 'installed') added++;
+        else skipped++;
+      } catch (err) {
+        failed++;
+        warnings.push(
+          `Skill "${skill.id}": ${err instanceof Error ? err.message : String(err)}`,
+        );
+      }
+    }
+
+    // Rules
+    const rules = capabilities.rules ?? [];
+    if (rules.length > 0) {
+      const bodies = new Map<string, string>();
+      for (const rule of rules) {
+        try {
+          bodies.set(
+            rule.id,
+            await resolveRuleBody(rule, {
+              capabilitiesFilePath: capabilitiesFile.path,
+              authFetch,
+              getRepoSnapshot,
+              noCache: !!opts.noCache,
+            }),
+          );
+        } catch (err) {
+          warnings.push(
+            `Rule "${rule.id}": ${err instanceof Error ? err.message : String(err)}`,
+          );
+        }
+      }
+      installRules(projectPath, rules, providers, bodies);
+      added += bodies.size;
+    }
+
+    // Hooks
+    const hooks = capabilities.hooks ?? [];
+    if (hooks.length > 0) {
+      const hookResult = await installHooks({
+        projectPath,
+        projectId,
+        capabilitiesFilePath: capabilitiesFile.path,
+        hooks,
+        providers,
+        db,
+        authFetch,
+        getRepoSnapshot,
+        noCache: !!opts.noCache,
+        trackManaged: false,
+        nameTagPrefix: '',
+      });
+      warnings.push(...hookResult.warnings);
+      added += hookResult.installed;
+    }
+
+    // Native MCP servers (explicit + plugin-merged)
+    for (const server of capabilities.servers ?? []) {
+      if (server.type !== 'mcp') {
+        warnings.push(`Skipping unsupported server type "${(server as MCPServer).type}" (${server.id})`);
+        continue;
+      }
+      const def = {
+        ...server.def,
+        env: expandEnvInRecord(server.def.env),
+        headers: expandEnvInRecord(server.def.headers),
+      };
+      const mcpResult = await upsertNativeMcpServer(projectPath, server.id, def, providers);
+      warnings.push(...mcpResult.warnings);
+      added += mcpResult.written.length;
+      if (server.def.url) {
+        warnings.push(
+          `Server "${server.id}": complete OAuth/auth in your provider if required.`,
+        );
+      }
+    }
+
+    // Tools summary
+    const tools = capabilities.tools ?? [];
+    if (tools.length > 0) {
+      const mcpTools = tools.filter((t) => t.type === 'mcp').length;
+      const cmdTools = tools.filter((t) => t.type === 'command').length;
+      if (mcpTools > 0) {
+        warnings.push(
+          `Skipped ${mcpTools} MCP tool alias(es) — passthrough exposes whole servers (defaults/formatters dropped).`,
+        );
+        skipped += mcpTools;
+      }
+      if (cmdTools > 0) {
+        warnings.push(
+          `Skipped ${cmdTools} command tool(s) — not representable in provider-native configs.`,
+        );
+        skipped += cmdTools;
+      }
+    }
+
+    for (const w of warnings) console.warn(`  ⚠ ${w}`);
+    console.log(
+      `\n✓ Passthrough install complete (added=${added}, skipped=${skipped}, failed=${failed}).`,
+    );
+    console.log('  No capa server was started. capa clean will not reverse these writes.\n');
+    if (failed > 0 && exitProcess) process.exit(1);
+  } finally {
+    try {
+      db.close();
+    } catch {}
+  }
+}

--- a/src/cli/utils/passthrough/index.ts
+++ b/src/cli/utils/passthrough/index.ts
@@ -24,6 +24,7 @@ import {
   buildHookEntry,
   type AddKind,
 } from '../../commands/add-builders';
+import { tryResolveRegistryItem } from '../../commands/resolve-registry-source';
 import { upsertNativeMcpServer } from './native-mcp';
 import type { Capabilities, Skill, MCPServer, Plugin } from '../../../types/capabilities';
 import type { Rule } from '../../../types/rules';
@@ -82,6 +83,98 @@ function emptyCapabilities(providers: string[]): Capabilities {
   };
 }
 
+async function passthroughInstallSkill(opts: {
+  skill: Skill;
+  projectPath: string;
+  projectId: string;
+  providers: string[];
+  db: CapaDatabase;
+  settings: Awaited<ReturnType<typeof loadSettings>>;
+  noCache: boolean;
+  written: string[];
+}): Promise<void> {
+  const { skill, projectPath, projectId, providers, db, settings, noCache, written } = opts;
+  const caps = emptyCapabilities(providers);
+  const lockBuilder = new LockfileBuilder(null);
+  const outcome = await installOneSkill(
+    skill,
+    projectPath,
+    projectId,
+    providers,
+    db,
+    settings,
+    caps,
+    join(projectPath, 'capabilities.yaml'),
+    lockBuilder,
+    noCache,
+    new Map(),
+    { trackManaged: false },
+  );
+  if (outcome === 'installed') {
+    for (const pid of providers) {
+      const prov = getProvider(pid);
+      if (prov) written.push(join(projectPath, prov.skillsDir, skill.id));
+    }
+    console.log(`✓ Passthrough: installed skill "${skill.id}"`);
+  } else {
+    console.log(`⚠ Skill "${skill.id}" was skipped (${outcome})`);
+  }
+}
+
+async function passthroughInstallPlugin(opts: {
+  plugin: Plugin;
+  projectPath: string;
+  projectId: string;
+  providers: string[];
+  db: CapaDatabase;
+  noCache: boolean;
+  written: string[];
+  warnings: string[];
+}): Promise<void> {
+  const { plugin, projectPath, projectId, providers, db, noCache, written, warnings } = opts;
+  const caps = emptyCapabilities(providers);
+  caps.plugins = [plugin];
+  const authFetch = createAuthenticatedFetch(db);
+  const lockBuilder = new LockfileBuilder(null);
+  const pluginsBaseDir = join(projectPath, '.capa-passthrough', 'plugins');
+  const result = await resolvePlugins(
+    caps,
+    projectPath,
+    projectId,
+    authFetch,
+    db,
+    getRepoSnapshot,
+    join(projectPath, 'capabilities.yaml'),
+    lockBuilder,
+    { noCache, trackManaged: false, pluginsBaseDir },
+  );
+  warnings.push(...result.warnings);
+  for (const skill of result.mergedCapabilities.skills ?? []) {
+    if (skill.type !== 'plugin' && skill.type !== 'installed') continue;
+    for (const pid of providers) {
+      const prov = getProvider(pid);
+      if (prov) written.push(join(projectPath, prov.skillsDir, skill.id));
+    }
+  }
+  for (const server of result.mergedCapabilities.servers ?? []) {
+    if (server.type !== 'mcp') continue;
+    const def = {
+      ...server.def,
+      env: expandEnvInRecord(server.def.env),
+      headers: expandEnvInRecord(server.def.headers),
+    };
+    const mcpResult = await upsertNativeMcpServer(projectPath, server.id, def, providers);
+    warnings.push(...mcpResult.warnings);
+    for (const w of mcpResult.written) written.push(`${w.configPath}#${w.serverKey}`);
+    if (server.def.url) {
+      warnings.push(
+        `Server "${server.id}" uses a remote URL — complete OAuth/auth in your provider if required.`,
+      );
+    }
+  }
+  console.log(`✓ Passthrough: installed plugin "${plugin.id}"`);
+}
+
 export async function passthroughAdd(
   source: string | undefined,
   kind: AddKind,
@@ -106,85 +199,104 @@ export async function passthroughAdd(
 
   const { db, settings } = await openAuthDb();
   try {
-    if (kind === 'skill') {
+    // Registry sources (skills-sh:…, claude-plugins:…, …) for skill/plugin kinds
+    if ((kind === 'skill' || kind === 'plugin') && source) {
+      const resolved = await tryResolveRegistryItem(source);
+      if (resolved) {
+        console.log(`Resolving from registry "${resolved.registryName}"...`);
+        if (options.plugin && resolved.capability !== 'plugins') {
+          console.warn(
+            `  ⚠ --plugin ignored: registry "${resolved.registryId}" resolved "${resolved.itemId}" as a ${resolved.capability.slice(0, -1)}.`,
+          );
+        }
+        if (options.skill && resolved.capability !== 'skills') {
+          console.warn(
+            `  ⚠ --skill ignored: registry "${resolved.registryId}" resolved "${resolved.itemId}" as a ${resolved.capability.slice(0, -1)}.`,
+          );
+        }
+        if (resolved.capability === 'skills' && resolved.skill) {
+          await passthroughInstallSkill({
+            skill: resolved.skill,
+            projectPath,
+            projectId,
+            providers,
+            db,
+            settings,
+            noCache: !!options.noCache,
+            written,
+          });
+        } else if (resolved.capability === 'plugins' && resolved.plugin) {
+          await passthroughInstallPlugin({
+            plugin: resolved.plugin,
+            projectPath,
+            projectId,
+            providers,
+            db,
+            noCache: !!options.noCache,
+            written,
+            warnings,
+          });
+        }
+        // fall through to summary
+      } else if (kind === 'skill') {
+        const skillDef = await parseSkillSource(source);
+        const skill: Skill = { id: skillDef.id, type: skillDef.type, def: skillDef.def };
+        await passthroughInstallSkill({
+          skill,
+          projectPath,
+          projectId,
+          providers,
+          db,
+          settings,
+          noCache: !!options.noCache,
+          written,
+        });
+      } else if (kind === 'plugin') {
+        const parsed = parsePluginSource(source);
+        const plugin: Plugin = { id: parsed.idHint, type: parsed.type, def: parsed.def };
+        await passthroughInstallPlugin({
+          plugin,
+          projectPath,
+          projectId,
+          providers,
+          db,
+          noCache: !!options.noCache,
+          written,
+          warnings,
+        });
+      }
+    } else if (kind === 'skill') {
       if (!source) {
         throw new Error('Missing <source>. Example: capa add owner/repo@skill --passthrough');
       }
       const skillDef = await parseSkillSource(source);
       const skill: Skill = { id: skillDef.id, type: skillDef.type, def: skillDef.def };
-      const caps = emptyCapabilities(providers);
-      const lockBuilder = new LockfileBuilder(null);
-      const outcome = await installOneSkill(
+      await passthroughInstallSkill({
         skill,
         projectPath,
         projectId,
         providers,
         db,
         settings,
-        caps,
-        join(projectPath, 'capabilities.yaml'),
-        lockBuilder,
-        !!options.noCache,
-        new Map(),
-        { trackManaged: false },
-      );
-      if (outcome === 'installed') {
-        for (const pid of providers) {
-          const prov = getProvider(pid);
-          if (prov) written.push(join(projectPath, prov.skillsDir, skill.id));
-        }
-        console.log(`✓ Passthrough: installed skill "${skill.id}"`);
-      } else {
-        console.log(`⚠ Skill "${skill.id}" was skipped (${outcome})`);
-      }
+        noCache: !!options.noCache,
+        written,
+      });
     } else if (kind === 'plugin') {
       if (!source) {
         throw new Error('Missing <source>. Example: capa add --plugin owner/repo --passthrough');
       }
       const parsed = parsePluginSource(source);
       const plugin: Plugin = { id: parsed.idHint, type: parsed.type, def: parsed.def };
-      const caps = emptyCapabilities(providers);
-      caps.plugins = [plugin];
-      const authFetch = createAuthenticatedFetch(db);
-      const lockBuilder = new LockfileBuilder(null);
-      const pluginsBaseDir = join(projectPath, '.capa-passthrough', 'plugins');
-      const result = await resolvePlugins(
-        caps,
+      await passthroughInstallPlugin({
+        plugin,
         projectPath,
         projectId,
-        authFetch,
+        providers,
         db,
-        getRepoSnapshot,
-        join(projectPath, 'capabilities.yaml'),
-        lockBuilder,
-        { noCache: !!options.noCache, trackManaged: false, pluginsBaseDir },
-      );
-      warnings.push(...result.warnings);
-      for (const skill of result.mergedCapabilities.skills ?? []) {
-        if (skill.type !== 'plugin' && skill.type !== 'installed') continue;
-        for (const pid of providers) {
-          const prov = getProvider(pid);
-          if (prov) written.push(join(projectPath, prov.skillsDir, skill.id));
-        }
-      }
-      // Native MCP for plugin servers
-      for (const server of result.mergedCapabilities.servers ?? []) {
-        if (server.type !== 'mcp') continue;
-        const def = {
-          ...server.def,
-          env: expandEnvInRecord(server.def.env),
-          headers: expandEnvInRecord(server.def.headers),
-        };
-        const mcpResult = await upsertNativeMcpServer(projectPath, server.id, def, providers);
-        warnings.push(...mcpResult.warnings);
-        for (const w of mcpResult.written) written.push(`${w.configPath}#${w.serverKey}`);
-        if (server.def.url) {
-          warnings.push(
-            `Server "${server.id}" uses a remote URL — complete OAuth/auth in your provider if required.`,
-          );
-        }
-      }
-      console.log(`✓ Passthrough: installed plugin "${plugin.id}"`);
+        noCache: !!options.noCache,
+        written,
+        warnings,
+      });
     } else if (kind === 'server') {
       if (source) {
         throw new Error('Server mode does not take a positional <source>; use --id/--cmd/--url flags.');

--- a/src/cli/utils/passthrough/index.ts
+++ b/src/cli/utils/passthrough/index.ts
@@ -26,11 +26,18 @@ import {
 } from '../../commands/add-builders';
 import { tryResolveRegistryItem } from '../../commands/resolve-registry-source';
 import { upsertNativeMcpServer } from './native-mcp';
+import {
+  runNativePluginInstall,
+  type NativePluginInstall,
+} from './native-plugin-install';
 import type { Capabilities, Skill, MCPServer, Plugin } from '../../../types/capabilities';
 import type { Rule } from '../../../types/rules';
 import type { Hook } from '../../../types/hooks';
 import type { GetSnapshotResult } from '../../../shared/cache';
 import { getProvider } from '../../../shared/providers';
+
+/** Project-local unpack root for plugins wired to providers without a native installer. */
+const PASSTHROUGH_PLUGINS_DIR = join('.capa', 'plugins');
 
 function expandEnvInRecord(
   record: Record<string, string> | undefined,
@@ -130,13 +137,48 @@ async function passthroughInstallPlugin(opts: {
   noCache: boolean;
   written: string[];
   warnings: string[];
+  /** When set, matching providers get the native CLI install instead of unpack. */
+  nativeInstall?: NativePluginInstall;
 }): Promise<void> {
-  const { plugin, projectPath, projectId, providers, db, noCache, written, warnings } = opts;
-  const caps = emptyCapabilities(providers);
+  const {
+    plugin,
+    projectPath,
+    projectId,
+    providers,
+    db,
+    noCache,
+    written,
+    warnings,
+    nativeInstall,
+  } = opts;
+
+  const nativeProviderIds = nativeInstall
+    ? providers.filter((p) => nativeInstall.providerIds.includes(p))
+    : [];
+  const unpackProviders = providers.filter((p) => !nativeProviderIds.includes(p));
+
+  for (const pid of nativeProviderIds) {
+    console.log(`Installing plugin "${plugin.id}" via ${pid} native CLI...`);
+    runNativePluginInstall(nativeInstall!.command);
+    written.push(`native:${pid}:${nativeInstall!.command}`);
+  }
+
+  if (unpackProviders.length === 0) {
+    console.log(`✓ Passthrough: installed plugin "${plugin.id}" (native)`);
+    return;
+  }
+
+  if (nativeProviderIds.length > 0) {
+    console.log(
+      `Unpacking plugin "${plugin.id}" for provider(s) without a native installer: ${unpackProviders.join(', ')}`,
+    );
+  }
+
+  const caps = emptyCapabilities(unpackProviders);
   caps.plugins = [plugin];
   const authFetch = createAuthenticatedFetch(db);
   const lockBuilder = new LockfileBuilder(null);
-  const pluginsBaseDir = join(projectPath, '.capa-passthrough', 'plugins');
+  const pluginsBaseDir = join(projectPath, PASSTHROUGH_PLUGINS_DIR);
   const result = await resolvePlugins(
     caps,
     projectPath,
@@ -151,7 +193,7 @@ async function passthroughInstallPlugin(opts: {
   warnings.push(...result.warnings);
   for (const skill of result.mergedCapabilities.skills ?? []) {
     if (skill.type !== 'plugin' && skill.type !== 'installed') continue;
-    for (const pid of providers) {
+    for (const pid of unpackProviders) {
       const prov = getProvider(pid);
       if (prov) written.push(join(projectPath, prov.skillsDir, skill.id));
     }
@@ -163,7 +205,7 @@ async function passthroughInstallPlugin(opts: {
       env: expandEnvInRecord(server.def.env),
       headers: expandEnvInRecord(server.def.headers),
     };
-    const mcpResult = await upsertNativeMcpServer(projectPath, server.id, def, providers);
+    const mcpResult = await upsertNativeMcpServer(projectPath, server.id, def, unpackProviders);
     warnings.push(...mcpResult.warnings);
     for (const w of mcpResult.written) written.push(`${w.configPath}#${w.serverKey}`);
     if (server.def.url) {
@@ -235,6 +277,7 @@ export async function passthroughAdd(
             noCache: !!options.noCache,
             written,
             warnings,
+            nativeInstall: resolved.nativeInstall,
           });
         }
         // fall through to summary
@@ -454,7 +497,7 @@ export async function passthroughInstall(opts: {
   let failed = 0;
 
   try {
-    const pluginsBaseDir = join(projectPath, '.capa-passthrough', 'plugins');
+    const pluginsBaseDir = join(projectPath, PASSTHROUGH_PLUGINS_DIR);
     const pluginResult = await resolvePlugins(
       capabilities,
       projectPath,

--- a/src/cli/utils/passthrough/native-mcp.ts
+++ b/src/cli/utils/passthrough/native-mcp.ts
@@ -1,0 +1,151 @@
+/**
+ * Upsert arbitrary upstream MCP server entries into provider-native configs.
+ * Unlike registerMCPServer (which always writes the capa proxy URL under key
+ * `capa`), these helpers write real command/url entries under the server's id.
+ */
+
+import { existsSync, readFileSync, writeFileSync, mkdirSync } from 'fs';
+import { dirname } from 'path';
+import { getProvider } from '../../../shared/providers';
+import { readTomlFile, writeTomlFile, setNestedKey } from '../../../shared/toml-io';
+import { getMcpConfigPath } from '../../../shared/providers/handlers';
+import type { MCPServerDefinition } from '../../../types/capabilities';
+import type { McpIntegration } from '../../../types/providers';
+
+type McpJsonConfig = Record<string, unknown>;
+
+function isPlainObject(x: unknown): x is Record<string, unknown> {
+  return x !== null && typeof x === 'object' && !Array.isArray(x);
+}
+
+function tryReadFile(path: string): string | null {
+  try {
+    return readFileSync(path, 'utf-8');
+  } catch (err: any) {
+    if (err?.code === 'ENOENT') return null;
+    throw err;
+  }
+}
+
+function parseJsonConfig(raw: string): McpJsonConfig | null {
+  try {
+    const parsed: unknown = JSON.parse(raw);
+    return isPlainObject(parsed) ? parsed : {};
+  } catch {
+    return null;
+  }
+}
+
+function getServerMap(config: McpJsonConfig, serversKey: string): Record<string, unknown> {
+  const existing = config[serversKey];
+  if (!isPlainObject(existing)) {
+    config[serversKey] = {};
+  }
+  return config[serversKey] as Record<string, unknown>;
+}
+
+/**
+ * Build a provider-native MCP entry from a capa MCPServerDefinition.
+ */
+export function buildNativeMcpEntry(
+  mcp: McpIntegration,
+  def: MCPServerDefinition,
+): Record<string, unknown> {
+  const entry: Record<string, unknown> = {};
+
+  if (def.url) {
+    if (mcp.entryType) entry.type = mcp.entryType;
+    entry[mcp.entryUrlKey] = def.url;
+    if (def.headers && Object.keys(def.headers).length > 0) {
+      entry.headers = { ...def.headers };
+    }
+    if (mcp.entryExtraFields) Object.assign(entry, mcp.entryExtraFields);
+    return entry;
+  }
+
+  if (def.cmd) {
+    // Stdio servers: most providers use `command` + `args` (+ optional `env`/`cwd`).
+    // Do not set entryType (that's for HTTP transport discriminators).
+    entry.command = def.cmd;
+    if (def.args && def.args.length > 0) entry.args = [...def.args];
+    if (def.env && Object.keys(def.env).length > 0) entry.env = { ...def.env };
+    if (def.cwd) entry.cwd = def.cwd;
+    return entry;
+  }
+
+  throw new Error('MCP server definition requires either def.url or def.cmd');
+}
+
+export interface UpsertNativeMcpResult {
+  written: Array<{ provider: string; configPath: string; serverKey: string }>;
+  warnings: string[];
+}
+
+/**
+ * Upsert a native MCP server entry for each provider. Never uses key `capa`.
+ */
+export async function upsertNativeMcpServer(
+  projectPath: string,
+  serverKey: string,
+  def: MCPServerDefinition,
+  providers: string[],
+): Promise<UpsertNativeMcpResult> {
+  if (serverKey === 'capa' || serverKey.startsWith('capa-')) {
+    throw new Error(
+      `Refusing to write passthrough MCP entry under reserved key "${serverKey}". Choose a different --id.`,
+    );
+  }
+
+  const written: UpsertNativeMcpResult['written'] = [];
+  const warnings: string[] = [];
+
+  for (const clientName of providers) {
+    const provider = getProvider(clientName);
+    if (!provider) {
+      warnings.push(`Unknown provider: ${clientName} (skipping MCP registration)`);
+      continue;
+    }
+    if (!provider.mcp) {
+      warnings.push(
+        `${provider.displayName} does not support project-level MCP configuration (skipping)`,
+      );
+      continue;
+    }
+
+    try {
+      const { mcp } = provider;
+      const configPath = getMcpConfigPath(provider, projectPath);
+      const configDir = dirname(configPath);
+      if (!existsSync(configDir)) {
+        mkdirSync(configDir, { recursive: true });
+      }
+
+      const entry = buildNativeMcpEntry(mcp, def);
+
+      if (mcp.format === 'json') {
+        let config: McpJsonConfig = {};
+        const existing = tryReadFile(configPath);
+        if (existing !== null) {
+          config = parseJsonConfig(existing) ?? {};
+        }
+        const servers = getServerMap(config, mcp.serversKey);
+        servers[serverKey] = entry;
+        writeFileSync(configPath, JSON.stringify(config, null, 2) + '\n', 'utf-8');
+      } else if (mcp.format === 'toml') {
+        const config = readTomlFile(configPath);
+        setNestedKey(config, [mcp.serversKey, serverKey], entry);
+        writeTomlFile(configPath, config);
+      }
+
+      written.push({ provider: provider.id, configPath, serverKey });
+    } catch (error) {
+      warnings.push(
+        `Failed to write MCP server "${serverKey}" for ${clientName}: ${
+          error instanceof Error ? error.message : String(error)
+        }`,
+      );
+    }
+  }
+
+  return { written, warnings };
+}

--- a/src/cli/utils/passthrough/native-mcp.ts
+++ b/src/cli/utils/passthrough/native-mcp.ts
@@ -126,7 +126,14 @@ export async function upsertNativeMcpServer(
         let config: McpJsonConfig = {};
         const existing = tryReadFile(configPath);
         if (existing !== null) {
-          config = parseJsonConfig(existing) ?? {};
+          const parsed = parseJsonConfig(existing);
+          if (parsed === null) {
+            throw new Error(
+              `Failed to parse existing MCP config at ${configPath}. ` +
+                `Fix the JSON (or remove the file) and retry — refusing to overwrite invalid config.`,
+            );
+          }
+          config = parsed;
         }
         const servers = getServerMap(config, mcp.serversKey);
         servers[serverKey] = entry;

--- a/src/cli/utils/passthrough/native-plugin-install.ts
+++ b/src/cli/utils/passthrough/native-plugin-install.ts
@@ -1,0 +1,75 @@
+/**
+ * Native provider plugin install (e.g. `claude plugin install name@marketplace`).
+ * Used by passthrough when the target provider can install the plugin itself.
+ */
+
+import { spawnSync } from 'child_process';
+
+export interface NativePluginInstall {
+  /** Provider ids that understand this install (e.g. `['claude-code']`). */
+  providerIds: string[];
+  /** Full command string, e.g. `claude plugin install frontend-design@claude-plugins-official`. */
+  command: string;
+}
+
+/**
+ * Run a native plugin install command. Uses the first token as the binary
+ * and the rest as argv (no shell), matching wrap's approach to `claude`.
+ */
+export function runNativePluginInstall(command: string): void {
+  const trimmed = command.trim();
+  if (!trimmed) {
+    throw new Error('Native plugin install command is empty.');
+  }
+
+  const parts = trimmed.split(/\s+/);
+  const bin = parts[0]!;
+  const args = parts.slice(1);
+
+  console.log(`  → ${trimmed}`);
+  const result = spawnSync(bin, args, {
+    stdio: 'inherit',
+    // Windows needs shell to resolve .cmd shims for `claude`.
+    shell: process.platform === 'win32',
+    env: process.env,
+  });
+
+  if (result.error) {
+    throw new Error(
+      `Failed to run native plugin install (${bin}): ${result.error.message}\n` +
+        `  Ensure the provider CLI is on PATH.`,
+    );
+  }
+  if (result.status !== 0) {
+    throw new Error(
+      `Native plugin install exited with code ${result.status ?? 'unknown'}: ${trimmed}`,
+    );
+  }
+}
+
+function readStringField(obj: object | undefined, key: string): string | undefined {
+  if (!obj || !(key in obj)) return undefined;
+  const value = (obj as Record<string, unknown>)[key];
+  return typeof value === 'string' ? value : undefined;
+}
+
+/**
+ * Derive a Claude Code native install command from a claude-plugins registry item.
+ * `snippetDef` may be a normal PluginDefinition or an inline registry def with
+ * extra `plugin` / `marketplace` / `command` fields.
+ */
+export function claudePluginsNativeInstall(
+  itemName: string,
+  snippetDef?: object,
+): NativePluginInstall {
+  const pluginName = readStringField(snippetDef, 'plugin') || itemName;
+  const marketplace = readStringField(snippetDef, 'marketplace') || 'claude-plugins-official';
+  const command =
+    readStringField(snippetDef, 'command') ||
+    `claude plugin install ${pluginName}@${marketplace}`;
+
+  return {
+    providerIds: ['claude-code'],
+    command,
+  };
+}

--- a/src/shared/providers/hook-handlers.ts
+++ b/src/shared/providers/hook-handlers.ts
@@ -30,6 +30,11 @@ export interface HookEntryInput {
   runReference: string;
   /** The mapping picked from `HooksIntegration.eventMap`. */
   mapping: ProviderEventMapping;
+  /**
+   * Prefix for the entry `name` tag. Default `'capa:'` (managed installs).
+   * Pass `''` for passthrough so `capa clean` does not claim the entry.
+   */
+  nameTagPrefix?: string;
 }
 
 /**
@@ -53,8 +58,8 @@ export interface HookEntryOutput {
 
 const NAME_TAG_PREFIX = "capa:";
 
-export function buildNameTag(hookId: string): string {
-  return `${NAME_TAG_PREFIX}${hookId}`;
+export function buildNameTag(hookId: string, prefix: string = NAME_TAG_PREFIX): string {
+  return `${prefix}${hookId}`;
 }
 
 export function isCapaNameTag(value: unknown, hookId?: string): boolean {
@@ -62,12 +67,6 @@ export function isCapaNameTag(value: unknown, hookId?: string): boolean {
   if (!value.startsWith(NAME_TAG_PREFIX)) return false;
   if (hookId && value !== buildNameTag(hookId)) return false;
   return true;
-}
-
-function idFromNameTag(tag: string): string {
-  return tag.startsWith(NAME_TAG_PREFIX)
-    ? tag.slice(NAME_TAG_PREFIX.length)
-    : tag;
 }
 
 /**
@@ -125,7 +124,8 @@ function buildClaudeLikeEntry(
     [isPrompt ? "prompt" : "command"]: runReference,
   };
   if (hook.timeout !== undefined) entry.timeout = hook.timeout;
-  const nameTag = supportsName ? buildNameTag(hook.id) : null;
+  const prefix = input.nameTagPrefix ?? NAME_TAG_PREFIX;
+  const nameTag = supportsName ? buildNameTag(hook.id, prefix) : null;
   if (nameTag) entry.name = nameTag;
   return {
     eventName: mapping.event,
@@ -150,7 +150,8 @@ function buildCursorEntry(input: HookEntryInput): HookEntryOutput {
   if (matcher) entry.pattern = matcher;
   if (hook.timeout !== undefined) entry.timeout = hook.timeout;
   if (hook.failClosed) entry.failClosed = true;
-  const nameTag = buildNameTag(hook.id);
+  const prefix = input.nameTagPrefix ?? NAME_TAG_PREFIX;
+  const nameTag = buildNameTag(hook.id, prefix);
   entry.name = nameTag;
   return {
     eventName: mapping.event,
@@ -244,8 +245,7 @@ export function upsertHookEntry(
       // for sibling hooks must coexist in the same matcher group.
       const existingIdx = nameTag
         ? group.hooks.findIndex(
-            (e) =>
-              isPlainObject(e) && isCapaNameTag(e.name, idFromNameTag(nameTag)),
+            (e) => isPlainObject(e) && e.name === nameTag,
           )
         : -1;
       if (existingIdx >= 0) {
@@ -259,10 +259,7 @@ export function upsertHookEntry(
       const { eventName, entry, nameTag } = output;
       const events = ensureArray(hooksRoot, eventName);
       const existingIdx = nameTag
-        ? events.findIndex(
-            (e) =>
-              isPlainObject(e) && isCapaNameTag(e.name, idFromNameTag(nameTag)),
-          )
+        ? events.findIndex((e) => isPlainObject(e) && e.name === nameTag)
         : -1;
       if (existingIdx >= 0) {
         events[existingIdx] = entry;

--- a/src/shared/providers/resolve.ts
+++ b/src/shared/providers/resolve.ts
@@ -26,6 +26,74 @@ export function validateProvider(id: string): string {
   );
 }
 
+export interface ResolveProvidersOpts {
+  flagProvider?: string;
+  capabilitiesProviders?: string[];
+  /** Previously stored providers. Omit for passthrough (no DB). */
+  storedProviders?: string[];
+  /**
+   * Prompt message when falling through to interactive selection.
+   * @default 'Which provider do you want to install for?'
+   */
+  promptMessage?: string;
+  /**
+   * Error hint when non-TTY and nothing is configured.
+   */
+  missingHint?: string;
+}
+
+/**
+ * Pure provider resolution (no DB writes).
+ *
+ * Priority:
+ *  1. --provider flag (single value, validated)
+ *  2. capabilities.providers
+ *  3. storedProviders (e.g. from a previous install DB row)
+ *  4. Interactive prompt (TTY only; errors in non-TTY)
+ */
+export async function resolveProviders(opts: ResolveProvidersOpts): Promise<string[]> {
+  if (opts.flagProvider) {
+    return [validateProvider(opts.flagProvider)];
+  }
+
+  if (opts.capabilitiesProviders && opts.capabilitiesProviders.length > 0) {
+    return opts.capabilitiesProviders.map((p) => validateProvider(p));
+  }
+
+  if (opts.storedProviders && opts.storedProviders.length > 0) {
+    return opts.storedProviders;
+  }
+
+  const missingHint =
+    opts.missingHint ??
+    'No provider specified. Pass --provider <id> or add a "providers" section to your capabilities file.\n\n' +
+      '  Examples:\n' +
+      '    capa install --provider cursor\n' +
+      '    capa install -p claude-code';
+
+  if (!process.stdin.isTTY) {
+    throw new Error(missingHint);
+  }
+
+  const detected = await detectInstalledProviders();
+  const options: SelectOption[] =
+    detected.length > 0
+      ? detected
+      : getAllProviders()
+          .filter((p) => p.showInUniversalList !== false)
+          .sort((a, b) => a.displayName.localeCompare(b.displayName))
+          .map((p) => ({ value: p.id, label: p.displayName }));
+
+  logger.info('');
+  logger.info('No provider detected in capabilities file.');
+  const selected = await prompt.select(
+    opts.promptMessage ?? 'Which provider do you want to install for?',
+    options,
+    '--provider <id>',
+  );
+  return [selected];
+}
+
 export interface ResolveInstallOpts {
   flagProvider?: string;
   capabilitiesProviders?: string[];
@@ -45,49 +113,11 @@ export interface ResolveInstallOpts {
 export async function resolveProvidersForInstall(
   opts: ResolveInstallOpts
 ): Promise<string[]> {
-  // 1. CLI flag
-  if (opts.flagProvider) {
-    return [validateProvider(opts.flagProvider)];
-  }
-
-  // 2. Capabilities file
-  if (opts.capabilitiesProviders && opts.capabilitiesProviders.length > 0) {
-    return opts.capabilitiesProviders.map((p) => validateProvider(p));
-  }
-
-  // 3. Database (previous install)
-  const stored = opts.db.getProjectProviders(opts.projectId);
-  if (stored.length > 0) {
-    return stored;
-  }
-
-  // 4. Interactive prompt
-  if (!process.stdin.isTTY) {
-    throw new Error(
-      'No provider specified. Pass --provider <id> or add a "providers" section to your capabilities file.\n\n' +
-        '  Examples:\n' +
-        '    capa install --provider cursor\n' +
-        '    capa install -p claude-code'
-    );
-  }
-
-  const detected = await detectInstalledProviders();
-  const options: SelectOption[] =
-    detected.length > 0
-      ? detected
-      : getAllProviders()
-          .filter((p) => p.showInUniversalList !== false)
-          .sort((a, b) => a.displayName.localeCompare(b.displayName))
-          .map((p) => ({ value: p.id, label: p.displayName }));
-
-  logger.info('');
-  logger.info('No provider detected in capabilities file.');
-  const selected = await prompt.select(
-    'Which provider do you want to install for?',
-    options,
-    '--provider <id>',
-  );
-  return [selected];
+  return resolveProviders({
+    flagProvider: opts.flagProvider,
+    capabilitiesProviders: opts.capabilitiesProviders,
+    storedProviders: opts.db.getProjectProviders(opts.projectId),
+  });
 }
 
 export interface ResolveCleanOpts {


### PR DESCRIPTION
## Summary
- Expand `capa add` to write **servers**, **tools**, **rules**, and **hooks** into the capabilities file (in addition to skills/plugins), with kind flags and type-specific options.
- Add `--passthrough` on `capa add` and `capa install` so capa acts as a file broker: resolve sources and write provider-native files with no capa server, proxy MCP entry, or managed DB tracking (`capa clean` does not reverse these writes).
- Plugins in passthrough unpack under `.capa-passthrough/plugins/` and register native MCP entries; tools are skipped/rejected in passthrough because they have no native provider form.

## Test plan
- [ ] `capa add --server --id owl --cmd npx --arg -y --arg owl-mcp@1.0.14 --arg serve` appends to capabilities.yaml
- [ ] `capa add --server --id aws-knowledge --url https://knowledge-mcp.global.api.aws` appends a remote server
- [ ] `capa add --tool --id search --mcp-server @atlassian --mcp-tool search --default cloudId=x` writes tool defaults
- [ ] `capa add --hook --id update-projects --on sessionStart --command "node scripts/x.mjs" --timeout 120` works
- [ ] `capa add --server --id owl --cmd npx --arg -y --arg owl-mcp@1.0.14 --arg serve --passthrough -p cursor` writes `.cursor/mcp.json` with key `owl` (not `capa`)
- [ ] `capa add --tool ... --passthrough` errors clearly
- [ ] `capa install --passthrough -p cursor` materializes skills/rules/hooks/servers without starting the capa server
- [ ] `capa clean` after passthrough add leaves passthrough MCP/skill files in place
- [ ] `bun test src/cli/commands/__tests__/add-builders.test.ts src/cli/utils/passthrough/__tests__/native-mcp.test.ts src/cli/commands/__tests__/add-kinds-passthrough.test.ts`
