### PR TITLE
feat: add Claude marketplace registry support

### DIFF
--- a/src/cli/commands/registry.ts
+++ b/src/cli/commands/registry.ts
@@ -23,6 +23,15 @@ function detectType(source: string, explicit?: RegistrySourceType): RegistrySour
   return 'github';
 }
 
+/** Types accepted by `capa registry add --type`. */
+export const REGISTRY_SOURCE_TYPES: RegistrySourceType[] = [
+  'github',
+  'gitlab',
+  'url',
+  'claude-marketplace',
+];
+
+
 export async function registryListCommand(): Promise<void> {
   const settings = await loadSettings();
   const db = new CapaDatabase(getDatabasePath(settings));
@@ -129,7 +138,9 @@ export async function registryAddCommand(
           task.output =
             ctx.type === 'url'
               ? `downloading ${ctx.source}`
-              : `cloning ${ctx.source} from ${ctx.type}`;
+              : ctx.type === 'claude-marketplace'
+                ? `fetching marketplace ${ctx.source}`
+                : `cloning ${ctx.source} from ${ctx.type}`;
           const authFetch = createAuthenticatedFetch(ctx.db);
           const result = await installRegistry(
             { slug: ctx.slug, type: ctx.type, source: ctx.source },

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -301,14 +301,21 @@ if (process.argv[2] === '__server__') {
       .description('Fetch a registry adapter from a git repo or HTTPS URL and install it')
       .option(
         '--type <type>',
-        'Source type: github, gitlab, or url (auto-detected from source by default)',
+        'Source type: github, gitlab, url, or claude-marketplace (auto-detected from source by default)',
       )
       .option('--no-cache', 'Bypass the on-disk repo cache when fetching')
       .action(async (source: string, slug: string | undefined, opts: { type?: string; cache?: boolean }) => {
         let type: RegistrySourceType | undefined;
         if (opts.type) {
-          if (opts.type !== 'github' && opts.type !== 'gitlab' && opts.type !== 'url') {
-            error(`Invalid --type "${opts.type}". Expected one of: github, gitlab, url.`);
+          if (
+            opts.type !== 'github' &&
+            opts.type !== 'gitlab' &&
+            opts.type !== 'url' &&
+            opts.type !== 'claude-marketplace'
+          ) {
+            error(
+              `Invalid --type "${opts.type}". Expected one of: github, gitlab, url, claude-marketplace.`,
+            );
             process.exit(ExitCode.USER_ERROR);
           }
           type = opts.type;

--- a/src/db/__tests__/registries.test.ts
+++ b/src/db/__tests__/registries.test.ts
@@ -116,6 +116,16 @@ describe('CapaDatabase — registry operations', () => {
     ).toThrow();
   });
 
+  it('accepts claude-marketplace as a valid type', () => {
+    const row = db.upsertRegistry({
+      slug: 'dk',
+      type: 'claude-marketplace',
+      source: 'owner/repo',
+      status: 'installed',
+    });
+    expect(row.type).toBe('claude-marketplace');
+  });
+
   it('rejects an invalid status via CHECK constraint', () => {
     expect(() =>
       db.upsertRegistry({

--- a/src/db/schema.ts
+++ b/src/db/schema.ts
@@ -146,7 +146,7 @@ export function initSchema(db: Database): void {
 	db.run(`
       CREATE TABLE IF NOT EXISTS registries (
         slug TEXT PRIMARY KEY,
-        type TEXT NOT NULL CHECK(type IN ('github','gitlab','url')),
+        type TEXT NOT NULL CHECK(type IN ('github','gitlab','url','claude-marketplace')),
         source TEXT NOT NULL,
         enabled INTEGER NOT NULL DEFAULT 1,
         status TEXT NOT NULL DEFAULT 'pending'
@@ -158,6 +158,8 @@ export function initSchema(db: Database): void {
         updated_at INTEGER NOT NULL
       )
     `);
+
+	migrateRegistriesAllowClaudeMarketplace(db);
 
 	// Tracks individual capa-installed hook entries (one row per
 	// (provider, hook) tuple). `locator` is the JSON-encoded path inside
@@ -231,4 +233,44 @@ function ensureColumn(
 	}>;
 	if (cols.some((c) => c.name === column)) return;
 	db.run(`ALTER TABLE ${table} ADD COLUMN ${column} ${typeSql}`);
+}
+
+/**
+ * Existing DBs created `registries` with CHECK(type IN ('github','gitlab','url')).
+ * SQLite cannot ALTER a CHECK constraint, so rebuild the table when needed.
+ */
+function migrateRegistriesAllowClaudeMarketplace(db: Database): void {
+	const row = db
+		.query(
+			`SELECT sql FROM sqlite_master WHERE type = 'table' AND name = 'registries'`,
+		)
+		.get() as { sql: string } | null;
+	if (!row?.sql) return;
+	if (row.sql.includes("'claude-marketplace'")) return;
+
+	db.run("BEGIN");
+	try {
+		db.run(`
+      CREATE TABLE registries_new (
+        slug TEXT PRIMARY KEY,
+        type TEXT NOT NULL CHECK(type IN ('github','gitlab','url','claude-marketplace')),
+        source TEXT NOT NULL,
+        enabled INTEGER NOT NULL DEFAULT 1,
+        status TEXT NOT NULL DEFAULT 'pending'
+               CHECK(status IN ('pending','installed','failed','disabled')),
+        last_error TEXT,
+        resolved_ref TEXT,
+        installed_at INTEGER,
+        created_at INTEGER NOT NULL,
+        updated_at INTEGER NOT NULL
+      )
+    `);
+		db.run(`INSERT INTO registries_new SELECT * FROM registries`);
+		db.run(`DROP TABLE registries`);
+		db.run(`ALTER TABLE registries_new RENAME TO registries`);
+		db.run("COMMIT");
+	} catch (err) {
+		db.run("ROLLBACK");
+		throw err;
+	}
 }

--- a/src/server/__tests__/registries-routes.test.ts
+++ b/src/server/__tests__/registries-routes.test.ts
@@ -521,7 +521,7 @@ describe('registries-routes', () => {
         id: 'developer-kit-typescript',
         type: 'github',
         def: {
-          repo: 'giuseppe-trisciuoglio/developer-kit@developer-kit-typescript',
+          repo: 'giuseppe-trisciuoglio/developer-kit::plugins/developer-kit-typescript',
         },
       });
 

--- a/src/server/__tests__/registries-routes.test.ts
+++ b/src/server/__tests__/registries-routes.test.ts
@@ -384,4 +384,154 @@ describe('registries-routes', () => {
       expect(res.status).toBe(400);
     });
   });
+
+  describe('claude-marketplace type', () => {
+    const MARKETPLACE_JSON = JSON.stringify(
+      {
+        name: "developer-kit",
+        description: "Modular marketplace for developer kit plugins",
+        owner: { name: "Giuseppe Trisciuoglio" },
+        plugins: [
+          {
+            name: "developer-kit-typescript",
+            description: "TypeScript toolkit",
+            source: "./plugins/developer-kit-typescript",
+            version: "2.8.0",
+          },
+          {
+            name: "developer-kit",
+            description: "Core",
+            source: "./plugins/developer-kit-core",
+            version: "2.8.0",
+          },
+        ],
+      },
+      null,
+      2,
+    );
+
+    it('previews a marketplace.json URL and derives the catalog name as slug', async () => {
+      const mpServer = Bun.serve({
+        port: 0,
+        fetch(req) {
+          if (new URL(req.url).pathname.endsWith('/marketplace.json')) {
+            return new Response(MARKETPLACE_JSON, {
+              headers: { 'content-type': 'application/json' },
+            });
+          }
+          return new Response('not found', { status: 404 });
+        },
+      });
+      const marketplaceUrl = `http://localhost:${mpServer.port}/marketplace.json`;
+      try {
+        const url = new URL(
+          `http://localhost/api/registries/preview?type=claude-marketplace&source=${encodeURIComponent(marketplaceUrl)}`,
+        );
+        const res = await previewRegistryHandler(db, url);
+        expect(res.status).toBe(200);
+        const body = await jsonOf(res);
+        expect(body.derivedSlug).toBe('developer-kit');
+        expect(body.pluginCount).toBe(2);
+        expect(body.content).toContain('"developer-kit-typescript"');
+        expect(db.listRegistries()).toEqual([]);
+      } finally {
+        mpServer.stop();
+      }
+    });
+
+    it('installs from a marketplace.json URL, loads via manager, and searches plugins', async () => {
+      const mpServer = Bun.serve({
+        port: 0,
+        fetch(req) {
+          if (new URL(req.url).pathname.endsWith('/marketplace.json')) {
+            return new Response(MARKETPLACE_JSON, {
+              headers: { 'content-type': 'application/json' },
+            });
+          }
+          return new Response('not found', { status: 404 });
+        },
+      });
+      const marketplaceUrl = `http://localhost:${mpServer.port}/marketplace.json`;
+      try {
+        const req = new Request('http://localhost/api/registries', {
+          method: 'POST',
+          body: JSON.stringify({
+            type: 'claude-marketplace',
+            source: marketplaceUrl,
+          }),
+        });
+        const res = await createRegistryHandler(db, manager, req);
+        expect(res.status).toBe(201);
+        const body = await jsonOf(res);
+        expect(body.registry.slug).toBe('developer-kit');
+        expect(body.registry.type).toBe('claude-marketplace');
+        expect(body.manifest.id).toBe('developer-kit');
+        expect(existsSync(join(managedDir, 'developer-kit', 'marketplace.json'))).toBe(true);
+        expect(existsSync(join(managedDir, 'developer-kit', 'marketplace.meta.json'))).toBe(true);
+
+        // Bare JSON URL marketplaces have no ownerRepo — relative sources
+        // are listed but not installable. Search still works.
+        await manager.reload();
+        const search = await manager.search('developer-kit', {
+          capability: 'plugins',
+          query: '',
+        });
+        expect(search.total).toBe(2);
+        expect(search.items.map((i) => i.id).sort()).toEqual([
+          'developer-kit',
+          'developer-kit-typescript',
+        ]);
+      } finally {
+        mpServer.stop();
+      }
+    });
+
+    it('installs a git-backed marketplace when materializing from a local snapshot fixture', async () => {
+      // Simulate install by writing managed files directly then loading —
+      // full git clone is covered by unit source-mapping tests.
+      const { writeFileSync: write } = await import('fs');
+      const slug = 'dk-local';
+      const dir = join(managedDir, slug);
+      mkdirSync(dir, { recursive: true });
+      write(join(dir, 'marketplace.json'), MARKETPLACE_JSON);
+      write(
+        join(dir, 'marketplace.meta.json'),
+        JSON.stringify({
+          source: 'giuseppe-trisciuoglio/developer-kit',
+          host: 'github',
+          ownerRepo: 'giuseppe-trisciuoglio/developer-kit',
+          marketplaceName: 'developer-kit',
+          pluginCount: 2,
+          fetchedAt: Date.now(),
+        }),
+      );
+      db.upsertRegistry({
+        slug,
+        type: 'claude-marketplace',
+        source: 'giuseppe-trisciuoglio/developer-kit',
+        status: 'installed',
+        enabled: true,
+      });
+      await manager.reload();
+      const detail = await manager.view(slug, {
+        capability: 'plugins',
+        id: 'developer-kit-typescript',
+      });
+      expect(detail.installSnippet).toMatchObject({
+        id: 'developer-kit-typescript',
+        type: 'github',
+        def: {
+          repo: 'giuseppe-trisciuoglio/developer-kit@developer-kit-typescript',
+        },
+      });
+
+      const core = await manager.view(slug, {
+        capability: 'plugins',
+        id: 'developer-kit',
+      });
+      expect((core.installSnippet as any).def.repo).toBe(
+        'giuseppe-trisciuoglio/developer-kit::plugins/developer-kit-core',
+      );
+    });
+  });
 });

--- a/src/server/registries-routes.ts
+++ b/src/server/registries-routes.ts
@@ -25,9 +25,19 @@ function jsonOk(body: unknown, status = 200): Response {
 }
 
 function parseTypeQuery(value: string | null): RegistrySourceType | null {
-	if (value === "github" || value === "gitlab" || value === "url") return value;
+	if (
+		value === "github" ||
+		value === "gitlab" ||
+		value === "url" ||
+		value === "claude-marketplace"
+	) {
+		return value;
+	}
 	return null;
 }
+
+const TYPE_HELP = "github, gitlab, url, claude-marketplace";
+
 
 export async function listRegistriesHandler(
 	db: CapaDatabase,
@@ -66,34 +76,47 @@ export async function createRegistryHandler(
 
 	const type = parseTypeQuery(body.type ?? null);
 	if (!type) {
-		return jsonError('Field "type" must be one of: github, gitlab, url.', 400);
+		return jsonError(`Field "type" must be one of: ${TYPE_HELP}.`, 400);
 	}
 	const source = body.source;
 	if (!source || typeof source !== "string") {
 		return jsonError('Field "source" is required.', 400);
 	}
 
-	let slug: string;
+	let installSlug: string;
 	try {
-		slug = body.slug ?? deriveSlug(source, type);
+		installSlug = body.slug?.trim() || deriveSlug(source, type);
 	} catch (err: any) {
 		return jsonError(`Cannot derive slug: ${err?.message ?? err}`, 400);
 	}
-	if (!isValidSlug(slug)) {
+	if (!isValidSlug(installSlug)) {
 		return jsonError(
-			`Invalid slug "${slug}". Allowed: lowercase letters, digits, and dashes; must start with a letter or digit.`,
+			`Invalid slug "${installSlug}". Allowed: lowercase letters, digits, and dashes; must start with a letter or digit.`,
 			400,
 		);
-	}
-	if (db.getRegistry(slug)) {
-		return jsonError(`Registry "${slug}" already exists.`, 409);
 	}
 
 	try {
 		const authFetch = createAuthenticatedFetch(db);
-		const result = await installRegistry({ slug, type, source }, authFetch);
+
+		// Prefer marketplace.json `name` as the slug when the caller omitted one.
+		if (type === "claude-marketplace" && !body.slug?.trim()) {
+			const preview = await fetchAdapterSource({ type, source }, authFetch);
+			if (preview.preferredSlug && isValidSlug(preview.preferredSlug)) {
+				installSlug = preview.preferredSlug;
+			}
+		}
+
+		if (db.getRegistry(installSlug)) {
+			return jsonError(`Registry "${installSlug}" already exists.`, 409);
+		}
+
+		const result = await installRegistry(
+			{ slug: installSlug, type, source },
+			authFetch,
+		);
 		const record = db.upsertRegistry({
-			slug,
+			slug: installSlug,
 			type,
 			source,
 			status: "installed",
@@ -159,7 +182,7 @@ export async function patchRegistryHandler(
 	// materialized adapter matches the new upstream pointer.
 	const newType = hasType ? parseTypeQuery(body.type!) : existing.type;
 	if (hasType && !newType) {
-		return jsonError('Field "type" must be one of: github, gitlab, url.', 400);
+		return jsonError(`Field "type" must be one of: ${TYPE_HELP}.`, 400);
 	}
 	const newSource = hasSource ? body.source!.trim() : existing.source;
 	if (hasSource && !newSource) {
@@ -259,25 +282,30 @@ export async function previewRegistryHandler(
 	const type = parseTypeQuery(url.searchParams.get("type"));
 	const source = url.searchParams.get("source");
 	if (!type) {
-		return jsonError('Query "type" must be one of: github, gitlab, url.', 400);
+		return jsonError(`Query "type" must be one of: ${TYPE_HELP}.`, 400);
 	}
 	if (!source) {
 		return jsonError('Query "source" is required.', 400);
 	}
 	try {
 		const authFetch = createAuthenticatedFetch(db);
-		const { content, resolvedRef } = await fetchAdapterSource(
-			{ type, source },
-			authFetch,
-		);
+		const { content, resolvedRef, preferredSlug, pluginCount } =
+			await fetchAdapterSource({ type, source }, authFetch);
 		let derivedSlug: string | null = null;
 		try {
-			const candidate = deriveSlug(source, type);
+			const candidate =
+				(preferredSlug && isValidSlug(preferredSlug) ? preferredSlug : null) ??
+				deriveSlug(source, type);
 			derivedSlug = isValidSlug(candidate) ? candidate : null;
 		} catch {
 			derivedSlug = null;
 		}
-		return jsonOk({ content, resolvedRef, derivedSlug });
+		return jsonOk({
+			content,
+			resolvedRef,
+			derivedSlug,
+			...(typeof pluginCount === "number" ? { pluginCount } : {}),
+		});
 	} catch (err: any) {
 		return jsonError(err?.message ?? String(err), 400);
 	}

--- a/src/shared/registries/__tests__/claude-marketplace.test.ts
+++ b/src/shared/registries/__tests__/claude-marketplace.test.ts
@@ -102,7 +102,7 @@ describe("claude-marketplace parse", () => {
 });
 
 describe("claude-marketplace source mapping", () => {
-	it("maps matching basename to @ form", () => {
+	it("maps matching basename to exact :: form", () => {
 		const catalog = parseMarketplaceJson(DEVELOPER_KIT_FIXTURE);
 		const ts = catalog.plugins.find((p) => p.name === "developer-kit-typescript")!;
 		const snippet = buildPluginInstallSnippet(ts, catalog, ORIGIN);
@@ -110,7 +110,7 @@ describe("claude-marketplace source mapping", () => {
 			id: "developer-kit-typescript",
 			type: "github",
 			def: {
-				repo: "giuseppe-trisciuoglio/developer-kit@developer-kit-typescript",
+				repo: "giuseppe-trisciuoglio/developer-kit::plugins/developer-kit-typescript",
 				description: ts.description,
 			},
 		});
@@ -148,19 +148,24 @@ describe("claude-marketplace source mapping", () => {
 		expect(snippet).toBeNull();
 	});
 
-	it("buildRepoString prefers @ when leaf matches plugin name", () => {
+	it("buildRepoString always uses :: when subpath is present", () => {
 		expect(
-			buildRepoString(
-				{ host: "github", ownerRepo: "a/b", subpath: "plugins/foo" },
-				"foo",
-			),
-		).toBe("a/b@foo");
+			buildRepoString({
+				host: "github",
+				ownerRepo: "a/b",
+				subpath: "plugins/foo",
+			}),
+		).toBe("a/b::plugins/foo");
 		expect(
-			buildRepoString(
-				{ host: "github", ownerRepo: "a/b", subpath: "plugins/bar" },
-				"foo",
-			),
+			buildRepoString({
+				host: "github",
+				ownerRepo: "a/b",
+				subpath: "plugins/bar",
+			}),
 		).toBe("a/b::plugins/bar");
+		expect(
+			buildRepoString({ host: "github", ownerRepo: "a/b" }),
+		).toBe("a/b");
 	});
 });
 
@@ -181,6 +186,25 @@ describe("parseClaudeMarketplaceSource", () => {
 			kind: "git",
 			ref: "v3.1.0",
 			locator: "giuseppe-trisciuoglio/developer-kit",
+		});
+	});
+
+	it("allows slashes in owner/repo@ref", () => {
+		expect(
+			parseClaudeMarketplaceSource("acme/marketplace@feature/foo"),
+		).toMatchObject({
+			kind: "git",
+			locator: "acme/marketplace",
+			ref: "feature/foo",
+			origin: {
+				ownerRepo: "acme/marketplace",
+				ref: "feature/foo",
+			},
+		});
+		expect(
+			parseClaudeMarketplaceSource("acme/marketplace@release/v1"),
+		).toMatchObject({
+			ref: "release/v1",
 		});
 	});
 
@@ -275,8 +299,8 @@ describe("createClaudeMarketplaceAdapter", () => {
 			id: "developer-kit-typescript",
 			type: "github",
 		});
-		expect((detail.installSnippet as { def: { repo: string } }).def.repo).toContain(
-			"@developer-kit-typescript",
+		expect((detail.installSnippet as { def: { repo: string } }).def.repo).toBe(
+			"giuseppe-trisciuoglio/developer-kit::plugins/developer-kit-typescript",
 		);
 	});
 

--- a/src/shared/registries/__tests__/claude-marketplace.test.ts
+++ b/src/shared/registries/__tests__/claude-marketplace.test.ts
@@ -1,0 +1,304 @@
+import { describe, it, expect } from "bun:test";
+import {
+	buildPluginInstallSnippet,
+	buildRepoString,
+	classifyMarketplaceSource,
+	createClaudeMarketplaceAdapter,
+	marketplaceIcon,
+	marketplaceNameToSlug,
+	parseClaudeMarketplaceSource,
+	parseMarketplaceJson,
+	siteFavicon,
+	sourceToInstallCoords,
+} from "../claude-marketplace";
+import type { MarketplaceOrigin } from "../claude-marketplace";
+
+const DEVELOPER_KIT_FIXTURE = {
+	name: "developer-kit",
+	version: "3.1.0",
+	description: "Modular marketplace for developer kit plugins",
+	owner: {
+		name: "Giuseppe Trisciuoglio",
+		email: "giuseppe.trisciuoglio@gmail.com",
+	},
+	plugins: [
+		{
+			name: "developer-kit",
+			description: "Core agents and commands required by all plugins",
+			source: "./plugins/developer-kit-core",
+			version: "2.8.0",
+		},
+		{
+			name: "developer-kit-typescript",
+			description: "TypeScript/JavaScript full-stack development",
+			source: "./plugins/developer-kit-typescript",
+			version: "2.8.0",
+		},
+		{
+			name: "developer-kit-ai",
+			description: "AI/ML skills",
+			source: "./plugins/developer-kit-ai",
+			version: "2.8.0",
+		},
+	],
+};
+
+const ORIGIN: MarketplaceOrigin = {
+	source: "giuseppe-trisciuoglio/developer-kit",
+	host: "github",
+	ownerRepo: "giuseppe-trisciuoglio/developer-kit",
+};
+
+describe("claude-marketplace parse", () => {
+	it("parses the developer-kit marketplace fixture", () => {
+		const catalog = parseMarketplaceJson(DEVELOPER_KIT_FIXTURE);
+		expect(catalog.name).toBe("developer-kit");
+		expect(catalog.plugins).toHaveLength(3);
+		expect(catalog.owner?.name).toBe("Giuseppe Trisciuoglio");
+		expect(marketplaceNameToSlug(catalog.name)).toBe("developer-kit");
+	});
+
+	it("applies metadata.pluginRoot when classifying relative sources", () => {
+		const catalog = parseMarketplaceJson({
+			name: "rooted",
+			metadata: { pluginRoot: "./plugins" },
+			plugins: [{ name: "formatter", source: "formatter" }],
+		});
+		expect(catalog.pluginRoot).toBe("plugins");
+		const coords = sourceToInstallCoords(
+			catalog.plugins[0].source,
+			{ source: "acme/tools", host: "github", ownerRepo: "acme/tools" },
+			catalog.pluginRoot,
+		);
+		expect(coords?.subpath).toBe("plugins/formatter");
+	});
+
+	it("rejects catalogs without plugins", () => {
+		expect(() =>
+			parseMarketplaceJson({ name: "empty", plugins: [] }),
+		).toThrow(/no valid plugins/);
+	});
+
+	it("classifies npm and github object sources", () => {
+		expect(classifyMarketplaceSource({ source: "npm", package: "@acme/p" })).toEqual({
+			kind: "npm",
+			package: "@acme/p",
+			version: undefined,
+		});
+		expect(
+			classifyMarketplaceSource({
+				source: "github",
+				repo: "acme/plugin",
+				ref: "v1",
+			}),
+		).toEqual({
+			kind: "repo",
+			repo: "acme/plugin",
+			ref: "v1",
+			sha: undefined,
+			commit: undefined,
+		});
+	});
+});
+
+describe("claude-marketplace source mapping", () => {
+	it("maps matching basename to @ form", () => {
+		const catalog = parseMarketplaceJson(DEVELOPER_KIT_FIXTURE);
+		const ts = catalog.plugins.find((p) => p.name === "developer-kit-typescript")!;
+		const snippet = buildPluginInstallSnippet(ts, catalog, ORIGIN);
+		expect(snippet).toEqual({
+			id: "developer-kit-typescript",
+			type: "github",
+			def: {
+				repo: "giuseppe-trisciuoglio/developer-kit@developer-kit-typescript",
+				description: ts.description,
+			},
+		});
+	});
+
+	it("maps mismatched basename to :: form", () => {
+		const catalog = parseMarketplaceJson(DEVELOPER_KIT_FIXTURE);
+		const core = catalog.plugins.find((p) => p.name === "developer-kit")!;
+		const snippet = buildPluginInstallSnippet(core, catalog, ORIGIN);
+		expect(snippet?.def.repo).toBe(
+			"giuseppe-trisciuoglio/developer-kit::plugins/developer-kit-core",
+		);
+	});
+
+	it("returns null for npm sources", () => {
+		const catalog = parseMarketplaceJson({
+			name: "mixed",
+			plugins: [
+				{
+					name: "pkg",
+					source: { source: "npm", package: "@acme/claude-plugin" },
+				},
+			],
+		});
+		expect(buildPluginInstallSnippet(catalog.plugins[0], catalog, ORIGIN)).toBeNull();
+	});
+
+	it("returns null for monorepo-local when origin has no ownerRepo", () => {
+		const catalog = parseMarketplaceJson(DEVELOPER_KIT_FIXTURE);
+		const snippet = buildPluginInstallSnippet(catalog.plugins[0], catalog, {
+			source: "https://example.com/marketplace.json",
+			host: "github",
+			ownerRepo: null,
+		});
+		expect(snippet).toBeNull();
+	});
+
+	it("buildRepoString prefers @ when leaf matches plugin name", () => {
+		expect(
+			buildRepoString(
+				{ host: "github", ownerRepo: "a/b", subpath: "plugins/foo" },
+				"foo",
+			),
+		).toBe("a/b@foo");
+		expect(
+			buildRepoString(
+				{ host: "github", ownerRepo: "a/b", subpath: "plugins/bar" },
+				"foo",
+			),
+		).toBe("a/b::plugins/bar");
+	});
+});
+
+describe("parseClaudeMarketplaceSource", () => {
+	it("parses owner/repo and owner/repo@ref", () => {
+		expect(parseClaudeMarketplaceSource("giuseppe-trisciuoglio/developer-kit")).toMatchObject({
+			kind: "git",
+			locator: "giuseppe-trisciuoglio/developer-kit",
+			origin: {
+				ownerRepo: "giuseppe-trisciuoglio/developer-kit",
+				host: "github",
+				baseUrl: "https://github.com",
+			},
+		});
+		expect(
+			parseClaudeMarketplaceSource("giuseppe-trisciuoglio/developer-kit@v3.1.0"),
+		).toMatchObject({
+			kind: "git",
+			ref: "v3.1.0",
+			locator: "giuseppe-trisciuoglio/developer-kit",
+		});
+	});
+
+	it("parses a direct marketplace.json URL and recovers GitHub coords from raw.githubusercontent.com", () => {
+		const parsed = parseClaudeMarketplaceSource(
+			"https://raw.githubusercontent.com/giuseppe-trisciuoglio/developer-kit/main/.claude-plugin/marketplace.json",
+		);
+		expect(parsed.kind).toBe("json-url");
+		expect(parsed.origin).toMatchObject({
+			host: "github",
+			ownerRepo: "giuseppe-trisciuoglio/developer-kit",
+			baseUrl: "https://github.com",
+		});
+	});
+
+	it("uses the site origin for unknown marketplace.json hosts", () => {
+		const parsed = parseClaudeMarketplaceSource(
+			"https://git.example.com/team/plugins/.claude-plugin/marketplace.json",
+		);
+		expect(parsed.origin).toMatchObject({
+			host: "other",
+			ownerRepo: null,
+			baseUrl: "https://git.example.com",
+		});
+	});
+});
+
+describe("marketplaceIcon", () => {
+	it("uses the GitHub owner avatar when host is github", () => {
+		expect(
+			marketplaceIcon({
+				source: "acme/kit",
+				host: "github",
+				ownerRepo: "acme/kit",
+				baseUrl: "https://github.com",
+			}),
+		).toBe("https://github.com/acme.png?size=64");
+	});
+
+	it("falls back to the site favicon for GitLab", () => {
+		expect(
+			marketplaceIcon({
+				source: "https://gitlab.com/acme/kit",
+				host: "gitlab",
+				ownerRepo: "acme/kit",
+				baseUrl: "https://gitlab.com",
+			}),
+		).toBe("https://gitlab.com/favicon.ico");
+	});
+
+	it("falls back to the site favicon for other git hosts", () => {
+		expect(
+			marketplaceIcon({
+				source: "https://git.example.com/team/plugins/.claude-plugin/marketplace.json",
+				host: "other",
+				ownerRepo: null,
+				baseUrl: "https://git.example.com",
+			}),
+		).toBe("https://git.example.com/favicon.ico");
+	});
+
+	it("siteFavicon rejects non-http URLs", () => {
+		expect(siteFavicon("file:///tmp/x")).toBe("https://claude.com/favicon.ico");
+	});
+});
+
+describe("createClaudeMarketplaceAdapter", () => {
+	it("searches and views installable plugins", async () => {
+		const catalog = parseMarketplaceJson(DEVELOPER_KIT_FIXTURE);
+		const adapter = createClaudeMarketplaceAdapter({
+			slug: "developer-kit",
+			catalog,
+			origin: ORIGIN,
+		});
+
+		expect(adapter.manifest.id).toBe("developer-kit");
+		expect(adapter.manifest.capabilities).toEqual(["plugins"]);
+		expect(adapter.manifest.icon).toBe(
+			"https://github.com/giuseppe-trisciuoglio.png?size=64",
+		);
+
+		const search = await adapter.search({ capability: "plugins", query: "typescript" });
+		expect(search.total).toBe(1);
+		expect(search.items[0].id).toBe("developer-kit-typescript");
+		expect(search.items[0].tags).toContain("source-resolved");
+
+		const detail = await adapter.view({
+			capability: "plugins",
+			id: "developer-kit-typescript",
+		});
+		expect(detail.installSnippet).toMatchObject({
+			id: "developer-kit-typescript",
+			type: "github",
+		});
+		expect((detail.installSnippet as { def: { repo: string } }).def.repo).toContain(
+			"@developer-kit-typescript",
+		);
+	});
+
+	it("lists unsupported plugins in search but rejects view install", async () => {
+		const catalog = parseMarketplaceJson({
+			name: "mixed",
+			plugins: [
+				{
+					name: "npm-only",
+					source: { source: "npm", package: "@acme/x" },
+				},
+			],
+		});
+		const adapter = createClaudeMarketplaceAdapter({
+			slug: "mixed",
+			catalog,
+			origin: ORIGIN,
+		});
+		const search = await adapter.search({ capability: "plugins" });
+		expect(search.items[0].tags).toContain("source-unsupported");
+		await expect(
+			adapter.view({ capability: "plugins", id: "npm-only" }),
+		).rejects.toThrow(/npm package/);
+	});
+});

--- a/src/shared/registries/claude-marketplace/adapter.ts
+++ b/src/shared/registries/claude-marketplace/adapter.ts
@@ -1,0 +1,268 @@
+import type { Plugin } from "../../../types/plugin";
+import type {
+	RegistryAdapter,
+	RegistryItemDetail,
+	RegistryItemSummary,
+	RegistryManifest,
+} from "../../../types/registry";
+import {
+	buildPluginInstallSnippet,
+	unsupportedSourceReason,
+} from "./sources";
+import type {
+	MarketplaceOrigin,
+	MarketplacePluginEntry,
+	ParsedMarketplace,
+} from "./types";
+
+export interface CreateClaudeMarketplaceAdapterOptions {
+	/** Registry slug / manifest id (DB primary key). */
+	slug: string;
+	catalog: ParsedMarketplace;
+	origin: MarketplaceOrigin;
+}
+
+function homepageFor(origin: MarketplaceOrigin): string | undefined {
+	if (origin.baseUrl && origin.ownerRepo) {
+		return `${origin.baseUrl.replace(/\/+$/, "")}/${origin.ownerRepo}`;
+	}
+	if (!origin.ownerRepo) {
+		if (origin.baseUrl) return origin.baseUrl;
+		return undefined;
+	}
+	const host =
+		origin.host === "gitlab" ? "https://gitlab.com" : "https://github.com";
+	return `${host}/${origin.ownerRepo}`;
+}
+
+function browsePluginUrl(
+	origin: MarketplaceOrigin,
+	plugin: MarketplacePluginEntry,
+	subpath?: string,
+): string | undefined {
+	const base = homepageFor(origin);
+	if (!base) return plugin.homepage;
+	if (subpath) {
+		const ref = origin.ref ?? "main";
+		return `${base}/tree/${ref}/${subpath}`;
+	}
+	return plugin.homepage ?? base;
+}
+
+function toSummary(
+	plugin: MarketplacePluginEntry,
+	installable: boolean,
+): RegistryItemSummary {
+	const tags: string[] = [];
+	if (plugin.category) tags.push(plugin.category);
+	if (installable) tags.push("source-resolved");
+	else tags.push("source-unsupported");
+	return {
+		id: plugin.name,
+		capability: "plugins",
+		title: plugin.name,
+		description: plugin.description,
+		author: plugin.author?.name,
+		version: plugin.version,
+		tags: tags.length > 0 ? tags : undefined,
+		homepage: plugin.homepage,
+	};
+}
+
+function buildPreview(
+	plugin: MarketplacePluginEntry,
+	catalog: ParsedMarketplace,
+	origin: MarketplaceOrigin,
+	snippet: Plugin | null,
+	slug: string,
+): string {
+	const parts: string[] = [];
+	parts.push(`# ${plugin.name}`);
+	parts.push("");
+	if (plugin.description) {
+		parts.push(plugin.description);
+		parts.push("");
+	}
+
+	const meta: string[] = [];
+	meta.push(`**Marketplace:** \`${catalog.name}\``);
+	if (catalog.owner?.name) meta.push(`**Owner:** ${catalog.owner.name}`);
+	if (plugin.version) meta.push(`**Version:** ${plugin.version}`);
+	if (plugin.category) meta.push(`**Category:** ${plugin.category}`);
+	if (plugin.author?.name) meta.push(`**Author:** ${plugin.author.name}`);
+	if (origin.ownerRepo) {
+		const hostLabel =
+			origin.host === "gitlab"
+				? "GitLab"
+				: origin.host === "github"
+					? "GitHub"
+					: "Git";
+		meta.push(`**Marketplace repo:** \`${origin.ownerRepo}\` (${hostLabel})`);
+	}
+	parts.push(meta.join("  \n"));
+	parts.push("");
+
+	parts.push("## Install");
+	parts.push("");
+	if (snippet) {
+		parts.push("Install via capa:");
+		parts.push("");
+		parts.push("```");
+		parts.push(`capa add ${slug}:${plugin.name}`);
+		parts.push("```");
+		parts.push("");
+		parts.push("YAML snippet:");
+		parts.push("");
+		parts.push("```yaml");
+		parts.push(`plugins:`);
+		parts.push(`  - id: ${snippet.id}`);
+		parts.push(`    type: ${snippet.type}`);
+		parts.push(`    def:`);
+		parts.push(`      repo: ${snippet.def.repo}`);
+		if (snippet.def.version) parts.push(`      version: ${snippet.def.version}`);
+		if (snippet.def.ref) parts.push(`      ref: ${snippet.def.ref}`);
+		parts.push("```");
+	} else {
+		parts.push(
+			`This plugin cannot be installed via capa: ${unsupportedSourceReason(plugin.source, origin)}.`,
+		);
+	}
+
+	return parts.join("\n");
+}
+
+const DEFAULT_ICON = "https://claude.com/favicon.ico";
+
+/** Resolve a site's `/favicon.ico` from a base URL or any absolute URL. */
+export function siteFavicon(url: string): string {
+	try {
+		const u = new URL(url);
+		if (u.protocol !== "http:" && u.protocol !== "https:") return DEFAULT_ICON;
+		return `${u.origin}/favicon.ico`;
+	} catch {
+		return DEFAULT_ICON;
+	}
+}
+
+/**
+ * Registry tab icon for a Claude marketplace.
+ *
+ * - GitHub with a known owner → owner avatar
+ * - Anything else with a site origin → that site's favicon
+ * - Last resort → Claude favicon
+ */
+export function marketplaceIcon(origin: MarketplaceOrigin): string {
+	if (origin.host === "github" && origin.ownerRepo) {
+		const owner = origin.ownerRepo.split("/")[0];
+		if (owner) return `https://github.com/${owner}.png?size=64`;
+	}
+
+	if (origin.baseUrl) {
+		return siteFavicon(origin.baseUrl);
+	}
+
+	if (/^https?:\/\//i.test(origin.source)) {
+		return siteFavicon(origin.source);
+	}
+
+	if (origin.host === "gitlab") {
+		return siteFavicon("https://gitlab.com");
+	}
+
+	return DEFAULT_ICON;
+}
+
+/**
+ * Build an in-process RegistryAdapter from a cached Claude marketplace catalog.
+ */
+export function createClaudeMarketplaceAdapter(
+	opts: CreateClaudeMarketplaceAdapterOptions,
+): RegistryAdapter {
+	const { slug, catalog, origin } = opts;
+	const byName = new Map(catalog.plugins.map((p) => [p.name, p]));
+
+	const displayName = catalog.name;
+	const description =
+		catalog.description ??
+		`Claude marketplace with ${catalog.plugins.length} plugin(s)`;
+
+	const manifest: RegistryManifest = {
+		id: slug,
+		name: displayName,
+		description,
+		homepage: homepageFor(origin),
+		icon: marketplaceIcon(origin),
+		capabilities: ["plugins"],
+	};
+
+	const adapter: RegistryAdapter = {
+		manifest,
+
+		async search({ capability, query, limit }) {
+			if (capability !== "plugins") {
+				return { items: [], total: 0 };
+			}
+			const q = (query ?? "").trim().toLowerCase();
+			const filtered = q
+				? catalog.plugins.filter((p) => pluginMatches(p, q))
+				: catalog.plugins;
+
+			const total = filtered.length;
+			const sliced =
+				typeof limit === "number" && limit > 0
+					? filtered.slice(0, limit)
+					: filtered;
+
+			return {
+				items: sliced.map((p) => {
+					const snippet = buildPluginInstallSnippet(p, catalog, origin);
+					return toSummary(p, snippet != null);
+				}),
+				total,
+			};
+		},
+
+		async view({ capability, id }): Promise<RegistryItemDetail> {
+			if (capability !== "plugins") {
+				throw new Error(
+					`Unsupported capability for Claude marketplace "${slug}": ${capability}`,
+				);
+			}
+			const plugin = byName.get(id);
+			if (!plugin) {
+				throw new Error(
+					`Plugin "${id}" not found in marketplace "${catalog.name}"`,
+				);
+			}
+
+			const snippet = buildPluginInstallSnippet(plugin, catalog, origin);
+			if (!snippet) {
+				throw new Error(
+					`Plugin "${id}" cannot be installed via capa: ${unsupportedSourceReason(plugin.source, origin)}.`,
+				);
+			}
+
+			const summary = toSummary(plugin, true);
+			summary.homepage =
+				plugin.homepage ??
+				browsePluginUrl(origin, plugin, undefined) ??
+				summary.homepage;
+
+			return {
+				...summary,
+				preview: buildPreview(plugin, catalog, origin, snippet, slug),
+				installSnippet: snippet,
+			};
+		},
+	};
+
+	return adapter;
+}
+
+function pluginMatches(plugin: MarketplacePluginEntry, q: string): boolean {
+	if (plugin.name.toLowerCase().includes(q)) return true;
+	if (plugin.description?.toLowerCase().includes(q)) return true;
+	if (plugin.category?.toLowerCase().includes(q)) return true;
+	if (plugin.author?.name?.toLowerCase().includes(q)) return true;
+	return false;
+}

--- a/src/shared/registries/claude-marketplace/fetch.ts
+++ b/src/shared/registries/claude-marketplace/fetch.ts
@@ -1,0 +1,331 @@
+import { existsSync, readFileSync } from "fs";
+import { join } from "path";
+import type { AuthenticatedFetch } from "../../authenticated-fetch";
+import { type CachePlatform, getOrCreateSnapshot } from "../../cache";
+import { getGitProvider } from "../../git-providers/registry";
+import { marketplaceNameToSlug, parseMarketplaceJson } from "./parse";
+import { parseGithubOrGitlabUrl } from "./sources";
+import type {
+	MarketplaceHost,
+	MarketplaceMetaFile,
+	MarketplaceOrigin,
+	ParsedMarketplace,
+} from "./types";
+
+const MARKETPLACE_REL_PATH = ".claude-plugin/marketplace.json";
+
+export interface ParsedMarketplaceSource {
+	kind: "git" | "json-url";
+	origin: MarketplaceOrigin;
+	/** For git: owner/repo. For json-url: the HTTPS URL. */
+	locator: string;
+	ref?: string;
+}
+
+/**
+ * Parse a user-supplied Claude marketplace source string.
+ *
+ * Accepted forms:
+ *   - `owner/repo` or `owner/repo@ref` (GitHub)
+ *   - `https://github.com/owner/repo[.git]` (optional `@ref` via path/tree not used; use owner/repo@ref)
+ *   - `https://gitlab.com/group/project`
+ *   - Direct HTTPS URL to a `marketplace.json` file
+ */
+export function parseClaudeMarketplaceSource(
+	source: string,
+): ParsedMarketplaceSource {
+	const trimmed = source.trim();
+	if (!trimmed) {
+		throw new Error("Marketplace source cannot be empty");
+	}
+
+	if (/^https?:\/\//i.test(trimmed)) {
+		let u: URL;
+		try {
+			u = new URL(trimmed);
+		} catch {
+			throw new Error(`Invalid marketplace URL "${trimmed}"`);
+		}
+		const isLocalhost =
+			u.hostname === "localhost" || u.hostname === "127.0.0.1";
+		if (u.protocol !== "https:" && !isLocalhost) {
+			throw new Error(
+				`Marketplace URL must use HTTPS (got ${u.protocol}//${u.hostname})`,
+			);
+		}
+
+		const path = u.pathname;
+		if (/marketplace\.json$/i.test(path)) {
+			// Prefer extracting GitHub/GitLab coords from known raw-content hosts so
+			// relative plugin sources remain installable and icons can use avatars.
+			if (u.hostname === "raw.githubusercontent.com") {
+				const m = path.match(/^\/([^/]+)\/([^/]+)\//);
+				if (m) {
+					return {
+						kind: "json-url",
+						locator: trimmed,
+						origin: {
+							source: trimmed,
+							host: "github",
+							ownerRepo: `${m[1]}/${m[2]}`,
+							baseUrl: "https://github.com",
+						},
+					};
+				}
+			}
+			const gitlabRaw = path.match(/^\/(.+)\/-\/raw\//);
+			if (
+				(u.hostname === "gitlab.com" || u.hostname.endsWith(".gitlab.com")) &&
+				gitlabRaw
+			) {
+				return {
+					kind: "json-url",
+					locator: trimmed,
+					origin: {
+						source: trimmed,
+						host: "gitlab",
+						ownerRepo: gitlabRaw[1],
+						baseUrl: u.origin,
+					},
+				};
+			}
+			return {
+				kind: "json-url",
+				locator: trimmed,
+				origin: {
+					source: trimmed,
+					host: "other",
+					ownerRepo: null,
+					baseUrl: u.origin,
+				},
+			};
+		}
+
+		const parsed = parseGithubOrGitlabUrl(trimmed);
+		if (!parsed) {
+			throw new Error(
+				`Unrecognized marketplace URL "${trimmed}". Expected a GitHub/GitLab repo URL ` +
+					`or a direct HTTPS link to marketplace.json.`,
+			);
+		}
+		return {
+			kind: "git",
+			locator: parsed.ownerRepo,
+			origin: {
+				source: trimmed,
+				host: parsed.host,
+				ownerRepo: parsed.ownerRepo,
+				baseUrl:
+					parsed.host === "gitlab" ? "https://gitlab.com" : "https://github.com",
+			},
+		};
+	}
+
+	// Bare owner/repo[@ref]
+	const atIdx = trimmed.lastIndexOf("@");
+	let ownerRepo = trimmed;
+	let ref: string | undefined;
+	if (atIdx > 0) {
+		ownerRepo = trimmed.slice(0, atIdx);
+		ref = trimmed.slice(atIdx + 1);
+		if (!ref) {
+			throw new Error(
+				`Invalid marketplace source "${trimmed}". Empty ref after "@".`,
+			);
+		}
+		if (ref.includes("/")) {
+			throw new Error(
+				`Invalid marketplace source "${trimmed}". Ref after "@" must be a branch or tag (no slashes).`,
+			);
+		}
+	}
+
+	if (!/^[^/\s]+\/[^/\s]+$/.test(ownerRepo)) {
+		throw new Error(
+			`Invalid marketplace source "${trimmed}". Expected "owner/repo" or "owner/repo@ref".`,
+		);
+	}
+
+	return {
+		kind: "git",
+		locator: ownerRepo,
+		ref,
+		origin: {
+			source: trimmed,
+			host: "github",
+			ownerRepo,
+			ref,
+			baseUrl: "https://github.com",
+		},
+	};
+}
+
+export interface FetchMarketplaceResult {
+	catalog: ParsedMarketplace;
+	origin: MarketplaceOrigin;
+	resolvedRef: string | null;
+	/** Preferred registry slug from marketplace name. */
+	preferredSlug: string;
+	meta: MarketplaceMetaFile;
+}
+
+export async function fetchClaudeMarketplace(
+	source: string,
+	authFetch: AuthenticatedFetch,
+	opts: { noCache?: boolean } = {},
+): Promise<FetchMarketplaceResult> {
+	const parsed = parseClaudeMarketplaceSource(source);
+
+	if (parsed.kind === "json-url") {
+		const catalog = await fetchJsonUrl(parsed.locator, authFetch);
+		const preferredSlug = marketplaceNameToSlug(catalog.name) || "marketplace";
+		const meta: MarketplaceMetaFile = {
+			source,
+			host: parsed.origin.host,
+			ownerRepo: parsed.origin.ownerRepo,
+			baseUrl: parsed.origin.baseUrl ?? null,
+			marketplaceName: catalog.name,
+			pluginCount: catalog.plugins.length,
+			fetchedAt: Date.now(),
+		};
+		return {
+			catalog,
+			origin: parsed.origin,
+			resolvedRef: null,
+			preferredSlug,
+			meta,
+		};
+	}
+
+	const host = parsed.origin.host;
+	if (host !== "github" && host !== "gitlab") {
+		throw new Error(
+			`Cannot clone marketplace from host type "${host}". Use a GitHub/GitLab repo or a direct marketplace.json URL.`,
+		);
+	}
+	const snapshot = await snapshotMarketplaceRepo(
+		host,
+		parsed.locator,
+		authFetch,
+		{ version: parsed.ref, noCache: opts.noCache },
+	);
+
+	const filePath = join(snapshot.snapshotDir, MARKETPLACE_REL_PATH);
+	if (!existsSync(filePath)) {
+		throw new Error(
+			`No ${MARKETPLACE_REL_PATH} found in ${parsed.locator} at ` +
+				`${snapshot.resolvedSha.slice(0, 7)}. Is this a Claude marketplace repo?`,
+		);
+	}
+
+	let data: unknown;
+	try {
+		data = JSON.parse(readFileSync(filePath, "utf-8"));
+	} catch (err: any) {
+		throw new Error(
+			`Failed to parse ${MARKETPLACE_REL_PATH} from ${parsed.locator}: ${err?.message ?? err}`,
+		);
+	}
+
+	const catalog = parseMarketplaceJson(data);
+	const preferredSlug = marketplaceNameToSlug(catalog.name) || "marketplace";
+	const origin: MarketplaceOrigin = {
+		...parsed.origin,
+		ref: parsed.ref,
+	};
+	const meta: MarketplaceMetaFile = {
+		source,
+		host,
+		ownerRepo: parsed.locator,
+		ref: parsed.ref,
+		baseUrl: origin.baseUrl ?? null,
+		marketplaceName: catalog.name,
+		pluginCount: catalog.plugins.length,
+		fetchedAt: Date.now(),
+	};
+
+	return {
+		catalog,
+		origin,
+		resolvedRef: snapshot.resolvedSha,
+		preferredSlug,
+		meta,
+	};
+}
+
+async function fetchJsonUrl(
+	url: string,
+	authFetch: AuthenticatedFetch,
+): Promise<ParsedMarketplace> {
+	let response: Response;
+	try {
+		response = await authFetch.fetch(url);
+	} catch (err: any) {
+		throw new Error(`Failed to fetch ${url}: ${err?.message ?? err}`);
+	}
+	if (!response.ok) {
+		throw new Error(
+			`Failed to fetch ${url}: ${response.status} ${response.statusText}`,
+		);
+	}
+	let data: unknown;
+	try {
+		data = await response.json();
+	} catch {
+		throw new Error(`Response from ${url} is not valid JSON`);
+	}
+	return parseMarketplaceJson(data);
+}
+
+async function snapshotMarketplaceRepo(
+	platform: "github" | "gitlab",
+	repoPath: string,
+	authFetch: AuthenticatedFetch,
+	opts: { version?: string; noCache?: boolean },
+): Promise<{ snapshotDir: string; resolvedSha: string }> {
+	const hasAuth = authFetch.hasAuth(`https://${platform}.com/${repoPath}`);
+	const platformName = getGitProvider(platform as CachePlatform)?.displayName ?? platform;
+	try {
+		return await getOrCreateSnapshot({
+			platform: platform as CachePlatform,
+			repoPath,
+			authFetch,
+			version: opts.version,
+			noCache: opts.noCache,
+		});
+	} catch (err: any) {
+		const message: string = err?.stderr || err?.message || "";
+		if (
+			message.includes("Authentication failed") ||
+			message.includes("could not read Username")
+		) {
+			throw new Error(
+				`${platformName} authentication failed for ${repoPath} — token may be expired; ` +
+					`run \`capa auth ${platform}.com\` to reconnect.`,
+			);
+		}
+		if (
+			message.includes("could not be found") ||
+			message.includes("not found") ||
+			message.includes("don't have permission")
+		) {
+			const hint = hasAuth
+				? `Check the path, or ensure your ${platformName} token has access.`
+				: `Check the path, or connect ${platformName} via \`capa auth ${platform}.com\` if the repo is private.`;
+			throw new Error(
+				`${platformName} repository not accessible: ${repoPath} — ${hint}`,
+			);
+		}
+		if (
+			message.includes("unable to access") ||
+			message.includes("Could not resolve host")
+		) {
+			throw new Error(
+				`Network error: cannot reach ${platform}.com — check your internet connection.`,
+			);
+		}
+		throw new Error(
+			`Failed to fetch ${repoPath} from ${platformName}: ${message || "Unknown error"}`,
+		);
+	}
+}

--- a/src/shared/registries/claude-marketplace/fetch.ts
+++ b/src/shared/registries/claude-marketplace/fetch.ts
@@ -133,11 +133,6 @@ export function parseClaudeMarketplaceSource(
 				`Invalid marketplace source "${trimmed}". Empty ref after "@".`,
 			);
 		}
-		if (ref.includes("/")) {
-			throw new Error(
-				`Invalid marketplace source "${trimmed}". Ref after "@" must be a branch or tag (no slashes).`,
-			);
-		}
 	}
 
 	if (!/^[^/\s]+\/[^/\s]+$/.test(ownerRepo)) {

--- a/src/shared/registries/claude-marketplace/index.ts
+++ b/src/shared/registries/claude-marketplace/index.ts
@@ -1,0 +1,35 @@
+export { createClaudeMarketplaceAdapter, marketplaceIcon, siteFavicon } from "./adapter";
+export {
+	fetchClaudeMarketplace,
+	parseClaudeMarketplaceSource,
+	type FetchMarketplaceResult,
+} from "./fetch";
+export {
+	classifyMarketplaceSource,
+	marketplaceNameToSlug,
+	parseMarketplaceJson,
+} from "./parse";
+export {
+	getInstalledMarketplaceMetaPath,
+	getInstalledMarketplacePath,
+	getMarketplaceManagedDir,
+	loadClaudeMarketplaceAdapter,
+	MARKETPLACE_JSON_FILENAME,
+	MARKETPLACE_META_FILENAME,
+} from "./paths";
+export {
+	buildPluginInstallSnippet,
+	buildRepoString,
+	parseGithubOrGitlabUrl,
+	sourceToInstallCoords,
+	unsupportedSourceReason,
+} from "./sources";
+export type {
+	InstallCoords,
+	MarketplaceHost,
+	MarketplaceMetaFile,
+	MarketplaceOrigin,
+	MarketplacePluginEntry,
+	MarketplaceSource,
+	ParsedMarketplace,
+} from "./types";

--- a/src/shared/registries/claude-marketplace/parse.ts
+++ b/src/shared/registries/claude-marketplace/parse.ts
@@ -1,0 +1,146 @@
+import type {
+	MarketplaceOwner,
+	MarketplacePluginEntry,
+	MarketplaceSource,
+	ParsedMarketplace,
+} from "./types";
+
+function asOwner(raw: unknown): MarketplaceOwner | undefined {
+	if (!raw || typeof raw !== "object") return undefined;
+	const o = raw as Record<string, unknown>;
+	const name = typeof o.name === "string" ? o.name : undefined;
+	const email = typeof o.email === "string" ? o.email : undefined;
+	const url = typeof o.url === "string" ? o.url : undefined;
+	if (!name && !email && !url) return undefined;
+	return { name, email, url };
+}
+
+/**
+ * Classify a marketplace.json plugin `source` field into a tagged union.
+ */
+export function classifyMarketplaceSource(raw: unknown): MarketplaceSource {
+	if (typeof raw === "string") {
+		return { kind: "monorepo-local", path: raw.replace(/^\.\/?/, "") };
+	}
+	if (raw && typeof raw === "object") {
+		const o = raw as Record<string, unknown>;
+		const sourceTag = typeof o.source === "string" ? o.source : undefined;
+		const url = typeof o.url === "string" ? o.url : undefined;
+		const path = typeof o.path === "string" ? o.path : undefined;
+		const ref = typeof o.ref === "string" ? o.ref : undefined;
+		const sha = typeof o.sha === "string" ? o.sha : undefined;
+		const repo = typeof o.repo === "string" ? o.repo : undefined;
+		const commit = typeof o.commit === "string" ? o.commit : undefined;
+		const pkg = typeof o.package === "string" ? o.package : undefined;
+		const version = typeof o.version === "string" ? o.version : undefined;
+
+		if (sourceTag === "npm" && pkg) {
+			return { kind: "npm", package: pkg, version };
+		}
+		if (sourceTag === "pip" && pkg) {
+			return { kind: "pip", package: pkg, version };
+		}
+		if (sourceTag === "git-subdir" && url && path) {
+			return { kind: "git-subdir", url, path, ref, sha };
+		}
+		if (sourceTag === "github" && repo) {
+			return { kind: "repo", repo, ref, sha, commit };
+		}
+		if (sourceTag === "url" && url && path) {
+			return { kind: "url-with-path", url, path, ref, sha };
+		}
+		if (sourceTag === "url" && url) {
+			return { kind: "url", url, ref, sha };
+		}
+		// Untagged shapes seen in the wild.
+		if (url && path) {
+			return { kind: "url-with-path", url, path, ref, sha };
+		}
+		if (url) {
+			return { kind: "url", url, ref, sha };
+		}
+		if (repo) {
+			return { kind: "repo", repo, ref, sha, commit };
+		}
+	}
+	return { kind: "unknown", raw };
+}
+
+/**
+ * Parse and validate a Claude marketplace.json document.
+ * @throws if required fields are missing or malformed.
+ */
+export function parseMarketplaceJson(data: unknown): ParsedMarketplace {
+	if (!data || typeof data !== "object") {
+		throw new Error("marketplace.json must be a JSON object");
+	}
+	const root = data as Record<string, unknown>;
+	const name = typeof root.name === "string" ? root.name.trim() : "";
+	if (!name) {
+		throw new Error('marketplace.json is missing required field "name"');
+	}
+
+	const pluginsRaw = root.plugins;
+	if (!Array.isArray(pluginsRaw)) {
+		throw new Error('marketplace.json is missing required field "plugins" (array)');
+	}
+
+	const metadata =
+		root.metadata && typeof root.metadata === "object"
+			? (root.metadata as Record<string, unknown>)
+			: undefined;
+	const pluginRootRaw =
+		typeof metadata?.pluginRoot === "string" ? metadata.pluginRoot : undefined;
+	const pluginRoot = pluginRootRaw
+		? pluginRootRaw.replace(/^\.\/?/, "").replace(/\/+$/, "")
+		: undefined;
+
+	const plugins: MarketplacePluginEntry[] = [];
+	for (const p of pluginsRaw) {
+		if (!p || typeof p !== "object") continue;
+		const entry = p as Record<string, unknown>;
+		const pluginName =
+			typeof entry.name === "string" ? entry.name.trim() : "";
+		if (!pluginName) continue;
+		if (entry.source === undefined || entry.source === null) {
+			throw new Error(
+				`marketplace.json plugin "${pluginName}" is missing required field "source"`,
+			);
+		}
+		plugins.push({
+			name: pluginName,
+			description:
+				typeof entry.description === "string" ? entry.description : undefined,
+			version: typeof entry.version === "string" ? entry.version : undefined,
+			author: asOwner(entry.author),
+			category: typeof entry.category === "string" ? entry.category : undefined,
+			homepage: typeof entry.homepage === "string" ? entry.homepage : undefined,
+			source: classifyMarketplaceSource(entry.source),
+			raw: entry,
+		});
+	}
+
+	if (plugins.length === 0) {
+		throw new Error("marketplace.json has no valid plugins");
+	}
+
+	return {
+		name,
+		description:
+			typeof root.description === "string" ? root.description : undefined,
+		version: typeof root.version === "string" ? root.version : undefined,
+		owner: asOwner(root.owner),
+		pluginRoot,
+		plugins,
+		raw: root,
+	};
+}
+
+/** Sanitize a marketplace `name` into a capa registry slug candidate. */
+export function marketplaceNameToSlug(name: string): string {
+	return name
+		.trim()
+		.toLowerCase()
+		.replace(/[^a-z0-9]+/g, "-")
+		.replace(/^-+|-+$/g, "");
+}

--- a/src/shared/registries/claude-marketplace/paths.ts
+++ b/src/shared/registries/claude-marketplace/paths.ts
@@ -1,0 +1,82 @@
+import { existsSync, readFileSync } from "fs";
+import { join } from "path";
+import { getManagedRegistriesDir } from "../../config";
+import { createClaudeMarketplaceAdapter } from "./adapter";
+import { parseMarketplaceJson } from "./parse";
+import type { MarketplaceMetaFile, MarketplaceOrigin } from "./types";
+import type { RegistryAdapter } from "../../../types/registry";
+
+export const MARKETPLACE_JSON_FILENAME = "marketplace.json";
+export const MARKETPLACE_META_FILENAME = "marketplace.meta.json";
+
+export function getMarketplaceManagedDir(slug: string): string {
+	return join(getManagedRegistriesDir(), slug);
+}
+
+export function getInstalledMarketplacePath(slug: string): string | null {
+	const candidate = join(
+		getMarketplaceManagedDir(slug),
+		MARKETPLACE_JSON_FILENAME,
+	);
+	return existsSync(candidate) ? candidate : null;
+}
+
+export function getInstalledMarketplaceMetaPath(slug: string): string | null {
+	const candidate = join(
+		getMarketplaceManagedDir(slug),
+		MARKETPLACE_META_FILENAME,
+	);
+	return existsSync(candidate) ? candidate : null;
+}
+
+/**
+ * Load a previously materialized Claude marketplace into a RegistryAdapter.
+ */
+export function loadClaudeMarketplaceAdapter(slug: string): RegistryAdapter {
+	const jsonPath = getInstalledMarketplacePath(slug);
+	if (!jsonPath) {
+		throw new Error(
+			`No materialized marketplace.json for slug "${slug}"; run \`capa registry refresh ${slug}\`.`,
+		);
+	}
+	const metaPath = getInstalledMarketplaceMetaPath(slug);
+	if (!metaPath) {
+		throw new Error(
+			`No marketplace.meta.json for slug "${slug}"; run \`capa registry refresh ${slug}\`.`,
+		);
+	}
+
+	let catalogRaw: unknown;
+	let meta: MarketplaceMetaFile;
+	try {
+		catalogRaw = JSON.parse(readFileSync(jsonPath, "utf-8"));
+	} catch (err: any) {
+		throw new Error(
+			`Failed to read marketplace.json for "${slug}": ${err?.message ?? err}`,
+		);
+	}
+	try {
+		meta = JSON.parse(readFileSync(metaPath, "utf-8")) as MarketplaceMetaFile;
+	} catch (err: any) {
+		throw new Error(
+			`Failed to read marketplace.meta.json for "${slug}": ${err?.message ?? err}`,
+		);
+	}
+
+	const catalog = parseMarketplaceJson(catalogRaw);
+	const origin: MarketplaceOrigin = {
+		source: meta.source,
+		host: meta.host,
+		ownerRepo: meta.ownerRepo,
+		ref: meta.ref,
+		baseUrl:
+			meta.baseUrl ??
+			(meta.host === "gitlab"
+				? "https://gitlab.com"
+				: meta.host === "github"
+					? "https://github.com"
+					: null),
+	};
+
+	return createClaudeMarketplaceAdapter({ slug, catalog, origin });
+}

--- a/src/shared/registries/claude-marketplace/sources.ts
+++ b/src/shared/registries/claude-marketplace/sources.ts
@@ -1,0 +1,175 @@
+import type { Plugin } from "../../../types/plugin";
+import type {
+	InstallCoords,
+	MarketplaceHost,
+	MarketplaceOrigin,
+	MarketplacePluginEntry,
+	MarketplaceSource,
+	ParsedMarketplace,
+} from "./types";
+
+export function parseGithubOrGitlabUrl(
+	url: string,
+): { host: MarketplaceHost; ownerRepo: string } | null {
+	const trimmed = url.trim().replace(/\.git$/, "");
+
+	const ghHttps = trimmed.match(
+		/^https?:\/\/github\.com\/([^/\s]+\/[^/\s]+?)(?:\/.*)?$/,
+	);
+	if (ghHttps) return { host: "github", ownerRepo: ghHttps[1] };
+
+	const ghSsh = trimmed.match(/^git@github\.com:([^/\s]+\/[^/\s]+?)$/);
+	if (ghSsh) return { host: "github", ownerRepo: ghSsh[1] };
+
+	const glHttps = trimmed.match(
+		/^https?:\/\/gitlab\.com\/(.+?)(?:\/-\/.*)?$/,
+	);
+	if (glHttps) {
+		const path = glHttps[1].replace(/\.git$/, "").replace(/\/$/, "");
+		if (path.includes("/")) return { host: "gitlab", ownerRepo: path };
+	}
+
+	const glSsh = trimmed.match(/^git@gitlab\.com:(.+?)$/);
+	if (glSsh) {
+		const path = glSsh[1].replace(/\.git$/, "");
+		if (path.includes("/")) return { host: "gitlab", ownerRepo: path };
+	}
+
+	if (/^[^/\s]+\/[^/\s]+$/.test(trimmed)) {
+		return { host: "github", ownerRepo: trimmed };
+	}
+
+	return null;
+}
+
+function joinPluginRoot(
+	pluginRoot: string | undefined,
+	relPath: string,
+): string {
+	const cleaned = relPath.replace(/^\.\/?/, "").replace(/^\/+/, "");
+	if (!pluginRoot) return cleaned;
+	return `${pluginRoot.replace(/\/+$/, "")}/${cleaned}`;
+}
+
+/**
+ * Translate a marketplace plugin source into git install coordinates.
+ * Returns null for npm/pip/unknown/non-git sources, or when a monorepo-local
+ * path has no marketplace origin repo (JSON-URL-only marketplaces).
+ */
+export function sourceToInstallCoords(
+	src: MarketplaceSource,
+	origin: MarketplaceOrigin,
+	pluginRoot?: string,
+): InstallCoords | null {
+	switch (src.kind) {
+		case "monorepo-local": {
+			if (!origin.ownerRepo) return null;
+			return {
+				host: origin.host,
+				ownerRepo: origin.ownerRepo,
+				subpath: joinPluginRoot(pluginRoot, src.path),
+				ref: origin.ref,
+			};
+		}
+		case "git-subdir":
+		case "url-with-path": {
+			const parsed = parseGithubOrGitlabUrl(src.url);
+			if (!parsed) return null;
+			return {
+				host: parsed.host,
+				ownerRepo: parsed.ownerRepo,
+				subpath: src.path.replace(/^\/+/, ""),
+				sha: src.sha,
+				ref: src.ref,
+			};
+		}
+		case "url": {
+			const parsed = parseGithubOrGitlabUrl(src.url);
+			if (!parsed) return null;
+			return {
+				host: parsed.host,
+				ownerRepo: parsed.ownerRepo,
+				sha: src.sha,
+				ref: src.ref,
+			};
+		}
+		case "repo": {
+			const parsed = parseGithubOrGitlabUrl(src.repo);
+			if (!parsed) return null;
+			return {
+				host: parsed.host,
+				ownerRepo: parsed.ownerRepo,
+				sha: src.sha ?? src.commit,
+				ref: src.ref,
+			};
+		}
+		case "npm":
+		case "pip":
+		case "unknown":
+			return null;
+	}
+}
+
+export function buildRepoString(
+	coords: InstallCoords,
+	pluginName: string,
+): string {
+	const { ownerRepo, subpath } = coords;
+	if (!subpath) return ownerRepo;
+	const leaf = subpath.replace(/\/+$/, "").split("/").pop() ?? subpath;
+	if (leaf === pluginName) {
+		return `${ownerRepo}@${pluginName}`;
+	}
+	return `${ownerRepo}::${subpath}`;
+}
+
+/**
+ * Build a capa `plugins:` install snippet, or null when the source cannot
+ * be installed via capa (npm/pip/non-git/JSON-only marketplace).
+ */
+export function buildPluginInstallSnippet(
+	plugin: MarketplacePluginEntry,
+	catalog: ParsedMarketplace,
+	origin: MarketplaceOrigin,
+): Plugin | null {
+	const coords = sourceToInstallCoords(
+		plugin.source,
+		origin,
+		catalog.pluginRoot,
+	);
+	if (!coords) return null;
+
+	const def: Plugin["def"] = {
+		repo: buildRepoString(coords, plugin.name),
+	};
+	if (coords.sha) def.ref = coords.sha;
+	else if (coords.ref) def.version = coords.ref;
+	if (plugin.description) def.description = plugin.description;
+
+	return {
+		id: plugin.name,
+		type: coords.host,
+		def,
+	};
+}
+
+export function unsupportedSourceReason(
+	src: MarketplaceSource,
+	origin: MarketplaceOrigin,
+): string {
+	switch (src.kind) {
+		case "npm":
+			return `npm package "${src.package}" (capa only installs git-based marketplace plugins)`;
+		case "pip":
+			return `pip package "${src.package}" (capa only installs git-based marketplace plugins)`;
+		case "monorepo-local":
+			if (!origin.ownerRepo) {
+				return "relative plugin path requires a git-backed marketplace (not a bare marketplace.json URL)";
+			}
+			return "unresolved monorepo-local source";
+		case "unknown":
+			return "unrecognized marketplace source shape";
+		default:
+			return "source does not resolve to a GitHub/GitLab repository";
+	}
+}

--- a/src/shared/registries/claude-marketplace/sources.ts
+++ b/src/shared/registries/claude-marketplace/sources.ts
@@ -110,16 +110,13 @@ export function sourceToInstallCoords(
 	}
 }
 
-export function buildRepoString(
-	coords: InstallCoords,
-	pluginName: string,
-): string {
+/**
+ * Prefer exact `owner/repo::subpath` over `owner/repo@name` so install
+ * resolution never depends on first-match basename/manifest search.
+ */
+export function buildRepoString(coords: InstallCoords): string {
 	const { ownerRepo, subpath } = coords;
 	if (!subpath) return ownerRepo;
-	const leaf = subpath.replace(/\/+$/, "").split("/").pop() ?? subpath;
-	if (leaf === pluginName) {
-		return `${ownerRepo}@${pluginName}`;
-	}
 	return `${ownerRepo}::${subpath}`;
 }
 
@@ -140,7 +137,7 @@ export function buildPluginInstallSnippet(
 	if (!coords) return null;
 
 	const def: Plugin["def"] = {
-		repo: buildRepoString(coords, plugin.name),
+		repo: buildRepoString(coords),
 	};
 	if (coords.sha) def.ref = coords.sha;
 	else if (coords.ref) def.version = coords.ref;

--- a/src/shared/registries/claude-marketplace/types.ts
+++ b/src/shared/registries/claude-marketplace/types.ts
@@ -1,0 +1,100 @@
+/**
+ * Parsed Claude Code marketplace catalog (`.claude-plugin/marketplace.json`).
+ */
+
+export type MarketplaceHost = "github" | "gitlab" | "other";
+
+/** Normalized plugin `source` field from marketplace.json. */
+export type MarketplaceSource =
+	| { kind: "monorepo-local"; path: string }
+	| {
+			kind: "git-subdir";
+			url: string;
+			path: string;
+			ref?: string;
+			sha?: string;
+	  }
+	| { kind: "url"; url: string; ref?: string; sha?: string }
+	| {
+			kind: "url-with-path";
+			url: string;
+			path: string;
+			ref?: string;
+			sha?: string;
+	  }
+	| { kind: "repo"; repo: string; ref?: string; sha?: string; commit?: string }
+	| { kind: "npm"; package: string; version?: string }
+	| { kind: "pip"; package: string; version?: string }
+	| { kind: "unknown"; raw: unknown };
+
+export interface MarketplaceOwner {
+	name?: string;
+	email?: string;
+	url?: string;
+}
+
+export interface MarketplacePluginEntry {
+	name: string;
+	description?: string;
+	version?: string;
+	author?: MarketplaceOwner;
+	category?: string;
+	homepage?: string;
+	source: MarketplaceSource;
+	raw: Record<string, unknown>;
+}
+
+export interface ParsedMarketplace {
+	name: string;
+	description?: string;
+	version?: string;
+	owner?: MarketplaceOwner;
+	/** Base directory prepended to relative plugin sources. */
+	pluginRoot?: string;
+	plugins: MarketplacePluginEntry[];
+	raw: Record<string, unknown>;
+}
+
+/**
+ * Where the marketplace catalog was fetched from — needed so monorepo-local
+ * plugin sources can be turned into capa `def.repo` strings.
+ */
+export interface MarketplaceOrigin {
+	/** Original user-supplied source string. */
+	source: string;
+	host: MarketplaceHost;
+	/**
+	 * `owner/repo` for git-backed marketplaces. Null when the catalog was
+	 * fetched from a bare JSON URL (relative plugin sources cannot install).
+	 */
+	ownerRepo: string | null;
+	/** Optional branch/tag from `owner/repo@ref`. */
+	ref?: string;
+	/**
+	 * Browseable site origin used for favicon fallback
+	 * (e.g. `https://github.com`, `https://gitlab.com`, `https://git.example.com`).
+	 */
+	baseUrl?: string | null;
+}
+
+/** Persisted next to marketplace.json under the managed registries dir. */
+export interface MarketplaceMetaFile {
+	source: string;
+	host: MarketplaceHost;
+	ownerRepo: string | null;
+	ref?: string;
+	/** Site origin for favicon fallback; may be absent on older meta files. */
+	baseUrl?: string | null;
+	marketplaceName: string;
+	pluginCount: number;
+	fetchedAt: number;
+}
+
+/** Git coordinates capa can install from. */
+export interface InstallCoords {
+	host: "github" | "gitlab";
+	ownerRepo: string;
+	subpath?: string;
+	sha?: string;
+	ref?: string;
+}

--- a/src/shared/registries/installer.ts
+++ b/src/shared/registries/installer.ts
@@ -17,6 +17,14 @@ import { getManagedRegistriesDir } from "../config";
 import { getGitProvider } from "../git-providers/registry";
 import { assertSafeRepoPath } from "../repo-file";
 import { parseRepoString } from "../repo-string";
+import {
+	createClaudeMarketplaceAdapter,
+	fetchClaudeMarketplace,
+	MARKETPLACE_JSON_FILENAME,
+	MARKETPLACE_META_FILENAME,
+	parseClaudeMarketplaceSource,
+	marketplaceNameToSlug,
+} from "./claude-marketplace";
 
 const ADAPTER_EXTENSIONS = [".ts", ".js", ".mjs"] as const;
 const ADAPTER_BASENAMES = ADAPTER_EXTENSIONS.map((ext) => `adapter${ext}`);
@@ -28,6 +36,19 @@ export function isValidSlug(slug: string): boolean {
 }
 
 export function deriveSlug(source: string, type: RegistrySourceType): string {
+	if (type === "claude-marketplace") {
+		try {
+			const parsed = parseClaudeMarketplaceSource(source);
+			if (parsed.kind === "json-url") {
+				const base = basename(new URL(parsed.locator).pathname);
+				const name = base.replace(/\.json$/i, "") || "marketplace";
+				return name === "marketplace" ? "marketplace" : name;
+			}
+			return basename(parsed.locator);
+		} catch {
+			return "marketplace";
+		}
+	}
 	if (type === "url") {
 		let u: URL;
 		try {
@@ -55,13 +76,15 @@ export interface RegistryInstallResult {
 	resolvedRef: string | null;
 	adapterPath: string;
 	manifest: RegistryManifest;
+	/** Preferred slug from marketplace.json `name` (claude-marketplace only). */
+	preferredSlug?: string;
 }
 
 /**
- * Fetches the adapter from the configured source, materializes it under
- * `<managed dir>/<slug>/adapter.{ts,js,mjs}`, and validates the file is a
- * well-formed RegistryAdapter by dynamic-importing it. Throws with a short,
- * actionable message on any failure and cleans up the partial managed dir.
+ * Fetches the adapter (or Claude marketplace catalog) from the configured
+ * source, materializes it under `<managed dir>/<slug>/`, and validates it.
+ * Throws with a short, actionable message on any failure and cleans up the
+ * partial managed dir.
  */
 export async function installRegistry(
 	input: RegistryInstallInput,
@@ -82,6 +105,10 @@ export async function installRegistry(
 			rmSync(targetDir, { recursive: true, force: true });
 		}
 		mkdirSync(targetDir, { recursive: true });
+
+		if (input.type === "claude-marketplace") {
+			return await installClaudeMarketplace(input, authFetch, targetDir, opts);
+		}
 
 		let adapterPath: string;
 		let resolvedRef: string | null = null;
@@ -116,16 +143,55 @@ export async function installRegistry(
 	}
 }
 
+async function installClaudeMarketplace(
+	input: RegistryInstallInput,
+	authFetch: AuthenticatedFetch,
+	targetDir: string,
+	opts: { noCache?: boolean },
+): Promise<RegistryInstallResult> {
+	const result = await fetchClaudeMarketplace(input.source, authFetch, opts);
+	const jsonPath = join(targetDir, MARKETPLACE_JSON_FILENAME);
+	const metaPath = join(targetDir, MARKETPLACE_META_FILENAME);
+	writeFileSync(jsonPath, JSON.stringify(result.catalog.raw, null, 2), "utf-8");
+	writeFileSync(metaPath, JSON.stringify(result.meta, null, 2), "utf-8");
+
+	const adapter = createClaudeMarketplaceAdapter({
+		slug: input.slug,
+		catalog: result.catalog,
+		origin: result.origin,
+	});
+
+	return {
+		resolvedRef: result.resolvedRef,
+		adapterPath: jsonPath,
+		manifest: adapter.manifest,
+		preferredSlug: result.preferredSlug,
+	};
+}
+
 /**
- * Returns the raw adapter source for preview purposes without persisting
- * anything to disk. Used by `GET /api/registries/preview` to populate the
- * "I trust this code" confirmation dialog in the UI.
+ * Returns the raw adapter source (or marketplace JSON) for preview purposes
+ * without persisting anything to disk.
  */
 export async function fetchAdapterSource(
 	input: Pick<RegistryInstallInput, "type" | "source">,
 	authFetch: AuthenticatedFetch,
 	opts: { noCache?: boolean } = {},
-): Promise<{ content: string; resolvedRef: string | null }> {
+): Promise<{
+	content: string;
+	resolvedRef: string | null;
+	preferredSlug?: string;
+	pluginCount?: number;
+}> {
+	if (input.type === "claude-marketplace") {
+		const result = await fetchClaudeMarketplace(input.source, authFetch, opts);
+		return {
+			content: JSON.stringify(result.catalog.raw, null, 2),
+			resolvedRef: result.resolvedRef,
+			preferredSlug: result.preferredSlug,
+			pluginCount: result.catalog.plugins.length,
+		};
+	}
 	if (input.type === "github" || input.type === "gitlab") {
 		const { adapterFile, resolvedSha } = await fetchAdapterFromRepo(
 			input.type,
@@ -145,7 +211,8 @@ export async function fetchAdapterSource(
 /**
  * Path of the materialized adapter file for a given slug, or null if no
  * adapter has been written yet. Iterates the known extensions in priority
- * order — first match wins.
+ * order — first match wins. Does not include Claude marketplace catalogs
+ * (see `getInstalledMarketplacePath`).
  */
 export function getInstalledAdapterPath(slug: string): string | null {
 	const dir = join(getManagedRegistriesDir(), slug);
@@ -162,6 +229,11 @@ export function removeInstalledAdapter(slug: string): void {
 		rmSync(dir, { recursive: true, force: true });
 	}
 }
+
+// Re-export for callers that need marketplace name → slug without importing
+// the whole marketplace module.
+export { marketplaceNameToSlug };
+
 
 async function fetchAdapterFromRepo(
 	platform: "github" | "gitlab",

--- a/src/shared/registries/loader.ts
+++ b/src/shared/registries/loader.ts
@@ -2,6 +2,10 @@ import { statSync } from "fs";
 import type { CapaDatabase } from "../../db/database";
 import type { RegistryAdapter } from "../../types/registry";
 import { logger } from "../logger";
+import {
+	getInstalledMarketplacePath,
+	loadClaudeMarketplaceAdapter,
+} from "./claude-marketplace";
 import { getInstalledAdapterPath } from "./installer";
 
 interface LoadedRegistry {
@@ -42,11 +46,9 @@ function isValidAdapter(obj: unknown): obj is RegistryAdapter {
 
 /**
  * Loads registry adapters whose DB row is `enabled = true` and
- * `status = 'installed'`, dynamic-importing each materialized adapter file
- * once and caching by mtime + DB updated_at. NOTE: Node/Bun's ESM loader
- * caches modules by URL, so we add a `?t=<mtime>` cache-buster to pick up
- * file changes; old module instances stay in the loader's internal cache
- * for the lifetime of the process.
+ * `status = 'installed'`. Adapter registries are dynamic-imported from
+ * materialized `adapter.*` files; Claude marketplaces are built in-process
+ * from cached `marketplace.json`.
  */
 export class RegistryLoader {
 	private cache = new Map<string, LoadedRegistry>();
@@ -65,6 +67,17 @@ export class RegistryLoader {
 
 		for (const record of records) {
 			activeSlugs.add(record.slug);
+
+			if (record.type === "claude-marketplace") {
+				await this.loadMarketplaceRecord(
+					record,
+					adapters,
+					failures,
+					seenIds,
+				);
+				continue;
+			}
+
 			const adapterPath = getInstalledAdapterPath(record.slug);
 			if (!adapterPath) {
 				failures.push({
@@ -152,5 +165,89 @@ export class RegistryLoader {
 		}
 
 		return failures.length > 0 ? { adapters, failures } : { adapters };
+	}
+
+	private async loadMarketplaceRecord(
+		record: {
+			slug: string;
+			updatedAt: number;
+		},
+		adapters: Map<string, RegistryAdapter>,
+		failures: RegistryLoadFailure[],
+		seenIds: Set<string>,
+	): Promise<void> {
+		const jsonPath = getInstalledMarketplacePath(record.slug);
+		if (!jsonPath) {
+			failures.push({
+				slug: record.slug,
+				error: `No materialized marketplace.json for slug "${record.slug}"; run \`capa registry refresh ${record.slug}\`.`,
+			});
+			return;
+		}
+
+		let mtime: number;
+		try {
+			mtime = statSync(jsonPath).mtimeMs;
+		} catch (err: any) {
+			failures.push({
+				slug: record.slug,
+				error: `Cannot stat ${jsonPath}: ${err?.message ?? err}`,
+			});
+			return;
+		}
+
+		const cached = this.cache.get(record.slug);
+		if (
+			cached &&
+			cached.mtime === mtime &&
+			cached.updatedAt === record.updatedAt
+		) {
+			const id = cached.adapter.manifest.id;
+			if (seenIds.has(id)) {
+				registryLogger.warn(
+					`Duplicate registry id "${id}" from slug "${record.slug}", skipping`,
+				);
+				return;
+			}
+			seenIds.add(id);
+			adapters.set(id, cached.adapter);
+			return;
+		}
+
+		try {
+			const adapter = loadClaudeMarketplaceAdapter(record.slug);
+			if (!isValidAdapter(adapter)) {
+				const msg = `Claude marketplace for slug "${record.slug}" produced an invalid RegistryAdapter.`;
+				registryLogger.warn(msg);
+				failures.push({ slug: record.slug, error: msg });
+				return;
+			}
+
+			const id = adapter.manifest.id;
+			if (seenIds.has(id)) {
+				const msg = `Duplicate registry id "${id}" from slug "${record.slug}"; skipping.`;
+				registryLogger.warn(msg);
+				failures.push({ slug: record.slug, error: msg });
+				return;
+			}
+
+			seenIds.add(id);
+			this.cache.set(record.slug, {
+				adapter,
+				slug: record.slug,
+				mtime,
+				updatedAt: record.updatedAt,
+			});
+			adapters.set(id, adapter);
+			registryLogger.info(
+				`Loaded Claude marketplace "${id}" from slug "${record.slug}"`,
+			);
+		} catch (err: unknown) {
+			const message = err instanceof Error ? err.message : String(err);
+			registryLogger.warn(
+				`Failed to load Claude marketplace for slug "${record.slug}": ${message}`,
+			);
+			failures.push({ slug: record.slug, error: message });
+		}
 	}
 }

--- a/src/shared/registries/loader.ts
+++ b/src/shared/registries/loader.ts
@@ -3,6 +3,7 @@ import type { CapaDatabase } from "../../db/database";
 import type { RegistryAdapter } from "../../types/registry";
 import { logger } from "../logger";
 import {
+	getInstalledMarketplaceMetaPath,
 	getInstalledMarketplacePath,
 	loadClaudeMarketplaceAdapter,
 } from "./claude-marketplace";
@@ -12,6 +13,8 @@ interface LoadedRegistry {
 	adapter: RegistryAdapter;
 	slug: string;
 	mtime: number;
+	/** marketplace.meta.json mtime; only set for Claude marketplaces. */
+	metaMtime?: number;
 	updatedAt: number;
 }
 
@@ -185,13 +188,24 @@ export class RegistryLoader {
 			return;
 		}
 
+		const metaPath = getInstalledMarketplaceMetaPath(record.slug);
+		if (!metaPath) {
+			failures.push({
+				slug: record.slug,
+				error: `No marketplace.meta.json for slug "${record.slug}"; run \`capa registry refresh ${record.slug}\`.`,
+			});
+			return;
+		}
+
 		let mtime: number;
+		let metaMtime: number;
 		try {
 			mtime = statSync(jsonPath).mtimeMs;
+			metaMtime = statSync(metaPath).mtimeMs;
 		} catch (err: any) {
 			failures.push({
 				slug: record.slug,
-				error: `Cannot stat ${jsonPath}: ${err?.message ?? err}`,
+				error: `Cannot stat marketplace files for "${record.slug}": ${err?.message ?? err}`,
 			});
 			return;
 		}
@@ -200,6 +214,7 @@ export class RegistryLoader {
 		if (
 			cached &&
 			cached.mtime === mtime &&
+			cached.metaMtime === metaMtime &&
 			cached.updatedAt === record.updatedAt
 		) {
 			const id = cached.adapter.manifest.id;
@@ -236,6 +251,7 @@ export class RegistryLoader {
 				adapter,
 				slug: record.slug,
 				mtime,
+				metaMtime,
 				updatedAt: record.updatedAt,
 			});
 			adapters.set(id, adapter);

--- a/src/types/database.ts
+++ b/src/types/database.ts
@@ -126,7 +126,7 @@ export interface OAuthFlowStateRow {
   created_at: number;
 }
 
-export type RegistrySourceType = 'github' | 'gitlab' | 'url';
+export type RegistrySourceType = 'github' | 'gitlab' | 'url' | 'claude-marketplace';
 export type RegistryStatus = 'pending' | 'installed' | 'failed' | 'disabled';
 
 export interface RegistryRow {

--- a/web-ui/src/features/projects/components/OptionsSection.tsx
+++ b/web-ui/src/features/projects/components/OptionsSection.tsx
@@ -1,8 +1,10 @@
 import { useState } from 'react';
+import { useNavigate } from 'react-router-dom';
 import { Settings, Plus, Trash2 } from 'lucide-react';
 import { useTranslation } from 'react-i18next';
 import type { CapabilitiesOptions, RequiredCommand } from '../../../types/api';
-import { usePatchOptions } from '../hooks';
+import { projectDisplayName } from '../../../lib/utils';
+import { useDeleteProject, usePatchOptions, useProject } from '../hooks';
 
 interface OptionsSectionProps {
   projectId: string;
@@ -13,12 +15,23 @@ const EXPOSURE_MODES = ['on-demand', 'expose-all', 'none'] as const;
 
 export function OptionsSection({ projectId, options }: OptionsSectionProps) {
   const { t } = useTranslation('projects');
+  const navigate = useNavigate();
+  const { data: project } = useProject(projectId);
   const patchMutation = usePatchOptions(projectId);
+  const deleteProject = useDeleteProject();
   const [cli, setCli] = useState('');
   const [cliDesc, setCliDesc] = useState('');
 
   const toolExposure = options?.toolExposure || 'on-demand';
   const requiresCommands: RequiredCommand[] = options?.requiresCommands || [];
+  const displayName = projectDisplayName(project?.path, projectId);
+
+  const handleDeleteProject = () => {
+    if (!confirm(t('actions.confirmDeleteProject', { name: displayName }))) return;
+    deleteProject.mutate(projectId, {
+      onSuccess: () => navigate('/'),
+    });
+  };
 
   return (
     <div className="mb-6 rounded-lg border border-border-primary bg-bg-secondary p-6">
@@ -149,6 +162,20 @@ export function OptionsSection({ projectId, options }: OptionsSectionProps) {
             </div>
           </div>
         )}
+
+        <div className="border-t border-border-secondary pt-5">
+          <h3 className="mb-1 text-xs font-medium text-error-text">{t('options.dangerZone')}</h3>
+          <p className="mb-3 text-xs text-text-tertiary">{t('options.dangerZoneDescription')}</p>
+          <button
+            type="button"
+            onClick={handleDeleteProject}
+            disabled={deleteProject.isPending}
+            className="inline-flex items-center gap-1.5 rounded-sm bg-error-btn px-3 py-1.5 text-xs font-medium text-white transition-colors hover:bg-error-btn-hover cursor-pointer disabled:opacity-50"
+          >
+            <Trash2 size={14} />
+            {t('actions.deleteProject')}
+          </button>
+        </div>
       </div>
     </div>
   );

--- a/web-ui/src/features/registries/admin/AddRegistryDialog.tsx
+++ b/web-ui/src/features/registries/admin/AddRegistryDialog.tsx
@@ -13,7 +13,9 @@ interface AddRegistryDialogProps {
   onAdded: (slug: string) => void;
 }
 
-const TYPE_OPTIONS: RegistrySourceType[] = ['github', 'gitlab', 'url'];
+type AddMode = 'adapter' | 'claude-marketplace';
+
+const ADAPTER_TYPE_OPTIONS: RegistrySourceType[] = ['github', 'gitlab', 'url'];
 
 function isErrorWithMessage(err: unknown): err is { message: string } {
   return !!err && typeof (err as any).message === 'string';
@@ -21,21 +23,31 @@ function isErrorWithMessage(err: unknown): err is { message: string } {
 
 export function AddRegistryDialog({ open, onOpenChange, onAdded }: AddRegistryDialogProps) {
   const { t } = useTranslation('registries');
+  const [mode, setMode] = useState<AddMode>('adapter');
   const [type, setType] = useState<RegistrySourceType>('github');
   const [source, setSource] = useState('');
   const [slug, setSlug] = useState('');
   const [trusted, setTrusted] = useState(false);
-  const [preview, setPreview] = useState<{ content: string; ref: string | null } | null>(null);
+  const [preview, setPreview] = useState<{
+    content: string;
+    ref: string | null;
+    pluginCount?: number;
+  } | null>(null);
   const [error, setError] = useState<string | null>(null);
 
   const previewMutation = usePreviewRegistry();
   const addMutation = useAddRegistry();
   const busy = previewMutation.isPending || addMutation.isPending;
 
+  const effectiveType: RegistrySourceType =
+    mode === 'claude-marketplace' ? 'claude-marketplace' : type;
+  const isMarketplace = mode === 'claude-marketplace';
+
   // Reset state whenever the dialog re-opens so a previously-failed attempt
   // doesn't leak into a fresh one.
   useEffect(() => {
     if (open) {
+      setMode('adapter');
       setType('github');
       setSource('');
       setSlug('');
@@ -49,7 +61,16 @@ export function AddRegistryDialog({ open, onOpenChange, onAdded }: AddRegistryDi
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [open]);
 
-  const canAdd = !!preview && trusted && !!source.trim() && !busy;
+  // Clearing preview when the mode/type/source changes avoids installing a
+  // previously-audited payload against a different source.
+  useEffect(() => {
+    setPreview(null);
+    setTrusted(false);
+  }, [mode, type, source]);
+
+  const canAdd = isMarketplace
+    ? !!preview && !!source.trim() && !busy
+    : !!preview && trusted && !!source.trim() && !busy;
 
   async function handlePreview() {
     setError(null);
@@ -59,8 +80,15 @@ export function AddRegistryDialog({ open, onOpenChange, onAdded }: AddRegistryDi
       return;
     }
     try {
-      const res = await previewMutation.mutateAsync({ type, source: source.trim() });
-      setPreview({ content: res.content, ref: res.resolvedRef });
+      const res = await previewMutation.mutateAsync({
+        type: effectiveType,
+        source: source.trim(),
+      });
+      setPreview({
+        content: res.content,
+        ref: res.resolvedRef,
+        pluginCount: res.pluginCount,
+      });
       if (!slug && res.derivedSlug) {
         setSlug(res.derivedSlug);
       }
@@ -78,12 +106,18 @@ export function AddRegistryDialog({ open, onOpenChange, onAdded }: AddRegistryDi
   async function handleAdd() {
     setError(null);
     if (!preview) {
-      setError(t('addDialog.errors.previewBeforeAdd'));
+      setError(
+        t(
+          isMarketplace
+            ? 'addDialog.errors.previewBeforeAddMarketplace'
+            : 'addDialog.errors.previewBeforeAdd',
+        ),
+      );
       return;
     }
     try {
       const res = await addMutation.mutateAsync({
-        type,
+        type: effectiveType,
         source: source.trim(),
         slug: slug.trim() || undefined,
       });
@@ -111,7 +145,7 @@ export function AddRegistryDialog({ open, onOpenChange, onAdded }: AddRegistryDi
                 {t('addDialog.title')}
               </Dialog.Title>
               <Dialog.Description className="mt-1 text-xs text-text-secondary">
-                {t('addDialog.description')}
+                {t(isMarketplace ? 'addDialog.descriptionMarketplace' : 'addDialog.description')}
               </Dialog.Description>
             </div>
             <Dialog.Close
@@ -124,22 +158,46 @@ export function AddRegistryDialog({ open, onOpenChange, onAdded }: AddRegistryDi
 
           <div className="flex-1 overflow-y-auto px-6 py-5">
             <div className="grid gap-4">
-              <label className="block">
-                <span className="mb-1 block text-xs font-medium text-text-secondary">
-                  {t('addDialog.fields.type')}
-                </span>
-                <select
-                  value={type}
-                  onChange={(e) => setType(e.target.value as RegistrySourceType)}
-                  className="w-full rounded-sm border border-border-primary bg-bg-primary px-2 py-2 text-sm text-text-primary"
-                >
-                  {TYPE_OPTIONS.map((opt) => (
-                    <option key={opt} value={opt}>
-                      {t(`addDialog.typeOptions.${opt}`)}
-                    </option>
+              <fieldset>
+                <legend className="mb-2 text-xs font-medium text-text-secondary">
+                  {t('addDialog.fields.mode')}
+                </legend>
+                <div className="flex flex-wrap gap-2">
+                  {(['adapter', 'claude-marketplace'] as const).map((m) => (
+                    <button
+                      key={m}
+                      type="button"
+                      onClick={() => setMode(m)}
+                      className={
+                        mode === m
+                          ? 'rounded-sm border border-accent-primary bg-accent-primary/10 px-3 py-1.5 text-sm text-text-primary'
+                          : 'rounded-sm border border-border-primary bg-bg-tertiary px-3 py-1.5 text-sm text-text-secondary hover:bg-hover-bg'
+                      }
+                    >
+                      {t(`addDialog.modes.${m}`)}
+                    </button>
                   ))}
-                </select>
-              </label>
+                </div>
+              </fieldset>
+
+              {!isMarketplace && (
+                <label className="block">
+                  <span className="mb-1 block text-xs font-medium text-text-secondary">
+                    {t('addDialog.fields.type')}
+                  </span>
+                  <select
+                    value={type}
+                    onChange={(e) => setType(e.target.value as RegistrySourceType)}
+                    className="w-full rounded-sm border border-border-primary bg-bg-primary px-2 py-2 text-sm text-text-primary"
+                  >
+                    {ADAPTER_TYPE_OPTIONS.map((opt) => (
+                      <option key={opt} value={opt}>
+                        {t(`addDialog.typeOptions.${opt}`)}
+                      </option>
+                    ))}
+                  </select>
+                </label>
+              )}
 
               <label className="block">
                 <span className="mb-1 block text-xs font-medium text-text-secondary">
@@ -149,7 +207,11 @@ export function AddRegistryDialog({ open, onOpenChange, onAdded }: AddRegistryDi
                   type="text"
                   value={source}
                   onChange={(e) => setSource(e.target.value)}
-                  placeholder={t(`addDialog.sourcePlaceholders.${type}`)}
+                  placeholder={t(
+                    isMarketplace
+                      ? 'addDialog.sourcePlaceholders.claude-marketplace'
+                      : `addDialog.sourcePlaceholders.${type}`,
+                  )}
                   className="w-full rounded-sm border border-border-primary bg-bg-primary px-2 py-2 font-mono text-sm text-text-primary placeholder:text-text-tertiary"
                 />
               </label>
@@ -186,19 +248,37 @@ export function AddRegistryDialog({ open, onOpenChange, onAdded }: AddRegistryDi
                     {t('addDialog.preview.resolvedRef', { ref: preview.ref.slice(0, 7) })}
                   </span>
                 )}
+                {isMarketplace && preview?.pluginCount != null && (
+                  <span className="text-xs text-text-secondary">
+                    {t('addDialog.preview.pluginCount', { count: preview.pluginCount })}
+                  </span>
+                )}
               </div>
 
               <div className="rounded-sm border border-border-primary bg-bg-primary">
                 <div className="border-b border-border-secondary px-3 py-2 text-xs font-medium text-text-secondary">
-                  {t('addDialog.preview.title')}
+                  {t(
+                    isMarketplace
+                      ? 'addDialog.preview.titleMarketplace'
+                      : 'addDialog.preview.title',
+                  )}
                 </div>
                 <div className="max-h-72 overflow-auto">
                   {preview ? (
-                    <CodeBlock code={preview.content} language="typescript" />
+                    <CodeBlock
+                      code={preview.content}
+                      language={isMarketplace ? 'json' : 'typescript'}
+                    />
                   ) : (
                     <div className="flex items-center gap-2 px-3 py-6 text-xs text-text-tertiary">
                       <AlertTriangle className="h-3.5 w-3.5" />
-                      <span>{t('addDialog.preview.emptyHint')}</span>
+                      <span>
+                        {t(
+                          isMarketplace
+                            ? 'addDialog.preview.emptyHintMarketplace'
+                            : 'addDialog.preview.emptyHint',
+                        )}
+                      </span>
                     </div>
                   )}
                 </div>
@@ -213,22 +293,26 @@ export function AddRegistryDialog({ open, onOpenChange, onAdded }: AddRegistryDi
           </div>
 
           <div className="flex flex-wrap items-center justify-between gap-3 border-t border-border-secondary px-6 py-4">
-            <label
-              className={
-                preview
-                  ? 'flex items-center gap-2 text-sm text-text-primary'
-                  : 'flex items-center gap-2 text-sm text-text-tertiary'
-              }
-              title={preview ? undefined : t('addDialog.errors.previewBeforeAdd')}
-            >
-              <input
-                type="checkbox"
-                checked={trusted}
-                onChange={(e) => setTrusted(e.target.checked)}
-                disabled={!preview}
-              />
-              <span>{t('addDialog.trust')}</span>
-            </label>
+            {isMarketplace ? (
+              <span className="text-xs text-text-secondary">{t('addDialog.marketplaceHint')}</span>
+            ) : (
+              <label
+                className={
+                  preview
+                    ? 'flex items-center gap-2 text-sm text-text-primary'
+                    : 'flex items-center gap-2 text-sm text-text-tertiary'
+                }
+                title={preview ? undefined : t('addDialog.errors.previewBeforeAdd')}
+              >
+                <input
+                  type="checkbox"
+                  checked={trusted}
+                  onChange={(e) => setTrusted(e.target.checked)}
+                  disabled={!preview}
+                />
+                <span>{t('addDialog.trust')}</span>
+              </label>
+            )}
             <div className="flex items-center gap-2">
               <Dialog.Close
                 type="button"

--- a/web-ui/src/features/registries/admin/EditRegistryDialog.tsx
+++ b/web-ui/src/features/registries/admin/EditRegistryDialog.tsx
@@ -14,7 +14,12 @@ interface EditRegistryDialogProps {
   onSaved: (slug: string) => void;
 }
 
-const TYPE_OPTIONS: RegistrySourceType[] = ['github', 'gitlab', 'url'];
+const TYPE_OPTIONS: RegistrySourceType[] = [
+  'github',
+  'gitlab',
+  'url',
+  'claude-marketplace',
+];
 
 function isErrorWithMessage(err: unknown): err is { message: string } {
   return !!err && typeof (err as any).message === 'string';
@@ -37,9 +42,8 @@ export function EditRegistryDialog({
   const editMutation = useEditRegistry();
   const busy = previewMutation.isPending || editMutation.isPending;
 
-  // Re-seed the form whenever a different record is opened or the dialog
-  // toggles open — so a previously-failed attempt doesn't leak into a
-  // fresh edit session.
+  const isMarketplace = type === 'claude-marketplace';
+
   useEffect(() => {
     if (open && record) {
       setType(record.type);
@@ -57,9 +61,10 @@ export function EditRegistryDialog({
 
   const trimmedSource = source.trim();
   const changed = type !== record.type || trimmedSource !== record.source;
-  // Same security gate as the Add dialog: a fresh preview + trust check is
-  // required before persisting *new* code under a known slug.
-  const canSave = !busy && trimmedSource.length > 0 && (!changed || (preview && trusted));
+  const canSave =
+    !busy &&
+    trimmedSource.length > 0 &&
+    (!changed || (preview && (isMarketplace || trusted)));
 
   async function handlePreview() {
     setError(null);
@@ -90,7 +95,13 @@ export function EditRegistryDialog({
       return;
     }
     if (!preview) {
-      setError(t('addDialog.errors.previewBeforeAdd'));
+      setError(
+        t(
+          isMarketplace
+            ? 'addDialog.errors.previewBeforeAddMarketplace'
+            : 'addDialog.errors.previewBeforeAdd',
+        ),
+      );
       return;
     }
     try {
@@ -123,7 +134,11 @@ export function EditRegistryDialog({
                 {t('editDialog.title', { slug: record.slug })}
               </Dialog.Title>
               <Dialog.Description className="mt-1 text-xs text-text-secondary">
-                {t('editDialog.description')}
+                {t(
+                  isMarketplace
+                    ? 'editDialog.descriptionMarketplace'
+                    : 'editDialog.description',
+                )}
               </Dialog.Description>
             </div>
             <Dialog.Close
@@ -157,7 +172,11 @@ export function EditRegistryDialog({
                 </span>
                 <select
                   value={type}
-                  onChange={(e) => setType(e.target.value as RegistrySourceType)}
+                  onChange={(e) => {
+                    setType(e.target.value as RegistrySourceType);
+                    setPreview(null);
+                    setTrusted(false);
+                  }}
                   className="w-full rounded-sm border border-border-primary bg-bg-primary px-2 py-2 text-sm text-text-primary"
                 >
                   {TYPE_OPTIONS.map((opt) => (
@@ -204,15 +223,28 @@ export function EditRegistryDialog({
 
               <div className="rounded-sm border border-border-primary bg-bg-primary">
                 <div className="border-b border-border-secondary px-3 py-2 text-xs font-medium text-text-secondary">
-                  {t('addDialog.preview.title')}
+                  {t(
+                    isMarketplace
+                      ? 'addDialog.preview.titleMarketplace'
+                      : 'addDialog.preview.title',
+                  )}
                 </div>
                 <div className="max-h-72 overflow-auto">
                   {preview ? (
-                    <CodeBlock code={preview.content} language="typescript" />
+                    <CodeBlock
+                      code={preview.content}
+                      language={isMarketplace ? 'json' : 'typescript'}
+                    />
                   ) : (
                     <div className="flex items-center gap-2 px-3 py-6 text-xs text-text-tertiary">
                       <AlertTriangle className="h-3.5 w-3.5" />
-                      <span>{t('addDialog.preview.emptyHint')}</span>
+                      <span>
+                        {t(
+                          isMarketplace
+                            ? 'addDialog.preview.emptyHintMarketplace'
+                            : 'addDialog.preview.emptyHint',
+                        )}
+                      </span>
                     </div>
                   )}
                 </div>
@@ -227,28 +259,32 @@ export function EditRegistryDialog({
           </div>
 
           <div className="flex flex-wrap items-center justify-between gap-3 border-t border-border-secondary px-6 py-4">
-            <label
-              className={
-                changed && preview
-                  ? 'flex items-center gap-2 text-sm text-text-primary'
-                  : 'flex items-center gap-2 text-sm text-text-tertiary'
-              }
-              title={
-                !changed
-                  ? t('editDialog.noChanges')
-                  : !preview
-                    ? t('addDialog.errors.previewBeforeAdd')
-                    : undefined
-              }
-            >
-              <input
-                type="checkbox"
-                checked={trusted}
-                onChange={(e) => setTrusted(e.target.checked)}
-                disabled={!preview || !changed}
-              />
-              <span>{t('addDialog.trust')}</span>
-            </label>
+            {isMarketplace ? (
+              <span className="text-xs text-text-secondary">{t('addDialog.marketplaceHint')}</span>
+            ) : (
+              <label
+                className={
+                  changed && preview
+                    ? 'flex items-center gap-2 text-sm text-text-primary'
+                    : 'flex items-center gap-2 text-sm text-text-tertiary'
+                }
+                title={
+                  !changed
+                    ? t('editDialog.noChanges')
+                    : !preview
+                      ? t('addDialog.errors.previewBeforeAdd')
+                      : undefined
+                }
+              >
+                <input
+                  type="checkbox"
+                  checked={trusted}
+                  onChange={(e) => setTrusted(e.target.checked)}
+                  disabled={!preview || !changed}
+                />
+                <span>{t('addDialog.trust')}</span>
+              </label>
+            )}
             <div className="flex items-center gap-2">
               <Dialog.Close
                 type="button"

--- a/web-ui/src/features/registries/admin/RegistriesTable.tsx
+++ b/web-ui/src/features/registries/admin/RegistriesTable.tsx
@@ -74,7 +74,7 @@ export function RegistriesTable({
                 </td>
                 <td className="px-4 py-3 align-top">
                   <span className="rounded-sm border border-border-secondary bg-bg-tertiary px-2 py-0.5 text-xs uppercase tracking-wide text-text-secondary">
-                    {r.type}
+                    {t(`addDialog.typeOptions.${r.type}`, { defaultValue: r.type })}
                   </span>
                 </td>
                 <td className="px-4 py-3 align-top">

--- a/web-ui/src/features/registries/api.ts
+++ b/web-ui/src/features/registries/api.ts
@@ -9,7 +9,7 @@ export interface RegistryManifest {
   capabilities: string[];
 }
 
-export type RegistrySourceType = 'github' | 'gitlab' | 'url';
+export type RegistrySourceType = 'github' | 'gitlab' | 'url' | 'claude-marketplace';
 export type RegistryStatus = 'pending' | 'installed' | 'failed' | 'disabled';
 
 export interface RegistryAdminRecord {
@@ -62,6 +62,7 @@ export interface RegistryPreviewResponse {
   content: string;
   resolvedRef: string | null;
   derivedSlug: string | null;
+  pluginCount?: number;
 }
 
 export interface RegistryMutationResponse {

--- a/web-ui/src/features/registries/components/RegistryTabs.tsx
+++ b/web-ui/src/features/registries/components/RegistryTabs.tsx
@@ -1,4 +1,6 @@
-import * as Tabs from '@radix-ui/react-tabs';
+import { useEffect, useRef } from 'react';
+import { useTranslation } from 'react-i18next';
+import { cn } from '../../../lib/utils';
 import type { RegistryManifest } from '../api';
 
 interface RegistryTabsProps {
@@ -9,27 +11,75 @@ interface RegistryTabsProps {
 }
 
 export function RegistryTabs({ registries, selected, onSelect, children }: RegistryTabsProps) {
+  const { t } = useTranslation('registries');
+  const listRef = useRef<HTMLDivElement>(null);
+
+  useEffect(() => {
+    const list = listRef.current;
+    if (!list) return;
+    const active = list.querySelector<HTMLElement>('[data-active="true"]');
+    if (active) {
+      active.scrollIntoView({ block: 'nearest', inline: 'nearest', behavior: 'smooth' });
+    }
+  }, [selected]);
+
   return (
-    <Tabs.Root value={selected} onValueChange={onSelect}>
-      <Tabs.List className="mb-4 flex gap-1 border-b border-border-secondary">
-        {registries.map((r) => (
-          <Tabs.Trigger
-            key={r.id}
-            value={r.id}
-            className="inline-flex items-center gap-2 border-b-2 border-transparent px-4 py-2 text-sm text-text-secondary transition-colors hover:text-text-primary data-[state=active]:border-accent-primary data-[state=active]:text-text-primary"
-          >
-            {r.icon && (
-              <img
-                src={r.icon}
-                alt=""
-                className="h-4 w-4 shrink-0 rounded-sm object-contain"
-              />
-            )}
-            {r.name}
-          </Tabs.Trigger>
-        ))}
-      </Tabs.List>
-      {children}
-    </Tabs.Root>
+    <div className="flex min-h-[calc(100vh-280px)] flex-col gap-4 lg:flex-row lg:gap-6">
+      {/* Registry picker — horizontal scroll on small screens, vertical rail on lg+ */}
+      <aside className="flex shrink-0 flex-col lg:w-56">
+        <div className="mb-2 hidden px-1 text-[11px] font-medium uppercase tracking-wide text-text-tertiary lg:block">
+          {t('registryList')}
+        </div>
+        <nav
+          ref={listRef}
+          aria-label={t('registryList')}
+          className={cn(
+            'flex gap-1',
+            // Mobile: single-row horizontal scroller
+            'overflow-x-auto border-b border-border-secondary pb-2',
+            // Desktop: fixed-height vertical list that scrolls independently
+            'lg:max-h-[calc(100vh-300px)] lg:flex-col lg:overflow-x-hidden lg:overflow-y-auto lg:border-b-0 lg:border-r lg:border-border-secondary lg:pb-0 lg:pr-3',
+          )}
+        >
+          {registries.map((r) => {
+            const active = r.id === selected;
+            return (
+              <button
+                key={r.id}
+                type="button"
+                data-active={active ? 'true' : undefined}
+                onClick={() => onSelect(r.id)}
+                title={r.description ? `${r.name} — ${r.description}` : r.name}
+                className={cn(
+                  'inline-flex shrink-0 items-center gap-2 rounded-sm px-3 py-2 text-left text-sm transition-colors',
+                  'max-w-[12rem] lg:max-w-none lg:w-full',
+                  active
+                    ? 'bg-accent-primary/10 text-text-primary'
+                    : 'text-text-secondary hover:bg-hover-bg hover:text-text-primary',
+                )}
+              >
+                {r.icon ? (
+                  <img
+                    src={r.icon}
+                    alt=""
+                    className="h-4 w-4 shrink-0 rounded-sm object-contain"
+                  />
+                ) : (
+                  <span
+                    aria-hidden
+                    className="flex h-4 w-4 shrink-0 items-center justify-center rounded-sm bg-bg-tertiary text-[9px] font-medium text-text-tertiary"
+                  >
+                    {(r.name[0] ?? '?').toUpperCase()}
+                  </span>
+                )}
+                <span className="min-w-0 truncate">{r.name}</span>
+              </button>
+            );
+          })}
+        </nav>
+      </aside>
+
+      <div className="min-w-0 flex-1">{children}</div>
+    </div>
   );
 }

--- a/web-ui/src/locales/en/projects.json
+++ b/web-ui/src/locales/en/projects.json
@@ -354,6 +354,8 @@
     "blockedPhrases": "Blocked Phrases",
     "allowedCharacters": "Allowed Characters",
     "requiredCommands": "Required Commands",
-    "noSecurityConfig": "No security configuration"
+    "noSecurityConfig": "No security configuration",
+    "dangerZone": "Danger zone",
+    "dangerZoneDescription": "Remove this project from capa. The capabilities file on disk is kept."
   }
 }

--- a/web-ui/src/locales/en/registries.json
+++ b/web-ui/src/locales/en/registries.json
@@ -2,12 +2,13 @@
   "title": "Registries",
   "subtitle": "Browse and install skills and plugins from third-party registries",
   "manageLink": "Manage registries",
+  "registryList": "Registries",
   "nav": {
     "registries": "Registries"
   },
   "empty": {
     "title": "No registries configured",
-    "description": "Add a registry from GitHub, GitLab, or an HTTPS URL to browse third-party skills and plugins.",
+    "description": "Add a registry adapter or a Claude marketplace to browse third-party skills and plugins.",
     "manageLink": "Manage registries"
   },
   "tabs": {
@@ -42,13 +43,13 @@
   },
   "settings": {
     "title": "Registry settings",
-    "subtitle": "Manage the third-party registries that supply skills and plugins.",
+    "subtitle": "Manage registry adapters and Claude marketplaces that supply skills and plugins.",
     "browseLink": "Back to browse",
     "addButton": "Add registry",
     "noneTitle": "No registries yet",
-    "noneDescription": "Add your first registry to start browsing skills and plugins.",
-    "warningTitle": "Trust before adding",
-    "warningBody": "Registry adapters are executable TypeScript — only install them from sources you trust.",
+    "noneDescription": "Add your first registry adapter or Claude marketplace to start browsing.",
+    "warningTitle": "Trust before adding adapters",
+    "warningBody": "Registry adapters are executable TypeScript — only install them from sources you trust. Claude marketplaces are JSON catalogs and do not run adapter code.",
     "table": {
       "name": "Registry",
       "type": "Type",
@@ -82,6 +83,7 @@
   "editDialog": {
     "title": "Edit registry \"{{slug}}\"",
     "description": "Repoint this slug at a different source. The new adapter is downloaded and validated before it replaces the existing one.",
+    "descriptionMarketplace": "Repoint this slug at a different Claude marketplace. The marketplace.json catalog is re-fetched before it replaces the existing one.",
     "slugImmutable": "The slug is the registry's identity and cannot be renamed. Remove and re-add to change it.",
     "noChanges": "No changes — Save closes the dialog.",
     "submit": "Save changes"
@@ -89,28 +91,40 @@
   "addDialog": {
     "title": "Add registry",
     "description": "Fetch an adapter from a Git repository or HTTPS URL. The file is downloaded and validated before it is enabled.",
+    "descriptionMarketplace": "Add a Claude Code marketplace by owner/repo. Capa fetches .claude-plugin/marketplace.json and lists its plugins.",
+    "marketplaceHint": "Claude marketplaces are JSON catalogs — no executable adapter code.",
     "fields": {
+      "mode": "What to add",
       "type": "Source type",
       "source": "Source",
       "slug": "Slug",
       "slugHint": "URL-safe identifier; auto-derived from the source if left blank."
     },
+    "modes": {
+      "adapter": "Registry adapter",
+      "claude-marketplace": "Claude marketplace"
+    },
     "typeOptions": {
       "github": "GitHub",
       "gitlab": "GitLab",
-      "url": "HTTPS URL"
+      "url": "HTTPS URL",
+      "claude-marketplace": "Claude marketplace"
     },
     "sourcePlaceholders": {
       "github": "owner/repo@adapter-name  or  owner/repo::path/to/adapter-name",
       "gitlab": "group/project@adapter-name  or  group/project::path/to/adapter-name",
-      "url": "https://example.com/path/to/adapter.ts"
+      "url": "https://example.com/path/to/adapter.ts",
+      "claude-marketplace": "owner/repo  or  owner/repo@ref"
     },
     "preview": {
       "button": "Preview",
       "loading": "Fetching adapter...",
       "title": "Adapter source",
+      "titleMarketplace": "Marketplace catalog",
       "emptyHint": "Press Preview to fetch the adapter file and inspect it before installing.",
-      "resolvedRef": "Resolved ref: {{ref}}"
+      "emptyHintMarketplace": "Press Preview to fetch marketplace.json and inspect the plugin catalog.",
+      "resolvedRef": "Resolved ref: {{ref}}",
+      "pluginCount": "{{count}} plugin(s)"
     },
     "trust": "I have reviewed the adapter source and trust this code.",
     "submit": "Add registry",
@@ -118,7 +132,8 @@
     "errors": {
       "missingType": "Source type is required.",
       "missingSource": "Source is required.",
-      "previewBeforeAdd": "Preview the adapter source and confirm trust before adding."
+      "previewBeforeAdd": "Preview the adapter source and confirm trust before adding.",
+      "previewBeforeAddMarketplace": "Preview the marketplace catalog before adding."
     }
   }
 }

--- a/web-ui/src/pages/ProjectDetailPage.tsx
+++ b/web-ui/src/pages/ProjectDetailPage.tsx
@@ -1,7 +1,7 @@
 import { useState, useEffect, useCallback } from 'react';
-import { useSearchParams, useNavigate } from 'react-router-dom';
+import { useSearchParams } from 'react-router-dom';
 import { useTranslation } from 'react-i18next';
-import { AlertTriangle, ArrowDown, Trash2 } from 'lucide-react';
+import { AlertTriangle, ArrowDown } from 'lucide-react';
 import { TopBar } from '../components/layout/TopBar';
 import { Page } from '../components/layout/Page';
 import { Alert } from '../components/common/Alert';
@@ -17,13 +17,11 @@ import {
   useProjectCapabilitiesLiveSync,
   useVariables,
   useOAuth2Servers,
-  useDeleteProject,
 } from '../features/projects/hooks';
 import { projectDisplayName, safeDecode } from '../lib/utils';
 
 export function ProjectDetailPage() {
   const { t } = useTranslation();
-  const navigate = useNavigate();
   const [searchParams] = useSearchParams();
   const projectId = searchParams.get('id') || searchParams.get('project');
   const returnUrl = searchParams.get('return');
@@ -36,7 +34,6 @@ export function ProjectDetailPage() {
   const { data: project, isLoading, error } = useProject(projectId);
   const { data: variables } = useVariables(projectId);
   const { data: oauth2Servers } = useOAuth2Servers(projectId);
-  const deleteProject = useDeleteProject();
   useProjectCapabilitiesLiveSync(projectId);
 
   useEffect(() => {
@@ -57,20 +54,6 @@ export function ProjectDetailPage() {
   const caps = project?.capabilities;
   const hasProviders = (caps?.providers?.length ?? 0) > 0;
   const showNoConfig = !isLoading && !caps && !error;
-
-  const handleDeleteProject = () => {
-    if (!projectId) return;
-    if (!confirm(t('projects:actions.confirmDeleteProject', { name: displayName }))) return;
-    deleteProject.mutate(projectId, {
-      onSuccess: () => navigate('/'),
-      onError: (err) => {
-        setMessage({
-          text: err instanceof Error ? err.message : String(err),
-          type: 'error',
-        });
-      },
-    });
-  };
 
   const missingVarCount = variables?.required
     ? variables.required.filter((v) => !variables.values?.[v]).length
@@ -149,18 +132,6 @@ export function ProjectDetailPage() {
           <Alert type="error">{(error as Error).message}</Alert>
         ) : (
           <>
-            <div className="mb-6 flex justify-end">
-              <button
-                type="button"
-                onClick={handleDeleteProject}
-                disabled={deleteProject.isPending}
-                className="inline-flex items-center gap-1.5 rounded-sm border border-border-primary bg-bg-secondary px-3 py-1.5 text-xs font-medium text-text-secondary transition-colors hover:bg-error-bg hover:text-error-text hover:border-transparent cursor-pointer disabled:opacity-50"
-              >
-                <Trash2 size={14} />
-                {t('projects:actions.deleteProject')}
-              </button>
-            </div>
-
             <ActivitySection projectId={projectId} />
 
             <div id="capabilities-section">
@@ -180,9 +151,9 @@ export function ProjectDetailPage() {
 
             {hasProviders && <ProvidersSection providers={caps!.providers} />}
 
-            <OptionsSection projectId={projectId} options={caps?.options ?? null} />
-
             <VariablesForm projectId={projectId} returnUrl={returnUrl} />
+
+            <OptionsSection projectId={projectId} options={caps?.options ?? null} />
 
             {showNoConfig && !caps && (
               <div className="rounded-lg border border-border-primary bg-bg-secondary p-6">

--- a/web-ui/src/pages/RegistriesPage.tsx
+++ b/web-ui/src/pages/RegistriesPage.tsx
@@ -130,7 +130,7 @@ export function RegistriesPage() {
                 selected={selectedCapability}
                 onSelect={handleCapabilityChange}
               >
-                <div className="grid min-h-[calc(100vh-340px)] grid-cols-1 gap-6 lg:grid-cols-[380px_1fr]">
+                <div className="grid min-h-[calc(100vh-340px)] grid-cols-1 gap-6 lg:grid-cols-[minmax(240px,320px)_1fr]">
                   {/* Left: search + results — height driven by right column */}
                   <div className="relative min-h-[300px]">
                     <div className="absolute inset-0 flex flex-col overflow-hidden rounded-lg border border-border-primary bg-bg-secondary p-4">


### PR DESCRIPTION
## Summary
- Add first-class Claude marketplace registries (`claude-marketplace` source type) so admins can browse/install plugins from any `owner/repo` marketplace.json
- Wire fetch/parse/adapter + installer/loader/API/CLI support, with tests for marketplace parsing and registry routes
- UI: Add Registry dialog marketplace mode, scrollable registry tabs for many entries, and move project delete into Options danger zone

## Test plan
- [x] Add a Claude marketplace via Registries UI (e.g. a known `owner/repo`) and confirm it lists plugins
- [x] Preview a marketplace plugin item without errors; confirm icon resolves (GitHub avatar or favicon)
- [x] Install a plugin from the marketplace into a project and verify it appears in capabilities
- [x] Confirm scrollable registry tabs work with many registries
- [x] Confirm project delete lives under Options → Danger zone
- [x] Run marketplace and registries route tests
