### PR TITLE
feat: unpack plugin rules, subagents, and hooks with UI lock parity

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -210,10 +210,11 @@ is the authoritative description of what ends up on disk. A
 `capabilities.plugins` entry is a *source* — typically a git repo — that
 capa clones, inspects, and decomposes into the same primitives every
 other capability uses
-(`skills`, `mcpServers`, `mcpTools`). Those primitives are then merged into
+(`skills`, `servers`, `rules`, `subagents`, `hooks`). Those primitives are then merged into
 `ctx.capabilitiesToUse` and flow through the same `install-skills`,
-`register-mcp-server`, `install-subagents` … tasks as if the user had
-written them inline.
+`install-rules`, `register-mcp-server`, `install-subagents`, `install-hooks`
+tasks as if the user had written them inline. The web UI shows plugin-sourced
+entries with a source badge and lock (same pattern as plugin skills/servers).
 
 The discovery pipeline lives in
 [`src/cli/commands/plugin-install.ts`](../src/cli/commands/plugin-install.ts)
@@ -234,12 +235,17 @@ and [`src/shared/plugin-manifest/detect.ts`](../src/shared/plugin-manifest/detec
    other format is currently unsupported — see
    [Plugin format support](#plugin-format-support) below.
 4. **Discover-mode fallback.** If no manifest is found, capa still scans
-   for a top-level `skills/` directory and a `.mcp.json` and treats them as
-   a claude-shaped pseudo-manifest.
+   for `skills/` (or a root `SKILL.md`), `commands/`, `agents/`, `hooks/`,
+   `rules/`, and `.mcp.json` and treats them as a claude-shaped
+   pseudo-manifest.
 5. **Decompose and merge.** The `UnifiedPluginManifest` exposes
-   `skillEntries`, `mcpServers`, and `mcpTools`. Each becomes a regular
-   capability entry that the normal install tasks pick up — there is no
-   separate plugin-write step.
+   `skillEntries`, `commandEntries` (legacy flat skills → synthetic skill
+   dirs), `mcpServers`, `agentEntries` → `subagents`, `hookEntries` →
+   `hooks` (provider-scoped; `${CLAUDE_PLUGIN_ROOT}` rewritten to the
+   stable plugin copy), and `ruleEntries` → `rules`. Unsupported artifacts
+   (LSP, monitors, themes, …) produce install warnings and are skipped.
+   There is no separate plugin-write step for rules/hooks/subagents —
+   later install tasks own provider files.
 
 ### Plugin format support
 

--- a/src/cli/commands/install-tasks/load-env.ts
+++ b/src/cli/commands/install-tasks/load-env.ts
@@ -34,7 +34,8 @@ export function loadEnvTask(): Task<InstallCtx> {
         throw new Error(`Failed to parse env file: ${error.message}`);
       }
 
-      const requiredVars = extractAllVariables(ctx.capabilitiesToUse);
+      // Authored file only — plugin-merged content must not invent credentials.
+      const requiredVars = extractAllVariables(ctx.capabilities);
       for (const varName of requiredVars) {
         if (envVariables[varName]) {
           ctx.db.setVariable(ctx.projectId, varName, envVariables[varName]);

--- a/src/cli/commands/plugin-install.ts
+++ b/src/cli/commands/plugin-install.ts
@@ -1,8 +1,9 @@
 import { existsSync, mkdirSync, readdirSync, readFileSync, rmSync, writeFileSync, cpSync } from 'fs';
-import { tmpdir } from 'os';
 import { join, resolve } from 'path';
-import type { Capabilities, Skill, MCPServer, SourcePlugin, ResolvedPluginInfo, OAuth2Config } from '../../types/capabilities';
+import type { Capabilities, Skill, MCPServer, SourcePlugin, ResolvedPluginInfo, OAuth2Config, SubAgent } from '../../types/capabilities';
 import type { UnifiedPluginManifest } from '../../types/plugin';
+import type { Rule } from '../../types/rules';
+import type { Hook } from '../../types/hooks';
 import type { CapaDatabase } from '../../db/database';
 import type { AuthenticatedFetch } from '../../shared/authenticated-fetch';
 import { validatePluginDef, getPluginInstallId } from '../../shared/plugin-source';
@@ -11,9 +12,14 @@ import {
   discoverPluginEntries,
   findPluginInDirectory,
   resolvePluginServerDef,
+  resolvePluginRootInString,
+  materializeCommandAsSkill,
 } from '../../shared/plugin-manifest';
+import { getProjectPluginsDir } from '../../shared/plugin-paths';
 import { getProvider } from '../../shared/providers';
 import { getGitProvider } from '../../shared/git-providers/registry';
+import { toCanonicalOrScopedHookOn } from '../utils/hooks/provider-map';
+import { coalescePluginHook } from '../utils/hooks/plugin-hook-merge';
 import {
   loadBlockedPhrases,
   checkBlockedPhrases,
@@ -29,9 +35,9 @@ import type { LockfileBuilder } from '../../shared/lockfile';
 import type { LockPluginEntry } from '../../types/lockfile';
 import { copySkillTree } from '../../shared/skill-copy';
 
-/** Base under system temp for extracted plugin content (MCP cwd). Per-project so projects don't clash. */
-function getPluginsTempBase(projectId: string): string {
-  return join(tmpdir(), 'capa-plugins', projectId);
+/** Map plugin provider id to capa provider id for hook scoping. */
+function pluginProviderToCapaId(provider: 'claude' | 'cursor'): string {
+  return provider === 'claude' ? 'claude-code' : 'cursor';
 }
 
 function copyPluginToStable(tempDir: string, pluginStablePath: string): void {
@@ -137,6 +143,11 @@ export async function resolvePlugins(
   // Preserve all explicitly defined servers from the capabilities file; never drop them when merging plugin servers
   const mergedServers: MCPServer[] = Array.isArray(capabilities.servers) ? [...capabilities.servers] : [];
   const mergedTools = Array.isArray(capabilities.tools) ? [...capabilities.tools] : [];
+  const mergedSubagents: SubAgent[] = Array.isArray(capabilities.subagents)
+    ? [...capabilities.subagents]
+    : [];
+  const mergedHooks: Hook[] = Array.isArray(capabilities.hooks) ? [...capabilities.hooks] : [];
+  const mergedRules: Rule[] = Array.isArray(capabilities.rules) ? [...capabilities.rules] : [];
   const resolvedPlugins: ResolvedPluginInfo[] = [];
   const tempDirs: string[] = [];
   const providers = capabilities.providers;
@@ -144,11 +155,15 @@ export async function resolvePlugins(
     throw new Error('No providers configured. Resolve providers before calling resolvePlugins.');
   }
 
-  const pluginsBase = options.pluginsBaseDir ?? getPluginsTempBase(projectId);
+  // Same unpack root for install, wrap, and passthrough: ~/.capa/plugins/<projectId>/
+  const pluginsBase = options.pluginsBaseDir ?? getProjectPluginsDir(projectId);
   const currentPluginIds = new Set<string>();
   const warnings: string[] = [];
 
   const registeredServerIds = new Set(mergedServers.map(s => s.id));
+  const registeredSubagentIds = new Set(mergedSubagents.map((a) => a.id));
+  const registeredHookIds = new Set(mergedHooks.map((h) => h.id));
+  const registeredRuleIds = new Set(mergedRules.map((r) => r.id));
 
   // Map of user-declared `type: plugin` skills by id. We attach `sourcePlugin`
   // to these when a matching plugin manifest skill is found, and avoid auto-adding
@@ -159,6 +174,59 @@ export async function resolvePlugins(
       userPluginSkills.set(skill.id, skill);
     }
   }
+
+  function installSkillTree(entryId: string, srcSkillDir: string, pluginName: string): void {
+    if (!existsSync(join(srcSkillDir, 'SKILL.md'))) return;
+
+    for (const client of providers) {
+      const providerEntry = getProvider(client);
+      if (!providerEntry) continue;
+      const skillsBaseDir = join(projectPath, providerEntry.skillsDir);
+      const destSkillDir = join(skillsBaseDir, entryId);
+      try {
+        if (existsSync(destSkillDir)) {
+          if (!trackManaged) {
+            warnings.push(
+              `Skill "${entryId}" for ${client}: directory already exists at ${destSkillDir}; ` +
+                `passthrough will not overwrite it. Delete it manually and retry.`,
+            );
+            continue;
+          }
+          rmSync(destSkillDir, { recursive: true, force: true });
+        }
+        mkdirSync(resolve(destSkillDir, '..'), { recursive: true });
+        if (hasSecurity) {
+          copySkillDirWithSecurity(
+            srcSkillDir,
+            destSkillDir,
+            entryId,
+            blockedPhrases,
+            allowedCharacters,
+            pluginName,
+          );
+        } else {
+          try {
+            cpSync(srcSkillDir, destSkillDir, { recursive: true });
+          } catch {
+            copySkillTree({ src: srcSkillDir, dst: destSkillDir });
+          }
+        }
+        if (trackManaged) {
+          db.addManagedFile(projectId, destSkillDir);
+        }
+      } catch (err: any) {
+        if (err instanceof BlockedPhraseError) {
+          throw err;
+        }
+        warnings.push(`Failed to install skill "${entryId}" for ${client}: ${err.message}`);
+      }
+    }
+  }
+
+  // Security flags are per-plugin (options are global); set inside the loop.
+  let hasSecurity = false;
+  let blockedPhrases: string[] = [];
+  let allowedCharacters: string | null = null;
 
   for (const pluginRef of plugins) {
     if (!getGitProvider(pluginRef.type)) continue;
@@ -247,7 +315,7 @@ export async function resolvePlugins(
     const pluginInstallId = getPluginInstallId(pluginRef.id ?? manifest.name);
     currentPluginIds.add(pluginInstallId);
 
-    const pluginStablePath = join(pluginsBase, pluginInstallId);
+    const pluginStablePath = resolve(join(pluginsBase, pluginInstallId));
     try {
       if (existsSync(pluginStablePath)) rmSync(pluginStablePath, { recursive: true, force: true });
       copyPluginToStable(manifestRoot, pluginStablePath);
@@ -285,6 +353,9 @@ export async function resolvePlugins(
     };
     const pluginSkillIds: string[] = [];
     const pluginServerIds: string[] = [];
+    const pluginSubagentIds: string[] = [];
+    const pluginHookIds: string[] = [];
+    const pluginRuleIds: string[] = [];
     const resolvedPluginInfo: ResolvedPluginInfo = {
       id: pluginInstallId,
       name: manifest.name,
@@ -293,81 +364,60 @@ export async function resolvePlugins(
       repository,
       skills: pluginSkillIds,
       serverIds: pluginServerIds,
+      subagentIds: pluginSubagentIds,
+      hookIds: pluginHookIds,
+      ruleIds: pluginRuleIds,
     };
     resolvedPlugins.push(resolvedPluginInfo);
 
     const security = capabilities.options?.security;
     const blockPhrasesEnabled = isBlockedPhrasesEnabled(security);
     const sanitizeEnabled = isCharacterSanitizationEnabled(security);
-    const hasSecurity = blockPhrasesEnabled || sanitizeEnabled;
-    const blockedPhrases = blockPhrasesEnabled ? loadBlockedPhrases(security, capabilitiesFilePath) : [];
-    const allowedCharacters = sanitizeEnabled ? getAllowedCharacters(security) : null;
+    hasSecurity = blockPhrasesEnabled || sanitizeEnabled;
+    blockedPhrases = blockPhrasesEnabled ? loadBlockedPhrases(security, capabilitiesFilePath) : [];
+    allowedCharacters = sanitizeEnabled ? getAllowedCharacters(security) : null;
 
-    for (const entry of manifest.skillEntries) {
+    if (manifest.skippedArtifacts?.length) {
+      warnings.push(
+        `Plugin "${manifest.name}" contains unsupported artifacts that were skipped: ${manifest.skippedArtifacts.join(', ')}`,
+      );
+    }
+
+    // Materialize legacy commands/ into skill dirs on the stable plugin copy
+    const commandSkillEntries: { id: string; relativePath: string }[] = [];
+    for (const cmd of manifest.commandEntries ?? []) {
+      const destRel = join('.capa-commands', cmd.id);
+      const destDir = join(pluginStablePath, destRel);
+      if (materializeCommandAsSkill(pluginStablePath, cmd, destDir)) {
+        commandSkillEntries.push({ id: cmd.id, relativePath: destRel });
+      }
+    }
+
+    const allSkillEntries = [
+      ...(manifest.skillEntries ?? []),
+      ...commandSkillEntries,
+    ];
+
+    for (const entry of allSkillEntries) {
       const srcSkillDir = join(pluginStablePath, entry.relativePath);
       if (!existsSync(join(srcSkillDir, 'SKILL.md'))) continue;
 
       pluginSkillIds.push(entry.id);
+      installSkillTree(entry.id, srcSkillDir, manifest.name);
 
-      for (const client of providers) {
-        const providerEntry = getProvider(client);
-        if (!providerEntry) continue;
-        const skillsBaseDir = join(projectPath, providerEntry.skillsDir);
-        const destSkillDir = join(skillsBaseDir, entry.id);
-        try {
-          if (existsSync(destSkillDir)) {
-            if (!trackManaged) {
-              warnings.push(
-                `Skill "${entry.id}" for ${client}: directory already exists at ${destSkillDir}; ` +
-                  `passthrough will not overwrite it. Delete it manually and retry.`,
-              );
-              continue;
-            }
-            rmSync(destSkillDir, { recursive: true, force: true });
-          }
-          mkdirSync(resolve(destSkillDir, '..'), { recursive: true });
-          if (hasSecurity) {
-            copySkillDirWithSecurity(
-              srcSkillDir,
-              destSkillDir,
-              entry.id,
-              blockedPhrases,
-              allowedCharacters,
-              manifest.name
-            );
-          } else {
-            try {
-              cpSync(srcSkillDir, destSkillDir, { recursive: true });
-            } catch {
-              copySkillTree({ src: srcSkillDir, dst: destSkillDir });
-            }
-          }
-          if (trackManaged) {
-            db.addManagedFile(projectId, destSkillDir);
-          }
-        } catch (err: any) {
-          if (err instanceof BlockedPhraseError) {
-            throw err;
-          }
-          // Non-fatal: the skill may still install for other clients. Surfaced
-          // post-tree via the `warnings` array so the user sees it.
-          warnings.push(`Failed to install skill "${entry.id}" for ${client}: ${err.message}`);
-        }
-      }
-
-      // If the user has declared a `type: plugin` skill with this id, attach the
-      // sourcePlugin attribution to their entry and skip the auto-merge.
       const userEntry = userPluginSkills.get(entry.id);
       if (userEntry) {
         userEntry.sourcePlugin = sourcePlugin;
         continue;
       }
 
-      // Auto-merge: the plugin contributed this skill and the user didn't
-      // declare it explicitly. We still surface it as `type: plugin` so the
-      // UI and any downstream tooling can tell where it came from. No
-      // `requires` are inferred — declare a `type: plugin` entry in
-      // capabilities.yaml to bind tools to the skill.
+      if (mergedSkills.some((s) => s.id === entry.id)) {
+        warnings.push(
+          `Plugin skill id "${entry.id}" collides with an existing skill; skipping auto-merge.`,
+        );
+        continue;
+      }
+
       mergedSkills.push({
         id: entry.id,
         type: 'plugin',
@@ -421,6 +471,113 @@ export async function resolvePlugins(
       }
     }
 
+    const capaProviderId = pluginProviderToCapaId(manifest.provider);
+    const pluginSkillIdSet = new Set(pluginSkillIds);
+
+    for (const agent of manifest.agentEntries ?? []) {
+      if (registeredSubagentIds.has(agent.id)) {
+        warnings.push(
+          `Plugin subagent id "${agent.id}" collides with an existing subagent; skipping.`,
+        );
+        continue;
+      }
+      if (agent.droppedFrontmatterKeys.length > 0) {
+        warnings.push(
+          `Plugin agent "${agent.id}": frontmatter fields not mapped into capa subagents: ${agent.droppedFrontmatterKeys.join(', ')}`,
+        );
+      }
+      registeredSubagentIds.add(agent.id);
+      pluginSubagentIds.push(agent.id);
+      const skillIds = agent.skillIds.filter((id) => pluginSkillIdSet.has(id));
+      mergedSubagents.push({
+        id: agent.id,
+        description: agent.description,
+        skills: skillIds,
+        tools: [],
+        instructions: agent.instructions || undefined,
+        sourcePlugin,
+      });
+    }
+
+    let hookIndex = 0;
+    for (const hookEntry of manifest.hookEntries ?? []) {
+      const targetProvider = hookEntry.targetProvider ?? capaProviderId;
+      const indexHint = hookEntry.idHint || hookIndex;
+      hookIndex++;
+
+      // Prefer capa canonical events (SessionStart → sessionStart) so install
+      // fans out via eventMap. Keep provider-scoped form only when unmapped.
+      const on = toCanonicalOrScopedHookOn(
+        targetProvider,
+        hookEntry.event,
+        hookEntry.matcher,
+      );
+      const command = hookEntry.command
+        ? resolvePluginRootInString(hookEntry.command, pluginStablePath)
+        : undefined;
+      const prompt = hookEntry.prompt
+        ? resolvePluginRootInString(hookEntry.prompt, pluginStablePath)
+        : undefined;
+
+      // Sibling Claude/Cursor manifests often declare the same hook twice.
+      // When rewritten bodies match, coalesce into one cross-provider entry.
+      const candidate: Hook = {
+        id: `plugin-${pluginInstallId}-${indexHint}`,
+        on,
+        type: hookEntry.type,
+        command,
+        prompt,
+        matcher: hookEntry.matcher,
+        timeout: hookEntry.timeout,
+        failClosed: hookEntry.failClosed,
+        sequential: hookEntry.sequential,
+        providers: [targetProvider],
+        sourcePlugin,
+      };
+      if (coalescePluginHook(mergedHooks, pluginInstallId, candidate, targetProvider)) {
+        continue;
+      }
+
+      let hookId = candidate.id;
+      if (registeredHookIds.has(hookId)) {
+        hookId = `plugin-${pluginInstallId}-${targetProvider}-${indexHint}`;
+        if (registeredHookIds.has(hookId)) {
+          warnings.push(`Plugin hook id "${hookId}" collides with an existing hook; skipping.`);
+          continue;
+        }
+        candidate.id = hookId;
+      }
+      if (hookEntry.matcher && /mcp__plugin_/i.test(hookEntry.matcher)) {
+        warnings.push(
+          `Plugin hook "${hookId}": matcher references plugin-scoped MCP tools (${hookEntry.matcher}); ` +
+            `it may not fire after capa proxies MCP under its own server id.`,
+        );
+      }
+      registeredHookIds.add(hookId);
+      pluginHookIds.push(hookId);
+      mergedHooks.push(candidate);
+    }
+
+    for (const ruleEntry of manifest.ruleEntries ?? []) {
+      if (registeredRuleIds.has(ruleEntry.id)) {
+        warnings.push(
+          `Plugin rule id "${ruleEntry.id}" collides with an existing rule; skipping.`,
+        );
+        continue;
+      }
+      registeredRuleIds.add(ruleEntry.id);
+      pluginRuleIds.push(ruleEntry.id);
+      mergedRules.push({
+        id: ruleEntry.id,
+        type: 'inline',
+        content: ruleEntry.content,
+        description: ruleEntry.description,
+        appliesTo: ruleEntry.appliesTo,
+        alwaysApply: ruleEntry.alwaysApply,
+        sourcePlugin,
+      });
+    }
+
     if (pluginRef.servers) {
       const manifestKeys = Object.keys(manifest.mcpServers);
       for (const configKey of Object.keys(pluginRef.servers)) {
@@ -462,6 +619,9 @@ export async function resolvePlugins(
     skills: mergedSkills,
     servers: mergedServers,
     tools: mergedTools,
+    subagents: mergedSubagents.length > 0 ? mergedSubagents : capabilities.subagents,
+    hooks: mergedHooks.length > 0 ? mergedHooks : capabilities.hooks,
+    rules: mergedRules.length > 0 ? mergedRules : capabilities.rules,
     resolvedPlugins,
   };
 

--- a/src/cli/commands/plugin-install.ts
+++ b/src/cli/commands/plugin-install.ts
@@ -150,8 +150,8 @@ export async function resolvePlugins(
   const mergedRules: Rule[] = Array.isArray(capabilities.rules) ? [...capabilities.rules] : [];
   const resolvedPlugins: ResolvedPluginInfo[] = [];
   const tempDirs: string[] = [];
-  const providers = capabilities.providers;
-  if (!providers || providers.length === 0) {
+  const providers: string[] = capabilities.providers ?? [];
+  if (providers.length === 0) {
     throw new Error('No providers configured. Resolve providers before calling resolvePlugins.');
   }
 

--- a/src/cli/commands/plugin-install.ts
+++ b/src/cli/commands/plugin-install.ts
@@ -513,10 +513,14 @@ export async function resolvePlugins(
         hookEntry.matcher,
       );
       const command = hookEntry.command
-        ? resolvePluginRootInString(hookEntry.command, pluginStablePath)
+        ? resolvePluginRootInString(hookEntry.command, pluginStablePath, {
+            shellQuote: true,
+          })
         : undefined;
       const prompt = hookEntry.prompt
-        ? resolvePluginRootInString(hookEntry.prompt, pluginStablePath)
+        ? resolvePluginRootInString(hookEntry.prompt, pluginStablePath, {
+            shellQuote: true,
+          })
         : undefined;
 
       // Sibling Claude/Cursor manifests often declare the same hook twice.

--- a/src/cli/utils/agents-file/subagents.ts
+++ b/src/cli/utils/agents-file/subagents.ts
@@ -1,5 +1,5 @@
 import { existsSync, mkdirSync, writeFileSync, unlinkSync } from 'fs';
-import { join } from 'path';
+import { isAbsolute, join, relative, resolve } from 'path';
 import type { SubAgent, Capabilities } from '../../../types/capabilities';
 import { getProvider } from '../../../shared/providers';
 import {
@@ -76,7 +76,16 @@ function writeSubAgentFile(
   const agentsDir = join(projectPath, sa.dir);
   mkdirSync(agentsDir, { recursive: true });
 
-  const filePath = join(agentsDir, `${subAgent.id}${sa.extension}`);
+  const agentsDirResolved = resolve(agentsDir);
+  const filePath = resolve(agentsDir, `${subAgent.id}${sa.extension}`);
+  const rel = relative(agentsDirResolved, filePath);
+  if (!rel || rel.startsWith('..') || isAbsolute(rel)) {
+    taskLog(
+      `  ⚠ Skipping subagent "${subAgent.id}": id escapes ${sa.dir} (refusing path traversal)`,
+    );
+    return;
+  }
+
   const content = buildSubAgentFileContent(provider, subAgent, capabilities, skillDescriptions);
   writeFileSync(filePath, content, 'utf8');
 

--- a/src/cli/utils/hooks/__tests__/plugin-hook-merge.test.ts
+++ b/src/cli/utils/hooks/__tests__/plugin-hook-merge.test.ts
@@ -1,0 +1,147 @@
+import { describe, it, expect } from 'bun:test';
+import type { Hook } from '../../../../types/hooks';
+import {
+  coalescePluginHook,
+  matchersCompatible,
+  normalizeHookBodyForDedupe,
+  pluginHookMergeKey,
+} from '../plugin-hook-merge';
+
+describe('normalizeHookBodyForDedupe', () => {
+  it('equates quoted Claude rewrite with unquoted Cursor rewrite', () => {
+    const claude =
+      '"C:/Users/me/.capa/plugins/p/superpowers/hooks/run-hook.cmd" session-start';
+    const cursor =
+      'C:/Users/me/.capa/plugins/p/superpowers/hooks/run-hook.cmd session-start';
+    expect(normalizeHookBodyForDedupe(claude)).toBe(
+      normalizeHookBodyForDedupe(cursor),
+    );
+  });
+});
+
+describe('pluginHookMergeKey', () => {
+  it('matches sibling sessionStart hooks after path rewrite', () => {
+    const a = {
+      on: 'sessionStart',
+      type: 'command' as const,
+      command:
+        '"C:/plugins/superpowers/hooks/run-hook.cmd" session-start',
+    };
+    const b = {
+      on: 'sessionStart',
+      type: 'command' as const,
+      command: 'C:/plugins/superpowers/hooks/run-hook.cmd session-start',
+    };
+    expect(pluginHookMergeKey(a)).toBe(pluginHookMergeKey(b));
+  });
+});
+
+describe('matchersCompatible', () => {
+  it('allows empty vs Claude SessionStart matcher', () => {
+    expect(matchersCompatible('startup|clear|compact', undefined)).toBe(true);
+    expect(matchersCompatible(undefined, 'startup|clear|compact')).toBe(true);
+  });
+
+  it('rejects two different non-empty matchers', () => {
+    expect(matchersCompatible('Write', 'Edit')).toBe(false);
+  });
+});
+
+describe('coalescePluginHook', () => {
+  const sourcePlugin = {
+    id: 'superpowers',
+    name: 'superpowers',
+    provider: 'claude' as const,
+  };
+
+  it('merges cursor into claude entry despite SessionStart matcher', () => {
+    const merged: Hook[] = [
+      {
+        id: 'plugin-superpowers-sessionstart-0',
+        on: 'sessionStart',
+        type: 'command',
+        command: '"C:/p/hooks/run-hook.cmd" session-start',
+        matcher: 'startup|clear|compact',
+        providers: ['claude-code'],
+        sourcePlugin,
+      },
+    ];
+    const absorbed = coalescePluginHook(
+      merged,
+      'superpowers',
+      {
+        id: 'plugin-superpowers-cursor-sessionstart-0',
+        on: 'sessionStart',
+        type: 'command',
+        command: 'C:/p/hooks/run-hook.cmd session-start',
+        providers: ['cursor'],
+        sourcePlugin,
+      },
+      'cursor',
+    );
+    expect(absorbed).toBe(true);
+    expect(merged).toHaveLength(1);
+    expect(merged[0].providers).toBeUndefined();
+    expect(merged[0].matcher).toBeUndefined();
+  });
+
+  it('does not merge different tool matchers with the same command', () => {
+    const merged: Hook[] = [
+      {
+        id: 'a',
+        on: 'beforeTool',
+        type: 'command',
+        command: 'echo',
+        matcher: 'Write',
+        providers: ['claude-code'],
+        sourcePlugin,
+      },
+    ];
+    expect(
+      coalescePluginHook(
+        merged,
+        'superpowers',
+        {
+          id: 'b',
+          on: 'beforeTool',
+          type: 'command',
+          command: 'echo',
+          matcher: 'Edit',
+          providers: ['cursor'],
+          sourcePlugin,
+        },
+        'cursor',
+      ),
+    ).toBe(false);
+    expect(merged).toHaveLength(1);
+  });
+
+  it('returns false when bodies differ', () => {
+    const merged: Hook[] = [
+      {
+        id: 'plugin-superpowers-sessionstart-0',
+        on: 'sessionStart',
+        type: 'command',
+        command: 'echo a',
+        providers: ['claude-code'],
+        sourcePlugin,
+      },
+    ];
+    expect(
+      coalescePluginHook(
+        merged,
+        'superpowers',
+        {
+          id: 'other',
+          on: 'sessionStart',
+          type: 'command',
+          command: 'echo b',
+          providers: ['cursor'],
+          sourcePlugin,
+        },
+        'cursor',
+      ),
+    ).toBe(false);
+    expect(merged).toHaveLength(1);
+  });
+});

--- a/src/cli/utils/hooks/__tests__/provider-map.test.ts
+++ b/src/cli/utils/hooks/__tests__/provider-map.test.ts
@@ -1,0 +1,28 @@
+import { describe, it, expect } from 'bun:test';
+import { toCanonicalOrScopedHookOn } from '../provider-map';
+
+describe('toCanonicalOrScopedHookOn', () => {
+  it('maps Claude SessionStart to canonical sessionStart', () => {
+    expect(toCanonicalOrScopedHookOn('claude-code', 'SessionStart')).toBe('sessionStart');
+  });
+
+  it('keeps Cursor sessionStart as canonical', () => {
+    expect(toCanonicalOrScopedHookOn('cursor', 'sessionStart')).toBe('sessionStart');
+  });
+
+  it('maps Claude PreToolUse without matcher to beforeTool', () => {
+    expect(toCanonicalOrScopedHookOn('claude-code', 'PreToolUse')).toBe('beforeTool');
+  });
+
+  it('narrows Claude PreToolUse + Bash matcher to beforeShell', () => {
+    expect(toCanonicalOrScopedHookOn('claude-code', 'PreToolUse', 'Bash')).toBe(
+      'beforeShell',
+    );
+  });
+
+  it('falls back to provider-scoped for unmapped events', () => {
+    expect(toCanonicalOrScopedHookOn('claude-code', 'Notification')).toBe(
+      'claude-code:Notification',
+    );
+  });
+});

--- a/src/cli/utils/hooks/plugin-hook-merge.ts
+++ b/src/cli/utils/hooks/plugin-hook-merge.ts
@@ -1,0 +1,84 @@
+import type { Hook } from '../../../types/hooks';
+
+/**
+ * Normalize command/prompt text so Claude-quoted and Cursor-relative rewrites
+ * of the same plugin script compare equal (quotes + path separators).
+ */
+export function normalizeHookBodyForDedupe(value: string | undefined): string {
+  if (value == null) return '';
+  return value.replace(/"/g, '').replace(/\\/g, '/').trim();
+}
+
+/** Identity for coalescing sibling Claude/Cursor plugin hooks into one entry. */
+export function pluginHookMergeKey(hook: {
+  on: string;
+  type?: string;
+  command?: string;
+  prompt?: string;
+}): string {
+  return [
+    hook.on,
+    hook.type ?? 'command',
+    normalizeHookBodyForDedupe(hook.command),
+    normalizeHookBodyForDedupe(hook.prompt),
+  ].join('\0');
+}
+
+/**
+ * Sibling manifests often attach a provider-only matcher on one side
+ * (e.g. Claude SessionStart `startup|clear|compact`) and omit it on the other.
+ * Those are still the same hook. Distinct non-empty matchers stay separate.
+ */
+export function matchersCompatible(
+  a: string | undefined,
+  b: string | undefined,
+): boolean {
+  const ma = a?.trim() || '';
+  const mb = b?.trim() || '';
+  if (!ma || !mb) return true;
+  return ma === mb;
+}
+
+/**
+ * If an equivalent hook from the same plugin already exists, union providers.
+ * When more than one provider declares the same body, drop `providers` so the
+ * hook installs for all project providers (canonical cross-provider behavior).
+ * Provider-specific matchers are cleared when they disagree across siblings.
+ * Returns true when the new entry was absorbed.
+ */
+export function coalescePluginHook(
+  mergedHooks: Hook[],
+  pluginInstallId: string,
+  candidate: Hook,
+  targetProvider: string,
+): boolean {
+  const key = pluginHookMergeKey(candidate);
+  const existing = mergedHooks.find(
+    (h) =>
+      h.sourcePlugin?.id === pluginInstallId &&
+      pluginHookMergeKey(h) === key &&
+      matchersCompatible(h.matcher, candidate.matcher),
+  );
+  if (!existing) return false;
+
+  if (!existing.providers || existing.providers.length === 0) {
+    if ((existing.matcher ?? '') !== (candidate.matcher ?? '')) {
+      delete existing.matcher;
+    }
+    return true;
+  }
+
+  const providers = new Set(existing.providers);
+  providers.add(targetProvider);
+  if (providers.size > 1) {
+    delete existing.providers;
+    // Matcher from one provider (e.g. Claude SessionStart kinds) must not
+    // become a Cursor `pattern` filter on the unified hook.
+    if ((existing.matcher ?? '') !== (candidate.matcher ?? '')) {
+      delete existing.matcher;
+    }
+  } else {
+    existing.providers = [...providers];
+  }
+  return true;
+}

--- a/src/cli/utils/hooks/provider-map.ts
+++ b/src/cli/utils/hooks/provider-map.ts
@@ -1,5 +1,11 @@
 import type { HooksIntegration, ProviderEventMapping } from '../../../types/providers';
-import type { CanonicalHookEvent, Hook } from '../../../types/hooks';
+import {
+  CANONICAL_HOOK_EVENTS,
+  type CanonicalHookEvent,
+  type Hook,
+  type ProviderScopedEvent,
+} from '../../../types/hooks';
+import { getProvider } from '../../../shared/providers';
 
 /**
  * Returns the list of provider ids targeted by this hook's `providers` field
@@ -29,4 +35,57 @@ export function resolveProviderEventName(
 ): string | null {
   const m = pickMapping(integration, hook.on, providerId);
   return m ? m.event : null;
+}
+
+function matcherMatchesPrefix(matcher: string, prefix: string): boolean {
+  if (prefix.endsWith('__')) {
+    return matcher.startsWith(prefix) || matcher.includes(prefix);
+  }
+  const alts = prefix.split('|').map((a) => a.trim()).filter(Boolean);
+  const parts = matcher.split('|').map((a) => a.trim()).filter(Boolean);
+  return alts.some((a) => parts.includes(a) || matcher === a);
+}
+
+/**
+ * Map a provider-native hook event (e.g. Claude `SessionStart`, Cursor
+ * `sessionStart`) onto capa's canonical event when `eventMap` has a match.
+ * Falls back to `<provider>:<event>` only when there is no canonical mapping
+ * (same rule as bootstrap discovery).
+ */
+export function toCanonicalOrScopedHookOn(
+  providerId: string,
+  nativeEvent: string,
+  matcher?: string,
+): CanonicalHookEvent | ProviderScopedEvent {
+  if ((CANONICAL_HOOK_EVENTS as readonly string[]).includes(nativeEvent)) {
+    return nativeEvent as CanonicalHookEvent;
+  }
+
+  const integration = getProvider(providerId)?.hooks;
+  if (!integration) {
+    return `${providerId}:${nativeEvent}`;
+  }
+
+  let best: CanonicalHookEvent | null = null;
+  let bestScore = -1;
+  for (const [canonical, mapping] of Object.entries(integration.eventMap) as [
+    CanonicalHookEvent,
+    ProviderEventMapping | undefined,
+  ][]) {
+    if (!mapping || mapping.event !== nativeEvent) continue;
+    if (mapping.matcherPrefix) {
+      if (!matcher || !matcherMatchesPrefix(matcher, mapping.matcherPrefix)) {
+        continue;
+      }
+      if (2 > bestScore) {
+        best = canonical;
+        bestScore = 2;
+      }
+    } else if (1 > bestScore) {
+      best = canonical;
+      bestScore = 1;
+    }
+  }
+
+  return best ?? `${providerId}:${nativeEvent}`;
 }

--- a/src/cli/utils/passthrough/env.ts
+++ b/src/cli/utils/passthrough/env.ts
@@ -1,12 +1,9 @@
-import { join, resolve } from 'path';
+import { resolve } from 'path';
 import { existsSync } from 'fs';
 import { resolveProviders } from '../../../shared/providers/resolve';
 import { loadSettings, getDatabasePath } from '../../../shared/config';
 import { CapaDatabase } from '../../../db/database';
 import type { Capabilities } from '../../../types/capabilities';
-
-/** Project-local unpack root for plugins wired to providers without a native installer. */
-export const PASSTHROUGH_PLUGINS_DIR = join('.capa', 'plugins');
 
 export function expandEnvInRecord(
   record: Record<string, string> | undefined,

--- a/src/cli/utils/passthrough/install-plugin.ts
+++ b/src/cli/utils/passthrough/install-plugin.ts
@@ -6,7 +6,10 @@ import { resolvePlugins } from '../../commands/plugin-install';
 import { getProvider } from '../../../shared/providers';
 import { upsertNativeMcpServer } from './native-mcp';
 import { runNativePluginInstall, type NativePluginInstall } from './native-plugin-install';
-import { expandEnvInRecord, emptyCapabilities, PASSTHROUGH_PLUGINS_DIR } from './env';
+import { expandEnvInRecord, emptyCapabilities } from './env';
+import { installRules } from '../rules-installer';
+import { installHooks } from '../hooks-installer';
+import { installSubAgentInstructions } from '../agents-file';
 import type { CapaDatabase } from '../../../db/database';
 import type { Plugin } from '../../../types/capabilities';
 
@@ -59,7 +62,7 @@ export async function passthroughInstallPlugin(opts: {
   caps.plugins = [plugin];
   const authFetch = createAuthenticatedFetch(db);
   const lockBuilder = new LockfileBuilder(null);
-  const pluginsBaseDir = join(projectPath, PASSTHROUGH_PLUGINS_DIR);
+  const capabilitiesFilePath = join(projectPath, 'capabilities.yaml');
   const result = await resolvePlugins(
     caps,
     projectPath,
@@ -67,19 +70,21 @@ export async function passthroughInstallPlugin(opts: {
     authFetch,
     db,
     getRepoSnapshot,
-    join(projectPath, 'capabilities.yaml'),
+    capabilitiesFilePath,
     lockBuilder,
-    { noCache, trackManaged: false, pluginsBaseDir },
+    { noCache, trackManaged: false },
   );
   warnings.push(...result.warnings);
-  for (const skill of result.mergedCapabilities.skills ?? []) {
+  const merged = result.mergedCapabilities;
+
+  for (const skill of merged.skills ?? []) {
     if (skill.type !== 'plugin' && skill.type !== 'installed') continue;
     for (const pid of unpackProviders) {
       const prov = getProvider(pid);
       if (prov) written.push(join(projectPath, prov.skillsDir, skill.id));
     }
   }
-  for (const server of result.mergedCapabilities.servers ?? []) {
+  for (const server of merged.servers ?? []) {
     if (server.type !== 'mcp') continue;
     const def = {
       ...server.def,
@@ -95,5 +100,41 @@ export async function passthroughInstallPlugin(opts: {
       );
     }
   }
+
+  const pluginRules = (merged.rules ?? []).filter((r) => r.sourcePlugin);
+  if (pluginRules.length > 0) {
+    const bodies = new Map<string, string>();
+    for (const rule of pluginRules) {
+      if (rule.content) bodies.set(rule.id, rule.content);
+    }
+    installRules(projectPath, pluginRules, unpackProviders, bodies);
+    for (const rule of pluginRules) written.push(`rule:${rule.id}`);
+  }
+
+  const pluginHooks = (merged.hooks ?? []).filter((h) => h.sourcePlugin);
+  if (pluginHooks.length > 0) {
+    const hookResult = await installHooks({
+      projectPath,
+      projectId,
+      capabilitiesFilePath,
+      hooks: pluginHooks,
+      providers: unpackProviders,
+      db,
+      authFetch,
+      getRepoSnapshot,
+      noCache,
+      trackManaged: false,
+      nameTagPrefix: '',
+    });
+    warnings.push(...hookResult.warnings);
+    for (const h of pluginHooks) written.push(`hook:${h.id}`);
+  }
+
+  const pluginSubagents = (merged.subagents ?? []).filter((a) => a.sourcePlugin);
+  for (const agent of pluginSubagents) {
+    installSubAgentInstructions(projectPath, agent, merged, unpackProviders);
+    written.push(`subagent:${agent.id}`);
+  }
+
   console.log(`✓ Passthrough: installed plugin "${plugin.id}"`);
 }

--- a/src/cli/utils/passthrough/install.ts
+++ b/src/cli/utils/passthrough/install.ts
@@ -1,4 +1,4 @@
-import { join, resolve } from 'path';
+import { resolve } from 'path';
 import { resolveProviders } from '../../../shared/providers/resolve';
 import { createAuthenticatedFetch } from '../../../shared/authenticated-fetch';
 import { LockfileBuilder } from '../../../shared/lockfile';
@@ -8,9 +8,10 @@ import { installOneSkill } from '../../commands/install-tasks/helpers/install-on
 import { resolveRuleBody } from '../../commands/install-tasks/install-rules';
 import { installRules } from '../rules-installer';
 import { installHooks } from '../hooks-installer';
+import { installSubAgentInstructions } from '../agents-file';
 import { resolvePlugins } from '../../commands/plugin-install';
 import { upsertNativeMcpServer } from './native-mcp';
-import { expandEnvInRecord, loadEnvFileOptional, openAuthDb, PASSTHROUGH_PLUGINS_DIR } from './env';
+import { expandEnvInRecord, loadEnvFileOptional, openAuthDb } from './env';
 import type { MCPServer } from '../../../types/capabilities';
 import type { GetSnapshotResult } from '../../../shared/cache';
 
@@ -65,7 +66,6 @@ export async function passthroughInstall(opts: {
   let failed = 0;
 
   try {
-    const pluginsBaseDir = join(projectPath, PASSTHROUGH_PLUGINS_DIR);
     const pluginResult = await resolvePlugins(
       capabilities,
       projectPath,
@@ -75,7 +75,7 @@ export async function passthroughInstall(opts: {
       getRepoSnapshot,
       capabilitiesFile.path,
       lockBuilder,
-      { noCache: !!opts.noCache, trackManaged: false, pluginsBaseDir },
+      { noCache: !!opts.noCache, trackManaged: false },
     );
     warnings.push(...pluginResult.warnings);
     capabilities = pluginResult.mergedCapabilities;
@@ -154,6 +154,14 @@ export async function passthroughInstall(opts: {
       });
       warnings.push(...hookResult.warnings);
       added += hookResult.installed;
+    }
+
+    const subagents = capabilities.subagents ?? [];
+    if (subagents.length > 0) {
+      for (const agent of subagents) {
+        installSubAgentInstructions(projectPath, agent, capabilities, providers);
+        added++;
+      }
     }
 
     for (const server of capabilities.servers ?? []) {

--- a/src/server/capabilities-mutations.ts
+++ b/src/server/capabilities-mutations.ts
@@ -113,7 +113,11 @@ export async function handleUpdate(
 	}
 	if (
 		isPluginSourced(existing) &&
-		(section === "skills" || section === "servers")
+		(section === "skills" ||
+			section === "servers" ||
+			section === "rules" ||
+			section === "hooks" ||
+			section === "subagents")
 	) {
 		return jsonError(
 			`Cannot edit plugin-sourced ${section.slice(0, -1)}; remove the plugin instead`,
@@ -269,7 +273,11 @@ export async function handleDelete(
 	}
 	if (
 		isPluginSourced(existing) &&
-		(section === "skills" || section === "servers")
+		(section === "skills" ||
+			section === "servers" ||
+			section === "rules" ||
+			section === "hooks" ||
+			section === "subagents")
 	) {
 		return jsonError(
 			`Cannot delete plugin-sourced ${section.slice(0, -1)}; remove the plugin instead`,

--- a/src/server/configure-routes.ts
+++ b/src/server/configure-routes.ts
@@ -261,7 +261,9 @@ export async function runProjectConfigure(
 	}
 
 	// -- Required variables ---------------------------------------------
-	const requiredVars = extractAllVariables(capabilitiesToUse);
+	// Authored capabilities only — plugin-merged subagents/skills/etc. can
+	// contain `${…}` as prose and must not become required credentials.
+	const requiredVars = extractAllVariables(capabilities);
 	apiLogger.info(`Required variables: ${requiredVars.join(", ")}`);
 
 	const missingVars: string[] = [];

--- a/src/server/project-routes.ts
+++ b/src/server/project-routes.ts
@@ -235,6 +235,7 @@ export async function handleGetProject(
 							skills: sa.skills,
 							tools: sa.tools,
 							instructions: sa.instructions || null,
+							sourcePlugin: sa.sourcePlugin || null,
 						})),
 						rules: (capabilities.rules || []).map((r) => ({
 							id: r.id,
@@ -247,6 +248,7 @@ export async function handleGetProject(
 							url: r.url || null,
 							path: r.path || null,
 							def: r.def || null,
+							sourcePlugin: r.sourcePlugin || null,
 						})),
 						hooks: (capabilities.hooks || []).map((h) => ({
 							id: h.id,
@@ -267,6 +269,7 @@ export async function handleGetProject(
 									? (h.source as { content: string }).content
 									: null,
 							installed: installedHooksByHookId.get(h.id) ?? [],
+							sourcePlugin: h.sourcePlugin || null,
 						})),
 						plugins: (capabilities.plugins || []).map((p) => ({
 							id: p.id || null,

--- a/src/server/resolve-effective-capabilities.ts
+++ b/src/server/resolve-effective-capabilities.ts
@@ -49,7 +49,7 @@ export function resolveProvidersForServer(
 }
 
 /**
- * Expand `plugins` into merged skills/servers (in memory only — not written to YAML).
+ * Expand `plugins` into merged skills/servers/rules/hooks/subagents (in memory only — not written to YAML).
  * Returns the authored capabilities unchanged when there are no plugins or providers.
  */
 export async function resolveEffectiveCapabilities(

--- a/src/shared/__tests__/variable-resolver.test.ts
+++ b/src/shared/__tests__/variable-resolver.test.ts
@@ -153,6 +153,26 @@ describe('variable-resolver', () => {
         null: null,
       });
     });
+
+    it('should not rewrite plugin-sourced string values', () => {
+      const obj = {
+        subagents: [
+          {
+            id: 'security-analyst',
+            instructions: 'Ask for ${API_KEY}',
+            sourcePlugin: { id: 'p', name: 'P', provider: 'claude' },
+          },
+        ],
+      };
+      const result = resolveVariablesInObject(obj, 'test-project', mockDb as any);
+      expect(result.subagents[0].instructions).toBe('Ask for ${API_KEY}');
+    });
+
+    it('should not rewrite object keys', () => {
+      const obj = { '${API_KEY}': '${BASE_URL}' };
+      const result = resolveVariablesInObject(obj, 'test-project', mockDb as any);
+      expect(result).toEqual({ '${API_KEY}': 'https://api.example.com' });
+    });
   });
 
   describe('hasUnresolvedVariables', () => {
@@ -215,6 +235,59 @@ describe('variable-resolver', () => {
       const variables = extractAllVariables(obj);
       
       expect(variables).toEqual([]);
+    });
+
+    it('should ignore object keys that look like placeholders', () => {
+      const obj = {
+        '${NOT_A_VAR}': 'literal',
+        nested: { '${ALSO_NOT}': true },
+      };
+      expect(extractAllVariables(obj)).toEqual([]);
+      expect(hasUnresolvedVariables(obj)).toBe(false);
+    });
+
+    it('should ignore placeholders inside plugin-sourced entries', () => {
+      const caps = {
+        servers: [
+          {
+            id: 'authored',
+            type: 'mcp',
+            def: { url: 'https://x', headers: { Authorization: 'Bearer ${TOKEN}' } },
+          },
+        ],
+        subagents: [
+          {
+            id: 'security-analyst',
+            instructions: 'Ask for ${email} and ${password}',
+            skills: [],
+            tools: [],
+            sourcePlugin: { id: 'security-analyst', name: 'Security Analyst', provider: 'claude' },
+          },
+        ],
+        hooks: [
+          {
+            id: 'plugin-hook',
+            command: 'echo ${SECRET_FROM_PLUGIN}',
+            sourcePlugin: { id: 'p', name: 'P', provider: 'claude' },
+          },
+        ],
+      };
+      expect(extractAllVariables(caps)).toEqual(['TOKEN']);
+      expect(hasUnresolvedVariables(caps)).toBe(true);
+    });
+
+    it('should still extract from authored entries without sourcePlugin', () => {
+      const caps = {
+        subagents: [
+          {
+            id: 'local-agent',
+            instructions: 'Use ${API_KEY} when calling the API',
+            skills: [],
+            tools: [],
+          },
+        ],
+      };
+      expect(extractAllVariables(caps)).toEqual(['API_KEY']);
     });
   });
 });

--- a/src/shared/capabilities.ts
+++ b/src/shared/capabilities.ts
@@ -166,7 +166,11 @@ export function capabilityEntryReorderKey(
 			: null;
 
 	if (
-		(section === "skills" || section === "servers") &&
+		(section === "skills" ||
+			section === "servers" ||
+			section === "rules" ||
+			section === "hooks" ||
+			section === "subagents") &&
 		pluginName
 	) {
 		return `plugin:${pluginName}:${entry.id}`;

--- a/src/shared/plugin-manifest/__tests__/full-unpack.test.ts
+++ b/src/shared/plugin-manifest/__tests__/full-unpack.test.ts
@@ -240,6 +240,7 @@ describe("plugin full unpack parsers", () => {
 		const resolved = resolvePluginRootInString(
 			'"${CLAUDE_PLUGIN_ROOT}/hooks/run-hook.cmd" session-start',
 			pluginRoot,
+			{ shellQuote: true },
 		);
 		expect(resolved).toBe(
 			`"${pluginRoot}/hooks/run-hook.cmd" session-start`,
@@ -250,9 +251,21 @@ describe("plugin full unpack parsers", () => {
 		const resolved = resolvePluginRootInString(
 			'"${CLAUDE_PLUGIN_ROOT}/hooks/run-hook.cmd" session-start',
 			"C:\\Users\\Tony Zaitoun\\.capa\\plugins\\meta\\superpowers",
+			{ shellQuote: true },
 		);
 		expect(resolved).toBe(
 			'"C:/Users/Tony Zaitoun/.capa/plugins/meta/superpowers/hooks/run-hook.cmd" session-start',
+		);
+	});
+
+	it("shell-quotes unquoted CLAUDE_PLUGIN_ROOT paths that contain spaces", () => {
+		const resolved = resolvePluginRootInString(
+			"${CLAUDE_PLUGIN_ROOT}/hooks/prevent-destructive-commands.py",
+			"C:\\Users\\Tony Zaitoun\\.capa\\plugins\\ontology-builder-a6a5\\developer-kit",
+			{ shellQuote: true },
+		);
+		expect(resolved).toBe(
+			'"C:/Users/Tony Zaitoun/.capa/plugins/ontology-builder-a6a5/developer-kit/hooks/prevent-destructive-commands.py"',
 		);
 	});
 
@@ -260,6 +273,7 @@ describe("plugin full unpack parsers", () => {
 		const resolved = resolvePluginRootInString(
 			"./hooks/run-hook.cmd session-start",
 			"C:\\Users\\Tony Zaitoun\\.capa\\plugins\\meta\\superpowers",
+			{ shellQuote: true },
 		);
 		expect(resolved).toBe(
 			'"C:/Users/Tony Zaitoun/.capa/plugins/meta/superpowers/hooks/run-hook.cmd" session-start',

--- a/src/shared/plugin-manifest/__tests__/full-unpack.test.ts
+++ b/src/shared/plugin-manifest/__tests__/full-unpack.test.ts
@@ -6,7 +6,9 @@ import { parseClaudeManifest } from "../claude-parser";
 import { parseCursorManifest } from "../cursor-parser";
 import { materializeCommandAsSkill } from "../commands-parser";
 import { detectAndParseManifest } from "../detect";
+import { parseHookEntries } from "../hooks-parser";
 import { resolvePluginRootInString } from "../mcp-parser";
+import { safePluginEntryId } from "../safe-id";
 
 describe("plugin full unpack parsers", () => {
 	let root: string;
@@ -299,5 +301,80 @@ describe("plugin full unpack parsers", () => {
 		expect(manifest).not.toBeNull();
 		expect(manifest!.agentEntries.map((a) => a.id)).toContain("helper");
 		expect(manifest!.hookEntries.some((h) => h.event === "Stop")).toBe(true);
+	});
+
+	it("discover-mode reads root SKILL.md frontmatter name", () => {
+		writeFileSync(
+			join(root, "SKILL.md"),
+			"---\nname: my-root-skill\ndescription: Root\n---\n\nBody\n",
+		);
+		const manifest = detectAndParseManifest(root, ["claude-code"]);
+		expect(manifest).not.toBeNull();
+		expect(manifest!.skillEntries).toEqual([
+			{ id: "my-root-skill", relativePath: "." },
+		]);
+	});
+
+	it("sanitizes agent frontmatter names that contain path separators", () => {
+		expect(safePluginEntryId("../evil", "reviewer")).toBe("evil");
+		expect(safePluginEntryId("..\\..\\x", "reviewer")).toBe("x");
+		mkdirSync(join(root, ".claude-plugin"), { recursive: true });
+		writeFileSync(
+			join(root, ".claude-plugin", "plugin.json"),
+			JSON.stringify({ name: "demo" }),
+		);
+		mkdirSync(join(root, "agents"), { recursive: true });
+		writeFileSync(
+			join(root, "agents", "safe.md"),
+			"---\nname: ../escape-hatch\ndescription: Bad\n---\n\nNope.\n",
+		);
+		const manifest = parseClaudeManifest(root, { name: "demo" });
+		expect(manifest.agentEntries).toHaveLength(1);
+		expect(manifest.agentEntries[0].id).toBe("escape-hatch");
+		expect(manifest.agentEntries[0].id).not.toContain("..");
+		expect(manifest.agentEntries[0].id).not.toContain("/");
+	});
+
+	it("keeps unique idHints when hook actions share a name", () => {
+		const entries = parseHookEntries(root, {
+			hooks: {
+				Stop: [
+					{
+						hooks: [
+							{ type: "prompt", name: "Same", prompt: "one" },
+							{ type: "prompt", name: "Same", prompt: "two" },
+						],
+					},
+				],
+			},
+		});
+		expect(entries).toHaveLength(2);
+		expect(entries[0].idHint).toBe("same-0");
+		expect(entries[1].idHint).toBe("same-1");
+		expect(new Set(entries.map((e) => e.idHint)).size).toBe(2);
+	});
+
+	it("concatenates overlapping events when hooks is an array of sources", () => {
+		mkdirSync(join(root, "hooks"), { recursive: true });
+		writeFileSync(
+			join(root, "hooks", "a.json"),
+			JSON.stringify({
+				hooks: {
+					Stop: [{ hooks: [{ type: "prompt", prompt: "from-a" }] }],
+				},
+			}),
+		);
+		writeFileSync(
+			join(root, "hooks", "b.json"),
+			JSON.stringify({
+				hooks: {
+					Stop: [{ hooks: [{ type: "prompt", prompt: "from-b" }] }],
+				},
+			}),
+		);
+		const entries = parseHookEntries(root, {
+			hooks: ["./hooks/a.json", "./hooks/b.json"],
+		});
+		expect(entries.map((e) => e.prompt)).toEqual(["from-a", "from-b"]);
 	});
 });

--- a/src/shared/plugin-manifest/__tests__/full-unpack.test.ts
+++ b/src/shared/plugin-manifest/__tests__/full-unpack.test.ts
@@ -1,0 +1,289 @@
+import { describe, it, expect, beforeEach, afterEach } from "bun:test";
+import { mkdtempSync, mkdirSync, writeFileSync, rmSync, readFileSync } from "fs";
+import { join } from "path";
+import { tmpdir } from "os";
+import { parseClaudeManifest } from "../claude-parser";
+import { parseCursorManifest } from "../cursor-parser";
+import { materializeCommandAsSkill } from "../commands-parser";
+import { detectAndParseManifest } from "../detect";
+import { resolvePluginRootInString } from "../mcp-parser";
+
+describe("plugin full unpack parsers", () => {
+	let root: string;
+
+	beforeEach(() => {
+		root = mkdtempSync(join(tmpdir(), "capa-plugin-full-"));
+	});
+
+	afterEach(() => {
+		rmSync(root, { recursive: true, force: true });
+	});
+
+	function writeClaudePlugin(opts: {
+		agents?: boolean;
+		hooks?: boolean;
+		commands?: boolean;
+		skills?: boolean;
+		rootSkill?: boolean;
+		lsp?: boolean;
+	}): void {
+		mkdirSync(join(root, ".claude-plugin"), { recursive: true });
+		writeFileSync(
+			join(root, ".claude-plugin", "plugin.json"),
+			JSON.stringify({ name: "demo-plugin", version: "1.0.0" }),
+		);
+		if (opts.skills !== false && !opts.rootSkill) {
+			mkdirSync(join(root, "skills", "hello"), { recursive: true });
+			writeFileSync(
+				join(root, "skills", "hello", "SKILL.md"),
+				"---\nname: hello\ndescription: Hi\n---\n\nHello body\n",
+			);
+		}
+		if (opts.rootSkill) {
+			writeFileSync(
+				join(root, "SKILL.md"),
+				"---\nname: root-skill\ndescription: Root\n---\n\nRoot body\n",
+			);
+		}
+		if (opts.agents) {
+			mkdirSync(join(root, "agents"), { recursive: true });
+			writeFileSync(
+				join(root, "agents", "reviewer.md"),
+				"---\nname: reviewer\ndescription: Reviews code\nmodel: sonnet\nskills: hello\n---\n\nBe thorough.\n",
+			);
+		}
+		if (opts.hooks) {
+			mkdirSync(join(root, "hooks"), { recursive: true });
+			writeFileSync(
+				join(root, "hooks", "hooks.json"),
+				JSON.stringify({
+					hooks: {
+						PreToolUse: [
+							{
+								matcher: "Write",
+								hooks: [
+									{
+										type: "command",
+										command: '"${CLAUDE_PLUGIN_ROOT}"/scripts/fmt.sh',
+									},
+								],
+							},
+						],
+					},
+				}),
+			);
+			mkdirSync(join(root, "scripts"), { recursive: true });
+			writeFileSync(join(root, "scripts", "fmt.sh"), "#!/bin/sh\necho ok\n");
+		}
+		if (opts.commands) {
+			mkdirSync(join(root, "commands"), { recursive: true });
+			writeFileSync(join(root, "commands", "deploy.md"), "# Deploy\n\nDeploy the app.\n");
+		}
+		if (opts.lsp) {
+			writeFileSync(join(root, ".lsp.json"), JSON.stringify({ go: { command: "gopls" } }));
+		}
+	}
+
+	it("parses agents, hooks, commands and skills from a Claude plugin", () => {
+		writeClaudePlugin({ agents: true, hooks: true, commands: true });
+		const manifest = parseClaudeManifest(root, {
+			name: "demo-plugin",
+			version: "1.0.0",
+		});
+		expect(manifest.skillEntries.map((s) => s.id)).toContain("hello");
+		expect(manifest.commandEntries.map((c) => c.id)).toEqual(["deploy"]);
+		expect(manifest.agentEntries).toHaveLength(1);
+		expect(manifest.agentEntries[0].id).toBe("reviewer");
+		expect(manifest.agentEntries[0].description).toBe("Reviews code");
+		expect(manifest.agentEntries[0].instructions).toContain("Be thorough");
+		expect(manifest.agentEntries[0].skillIds).toEqual(["hello"]);
+		expect(manifest.agentEntries[0].droppedFrontmatterKeys).toContain("model");
+		expect(manifest.hookEntries).toHaveLength(1);
+		expect(manifest.hookEntries[0].event).toBe("PreToolUse");
+		expect(manifest.hookEntries[0].matcher).toBe("Write");
+		expect(manifest.hookEntries[0].command).toContain("${CLAUDE_PLUGIN_ROOT}");
+		expect(manifest.hookEntries[0].targetProvider).toBe("claude-code");
+	});
+
+	it("parses Cursor manifest hooks path (hooks-cursor.json)", () => {
+		mkdirSync(join(root, ".cursor-plugin"), { recursive: true });
+		writeFileSync(
+			join(root, ".cursor-plugin", "plugin.json"),
+			JSON.stringify({
+				name: "superpowers",
+				hooks: "./hooks/hooks-cursor.json",
+			}),
+		);
+		mkdirSync(join(root, "hooks"), { recursive: true });
+		writeFileSync(
+			join(root, "hooks", "hooks-cursor.json"),
+			JSON.stringify({
+				version: 1,
+				hooks: {
+					sessionStart: [{ command: "./hooks/run-hook.cmd session-start" }],
+				},
+			}),
+		);
+		const manifest = parseCursorManifest(root, {
+			name: "superpowers",
+			hooks: "./hooks/hooks-cursor.json",
+		});
+		expect(manifest.hookEntries).toHaveLength(1);
+		expect(manifest.hookEntries[0].event).toBe("sessionStart");
+		expect(manifest.hookEntries[0].targetProvider).toBe("cursor");
+		expect(manifest.hookEntries[0].command).toBe(
+			"./hooks/run-hook.cmd session-start",
+		);
+	});
+
+	it("merges Cursor sibling hooks when Claude manifest wins detection", () => {
+		mkdirSync(join(root, ".claude-plugin"), { recursive: true });
+		writeFileSync(
+			join(root, ".claude-plugin", "plugin.json"),
+			JSON.stringify({ name: "superpowers" }),
+		);
+		mkdirSync(join(root, ".cursor-plugin"), { recursive: true });
+		writeFileSync(
+			join(root, ".cursor-plugin", "plugin.json"),
+			JSON.stringify({
+				name: "superpowers",
+				hooks: "./hooks/hooks-cursor.json",
+			}),
+		);
+		mkdirSync(join(root, "hooks"), { recursive: true });
+		writeFileSync(
+			join(root, "hooks", "hooks.json"),
+			JSON.stringify({
+				hooks: {
+					SessionStart: [
+						{
+							hooks: [
+								{
+									type: "command",
+									command:
+										'"${CLAUDE_PLUGIN_ROOT}/hooks/run-hook.cmd" session-start',
+								},
+							],
+						},
+					],
+				},
+			}),
+		);
+		writeFileSync(
+			join(root, "hooks", "hooks-cursor.json"),
+			JSON.stringify({
+				version: 1,
+				hooks: {
+					sessionStart: [{ command: "./hooks/run-hook.cmd session-start" }],
+				},
+			}),
+		);
+		const manifest = detectAndParseManifest(root, ["claude-code", "cursor"]);
+		expect(manifest).not.toBeNull();
+		expect(manifest!.provider).toBe("claude");
+		const events = manifest!.hookEntries.map((h) => `${h.targetProvider}:${h.event}`);
+		expect(events).toContain("claude-code:SessionStart");
+		expect(events).toContain("cursor:sessionStart");
+	});
+
+	it("discovers root SKILL.md when skills/ is absent", () => {
+		writeClaudePlugin({ skills: false, rootSkill: true });
+		const manifest = parseClaudeManifest(root, { name: "demo-plugin" });
+		expect(manifest.skillEntries).toEqual([
+			{ id: "root-skill", relativePath: "." },
+		]);
+	});
+
+	it("warns about skipped unsupported artifacts", () => {
+		writeClaudePlugin({ lsp: true });
+		const manifest = parseClaudeManifest(root, { name: "demo-plugin" });
+		expect(manifest.skippedArtifacts).toContain("lsp");
+	});
+
+	it("parses Cursor rules from rules/", () => {
+		mkdirSync(join(root, ".cursor-plugin"), { recursive: true });
+		writeFileSync(
+			join(root, ".cursor-plugin", "plugin.json"),
+			JSON.stringify({ name: "cursor-demo" }),
+		);
+		mkdirSync(join(root, "rules"), { recursive: true });
+		writeFileSync(
+			join(root, "rules", "style.mdc"),
+			"---\ndescription: Style guide\nglobs: \"**/*.ts\"\nalwaysApply: true\n---\n\nUse consistent style.\n",
+		);
+		const manifest = parseCursorManifest(root, { name: "cursor-demo" });
+		expect(manifest.ruleEntries).toHaveLength(1);
+		expect(manifest.ruleEntries[0].id).toBe("style");
+		expect(manifest.ruleEntries[0].description).toBe("Style guide");
+		expect(manifest.ruleEntries[0].alwaysApply).toBe(true);
+		expect(manifest.ruleEntries[0].appliesTo).toEqual(["**/*.ts"]);
+		expect(manifest.ruleEntries[0].content).toContain("consistent style");
+	});
+
+	it("materializes commands as SKILL.md trees", () => {
+		mkdirSync(join(root, "commands"), { recursive: true });
+		writeFileSync(join(root, "commands", "ship.md"), "Ship it.\n");
+		const dest = join(root, "out", "ship");
+		const ok = materializeCommandAsSkill(
+			root,
+			{ id: "ship", relativePath: "commands/ship.md" },
+			dest,
+		);
+		expect(ok).toBe(true);
+		const skillMd = readFileSync(join(dest, "SKILL.md"), "utf-8");
+		expect(skillMd).toContain("name: ship");
+		expect(skillMd).toContain("Ship it.");
+	});
+
+	it("rewrites CLAUDE_PLUGIN_ROOT in hook commands", () => {
+		const pluginRoot = "/Users/me/.capa/plugins/proj/demo";
+		const resolved = resolvePluginRootInString(
+			'"${CLAUDE_PLUGIN_ROOT}/hooks/run-hook.cmd" session-start',
+			pluginRoot,
+		);
+		expect(resolved).toBe(
+			`"${pluginRoot}/hooks/run-hook.cmd" session-start`,
+		);
+	});
+
+	it("normalizes Windows backslashes in plugin root for hook commands", () => {
+		const resolved = resolvePluginRootInString(
+			'"${CLAUDE_PLUGIN_ROOT}/hooks/run-hook.cmd" session-start',
+			"C:\\Users\\Tony Zaitoun\\.capa\\plugins\\meta\\superpowers",
+		);
+		expect(resolved).toBe(
+			'"C:/Users/Tony Zaitoun/.capa/plugins/meta/superpowers/hooks/run-hook.cmd" session-start',
+		);
+	});
+
+	it("resolves Cursor relative hook commands with args against the plugin root", () => {
+		const resolved = resolvePluginRootInString(
+			"./hooks/run-hook.cmd session-start",
+			"C:\\Users\\Tony Zaitoun\\.capa\\plugins\\meta\\superpowers",
+		);
+		expect(resolved).toBe(
+			'"C:/Users/Tony Zaitoun/.capa/plugins/meta/superpowers/hooks/run-hook.cmd" session-start',
+		);
+	});
+
+	it("discover-mode surfaces agents and hooks without a manifest", () => {
+		mkdirSync(join(root, "agents"), { recursive: true });
+		writeFileSync(
+			join(root, "agents", "helper.md"),
+			"---\nname: helper\ndescription: Helps\n---\n\nHelp.\n",
+		);
+		mkdirSync(join(root, "hooks"), { recursive: true });
+		writeFileSync(
+			join(root, "hooks", "hooks.json"),
+			JSON.stringify({
+				hooks: {
+					Stop: [{ hooks: [{ type: "prompt", prompt: "Summarize" }] }],
+				},
+			}),
+		);
+		const manifest = detectAndParseManifest(root, ["claude-code"]);
+		expect(manifest).not.toBeNull();
+		expect(manifest!.agentEntries.map((a) => a.id)).toContain("helper");
+		expect(manifest!.hookEntries.some((h) => h.event === "Stop")).toBe(true);
+	});
+});

--- a/src/shared/plugin-manifest/__tests__/mcp-parser.test.ts
+++ b/src/shared/plugin-manifest/__tests__/mcp-parser.test.ts
@@ -43,8 +43,23 @@ describe('resolvePluginServerDef', () => {
       { cmd: './bin/server', args: ['./config.json'] },
       PLUGIN_ROOT
     );
-    expect(resolved.cmd).toBe(resolve(PLUGIN_ROOT, './bin/server'));
-    expect(resolved.args).toEqual([resolve(PLUGIN_ROOT, './config.json')]);
+    expect(resolved.cmd).toBe(resolve(PLUGIN_ROOT, './bin/server').replace(/\\/g, '/'));
+    expect(resolved.args).toEqual([resolve(PLUGIN_ROOT, './config.json').replace(/\\/g, '/')]);
+  });
+
+  it('rewrites Windows plugin roots with forward slashes for shell/Git Bash', () => {
+    const winRoot = 'C:\\Users\\Tony Zaitoun\\.capa\\plugins\\proj\\superpowers';
+    const resolved = resolvePluginServerDef(
+      {
+        cmd: 'node',
+        args: ['${CLAUDE_PLUGIN_ROOT}/hooks/run-hook.cmd', 'session-start'],
+      },
+      winRoot,
+    );
+    expect(resolved.args).toEqual([
+      'C:/Users/Tony Zaitoun/.capa/plugins/proj/superpowers/hooks/run-hook.cmd',
+      'session-start',
+    ]);
   });
 
   it('passes remote (url) servers through unchanged', () => {

--- a/src/shared/plugin-manifest/agents-parser.ts
+++ b/src/shared/plugin-manifest/agents-parser.ts
@@ -7,6 +7,7 @@ import {
 	splitMarkdownFrontmatter,
 } from "./frontmatter";
 import { collectFiles, resolveComponentPaths } from "./path-field";
+import { safePluginEntryId } from "./safe-id";
 
 /** Frontmatter keys we map into capa SubAgent fields. */
 const MAPPED_KEYS = new Set(["name", "description", "skills"]);
@@ -44,10 +45,8 @@ export function parseAgentEntries(
 		}
 		const { frontmatter, body } = splitMarkdownFrontmatter(content);
 		const fm = frontmatter ?? {};
-		const id =
-			asOptionalString(fm.name) ??
-			basename(rel).replace(/\.md$/i, "") ??
-			"agent";
+		const fileStem = basename(rel).replace(/\.md$/i, "") || "agent";
+		const id = safePluginEntryId(asOptionalString(fm.name), fileStem);
 		if (seen.has(id)) continue;
 		seen.add(id);
 

--- a/src/shared/plugin-manifest/agents-parser.ts
+++ b/src/shared/plugin-manifest/agents-parser.ts
@@ -1,0 +1,72 @@
+import { existsSync, readFileSync } from "fs";
+import { basename, join } from "path";
+import type { UnifiedAgentEntry } from "../../types/plugin";
+import {
+	asOptionalString,
+	asStringArray,
+	splitMarkdownFrontmatter,
+} from "./frontmatter";
+import { collectFiles, resolveComponentPaths } from "./path-field";
+
+/** Frontmatter keys we map into capa SubAgent fields. */
+const MAPPED_KEYS = new Set(["name", "description", "skills"]);
+
+/**
+ * Parse agent markdown files from default `agents/` or manifest `agents` paths.
+ */
+export function parseAgentEntries(
+	repoRoot: string,
+	record: Record<string, unknown>,
+	knownSkillIds: Set<string>,
+): UnifiedAgentEntry[] {
+	const paths = resolveComponentPaths(record, "agents", "agents");
+	const files: string[] = [];
+	for (const p of paths) {
+		files.push(
+			...collectFiles(repoRoot, p, {
+				extensions: [".md"],
+				recursive: true,
+			}),
+		);
+	}
+
+	const entries: UnifiedAgentEntry[] = [];
+	const seen = new Set<string>();
+
+	for (const rel of files) {
+		const abs = join(repoRoot, rel);
+		if (!existsSync(abs)) continue;
+		let content: string;
+		try {
+			content = readFileSync(abs, "utf-8");
+		} catch {
+			continue;
+		}
+		const { frontmatter, body } = splitMarkdownFrontmatter(content);
+		const fm = frontmatter ?? {};
+		const id =
+			asOptionalString(fm.name) ??
+			basename(rel).replace(/\.md$/i, "") ??
+			"agent";
+		if (seen.has(id)) continue;
+		seen.add(id);
+
+		const droppedFrontmatterKeys = Object.keys(fm).filter(
+			(k) => !MAPPED_KEYS.has(k),
+		);
+		const skillIds = asStringArray(fm.skills).filter((s) =>
+			knownSkillIds.has(s),
+		);
+
+		entries.push({
+			id,
+			relativePath: rel,
+			description: asOptionalString(fm.description),
+			instructions: body,
+			skillIds,
+			droppedFrontmatterKeys,
+		});
+	}
+
+	return entries;
+}

--- a/src/shared/plugin-manifest/claude-parser.ts
+++ b/src/shared/plugin-manifest/claude-parser.ts
@@ -1,11 +1,58 @@
 import type { UnifiedPluginManifest } from "../../types/plugin";
 import { getProvider, getProviderByPluginProviderId } from "../providers";
+import { parseAgentEntries } from "./agents-parser";
+import { parseCommandEntries } from "./commands-parser";
+import { parseHookEntries } from "./hooks-parser";
 import { parseMcpServers } from "./mcp-parser";
+import { parseRuleEntries } from "./rules-parser";
+import { detectSkippedArtifacts } from "./skipped-artifacts";
 import {
 	isPlainObject,
 	parseSkillsField,
 	parseSkillsRaw,
 } from "./types-helpers";
+
+function buildUnified(
+	repoRoot: string,
+	record: Record<string, unknown>,
+	provider: "claude" | "cursor",
+	mcpServers: ReturnType<typeof parseMcpServers>,
+): UnifiedPluginManifest {
+	const name = typeof record.name === "string" ? record.name : "unknown";
+	const skillEntries = parseSkillsField(
+		repoRoot,
+		parseSkillsRaw(record.skills),
+		"skills",
+	);
+	const knownSkillIds = new Set(skillEntries.map((s) => s.id));
+	const commandEntries = parseCommandEntries(repoRoot, record);
+	for (const c of commandEntries) knownSkillIds.add(c.id);
+
+	const agentEntries = parseAgentEntries(repoRoot, record, knownSkillIds);
+	const hookEntries = parseHookEntries(repoRoot, record).map((h) => ({
+		...h,
+		targetProvider: "claude-code" as const,
+	}));
+	// Rules are primarily a Cursor plugin component; still scan for Claude
+	// plugins that happen to ship a rules/ directory.
+	const ruleEntries = parseRuleEntries(repoRoot, record);
+	const skippedArtifacts = detectSkippedArtifacts(repoRoot);
+
+	return {
+		name,
+		version: typeof record.version === "string" ? record.version : undefined,
+		description:
+			typeof record.description === "string" ? record.description : undefined,
+		provider,
+		skillEntries,
+		commandEntries,
+		agentEntries,
+		hookEntries,
+		ruleEntries,
+		mcpServers,
+		skippedArtifacts: skippedArtifacts.length > 0 ? skippedArtifacts : undefined,
+	};
+}
 
 export function parseClaudeManifest(
 	repoRoot: string,
@@ -13,24 +60,9 @@ export function parseClaudeManifest(
 	manifestDir: string = ".claude-plugin",
 ): UnifiedPluginManifest {
 	const record = isPlainObject(data) ? data : {};
-	const name = typeof record.name === "string" ? record.name : "unknown";
-	const skills = parseSkillsField(
-		repoRoot,
-		parseSkillsRaw(record.skills),
-		"skills",
-	);
 	const fallback =
 		getProvider("claude-code")?.mcp?.defaultMcpFallbackPath ??
 		getProviderByPluginProviderId("claude")?.mcp?.defaultMcpFallbackPath;
 	const mcpServers = parseMcpServers(repoRoot, data, fallback, manifestDir);
-
-	return {
-		name,
-		version: typeof record.version === "string" ? record.version : undefined,
-		description:
-			typeof record.description === "string" ? record.description : undefined,
-		provider: "claude",
-		skillEntries: skills,
-		mcpServers,
-	};
+	return buildUnified(repoRoot, record, "claude", mcpServers);
 }

--- a/src/shared/plugin-manifest/commands-parser.ts
+++ b/src/shared/plugin-manifest/commands-parser.ts
@@ -1,0 +1,77 @@
+import { existsSync, mkdirSync, readdirSync, readFileSync, writeFileSync } from "fs";
+import { basename, join } from "path";
+import type { UnifiedCommandEntry } from "../../types/plugin";
+import { collectFiles, resolveComponentPaths } from "./path-field";
+
+/**
+ * Legacy flat slash-command markdown files (`commands/*.md`).
+ * Converted to skill trees at merge time.
+ */
+export function parseCommandEntries(
+	repoRoot: string,
+	record: Record<string, unknown>,
+): UnifiedCommandEntry[] {
+	const paths = resolveComponentPaths(record, "commands", "commands");
+	const files: string[] = [];
+	for (const p of paths) {
+		files.push(
+			...collectFiles(repoRoot, p, {
+				extensions: [".md"],
+				recursive: true,
+			}),
+		);
+	}
+
+	const entries: UnifiedCommandEntry[] = [];
+	const seen = new Set<string>();
+	for (const rel of files) {
+		const id = basename(rel).replace(/\.md$/i, "");
+		if (!id || seen.has(id)) continue;
+		seen.add(id);
+		entries.push({ id, relativePath: rel });
+	}
+	return entries;
+}
+
+/**
+ * Materialize a command `.md` as `<destDir>/SKILL.md`.
+ * Returns false if the source is missing.
+ */
+export function materializeCommandAsSkill(
+	pluginRoot: string,
+	entry: UnifiedCommandEntry,
+	destSkillDir: string,
+): boolean {
+	const src = join(pluginRoot, entry.relativePath);
+	if (!existsSync(src)) return false;
+	let content: string;
+	try {
+		content = readFileSync(src, "utf-8");
+	} catch {
+		return false;
+	}
+	if (!/^---\s*\r?\n/.test(content)) {
+		content = `---\nname: ${entry.id}\n---\n\n${content}`;
+	} else if (!/^---\s*\r?\n[\s\S]*?\bname\s*:/m.test(content)) {
+		content = content.replace(/^---\s*\r?\n/, `---\nname: ${entry.id}\n`);
+	}
+	mkdirSync(destSkillDir, { recursive: true });
+	writeFileSync(join(destSkillDir, "SKILL.md"), content, "utf-8");
+	return true;
+}
+
+/** List top-level `.md` files in commands/ without parsing a manifest record. */
+export function discoverDefaultCommands(repoRoot: string): UnifiedCommandEntry[] {
+	const dir = join(repoRoot, "commands");
+	if (!existsSync(dir)) return [];
+	try {
+		return readdirSync(dir, { withFileTypes: true })
+			.filter((d) => d.isFile() && d.name.toLowerCase().endsWith(".md"))
+			.map((d) => ({
+				id: d.name.replace(/\.md$/i, ""),
+				relativePath: `commands/${d.name}`,
+			}));
+	} catch {
+		return [];
+	}
+}

--- a/src/shared/plugin-manifest/cursor-parser.ts
+++ b/src/shared/plugin-manifest/cursor-parser.ts
@@ -1,6 +1,11 @@
 import type { UnifiedPluginManifest } from "../../types/plugin";
 import { getProvider } from "../providers";
+import { parseAgentEntries } from "./agents-parser";
+import { parseCommandEntries } from "./commands-parser";
+import { parseHookEntries } from "./hooks-parser";
 import { parseMcpServers } from "./mcp-parser";
+import { parseRuleEntries } from "./rules-parser";
+import { detectSkippedArtifacts } from "./skipped-artifacts";
 import {
 	isPlainObject,
 	parseSkillsField,
@@ -49,7 +54,7 @@ export function parseCursorManifest(
 ): UnifiedPluginManifest {
 	const record = isPlainObject(data) ? data : {};
 	const name = typeof record.name === "string" ? record.name : "unknown";
-	const skills = parseSkillsField(
+	const skillEntries = parseSkillsField(
 		repoRoot,
 		parseSkillsRaw(record.skills),
 		"skills",
@@ -58,13 +63,30 @@ export function parseCursorManifest(
 	const mcpServers = parseMcpServers(repoRoot, data, fallback, manifestDir);
 	applyCursorCliLoopback(mcpServers);
 
+	const knownSkillIds = new Set(skillEntries.map((s) => s.id));
+	const commandEntries = parseCommandEntries(repoRoot, record);
+	for (const c of commandEntries) knownSkillIds.add(c.id);
+
+	const agentEntries = parseAgentEntries(repoRoot, record, knownSkillIds);
+	const hookEntries = parseHookEntries(repoRoot, record).map((h) => ({
+		...h,
+		targetProvider: "cursor" as const,
+	}));
+	const ruleEntries = parseRuleEntries(repoRoot, record);
+	const skippedArtifacts = detectSkippedArtifacts(repoRoot);
+
 	return {
 		name,
 		version: typeof record.version === "string" ? record.version : undefined,
 		description:
 			typeof record.description === "string" ? record.description : undefined,
 		provider: "cursor",
-		skillEntries: skills,
+		skillEntries,
+		commandEntries,
+		agentEntries,
+		hookEntries,
+		ruleEntries,
 		mcpServers,
+		skippedArtifacts: skippedArtifacts.length > 0 ? skippedArtifacts : undefined,
 	};
 }

--- a/src/shared/plugin-manifest/detect.ts
+++ b/src/shared/plugin-manifest/detect.ts
@@ -19,7 +19,7 @@ import { discoverDefaultHooks } from "./hooks-parser";
 import { normalizeMcpServerEntry } from "./mcp-parser";
 import { discoverDefaultRules } from "./rules-parser";
 import { detectSkippedArtifacts } from "./skipped-artifacts";
-import { getSkillEntriesFromPath } from "./types-helpers";
+import { parseSkillsField } from "./types-helpers";
 
 /** Map capabilities provider names to plugin provider (manifest) names */
 function toPluginProvider(provider: string): PluginProvider | null {
@@ -152,10 +152,7 @@ export function detectAndParseManifest(
 	}
 
 	// Fallback: no manifest — discover skills/, commands/, agents/, hooks/, rules/, .mcp.json
-	const skillEntries = getSkillEntriesFromPath(repoRoot, "skills");
-	if (skillEntries.length === 0 && existsSync(join(repoRoot, "SKILL.md"))) {
-		skillEntries.push({ id: "skill", relativePath: "." });
-	}
+	const skillEntries = parseSkillsField(repoRoot, undefined, "skills");
 	const defaultMcpRel =
 		getProvider("claude-code")?.mcp?.defaultMcpFallbackPath ??
 		getProviderByPluginProviderId("claude")?.mcp?.defaultMcpFallbackPath ??

--- a/src/shared/plugin-manifest/detect.ts
+++ b/src/shared/plugin-manifest/detect.ts
@@ -11,10 +11,15 @@ import {
 	getProvider,
 	getProviderByPluginProviderId,
 } from "../providers";
+import { parseAgentEntries } from "./agents-parser";
 import { parseClaudeManifest } from "./claude-parser";
+import { discoverDefaultCommands } from "./commands-parser";
 import { parseCursorManifest } from "./cursor-parser";
+import { discoverDefaultHooks } from "./hooks-parser";
 import { normalizeMcpServerEntry } from "./mcp-parser";
-import { getSkillEntriesFromPath, isPlainObject } from "./types-helpers";
+import { discoverDefaultRules } from "./rules-parser";
+import { detectSkippedArtifacts } from "./skipped-artifacts";
+import { getSkillEntriesFromPath } from "./types-helpers";
 
 /** Map capabilities provider names to plugin provider (manifest) names */
 function toPluginProvider(provider: string): PluginProvider | null {
@@ -104,6 +109,11 @@ function getManifestSearchOrder(
 /**
  * Detect and parse the first available plugin manifest in the repo.
  * preferredProviders: e.g. capabilities.providers (['cursor', 'claude-code']).
+ *
+ * Dual-manifest plugins (both `.claude-plugin` and `.cursor-plugin`) contribute
+ * hooks from the sibling manifest as well — e.g. Cursor's
+ * `hooks: "./hooks/hooks-cursor.json"` — so preferring Claude for MCP/OAuth
+ * does not drop Cursor-declared hooks.
  */
 export function detectAndParseManifest(
 	repoRoot: string,
@@ -121,24 +131,31 @@ export function detectAndParseManifest(
 			const reg =
 				getProvider(provider) ?? getProviderByPluginProviderId(provider);
 			const manifestDir = posix.dirname(path.split(/[/\\]/).join("/")) || ".";
+			let manifest: UnifiedPluginManifest | null = null;
 			if (reg?.parsePluginManifest) {
-				return reg.parsePluginManifest(
+				manifest = reg.parsePluginManifest(
 					repoRoot,
 					data,
 					manifestDir,
 				) as UnifiedPluginManifest;
+			} else if (provider === "cursor") {
+				manifest = parseCursorManifest(repoRoot, data, manifestDir);
+			} else if (provider === "claude") {
+				manifest = parseClaudeManifest(repoRoot, data, manifestDir);
 			}
-			if (provider === "cursor")
-				return parseCursorManifest(repoRoot, data, manifestDir);
-			if (provider === "claude")
-				return parseClaudeManifest(repoRoot, data, manifestDir);
+			if (manifest) {
+				return mergeSiblingProviderHooks(repoRoot, manifest);
+			}
 		} catch {
 			// skip invalid manifest
 		}
 	}
 
-	// Fallback: no manifest — discover skills/ and .mcp.json as claude-style
+	// Fallback: no manifest — discover skills/, commands/, agents/, hooks/, rules/, .mcp.json
 	const skillEntries = getSkillEntriesFromPath(repoRoot, "skills");
+	if (skillEntries.length === 0 && existsSync(join(repoRoot, "SKILL.md"))) {
+		skillEntries.push({ id: "skill", relativePath: "." });
+	}
 	const defaultMcpRel =
 		getProvider("claude-code")?.mcp?.defaultMcpFallbackPath ??
 		getProviderByPluginProviderId("claude")?.mcp?.defaultMcpFallbackPath ??
@@ -161,16 +178,106 @@ export function detectAndParseManifest(
 		}
 	}
 
-	if (skillEntries.length > 0 || Object.keys(mcpServers).length > 0) {
+	const commandEntries = discoverDefaultCommands(repoRoot);
+	const knownSkillIds = new Set([
+		...skillEntries.map((s) => s.id),
+		...commandEntries.map((c) => c.id),
+	]);
+	const agentEntries = parseAgentEntries(repoRoot, {}, knownSkillIds);
+	const hookEntries = discoverDefaultHooks(repoRoot);
+	const ruleEntries = discoverDefaultRules(repoRoot);
+	const skippedArtifacts = detectSkippedArtifacts(repoRoot);
+
+	if (
+		skillEntries.length > 0 ||
+		commandEntries.length > 0 ||
+		agentEntries.length > 0 ||
+		hookEntries.length > 0 ||
+		ruleEntries.length > 0 ||
+		Object.keys(mcpServers).length > 0
+	) {
 		return {
 			name: "discovered",
 			provider: "claude",
 			skillEntries,
+			commandEntries,
+			agentEntries,
+			hookEntries,
+			ruleEntries,
 			mcpServers,
+			skippedArtifacts:
+				skippedArtifacts.length > 0 ? skippedArtifacts : undefined,
 		};
 	}
 
 	return null;
+}
+
+/**
+ * When the winning manifest is Claude, also absorb hooks declared by a
+ * sibling `.cursor-plugin/plugin.json` (and vice versa). Dual-shipped plugins
+ * like Superpowers keep provider-specific hook files behind each manifest's
+ * `hooks` field.
+ */
+function mergeSiblingProviderHooks(
+	repoRoot: string,
+	primary: UnifiedPluginManifest,
+): UnifiedPluginManifest {
+	const siblings: {
+		provider: "claude" | "cursor";
+		path: string;
+		dir: string;
+		parse: typeof parseClaudeManifest;
+		target: "claude-code" | "cursor";
+	}[] = [];
+
+	if (primary.provider === "claude") {
+		siblings.push({
+			provider: "cursor",
+			path: join(repoRoot, ".cursor-plugin", "plugin.json"),
+			dir: ".cursor-plugin",
+			parse: parseCursorManifest,
+			target: "cursor",
+		});
+	} else if (primary.provider === "cursor") {
+		siblings.push({
+			provider: "claude",
+			path: join(repoRoot, ".claude-plugin", "plugin.json"),
+			dir: ".claude-plugin",
+			parse: parseClaudeManifest,
+			target: "claude-code",
+		});
+	}
+
+	let hookEntries = [...(primary.hookEntries ?? [])];
+	for (const sib of siblings) {
+		if (!existsSync(sib.path)) continue;
+		try {
+			const data = JSON.parse(readFileSync(sib.path, "utf-8"));
+			const sibling = sib.parse(repoRoot, data, sib.dir);
+			for (const h of sibling.hookEntries ?? []) {
+				const tagged = {
+					...h,
+					targetProvider: h.targetProvider ?? sib.target,
+				};
+				const dup = hookEntries.some(
+					(e) =>
+						e.event === tagged.event &&
+						e.command === tagged.command &&
+						e.prompt === tagged.prompt &&
+						(e.targetProvider ?? sib.target) === tagged.targetProvider,
+				);
+				if (!dup) hookEntries.push(tagged);
+			}
+		} catch {
+			// sibling manifest unreadable — keep primary only
+		}
+	}
+
+	if (hookEntries.length === (primary.hookEntries ?? []).length) {
+		return primary;
+	}
+	return { ...primary, hookEntries };
 }
 
 /**

--- a/src/shared/plugin-manifest/frontmatter.ts
+++ b/src/shared/plugin-manifest/frontmatter.ts
@@ -1,0 +1,67 @@
+import * as yaml from "js-yaml";
+
+/**
+ * Split markdown into optional YAML frontmatter and body.
+ * Returns null frontmatter when the file has no `---` fence.
+ */
+export function splitMarkdownFrontmatter(content: string): {
+	frontmatter: Record<string, unknown> | null;
+	body: string;
+} {
+	const trimmed = content.replace(/^\uFEFF/, "");
+	const match = trimmed.match(/^---\s*\r?\n([\s\S]*?)\r?\n---\s*\r?\n?([\s\S]*)$/);
+	if (!match) {
+		return { frontmatter: null, body: trimmed.trim() };
+	}
+	const raw = match[1];
+	const body = (match[2] ?? "").trim();
+	let parsed: unknown;
+	try {
+		parsed = yaml.load(raw);
+	} catch {
+		// Cursor-style unquoted globs starting with `*`
+		const requoted = raw.replace(
+			/^([ \t]*[\w-]+[ \t]*:[ \t]*)(\*[^\n#]*?)(\s*)$/gm,
+			(_m, prefix, value, trailing) =>
+				`${prefix}"${(value as string).replace(/\\/g, "\\\\").replace(/"/g, '\\"')}"${trailing}`,
+		);
+		try {
+			parsed = yaml.load(requoted);
+		} catch {
+			return { frontmatter: null, body: trimmed.trim() };
+		}
+	}
+	if (!parsed || typeof parsed !== "object" || Array.isArray(parsed)) {
+		return { frontmatter: null, body };
+	}
+	return { frontmatter: parsed as Record<string, unknown>, body };
+}
+
+export function asStringArray(value: unknown): string[] {
+	if (typeof value === "string") {
+		return value
+			.split(/[,|]/)
+			.map((s) => s.trim())
+			.filter(Boolean);
+	}
+	if (Array.isArray(value)) {
+		return value.filter((v): v is string => typeof v === "string" && v.length > 0);
+	}
+	return [];
+}
+
+export function asOptionalString(value: unknown): string | undefined {
+	return typeof value === "string" && value.trim().length > 0
+		? value.trim()
+		: undefined;
+}
+
+export function asOptionalBoolean(value: unknown): boolean | undefined {
+	if (typeof value === "boolean") return value;
+	if (typeof value === "string") {
+		const v = value.trim().toLowerCase();
+		if (["true", "yes", "on", "1"].includes(v)) return true;
+		if (["false", "no", "off", "0"].includes(v)) return false;
+	}
+	return undefined;
+}

--- a/src/shared/plugin-manifest/hooks-parser.ts
+++ b/src/shared/plugin-manifest/hooks-parser.ts
@@ -1,0 +1,174 @@
+import { existsSync, readFileSync } from "fs";
+import { join } from "path";
+import type { UnifiedHookEntry } from "../../types/plugin";
+import { isPlainObject } from "./types-helpers";
+
+function slugify(s: string): string {
+	return s
+		.toLowerCase()
+		.replace(/[^a-z0-9]+/g, "-")
+		.replace(/^-+|-+$/g, "")
+		.slice(0, 48);
+}
+
+function loadHooksObject(
+	repoRoot: string,
+	raw: unknown,
+): Record<string, unknown> | null {
+	if (isPlainObject(raw)) {
+		// Inline: { hooks: { Event: [...] } } or bare { Event: [...] }
+		if (isPlainObject(raw.hooks)) return raw.hooks as Record<string, unknown>;
+		return raw;
+	}
+	if (typeof raw === "string") {
+		const rel = raw.replace(/^\.\//, "");
+		const abs = join(repoRoot, rel);
+		if (!existsSync(abs)) return null;
+		try {
+			const data = JSON.parse(readFileSync(abs, "utf-8"));
+			if (isPlainObject(data?.hooks)) return data.hooks as Record<string, unknown>;
+			if (isPlainObject(data)) return data;
+		} catch {
+			return null;
+		}
+	}
+	return null;
+}
+
+function parseHookAction(
+	event: string,
+	action: unknown,
+	index: number,
+	matcher?: string,
+): UnifiedHookEntry | null {
+	if (!isPlainObject(action)) return null;
+	const typeRaw = action.type;
+	const type: "command" | "prompt" =
+		typeRaw === "prompt" ? "prompt" : "command";
+
+	const command =
+		typeof action.command === "string" ? action.command : undefined;
+	const prompt =
+		typeof action.prompt === "string"
+			? action.prompt
+			: typeof action.text === "string"
+				? action.text
+				: undefined;
+
+	if (type === "command" && !command) return null;
+	if (type === "prompt" && !prompt) return null;
+
+	const name =
+		typeof action.name === "string" && action.name.length > 0
+			? action.name
+			: undefined;
+	const idHint = name
+		? slugify(name)
+		: `${slugify(event) || "hook"}-${index}`;
+
+	const timeout =
+		typeof action.timeout === "number" && action.timeout > 0
+			? action.timeout
+			: undefined;
+	const failClosed =
+		typeof action.failClosed === "boolean"
+			? action.failClosed
+			: typeof action.fail_closed === "boolean"
+				? action.fail_closed
+				: undefined;
+	const sequential =
+		typeof action.sequential === "boolean" ? action.sequential : undefined;
+
+	return {
+		idHint,
+		event,
+		type,
+		command,
+		prompt,
+		matcher,
+		timeout,
+		failClosed,
+		sequential,
+	};
+}
+
+/**
+ * Expand one event's matcher groups into UnifiedHookEntry list.
+ * Claude shape: Event -> [{ matcher?, hooks: [{ type, command }] }]
+ * Cursor may also use Event -> [{ command, ... }] directly.
+ */
+function expandEventHooks(
+	event: string,
+	groups: unknown,
+): UnifiedHookEntry[] {
+	if (!Array.isArray(groups)) return [];
+	const out: UnifiedHookEntry[] = [];
+	let actionIndex = 0;
+
+	for (const group of groups) {
+		if (!isPlainObject(group)) continue;
+		const matcher =
+			typeof group.matcher === "string"
+				? group.matcher
+				: typeof group.pattern === "string"
+					? group.pattern
+					: undefined;
+
+		const nested = group.hooks;
+		if (Array.isArray(nested)) {
+			for (const action of nested) {
+				const entry = parseHookAction(event, action, actionIndex++, matcher);
+				if (entry) out.push(entry);
+			}
+			continue;
+		}
+
+		// Flat action on the group itself (Cursor-style)
+		const entry = parseHookAction(event, group, actionIndex++, matcher);
+		if (entry) out.push(entry);
+	}
+	return out;
+}
+
+/**
+ * Parse hooks from the manifest `hooks` field (path or inline object) and/or
+ * the default `hooks/hooks.json` when the field is omitted.
+ *
+ * Cursor manifests typically set `hooks: "./hooks/hooks-cursor.json"`.
+ * Claude manifests omit the field and rely on `hooks/hooks.json`.
+ */
+export function parseHookEntries(
+	repoRoot: string,
+	record: Record<string, unknown>,
+): UnifiedHookEntry[] {
+	const fromManifest = record.hooks;
+	let hooksObj: Record<string, unknown> | null = null;
+
+	if (fromManifest !== undefined && fromManifest !== null) {
+		if (Array.isArray(fromManifest)) {
+			for (const item of fromManifest) {
+				const part = loadHooksObject(repoRoot, item);
+				if (part) {
+					hooksObj = { ...(hooksObj ?? {}), ...part };
+				}
+			}
+		} else {
+			hooksObj = loadHooksObject(repoRoot, fromManifest);
+		}
+	} else {
+		hooksObj = loadHooksObject(repoRoot, "hooks/hooks.json");
+	}
+
+	if (!hooksObj) return [];
+
+	const entries: UnifiedHookEntry[] = [];
+	for (const [event, groups] of Object.entries(hooksObj)) {
+		if (event === "description" || event === "version") continue;
+		entries.push(...expandEventHooks(event, groups));
+	}
+	return entries;
+}
+
+export function discoverDefaultHooks(repoRoot: string): UnifiedHookEntry[] {
+	return parseHookEntries(repoRoot, {});
+}

--- a/src/shared/plugin-manifest/hooks-parser.ts
+++ b/src/shared/plugin-manifest/hooks-parser.ts
@@ -35,6 +35,22 @@ function loadHooksObject(
 	return null;
 }
 
+function mergeHooksObjects(
+	into: Record<string, unknown>,
+	part: Record<string, unknown>,
+): Record<string, unknown> {
+	const out: Record<string, unknown> = { ...into };
+	for (const [key, value] of Object.entries(part)) {
+		const existing = out[key];
+		if (Array.isArray(existing) && Array.isArray(value)) {
+			out[key] = [...existing, ...value];
+		} else {
+			out[key] = value;
+		}
+	}
+	return out;
+}
+
 function parseHookAction(
 	event: string,
 	action: unknown,
@@ -62,8 +78,9 @@ function parseHookAction(
 		typeof action.name === "string" && action.name.length > 0
 			? action.name
 			: undefined;
+	// Always include index so duplicate `name` values cannot collide on Hook.id.
 	const idHint = name
-		? slugify(name)
+		? `${slugify(name) || "hook"}-${index}`
 		: `${slugify(event) || "hook"}-${index}`;
 
 	const timeout =
@@ -149,7 +166,7 @@ export function parseHookEntries(
 			for (const item of fromManifest) {
 				const part = loadHooksObject(repoRoot, item);
 				if (part) {
-					hooksObj = { ...(hooksObj ?? {}), ...part };
+					hooksObj = mergeHooksObjects(hooksObj ?? {}, part);
 				}
 			}
 		} else {

--- a/src/shared/plugin-manifest/index.ts
+++ b/src/shared/plugin-manifest/index.ts
@@ -5,4 +5,5 @@ export {
 	findPluginInDirectory,
 } from "./detect";
 
-export { resolvePluginServerDef } from "./mcp-parser";
+export { resolvePluginServerDef, resolvePluginRootInString } from "./mcp-parser";
+export { materializeCommandAsSkill } from "./commands-parser";

--- a/src/shared/plugin-manifest/mcp-parser.ts
+++ b/src/shared/plugin-manifest/mcp-parser.ts
@@ -242,23 +242,41 @@ export function parseMcpServers(
  *
  * Hook commands may include args after the path (`./hooks/run-hook.cmd session-start`);
  * only the leading path token is resolved in that case.
+ *
+ * Pass `shellQuote: true` for hook commands run via a shell (Claude/Cursor → Git Bash).
+ * Without it, MCP argv/env values keep bare paths so Node spawn does not see literal quotes.
  */
-export function resolvePluginRootInString(value: string, pluginRoot: string): string {
+export function resolvePluginRootInString(
+	value: string,
+	pluginRoot: string,
+	opts?: { shellQuote?: boolean },
+): string {
 	const root = pluginRoot.replace(/\\/g, "/");
+	const shellQuote = opts?.shellQuote === true;
+
 	if (value.includes("${CLAUDE_PLUGIN_ROOT}")) {
-		return value.replace(/\$\{CLAUDE_PLUGIN_ROOT\}/g, root);
+		const expanded = value.replace(/\$\{CLAUDE_PLUGIN_ROOT\}/g, root);
+		if (!shellQuote || !/\s/.test(root)) return expanded;
+		// Already quoted around the expanded root (plugin authors often quote the placeholder).
+		if (expanded.includes(`"${root}`)) return expanded;
+		const escapedRoot = root.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+		return expanded.replace(
+			new RegExp(`${escapedRoot}[^\\s]*`, "g"),
+			(path) => (/\s/.test(path) ? `"${path}"` : path),
+		);
 	}
 
 	// "./path/to/cmd args..." or "../path args..." — resolve path token only.
 	const relWithArgs = value.match(/^(\.[/\\][^\s]+|\.\.[/\\][^\s]+)(\s+[\s\S]*)?$/);
 	if (relWithArgs) {
 		const abs = resolve(pluginRoot, relWithArgs[1]).replace(/\\/g, "/");
-		const quoted = /\s/.test(abs) ? `"${abs}"` : abs;
+		const quoted = shellQuote && /\s/.test(abs) ? `"${abs}"` : abs;
 		return `${quoted}${relWithArgs[2] ?? ""}`;
 	}
 
 	if (value === "." || value.startsWith("./") || value.startsWith("../")) {
-		return resolve(pluginRoot, value).replace(/\\/g, "/");
+		const abs = resolve(pluginRoot, value).replace(/\\/g, "/");
+		return shellQuote && /\s/.test(abs) ? `"${abs}"` : abs;
 	}
 	return value;
 }

--- a/src/shared/plugin-manifest/mcp-parser.ts
+++ b/src/shared/plugin-manifest/mcp-parser.ts
@@ -235,13 +235,30 @@ export function parseMcpServers(
  * are returned untouched so they resolve from PATH or are interpreted by the
  * launched process. Rewriting them to `<pluginRoot>/<token>` produced
  * non-existent paths and silently broke command-based MCP servers (#94).
+ *
+ * On Windows the expanded root uses forward slashes. Claude Code (and Cursor)
+ * often run hook commands through Git Bash, which treats `\U`, `\T`, etc. as
+ * escapes and strips backslashes — breaking absolute Windows paths.
+ *
+ * Hook commands may include args after the path (`./hooks/run-hook.cmd session-start`);
+ * only the leading path token is resolved in that case.
  */
-function resolvePluginRootInString(value: string, pluginRoot: string): string {
+export function resolvePluginRootInString(value: string, pluginRoot: string): string {
+	const root = pluginRoot.replace(/\\/g, "/");
 	if (value.includes("${CLAUDE_PLUGIN_ROOT}")) {
-		return value.replace(/\$\{CLAUDE_PLUGIN_ROOT\}/g, pluginRoot);
+		return value.replace(/\$\{CLAUDE_PLUGIN_ROOT\}/g, root);
 	}
+
+	// "./path/to/cmd args..." or "../path args..." — resolve path token only.
+	const relWithArgs = value.match(/^(\.[/\\][^\s]+|\.\.[/\\][^\s]+)(\s+[\s\S]*)?$/);
+	if (relWithArgs) {
+		const abs = resolve(pluginRoot, relWithArgs[1]).replace(/\\/g, "/");
+		const quoted = /\s/.test(abs) ? `"${abs}"` : abs;
+		return `${quoted}${relWithArgs[2] ?? ""}`;
+	}
+
 	if (value === "." || value.startsWith("./") || value.startsWith("../")) {
-		return resolve(pluginRoot, value);
+		return resolve(pluginRoot, value).replace(/\\/g, "/");
 	}
 	return value;
 }

--- a/src/shared/plugin-manifest/path-field.ts
+++ b/src/shared/plugin-manifest/path-field.ts
@@ -1,0 +1,83 @@
+import { existsSync, readdirSync, statSync } from "fs";
+import { join, relative } from "path";
+import { isPlainObject } from "./types-helpers";
+
+/**
+ * Normalize a manifest path field (string | string[]) into relative paths
+ * from the plugin root. Leading `./` is stripped for joins.
+ */
+export function normalizePathField(raw: unknown): string[] | undefined {
+	if (raw === undefined || raw === null) return undefined;
+	const list = typeof raw === "string" ? [raw] : Array.isArray(raw) ? raw : null;
+	if (!list || !list.every((p) => typeof p === "string")) return undefined;
+	return list.map((p) => {
+		let s = (p as string).replace(/\\/g, "/");
+		if (s.startsWith("./")) s = s.slice(2);
+		return s.replace(/\/+$/, "");
+	});
+}
+
+/**
+ * Claude/Cursor semantics: when the manifest key is set it *replaces* the
+ * default directory. When unset, use `defaultRel`.
+ */
+export function resolveComponentPaths(
+	record: Record<string, unknown>,
+	field: string,
+	defaultRel: string,
+): string[] {
+	const fromManifest = normalizePathField(record[field]);
+	if (fromManifest !== undefined) return fromManifest;
+	return [defaultRel];
+}
+
+/**
+ * Collect files under a path (file or directory) matching an extension predicate.
+ * Paths returned are relative to `repoRoot` using forward slashes.
+ */
+export function collectFiles(
+	repoRoot: string,
+	relativePath: string,
+	opts: { extensions?: string[]; recursive?: boolean } = {},
+): string[] {
+	const full = join(repoRoot, relativePath);
+	if (!existsSync(full)) return [];
+
+	const exts = opts.extensions?.map((e) => e.toLowerCase());
+	const out: string[] = [];
+
+	function accept(abs: string): void {
+		const rel = relative(repoRoot, abs).replace(/\\/g, "/");
+		if (exts) {
+			const lower = abs.toLowerCase();
+			if (!exts.some((e) => lower.endsWith(e))) return;
+		}
+		out.push(rel);
+	}
+
+	const st = statSync(full);
+	if (st.isFile()) {
+		accept(full);
+		return out;
+	}
+
+	function walk(dir: string): void {
+		let items;
+		try {
+			items = readdirSync(dir, { withFileTypes: true });
+		} catch {
+			return;
+		}
+		for (const item of items) {
+			const abs = join(dir, item.name);
+			if (item.isFile()) accept(abs);
+			else if (item.isDirectory() && opts.recursive !== false) walk(abs);
+		}
+	}
+	walk(full);
+	return out;
+}
+
+export function readManifestRecord(data: unknown): Record<string, unknown> {
+	return isPlainObject(data) ? data : {};
+}

--- a/src/shared/plugin-manifest/rules-parser.ts
+++ b/src/shared/plugin-manifest/rules-parser.ts
@@ -1,0 +1,66 @@
+import { existsSync, readFileSync } from "fs";
+import { basename, join } from "path";
+import type { UnifiedRuleEntry } from "../../types/plugin";
+import {
+	asOptionalBoolean,
+	asOptionalString,
+	asStringArray,
+	splitMarkdownFrontmatter,
+} from "./frontmatter";
+import { collectFiles, resolveComponentPaths } from "./path-field";
+
+/**
+ * Parse Cursor-style rule files (`.mdc` / `.md`) from `rules/` or manifest `rules`.
+ */
+export function parseRuleEntries(
+	repoRoot: string,
+	record: Record<string, unknown>,
+): UnifiedRuleEntry[] {
+	const paths = resolveComponentPaths(record, "rules", "rules");
+	const files: string[] = [];
+	for (const p of paths) {
+		files.push(
+			...collectFiles(repoRoot, p, {
+				extensions: [".mdc", ".md"],
+				recursive: true,
+			}),
+		);
+	}
+
+	const entries: UnifiedRuleEntry[] = [];
+	const seen = new Set<string>();
+
+	for (const rel of files) {
+		const abs = join(repoRoot, rel);
+		if (!existsSync(abs)) continue;
+		let raw: string;
+		try {
+			raw = readFileSync(abs, "utf-8");
+		} catch {
+			continue;
+		}
+		const { frontmatter, body } = splitMarkdownFrontmatter(raw);
+		const fm = frontmatter ?? {};
+		const id = basename(rel).replace(/\.(mdc|md)$/i, "");
+		if (!id || seen.has(id)) continue;
+		seen.add(id);
+
+		const globs = asStringArray(fm.globs ?? fm.appliesTo ?? fm.paths);
+		const appliesTo = globs.length > 0 ? globs : undefined;
+
+		entries.push({
+			id,
+			relativePath: rel,
+			content: body,
+			description: asOptionalString(fm.description),
+			appliesTo,
+			alwaysApply: asOptionalBoolean(fm.alwaysApply ?? fm.always_apply),
+		});
+	}
+
+	return entries;
+}
+
+export function discoverDefaultRules(repoRoot: string): UnifiedRuleEntry[] {
+	return parseRuleEntries(repoRoot, {});
+}

--- a/src/shared/plugin-manifest/safe-id.ts
+++ b/src/shared/plugin-manifest/safe-id.ts
@@ -1,0 +1,32 @@
+import { slugify } from "../slug";
+
+/**
+ * Derive a filesystem-/capa-safe entry id from plugin frontmatter or a fallback
+ * (e.g. filename stem). Strips path segments so `../evil` cannot escape
+ * provider install directories.
+ */
+export function safePluginEntryId(
+	candidate: string | undefined,
+	fallback: string,
+): string {
+	const pickSegment = (raw: string): string => {
+		const parts = raw
+			.replace(/\\/g, "/")
+			.split("/")
+			.filter((p) => p.length > 0 && p !== "." && p !== "..");
+		return parts.length > 0 ? parts[parts.length - 1]! : "";
+	};
+
+	const fromCandidate = candidate ? pickSegment(candidate.trim()) : "";
+	const fromFallback = pickSegment(fallback.trim()) || "entry";
+	const slug = slugify(fromCandidate || fromFallback)
+		.replace(/[^a-z0-9_-]/g, "")
+		.replace(/^-+|-+$/g, "");
+
+	if (slug && /^[a-z_][a-z0-9_-]*$/i.test(slug)) return slug;
+
+	const fb = slugify(fromFallback)
+		.replace(/[^a-z0-9_-]/g, "")
+		.replace(/^-+|-+$/g, "");
+	return fb || "entry";
+}

--- a/src/shared/plugin-manifest/skipped-artifacts.ts
+++ b/src/shared/plugin-manifest/skipped-artifacts.ts
@@ -1,0 +1,24 @@
+import { existsSync } from "fs";
+import { join } from "path";
+
+/** Artifact kinds capa does not install from plugins. */
+const SKIP_CHECKS: { kind: string; rel: string }[] = [
+	{ kind: "lsp", rel: ".lsp.json" },
+	{ kind: "monitors", rel: "monitors" },
+	{ kind: "themes", rel: "themes" },
+	{ kind: "workflows", rel: "workflows" },
+	{ kind: "output-styles", rel: "output-styles" },
+	{ kind: "bin", rel: "bin" },
+	{ kind: "settings", rel: "settings.json" },
+];
+
+/**
+ * Detect unsupported plugin artifacts present on disk for warning messages.
+ */
+export function detectSkippedArtifacts(repoRoot: string): string[] {
+	const found: string[] = [];
+	for (const { kind, rel } of SKIP_CHECKS) {
+		if (existsSync(join(repoRoot, rel))) found.push(kind);
+	}
+	return found;
+}

--- a/src/shared/plugin-manifest/types-helpers.ts
+++ b/src/shared/plugin-manifest/types-helpers.ts
@@ -1,6 +1,7 @@
-import { existsSync, readdirSync } from "fs";
+import { existsSync, readdirSync, readFileSync } from "fs";
 import { join } from "path";
 import type { UnifiedSkillEntry } from "../../types/plugin";
+import { asOptionalString, splitMarkdownFrontmatter } from "./frontmatter";
 
 export interface ParsedMcpServerEntry {
 	url?: string;
@@ -55,7 +56,7 @@ export function getSkillEntriesFromPath(
 		const items = readdirSync(fullPath, { withFileTypes: true });
 		for (const item of items) {
 			if (!item.isDirectory()) continue;
-			const subPath = join(relativePath, item.name);
+			const subPath = join(relativePath, item.name).replace(/\\/g, "/");
 			const subSkillMd = join(repoRoot, subPath, "SKILL.md");
 			if (existsSync(subSkillMd)) {
 				entries.push({ id: item.name, relativePath: subPath });
@@ -69,6 +70,8 @@ export function getSkillEntriesFromPath(
 
 /**
  * Parse skills field (string or array) and return unified skill entries.
+ * When no `skills` field is set and `skills/` is empty/missing, fall back to
+ * a root-level `SKILL.md` (Claude single-skill plugin layout).
  */
 export function parseSkillsField(
 	repoRoot: string,
@@ -90,5 +93,21 @@ export function parseSkillsField(
 	for (const p of paths) {
 		entries.push(...getSkillEntriesFromPath(repoRoot, p));
 	}
+
+	if (entries.length === 0 && (raw === undefined || raw === null)) {
+		const rootSkill = join(repoRoot, "SKILL.md");
+		if (existsSync(rootSkill)) {
+			let id = "skill";
+			try {
+				const content = readFileSync(rootSkill, "utf-8");
+				const { frontmatter } = splitMarkdownFrontmatter(content);
+				id = asOptionalString(frontmatter?.name) ?? id;
+			} catch {
+				// keep default id
+			}
+			entries.push({ id, relativePath: "." });
+		}
+	}
+
 	return entries;
 }

--- a/src/shared/plugin-paths.ts
+++ b/src/shared/plugin-paths.ts
@@ -1,0 +1,10 @@
+import { join } from "path";
+import { getCapaDir } from "./config";
+
+/**
+ * Unpacked plugin trees live under `~/.capa/plugins/<projectId>/`
+ * (same global capa home as hooks/cache). Shared by wrap, install, and passthrough.
+ */
+export function getProjectPluginsDir(projectId: string): string {
+	return join(getCapaDir(), "plugins", projectId);
+}

--- a/src/shared/registries/__tests__/claude-marketplace.test.ts
+++ b/src/shared/registries/__tests__/claude-marketplace.test.ts
@@ -304,6 +304,38 @@ describe("createClaudeMarketplaceAdapter", () => {
 		);
 	});
 
+	it("includes plugin contents in preview when inspectPlugin is provided", async () => {
+		const catalog = parseMarketplaceJson(DEVELOPER_KIT_FIXTURE);
+		const adapter = createClaudeMarketplaceAdapter({
+			slug: "developer-kit",
+			catalog,
+			origin: ORIGIN,
+			inspectPlugin: async () => ({
+				skills: ["code-review"],
+				commands: [],
+				agents: ["security-analyst"],
+				hooks: [],
+				rules: [],
+				mcpServers: ["docs"],
+				skippedArtifacts: [],
+			}),
+		});
+
+		const detail = await adapter.view({
+			capability: "plugins",
+			id: "developer-kit-typescript",
+		});
+		expect(detail.preview).toContain("## Contents");
+		expect(detail.preview).toContain("`security-analyst`");
+		expect(detail.preview).toContain("`code-review`");
+		expect(detail.preview).toContain("`docs`");
+		expect(detail.files).toEqual([
+			"skills/code-review/",
+			"agents/security-analyst.md",
+			"mcp/docs",
+		]);
+	});
+
 	it("lists unsupported plugins in search but rejects view install", async () => {
 		const catalog = parseMarketplaceJson({
 			name: "mixed",

--- a/src/shared/registries/claude-marketplace/adapter.ts
+++ b/src/shared/registries/claude-marketplace/adapter.ts
@@ -6,10 +6,17 @@ import type {
 	RegistryManifest,
 } from "../../../types/registry";
 import {
+	formatPluginContentsMarkdown,
+	pluginContentsToFiles,
+	type PluginContentsSummary,
+} from "./plugin-contents";
+import {
 	buildPluginInstallSnippet,
+	sourceToInstallCoords,
 	unsupportedSourceReason,
 } from "./sources";
 import type {
+	InstallCoords,
 	MarketplaceOrigin,
 	MarketplacePluginEntry,
 	ParsedMarketplace,
@@ -20,6 +27,14 @@ export interface CreateClaudeMarketplaceAdapterOptions {
 	slug: string;
 	catalog: ParsedMarketplace;
 	origin: MarketplaceOrigin;
+	/**
+	 * Optional: fetch + parse the plugin tree so the preview can list what
+	 * capa will unpack (skills, agents, hooks, rules, MCP). Failures are
+	 * ignored and the preview falls back to marketplace metadata only.
+	 */
+	inspectPlugin?: (
+		coords: InstallCoords,
+	) => Promise<PluginContentsSummary | null>;
 }
 
 function homepageFor(origin: MarketplaceOrigin): string | undefined {
@@ -69,12 +84,13 @@ function toSummary(
 	};
 }
 
-function buildPreview(
+export function buildPreview(
 	plugin: MarketplacePluginEntry,
 	catalog: ParsedMarketplace,
 	origin: MarketplaceOrigin,
 	snippet: Plugin | null,
 	slug: string,
+	contents?: PluginContentsSummary | null,
 ): string {
 	const parts: string[] = [];
 	parts.push(`# ${plugin.name}`);
@@ -101,6 +117,10 @@ function buildPreview(
 	}
 	parts.push(meta.join("  \n"));
 	parts.push("");
+
+	if (contents) {
+		parts.push(formatPluginContentsMarkdown(contents));
+	}
 
 	parts.push("## Install");
 	parts.push("");
@@ -178,8 +198,9 @@ export function marketplaceIcon(origin: MarketplaceOrigin): string {
 export function createClaudeMarketplaceAdapter(
 	opts: CreateClaudeMarketplaceAdapterOptions,
 ): RegistryAdapter {
-	const { slug, catalog, origin } = opts;
+	const { slug, catalog, origin, inspectPlugin } = opts;
 	const byName = new Map(catalog.plugins.map((p) => [p.name, p]));
+	const contentsCache = new Map<string, PluginContentsSummary | null>();
 
 	const displayName = catalog.name;
 	const description =
@@ -242,16 +263,52 @@ export function createClaudeMarketplaceAdapter(
 				);
 			}
 
+			const coords = sourceToInstallCoords(
+				plugin.source,
+				origin,
+				catalog.pluginRoot,
+			);
+
+			let contents: PluginContentsSummary | null = null;
+			if (inspectPlugin && coords) {
+				if (contentsCache.has(plugin.name)) {
+					contents = contentsCache.get(plugin.name) ?? null;
+				} else {
+					try {
+						// Bound inspect so a slow first clone doesn't fail the whole view.
+						contents = await Promise.race([
+							inspectPlugin(coords),
+							new Promise<null>((resolve) =>
+								setTimeout(() => resolve(null), 12_000),
+							),
+						]);
+					} catch {
+						contents = null;
+					}
+					contentsCache.set(plugin.name, contents);
+				}
+			}
+
 			const summary = toSummary(plugin, true);
 			summary.homepage =
 				plugin.homepage ??
-				browsePluginUrl(origin, plugin, undefined) ??
+				browsePluginUrl(origin, plugin, coords?.subpath) ??
 				summary.homepage;
+
+			const files = contents ? pluginContentsToFiles(contents) : undefined;
 
 			return {
 				...summary,
-				preview: buildPreview(plugin, catalog, origin, snippet, slug),
+				preview: buildPreview(
+					plugin,
+					catalog,
+					origin,
+					snippet,
+					slug,
+					contents,
+				),
 				installSnippet: snippet,
+				files: files && files.length > 0 ? files : undefined,
 			};
 		},
 	};

--- a/src/shared/registries/claude-marketplace/index.ts
+++ b/src/shared/registries/claude-marketplace/index.ts
@@ -5,11 +5,18 @@ export {
 	type FetchMarketplaceResult,
 } from "./fetch";
 export {
+	formatPluginContentsMarkdown,
+	pluginContentsToFiles,
+	summarizeUnifiedManifest,
+	type PluginContentsSummary,
+} from "./plugin-contents";
+export {
 	classifyMarketplaceSource,
 	marketplaceNameToSlug,
 	parseMarketplaceJson,
 } from "./parse";
 export {
+	createPluginInspector,
 	getInstalledMarketplaceMetaPath,
 	getInstalledMarketplacePath,
 	getMarketplaceManagedDir,

--- a/src/shared/registries/claude-marketplace/paths.ts
+++ b/src/shared/registries/claude-marketplace/paths.ts
@@ -1,13 +1,25 @@
 import { existsSync, readFileSync } from "fs";
 import { join } from "path";
-import { getManagedRegistriesDir } from "../../config";
-import { createClaudeMarketplaceAdapter } from "./adapter";
-import { parseMarketplaceJson } from "./parse";
-import type { MarketplaceMetaFile, MarketplaceOrigin } from "./types";
+import type { CapaDatabase } from "../../../db/database";
 import type { RegistryAdapter } from "../../../types/registry";
+import { createAuthenticatedFetch } from "../../authenticated-fetch";
+import { getOrCreateSnapshot } from "../../cache";
+import { getManagedRegistriesDir } from "../../config";
+import { logger } from "../../logger";
+import { detectAndParseManifest } from "../../plugin-manifest";
+import { createClaudeMarketplaceAdapter } from "./adapter";
+import { summarizeUnifiedManifest } from "./plugin-contents";
+import { parseMarketplaceJson } from "./parse";
+import type {
+	InstallCoords,
+	MarketplaceMetaFile,
+	MarketplaceOrigin,
+} from "./types";
 
 export const MARKETPLACE_JSON_FILENAME = "marketplace.json";
 export const MARKETPLACE_META_FILENAME = "marketplace.meta.json";
+
+const inspectLog = logger.child("claude-marketplace");
 
 export function getMarketplaceManagedDir(slug: string): string {
 	return join(getManagedRegistriesDir(), slug);
@@ -30,9 +42,53 @@ export function getInstalledMarketplaceMetaPath(slug: string): string | null {
 }
 
 /**
+ * Clone (or reuse cache) the plugin repo and summarize what capa unpacks.
+ * Returns null on any failure so marketplace preview still works without contents.
+ */
+export function createPluginInspector(db: CapaDatabase) {
+	const authFetch = createAuthenticatedFetch(db);
+
+	return async (coords: InstallCoords) => {
+		try {
+			const snapshot = await getOrCreateSnapshot({
+				platform: coords.host,
+				repoPath: coords.ownerRepo,
+				authFetch,
+				version: coords.ref,
+				ref: coords.sha,
+			});
+			const root = coords.subpath
+				? join(snapshot.snapshotDir, coords.subpath)
+				: snapshot.snapshotDir;
+			if (!existsSync(root)) {
+				inspectLog.debug(
+					`Plugin inspect: path missing ${coords.ownerRepo}/${coords.subpath ?? ""}`,
+				);
+				return null;
+			}
+			const manifest = detectAndParseManifest(root, [
+				"claude-code",
+				"cursor",
+			]);
+			if (!manifest) return null;
+			return summarizeUnifiedManifest(manifest);
+		} catch (err: unknown) {
+			const message = err instanceof Error ? err.message : String(err);
+			inspectLog.debug(
+				`Plugin inspect failed for ${coords.ownerRepo}: ${message}`,
+			);
+			return null;
+		}
+	};
+}
+
+/**
  * Load a previously materialized Claude marketplace into a RegistryAdapter.
  */
-export function loadClaudeMarketplaceAdapter(slug: string): RegistryAdapter {
+export function loadClaudeMarketplaceAdapter(
+	slug: string,
+	opts: { db?: CapaDatabase } = {},
+): RegistryAdapter {
 	const jsonPath = getInstalledMarketplacePath(slug);
 	if (!jsonPath) {
 		throw new Error(
@@ -78,5 +134,10 @@ export function loadClaudeMarketplaceAdapter(slug: string): RegistryAdapter {
 					: null),
 	};
 
-	return createClaudeMarketplaceAdapter({ slug, catalog, origin });
+	return createClaudeMarketplaceAdapter({
+		slug,
+		catalog,
+		origin,
+		inspectPlugin: opts.db ? createPluginInspector(opts.db) : undefined,
+	});
 }

--- a/src/shared/registries/claude-marketplace/plugin-contents.ts
+++ b/src/shared/registries/claude-marketplace/plugin-contents.ts
@@ -1,0 +1,95 @@
+import type { UnifiedPluginManifest } from "../../../types/plugin";
+
+/** Lightweight inventory of what a plugin unpacks into capa. */
+export interface PluginContentsSummary {
+	skills: string[];
+	/** Legacy commands (installed as skills). */
+	commands: string[];
+	agents: string[];
+	hooks: string[];
+	rules: string[];
+	mcpServers: string[];
+	skippedArtifacts: string[];
+}
+
+export function summarizeUnifiedManifest(
+	manifest: UnifiedPluginManifest,
+): PluginContentsSummary {
+	return {
+		skills: manifest.skillEntries.map((s) => s.id).sort(),
+		commands: (manifest.commandEntries ?? []).map((c) => c.id).sort(),
+		agents: (manifest.agentEntries ?? []).map((a) => a.id).sort(),
+		hooks: (manifest.hookEntries ?? []).map((h) => h.idHint || h.event).sort(),
+		rules: (manifest.ruleEntries ?? []).map((r) => r.id).sort(),
+		mcpServers: Object.keys(manifest.mcpServers).sort(),
+		skippedArtifacts: [...(manifest.skippedArtifacts ?? [])].sort(),
+	};
+}
+
+export function isEmptyPluginContents(summary: PluginContentsSummary): boolean {
+	return (
+		summary.skills.length === 0 &&
+		summary.commands.length === 0 &&
+		summary.agents.length === 0 &&
+		summary.hooks.length === 0 &&
+		summary.rules.length === 0 &&
+		summary.mcpServers.length === 0 &&
+		summary.skippedArtifacts.length === 0
+	);
+}
+
+function listSection(title: string, items: string[]): string[] {
+	if (items.length === 0) return [];
+	const lines = [`### ${title}`, ""];
+	for (const id of items) {
+		lines.push(`- \`${id}\``);
+	}
+	lines.push("");
+	return lines;
+}
+
+/**
+ * Markdown section describing what capa will unpack from this plugin.
+ */
+export function formatPluginContentsMarkdown(
+	summary: PluginContentsSummary,
+): string {
+	if (isEmptyPluginContents(summary)) {
+		return [
+			"## Contents",
+			"",
+			"_No skills, agents, hooks, rules, or MCP servers were detected in this plugin._",
+			"",
+		].join("\n");
+	}
+
+	const parts: string[] = ["## Contents", ""];
+	parts.push(
+		...listSection("Skills", summary.skills),
+		...listSection("Commands (as skills)", summary.commands),
+		...listSection("Sub-agents", summary.agents),
+		...listSection("Hooks", summary.hooks),
+		...listSection("Rules", summary.rules),
+		...listSection("MCP servers", summary.mcpServers),
+	);
+	if (summary.skippedArtifacts.length > 0) {
+		parts.push("### Not installed by capa", "");
+		for (const kind of summary.skippedArtifacts) {
+			parts.push(`- \`${kind}\``);
+		}
+		parts.push("");
+	}
+	return parts.join("\n");
+}
+
+/** Paths suitable for the registry detail file tree. */
+export function pluginContentsToFiles(summary: PluginContentsSummary): string[] {
+	const files: string[] = [];
+	for (const id of summary.skills) files.push(`skills/${id}/`);
+	for (const id of summary.commands) files.push(`commands/${id}.md`);
+	for (const id of summary.agents) files.push(`agents/${id}.md`);
+	for (const id of summary.hooks) files.push(`hooks/${id}`);
+	for (const id of summary.rules) files.push(`rules/${id}`);
+	for (const id of summary.mcpServers) files.push(`mcp/${id}`);
+	return files;
+}

--- a/src/shared/registries/loader.ts
+++ b/src/shared/registries/loader.ts
@@ -230,7 +230,9 @@ export class RegistryLoader {
 		}
 
 		try {
-			const adapter = loadClaudeMarketplaceAdapter(record.slug);
+			const adapter = loadClaudeMarketplaceAdapter(record.slug, {
+				db: this.db,
+			});
 			if (!isValidAdapter(adapter)) {
 				const msg = `Claude marketplace for slug "${record.slug}" produced an invalid RegistryAdapter.`;
 				registryLogger.warn(msg);

--- a/src/shared/variable-resolver.ts
+++ b/src/shared/variable-resolver.ts
@@ -42,7 +42,18 @@ function isPlainObject(x: unknown): x is Record<string, unknown> {
 }
 
 /**
- * Recursively resolve variables in an object
+ * Plugin-merged entries (skills, servers, subagents, hooks, rules) are stamped
+ * with `sourcePlugin`. Their bodies can contain `${…}` as documentation or
+ * agent prose — those must not be treated as capa credential placeholders.
+ */
+function isPluginSourcedObject(obj: Record<string, unknown>): boolean {
+	return obj.sourcePlugin != null && typeof obj.sourcePlugin === "object";
+}
+
+/**
+ * Recursively resolve variables in an object.
+ * Only string *values* are resolved — object keys are left untouched.
+ * Plugin-sourced entries (`sourcePlugin`) are skipped entirely.
  */
 export function resolveVariablesInObject<T>(
 	obj: T,
@@ -60,8 +71,12 @@ export function resolveVariablesInObject<T>(
 	}
 
 	if (isPlainObject(obj)) {
+		if (isPluginSourcedObject(obj)) {
+			return obj;
+		}
 		const resolved: Record<string, unknown> = {};
 		for (const [key, value] of Object.entries(obj)) {
+			// Keys are never interpolated — only string values.
 			resolved[key] = resolveVariablesInObject(value, projectId, db);
 		}
 		return resolved as T;
@@ -71,7 +86,9 @@ export function resolveVariablesInObject<T>(
 }
 
 /**
- * Check if a string or object contains unresolved variables
+ * Check if a string or object contains unresolved variables.
+ * Only string values are inspected; object keys and plugin-sourced entries
+ * are ignored.
  */
 export function hasUnresolvedVariables(input: unknown): boolean {
 	if (typeof input === "string") {
@@ -83,6 +100,9 @@ export function hasUnresolvedVariables(input: unknown): boolean {
 	}
 
 	if (isPlainObject(input)) {
+		if (isPluginSourcedObject(input)) {
+			return false;
+		}
 		return Object.values(input).some(hasUnresolvedVariables);
 	}
 
@@ -90,7 +110,11 @@ export function hasUnresolvedVariables(input: unknown): boolean {
 }
 
 /**
- * Extract all unresolved variables from an object
+ * Extract all unresolved variables from an object.
+ *
+ * Scans string values only (never object keys). Skips any entry stamped with
+ * `sourcePlugin` so plugin-contributed content (e.g. subagent instructions)
+ * cannot invent required project credentials.
  */
 export function extractAllVariables(obj: unknown): string[] {
 	const variables = new Set<string>();
@@ -101,6 +125,9 @@ export function extractAllVariables(obj: unknown): string[] {
 		} else if (Array.isArray(value)) {
 			value.forEach(extract);
 		} else if (isPlainObject(value)) {
+			if (isPluginSourcedObject(value)) {
+				return;
+			}
 			Object.values(value).forEach(extract);
 		}
 	}

--- a/src/types/capabilities.ts
+++ b/src/types/capabilities.ts
@@ -243,6 +243,8 @@ export interface SubAgent {
    * Use this for role-specific instructions, scope constraints, or rules.
    */
   instructions?: string;
+  /** Set when this sub-agent was unpacked from a plugin. */
+  sourcePlugin?: SourcePlugin;
 }
 
 export interface Capabilities {

--- a/src/types/hooks.ts
+++ b/src/types/hooks.ts
@@ -7,6 +7,8 @@
  * (e.g. `.claude/settings.json`) without disturbing user-authored entries.
  */
 
+import type { SourcePlugin } from './plugin';
+
 /**
  * Repo locator for `source: { type: 'github' | 'gitlab' }`.
  *
@@ -132,4 +134,7 @@ export interface Hook {
 
   /** Optional alternate body source (overrides `command`/`prompt`). */
   source?: HookSource;
+
+  /** Set when this hook was unpacked from a plugin. */
+  sourcePlugin?: SourcePlugin;
 }

--- a/src/types/plugin.ts
+++ b/src/types/plugin.ts
@@ -69,7 +69,8 @@ export interface PluginDefinition {
 }
 
 /**
- * Attribution for capabilities that came from a plugin (skills, servers, tools).
+ * Attribution for capabilities that came from a plugin
+ * (skills, servers, tools, rules, hooks, subagents).
  */
 export interface SourcePlugin {
   id: string;   // Stable plugin id (e.g. slug + short ref)
@@ -97,6 +98,12 @@ export interface ResolvedPluginInfo {
    * are never referenced by user-declared tools.
    */
   serverIds?: string[];
+  /** Sub-agent IDs contributed by this plugin. */
+  subagentIds?: string[];
+  /** Hook IDs contributed by this plugin. */
+  hookIds?: string[];
+  /** Rule IDs contributed by this plugin. */
+  ruleIds?: string[];
 }
 
 /**
@@ -105,6 +112,67 @@ export interface ResolvedPluginInfo {
 export interface UnifiedSkillEntry {
   id: string;
   relativePath: string;
+}
+
+/**
+ * Legacy flat command (slash-command markdown) to convert into a skill tree.
+ */
+export interface UnifiedCommandEntry {
+  id: string;
+  /** Path to the `.md` file relative to the plugin root. */
+  relativePath: string;
+}
+
+/**
+ * Plugin agent markdown, mapped toward a capa `SubAgent`.
+ */
+export interface UnifiedAgentEntry {
+  id: string;
+  relativePath: string;
+  description?: string;
+  /** Body after frontmatter — becomes `SubAgent.instructions`. */
+  instructions: string;
+  /** Skill ids listed in agent frontmatter that exist in this plugin. */
+  skillIds: string[];
+  /** Frontmatter keys beyond name/description/skills that were not mapped. */
+  droppedFrontmatterKeys: string[];
+}
+
+/**
+ * One hook action from a provider plugin manifest's hooks file.
+ * Paths may still contain `${CLAUDE_PLUGIN_ROOT}` or `./…` until merge time.
+ */
+export interface UnifiedHookEntry {
+  /** Stable hint used to build `plugin-<installId>-…` ids at merge. */
+  idHint: string;
+  /** Native provider event name (e.g. `PreToolUse`, `sessionStart`). */
+  event: string;
+  type: 'command' | 'prompt';
+  command?: string;
+  prompt?: string;
+  matcher?: string;
+  timeout?: number;
+  failClosed?: boolean;
+  sequential?: boolean;
+  /**
+   * Capa provider this hook was declared for (`claude-code` from a Claude
+   * manifest, `cursor` from a Cursor manifest). Dual-manifest plugins can
+   * contribute both.
+   */
+  targetProvider?: 'claude-code' | 'cursor';
+}
+
+/**
+ * Cursor (or compatible) rule file from the plugin.
+ */
+export interface UnifiedRuleEntry {
+  id: string;
+  relativePath: string;
+  /** Rule body (frontmatter stripped). */
+  content: string;
+  description?: string;
+  appliesTo?: string[];
+  alwaysApply?: boolean;
 }
 
 /**
@@ -132,5 +200,15 @@ export interface UnifiedPluginManifest {
   description?: string;
   provider: PluginProvider;
   skillEntries: UnifiedSkillEntry[];
+  /** Legacy flat commands; materialised as skills at merge time. */
+  commandEntries?: UnifiedCommandEntry[];
+  agentEntries?: UnifiedAgentEntry[];
+  hookEntries?: UnifiedHookEntry[];
+  ruleEntries?: UnifiedRuleEntry[];
   mcpServers: Record<string, NormalizedPluginMCPServerDef>;
+  /**
+   * Artifact kinds present in the plugin tree that capa does not install
+   * (e.g. `lsp`, `monitors`, `themes`). Surfaced as install warnings.
+   */
+  skippedArtifacts?: string[];
 }

--- a/src/types/rules.ts
+++ b/src/types/rules.ts
@@ -1,4 +1,5 @@
 import type { AgentSnippetDef } from './capabilities';
+import type { SourcePlugin } from './plugin';
 
 /**
  * A rule to install across providers.
@@ -32,4 +33,6 @@ export interface Rule {
   path?: string;
   /** Repository + file definition (required when type is 'github' or 'gitlab'). */
   def?: AgentSnippetDef;
+  /** Set when this rule was unpacked from a plugin. */
+  sourcePlugin?: SourcePlugin;
 }

--- a/web-ui/src/features/projects/components/HooksList.tsx
+++ b/web-ui/src/features/projects/components/HooksList.tsx
@@ -1,12 +1,15 @@
 import { useEffect, useState, type FormEvent } from 'react';
 import * as Dialog from '@radix-ui/react-dialog';
-import { Trash2, X, Loader2 } from 'lucide-react';
+import { Trash2, X, Loader2, Lock } from 'lucide-react';
 import { useTranslation } from 'react-i18next';
 import type { Hook } from '../../../types/api';
 import { matchesSearch } from '../../../lib/utils';
 import { capaIdErrorMessage, sanitizeCapaIdInput } from '../../../lib/ids';
 import { ReorderableList } from '../../../components/common/ReorderableList';
+import { SourceBadge } from '../../../components/common/ServerBadge';
+import { sourceTypeBadgeClasses } from './sourceTypeColors';
 import { useAppendCapability, useDeleteCapability, useReorderCapability, useUpdateCapability } from '../hooks';
+import { authoredReorderKeys, isPluginSourced } from '../lib/reorderKeys';
 
 const HOOK_EVENTS = [
   'sessionStart',
@@ -61,20 +64,32 @@ export function HooksList({ hooks, search, projectId, addOpen, onAddOpenChange }
         <ReorderableList
           items={visible}
           getId={(h) => h.id}
+          isLocked={(h) => isPluginSourced(h)}
           disabled={searching}
           handleLabel={t('actions.dragToReorder')}
           className="space-y-2"
-          onReorder={(ids) => reorderMutation.mutate({ section: 'hooks', ids })}
-          renderItem={(hook, { handle }) => (
-            <div className="flex items-start gap-1 rounded-sm border border-border-tertiary bg-bg-tertiary p-3 pl-1">
+          onReorder={(ids) =>
+            reorderMutation.mutate({
+              section: 'hooks',
+              ids: authoredReorderKeys(hooks, ids, (h) => h.id),
+            })
+          }
+          renderItem={(hook, { handle, locked }) => (
+            <div className="flex w-full items-stretch gap-1 rounded-sm border border-border-tertiary bg-bg-tertiary pl-1">
               {handle}
               <button
                 type="button"
-                className="min-w-0 flex-1 text-left cursor-pointer"
-                onClick={() => setEditing(hook)}
+                className={`min-w-0 flex-1 p-3 text-left ${locked ? 'cursor-default' : 'cursor-pointer ui-row-hover hover:bg-hover-bg'}`}
+                onClick={() => !locked && setEditing(hook)}
+                disabled={locked}
               >
                 <div className="flex flex-wrap items-center gap-2">
                   <span className="font-mono text-[13px] font-medium text-text-primary">{hook.id}</span>
+                  {locked && (
+                    <span className={`rounded-sm px-1.5 py-0.5 text-[10px] uppercase ${sourceTypeBadgeClasses('plugin')}`}>
+                      plugin
+                    </span>
+                  )}
                   <span className="rounded-sm bg-bg-secondary px-1.5 py-0.5 text-[10px] text-text-tertiary">
                     {hook.on}
                   </span>
@@ -90,28 +105,42 @@ export function HooksList({ hooks, search, projectId, addOpen, onAddOpenChange }
                     {hookBody(hook)}
                   </p>
                 )}
+                {hook.sourcePlugin?.name && (
+                  <div className="mt-2 flex items-center gap-1.5 text-[11px] text-text-tertiary">
+                    <span>from</span>
+                    <SourceBadge name={hook.sourcePlugin.name} kind="plugin" />
+                  </div>
+                )}
               </button>
-              <button
-                type="button"
-                title={t('actions.delete')}
-                disabled={deleteMutation.isPending}
-                onClick={() => {
-                  if (confirm(t('actions.confirmDeleteHook', { id: hook.id }))) {
-                    deleteMutation.mutate({ section: 'hooks', entryId: hook.id });
-                  }
-                }}
-                className="rounded-sm p-2 text-text-tertiary hover:bg-error-bg hover:text-error-text cursor-pointer"
-              >
-                <Trash2 size={14} />
-              </button>
+              <div className="flex items-center pr-2">
+                {locked ? (
+                  <span title={t('actions.pluginLocked')} className="p-2 text-text-tertiary">
+                    <Lock size={14} />
+                  </span>
+                ) : (
+                  <button
+                    type="button"
+                    title={t('actions.delete')}
+                    disabled={deleteMutation.isPending}
+                    onClick={() => {
+                      if (confirm(t('actions.confirmDeleteHook', { id: hook.id }))) {
+                        deleteMutation.mutate({ section: 'hooks', entryId: hook.id });
+                      }
+                    }}
+                    className="rounded-sm p-2 text-text-tertiary hover:bg-error-bg hover:text-error-text cursor-pointer"
+                  >
+                    <Trash2 size={14} />
+                  </button>
+                )}
+              </div>
             </div>
           )}
         />
       )}
 
       <HookDialog
-        open={addOpen || !!editing}
-        initial={editing}
+        open={(addOpen || !!editing) && !editing?.sourcePlugin}
+        initial={editing?.sourcePlugin ? null : editing}
         projectId={projectId}
         busy={updateMutation.isPending}
         onOpenChange={(open) => {
@@ -121,6 +150,7 @@ export function HooksList({ hooks, search, projectId, addOpen, onAddOpenChange }
           }
         }}
         onUpdate={async (entryId, patch) => {
+          if (editing?.sourcePlugin) return;
           await updateMutation.mutateAsync({ section: 'hooks', entryId, patch });
         }}
       />

--- a/web-ui/src/features/projects/components/PluginPreviewDialog.tsx
+++ b/web-ui/src/features/projects/components/PluginPreviewDialog.tsx
@@ -19,31 +19,49 @@ function renderMarkdown(md: string): string {
   return DOMPurify.sanitize(raw);
 }
 
+function listSection(title: string, items: string[] | undefined): string[] {
+  if (!items?.length) return [];
+  const lines = [`### ${title}`, ''];
+  for (const id of items) {
+    lines.push(`- \`${id}\``);
+  }
+  lines.push('');
+  return lines;
+}
+
 function buildLocalPluginPreview(
   plugin: AuthoredPlugin,
   resolved: ResolvedPlugin | undefined,
 ): string {
   const title = resolved?.name || plugin.id || plugin.def.repo;
-  const parts: string[] = [`# ${title}\n`];
-  if (plugin.def.repo) parts.push(`**Repository:** \`${plugin.def.repo}\`\n`);
+  const parts: string[] = [`# ${title}`, ''];
+  if (plugin.def.repo) parts.push(`**Repository:** \`${plugin.def.repo}\``, '');
   if (resolved?.version || plugin.def.version) {
-    parts.push(`**Version:** ${resolved?.version || plugin.def.version}\n`);
+    parts.push(`**Version:** ${resolved?.version || plugin.def.version}`, '');
   }
-  if (resolved?.skills?.length) {
-    parts.push(`## Skills\n`);
-    for (const s of resolved.skills) {
-      parts.push(`- **${s}**`);
-    }
-    parts.push('');
+  if (resolved?.provider) {
+    parts.push(`**Provider:** \`${resolved.provider}\``, '');
   }
-  if (resolved?.serverIds?.length) {
-    parts.push(`## MCP Servers\n`);
-    for (const id of resolved.serverIds) {
-      parts.push(`- **${id}**`);
-    }
-    parts.push('');
+
+  const hasContents =
+    (resolved?.skills?.length ?? 0) > 0 ||
+    (resolved?.serverIds?.length ?? 0) > 0 ||
+    (resolved?.subagentIds?.length ?? 0) > 0 ||
+    (resolved?.hookIds?.length ?? 0) > 0 ||
+    (resolved?.ruleIds?.length ?? 0) > 0;
+
+  if (hasContents) {
+    parts.push('## Contents', '');
+    parts.push(
+      ...listSection('Skills', resolved?.skills),
+      ...listSection('Sub-agents', resolved?.subagentIds),
+      ...listSection('Hooks', resolved?.hookIds),
+      ...listSection('Rules', resolved?.ruleIds),
+      ...listSection('MCP servers', resolved?.serverIds),
+    );
   }
-  parts.push('## Install\n');
+
+  parts.push('## Install', '');
   parts.push('```');
   parts.push(`capa add ${plugin.def.repo}`);
   parts.push('```');

--- a/web-ui/src/features/projects/components/RulesList.tsx
+++ b/web-ui/src/features/projects/components/RulesList.tsx
@@ -1,14 +1,16 @@
 import { useEffect, useState, type FormEvent } from 'react';
 import * as Dialog from '@radix-ui/react-dialog';
-import { Trash2, X, Loader2 } from 'lucide-react';
+import { Trash2, X, Loader2, Lock } from 'lucide-react';
 import { useTranslation } from 'react-i18next';
 import type { Rule } from '../../../types/api';
 import { matchesSearch } from '../../../lib/utils';
 import { capaIdErrorMessage, sanitizeCapaIdInput } from '../../../lib/ids';
 import { ReorderableList } from '../../../components/common/ReorderableList';
+import { SourceBadge } from '../../../components/common/ServerBadge';
 import { sourceTypeBadgeClasses } from './sourceTypeColors';
 import { LocalPathPicker } from './LocalPathPicker';
 import { useAppendCapability, useDeleteCapability, useReorderCapability, useUpdateCapability } from '../hooks';
+import { authoredReorderKeys, isPluginSourced } from '../lib/reorderKeys';
 
 interface RulesListProps {
   rules: Rule[];
@@ -37,22 +39,31 @@ export function RulesList({ rules, search, projectId, addOpen, onAddOpenChange }
         <ReorderableList
           items={visible}
           getId={(r) => r.id}
+          isLocked={(r) => isPluginSourced(r)}
           disabled={searching}
           handleLabel={t('actions.dragToReorder')}
           className="space-y-2"
-          onReorder={(ids) => reorderMutation.mutate({ section: 'rules', ids })}
-          renderItem={(rule, { handle }) => (
-            <div className="flex items-start gap-1 rounded-sm border border-border-tertiary bg-bg-tertiary p-3 pl-1">
+          onReorder={(ids) =>
+            reorderMutation.mutate({
+              section: 'rules',
+              ids: authoredReorderKeys(rules, ids, (r) => r.id),
+            })
+          }
+          renderItem={(rule, { handle, locked }) => (
+            <div className="flex w-full items-stretch gap-1 rounded-sm border border-border-tertiary bg-bg-tertiary pl-1">
               {handle}
               <button
                 type="button"
-                className="min-w-0 flex-1 text-left cursor-pointer"
-                onClick={() => (rule.type === 'inline' || rule.type === 'local') && setEditing(rule)}
+                className={`min-w-0 flex-1 p-3 text-left ${locked ? 'cursor-default' : 'cursor-pointer ui-row-hover hover:bg-hover-bg'}`}
+                onClick={() =>
+                  !locked && (rule.type === 'inline' || rule.type === 'local') && setEditing(rule)
+                }
+                disabled={locked}
               >
                 <div className="flex items-center gap-2">
                   <span className="font-mono text-[13px] font-medium text-text-primary">{rule.id}</span>
-                  <span className={`rounded-sm px-1.5 py-0.5 text-[10px] uppercase ${sourceTypeBadgeClasses(rule.type)}`}>
-                    {rule.type}
+                  <span className={`rounded-sm px-1.5 py-0.5 text-[10px] uppercase ${sourceTypeBadgeClasses(locked ? 'plugin' : rule.type)}`}>
+                    {locked ? 'plugin' : rule.type}
                   </span>
                 </div>
                 {rule.description && (
@@ -66,29 +77,43 @@ export function RulesList({ rules, search, projectId, addOpen, onAddOpenChange }
                 {rule.content && (
                   <p className="mt-1 line-clamp-2 font-mono text-[11px] text-text-tertiary">{rule.content}</p>
                 )}
+                {rule.sourcePlugin?.name && (
+                  <div className="mt-2 flex items-center gap-1.5 text-[11px] text-text-tertiary">
+                    <span>from</span>
+                    <SourceBadge name={rule.sourcePlugin.name} kind="plugin" />
+                  </div>
+                )}
               </button>
-              <button
-                type="button"
-                title={t('actions.delete')}
-                disabled={deleteMutation.isPending}
-                onClick={() => {
-                  if (confirm(t('actions.confirmDeleteRule', { id: rule.id }))) {
-                    deleteMutation.mutate({ section: 'rules', entryId: rule.id });
-                  }
-                }}
-                className="rounded-sm p-2 text-text-tertiary hover:bg-error-bg hover:text-error-text cursor-pointer"
-              >
-                <Trash2 size={14} />
-              </button>
+              <div className="flex items-center pr-2">
+                {locked ? (
+                  <span title={t('actions.pluginLocked')} className="p-2 text-text-tertiary">
+                    <Lock size={14} />
+                  </span>
+                ) : (
+                  <button
+                    type="button"
+                    title={t('actions.delete')}
+                    disabled={deleteMutation.isPending}
+                    onClick={() => {
+                      if (confirm(t('actions.confirmDeleteRule', { id: rule.id }))) {
+                        deleteMutation.mutate({ section: 'rules', entryId: rule.id });
+                      }
+                    }}
+                    className="rounded-sm p-2 text-text-tertiary hover:bg-error-bg hover:text-error-text cursor-pointer"
+                  >
+                    <Trash2 size={14} />
+                  </button>
+                )}
+              </div>
             </div>
           )}
         />
       )}
 
       <RuleDialog
-        open={addOpen || !!editing}
+        open={(addOpen || !!editing) && !editing?.sourcePlugin}
         mode={editing ? 'edit' : 'add'}
-        initial={editing}
+        initial={editing?.sourcePlugin ? null : editing}
         busy={updateMutation.isPending}
         onOpenChange={(open) => {
           if (!open) {
@@ -97,6 +122,7 @@ export function RulesList({ rules, search, projectId, addOpen, onAddOpenChange }
           }
         }}
         onSubmit={async (entry) => {
+          if (editing?.sourcePlugin) return;
           if (editing) {
             await updateMutation.mutateAsync({
               section: 'rules',
@@ -106,7 +132,7 @@ export function RulesList({ rules, search, projectId, addOpen, onAddOpenChange }
           }
         }}
         projectId={projectId}
-        isEdit={!!editing}
+        isEdit={!!editing && !editing.sourcePlugin}
       />
     </div>
   );

--- a/web-ui/src/features/projects/components/RulesList.tsx
+++ b/web-ui/src/features/projects/components/RulesList.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useState, type FormEvent } from 'react';
+import { useEffect, useMemo, useState, type FormEvent } from 'react';
 import * as Dialog from '@radix-ui/react-dialog';
 import { Trash2, X, Loader2, Lock } from 'lucide-react';
 import { useTranslation } from 'react-i18next';
@@ -8,6 +8,7 @@ import { capaIdErrorMessage, sanitizeCapaIdInput } from '../../../lib/ids';
 import { ReorderableList } from '../../../components/common/ReorderableList';
 import { SourceBadge } from '../../../components/common/ServerBadge';
 import { sourceTypeBadgeClasses } from './sourceTypeColors';
+import { renderMarkdown } from './registry-browse/markdown';
 import { LocalPathPicker } from './LocalPathPicker';
 import { useAppendCapability, useDeleteCapability, useReorderCapability, useUpdateCapability } from '../hooks';
 import { authoredReorderKeys, isPluginSourced } from '../lib/reorderKeys';
@@ -26,6 +27,7 @@ export function RulesList({ rules, search, projectId, addOpen, onAddOpenChange }
   const reorderMutation = useReorderCapability(projectId);
   const updateMutation = useUpdateCapability(projectId);
   const [editing, setEditing] = useState<Rule | null>(null);
+  const [viewing, setViewing] = useState<Rule | null>(null);
   const searching = !!search.trim();
   const visible = rules.filter((r) => matchesSearch([r.id, r.description, r.content, r.path], search));
 
@@ -54,11 +56,14 @@ export function RulesList({ rules, search, projectId, addOpen, onAddOpenChange }
               {handle}
               <button
                 type="button"
-                className={`min-w-0 flex-1 p-3 text-left ${locked ? 'cursor-default' : 'cursor-pointer ui-row-hover hover:bg-hover-bg'}`}
-                onClick={() =>
-                  !locked && (rule.type === 'inline' || rule.type === 'local') && setEditing(rule)
-                }
-                disabled={locked}
+                className="min-w-0 flex-1 p-3 text-left cursor-pointer ui-row-hover hover:bg-hover-bg"
+                onClick={() => {
+                  if (locked) {
+                    setViewing(rule);
+                    return;
+                  }
+                  if (rule.type === 'inline' || rule.type === 'local') setEditing(rule);
+                }}
               >
                 <div className="flex items-center gap-2">
                   <span className="font-mono text-[13px] font-medium text-text-primary">{rule.id}</span>
@@ -134,7 +139,111 @@ export function RulesList({ rules, search, projectId, addOpen, onAddOpenChange }
         projectId={projectId}
         isEdit={!!editing && !editing.sourcePlugin}
       />
+
+      <RuleViewDialog
+        rule={viewing}
+        open={!!viewing}
+        onOpenChange={(open) => {
+          if (!open) setViewing(null);
+        }}
+      />
     </div>
+  );
+}
+
+function RuleViewDialog({
+  rule,
+  open,
+  onOpenChange,
+}: {
+  rule: Rule | null;
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+}) {
+  const { t } = useTranslation('projects');
+  const contentHtml = useMemo(
+    () => (rule?.content ? renderMarkdown(rule.content) : ''),
+    [rule?.content],
+  );
+
+  return (
+    <Dialog.Root open={open} onOpenChange={onOpenChange}>
+      <Dialog.Portal>
+        <Dialog.Overlay className="ui-overlay fixed inset-0 z-50 bg-black/50" />
+        <Dialog.Content className="ui-dialog fixed z-50 flex max-h-[90vh] w-[min(90vw,720px)] flex-col overflow-hidden rounded-lg border border-border-primary bg-bg-secondary shadow-lg">
+          <div className="flex items-start justify-between border-b border-border-secondary px-6 py-4">
+            <div className="min-w-0 flex-1 pr-4">
+              <Dialog.Title className="truncate font-mono text-lg font-medium text-text-primary">
+                {rule?.id ?? t('rules.viewTitle')}
+              </Dialog.Title>
+              {rule && (
+                <div className="mt-2 flex flex-wrap items-center gap-2">
+                  <span
+                    className={`shrink-0 rounded-sm px-1.5 py-0.5 text-[10px] font-medium uppercase ${sourceTypeBadgeClasses('plugin')}`}
+                  >
+                    plugin
+                  </span>
+                  {rule.sourcePlugin?.name && (
+                    <SourceBadge name={rule.sourcePlugin.name} kind="plugin" />
+                  )}
+                </div>
+              )}
+              <Dialog.Description className="sr-only">
+                {t('rules.viewTitle')}
+              </Dialog.Description>
+            </div>
+            <Dialog.Close
+              className="rounded-sm p-1 text-text-secondary transition-colors hover:bg-hover-bg cursor-pointer"
+              aria-label="Close"
+            >
+              <X className="h-4 w-4" />
+            </Dialog.Close>
+          </div>
+
+          <div className="min-h-0 flex-1 space-y-4 overflow-y-auto px-6 py-5">
+            {rule?.description && (
+              <p className="text-sm text-text-secondary">{rule.description}</p>
+            )}
+
+            {(rule?.appliesTo.length ?? 0) > 0 && (
+              <div>
+                <div className="mb-1.5 text-xs font-medium text-text-tertiary">
+                  {t('rules.appliesTo')}
+                </div>
+                <div className="flex flex-wrap gap-1">
+                  {rule!.appliesTo.map((glob) => (
+                    <span
+                      key={glob}
+                      className="rounded-sm bg-bg-secondary px-1.5 py-0.5 font-mono text-[10px] text-text-tertiary"
+                    >
+                      {glob}
+                    </span>
+                  ))}
+                </div>
+              </div>
+            )}
+
+            {rule?.alwaysApply && (
+              <div className="text-xs text-text-tertiary">{t('rules.alwaysApply')}</div>
+            )}
+
+            <div>
+              <div className="mb-1.5 text-xs font-medium text-text-tertiary">
+                {t('rules.content')}
+              </div>
+              {contentHtml ? (
+                <div
+                  className="registry-markdown overflow-hidden text-sm text-text-secondary"
+                  dangerouslySetInnerHTML={{ __html: contentHtml }}
+                />
+              ) : (
+                <p className="text-xs text-text-tertiary">{t('rules.noContent')}</p>
+              )}
+            </div>
+          </div>
+        </Dialog.Content>
+      </Dialog.Portal>
+    </Dialog.Root>
   );
 }
 

--- a/web-ui/src/features/projects/components/SubagentsList.tsx
+++ b/web-ui/src/features/projects/components/SubagentsList.tsx
@@ -1,13 +1,17 @@
-import { useEffect, useState, type FormEvent } from 'react';
+import { useEffect, useMemo, useState, type FormEvent } from 'react';
 import * as Dialog from '@radix-ui/react-dialog';
-import { Trash2, X, Loader2 } from 'lucide-react';
+import { Trash2, X, Loader2, Lock } from 'lucide-react';
 import { useTranslation } from 'react-i18next';
 import type { Skill, SubAgent, Tool } from '../../../types/api';
 import { matchesSearch } from '../../../lib/utils';
 import { capaIdErrorMessage, sanitizeCapaIdInput } from '../../../lib/ids';
 import { refMatchesTool, skillRequiresRef } from '../../../lib/toolRefs';
 import { ReorderableList } from '../../../components/common/ReorderableList';
+import { SourceBadge } from '../../../components/common/ServerBadge';
+import { sourceTypeBadgeClasses } from './sourceTypeColors';
+import { renderMarkdown } from './registry-browse/markdown';
 import { useAppendCapability, useDeleteCapability, useReorderCapability, useUpdateCapability } from '../hooks';
+import { authoredReorderKeys, isPluginSourced } from '../lib/reorderKeys';
 
 interface SubagentsListProps {
   subagents: SubAgent[];
@@ -33,6 +37,7 @@ export function SubagentsList({
   const reorderMutation = useReorderCapability(projectId);
   const updateMutation = useUpdateCapability(projectId);
   const [editing, setEditing] = useState<SubAgent | null>(null);
+  const [viewing, setViewing] = useState<SubAgent | null>(null);
   const searching = !!search.trim();
   const visible = subagents.filter((s) =>
     matchesSearch([s.id, s.description, s.instructions, ...s.skills, ...s.tools], search),
@@ -48,19 +53,35 @@ export function SubagentsList({
         <ReorderableList
           items={visible}
           getId={(a) => a.id}
+          isLocked={(a) => isPluginSourced(a)}
           disabled={searching}
           handleLabel={t('actions.dragToReorder')}
           className="space-y-2"
-          onReorder={(ids) => reorderMutation.mutate({ section: 'subagents', ids })}
-          renderItem={(agent, { handle }) => (
-            <div className="flex items-start gap-1 rounded-sm border border-border-tertiary bg-bg-tertiary p-3 pl-1">
+          onReorder={(ids) =>
+            reorderMutation.mutate({
+              section: 'subagents',
+              ids: authoredReorderKeys(subagents, ids, (a) => a.id),
+            })
+          }
+          renderItem={(agent, { handle, locked }) => (
+            <div className="flex w-full items-stretch gap-1 rounded-sm border border-border-tertiary bg-bg-tertiary pl-1">
               {handle}
               <button
                 type="button"
-                className="min-w-0 flex-1 text-left cursor-pointer"
-                onClick={() => setEditing(agent)}
+                className="min-w-0 flex-1 p-3 text-left cursor-pointer ui-row-hover hover:bg-hover-bg"
+                onClick={() => {
+                  if (locked) setViewing(agent);
+                  else setEditing(agent);
+                }}
               >
-                <div className="font-mono text-[13px] font-medium text-text-primary">{agent.id}</div>
+                <div className="flex flex-wrap items-center gap-2">
+                  <span className="font-mono text-[13px] font-medium text-text-primary">{agent.id}</span>
+                  {locked && (
+                    <span className={`rounded-sm px-1.5 py-0.5 text-[10px] uppercase ${sourceTypeBadgeClasses('plugin')}`}>
+                      plugin
+                    </span>
+                  )}
+                </div>
                 {agent.description && (
                   <p className="mt-1 text-xs text-text-secondary">{agent.description}</p>
                 )}
@@ -76,28 +97,42 @@ export function SubagentsList({
                     </span>
                   ))}
                 </div>
+                {agent.sourcePlugin?.name && (
+                  <div className="mt-2 flex items-center gap-1.5 text-[11px] text-text-tertiary">
+                    <span>from</span>
+                    <SourceBadge name={agent.sourcePlugin.name} kind="plugin" />
+                  </div>
+                )}
               </button>
-              <button
-                type="button"
-                title={t('actions.delete')}
-                disabled={deleteMutation.isPending}
-                onClick={() => {
-                  if (confirm(t('actions.confirmDeleteSubagent', { id: agent.id }))) {
-                    deleteMutation.mutate({ section: 'subagents', entryId: agent.id });
-                  }
-                }}
-                className="rounded-sm p-2 text-text-tertiary hover:bg-error-bg hover:text-error-text cursor-pointer"
-              >
-                <Trash2 size={14} />
-              </button>
+              <div className="flex items-center pr-2">
+                {locked ? (
+                  <span title={t('actions.pluginLocked')} className="p-2 text-text-tertiary">
+                    <Lock size={14} />
+                  </span>
+                ) : (
+                  <button
+                    type="button"
+                    title={t('actions.delete')}
+                    disabled={deleteMutation.isPending}
+                    onClick={() => {
+                      if (confirm(t('actions.confirmDeleteSubagent', { id: agent.id }))) {
+                        deleteMutation.mutate({ section: 'subagents', entryId: agent.id });
+                      }
+                    }}
+                    className="rounded-sm p-2 text-text-tertiary hover:bg-error-bg hover:text-error-text cursor-pointer"
+                  >
+                    <Trash2 size={14} />
+                  </button>
+                )}
+              </div>
             </div>
           )}
         />
       )}
 
       <SubagentDialog
-        open={addOpen || !!editing}
-        initial={editing}
+        open={addOpen || (!!editing && !editing.sourcePlugin)}
+        initial={editing?.sourcePlugin ? null : editing}
         skills={skills}
         tools={tools}
         projectId={projectId}
@@ -109,10 +144,129 @@ export function SubagentsList({
           }
         }}
         onUpdate={async (entryId, patch) => {
+          if (editing?.sourcePlugin) return;
           await updateMutation.mutateAsync({ section: 'subagents', entryId, patch });
         }}
       />
+
+      <SubagentViewDialog
+        agent={viewing}
+        open={!!viewing}
+        onOpenChange={(open) => {
+          if (!open) setViewing(null);
+        }}
+      />
     </div>
+  );
+}
+
+function SubagentViewDialog({
+  agent,
+  open,
+  onOpenChange,
+}: {
+  agent: SubAgent | null;
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+}) {
+  const { t } = useTranslation('projects');
+  const instructionsHtml = useMemo(
+    () => (agent?.instructions ? renderMarkdown(agent.instructions) : ''),
+    [agent?.instructions],
+  );
+
+  return (
+    <Dialog.Root open={open} onOpenChange={onOpenChange}>
+      <Dialog.Portal>
+        <Dialog.Overlay className="ui-overlay fixed inset-0 z-50 bg-black/50" />
+        <Dialog.Content className="ui-dialog fixed z-50 flex max-h-[90vh] w-[min(90vw,720px)] flex-col overflow-hidden rounded-lg border border-border-primary bg-bg-secondary shadow-lg">
+          <div className="flex items-start justify-between border-b border-border-secondary px-6 py-4">
+            <div className="min-w-0 flex-1 pr-4">
+              <Dialog.Title className="truncate font-mono text-lg font-medium text-text-primary">
+                {agent?.id ?? t('subagents.viewTitle')}
+              </Dialog.Title>
+              {agent && (
+                <div className="mt-2 flex flex-wrap items-center gap-2">
+                  <span
+                    className={`shrink-0 rounded-sm px-1.5 py-0.5 text-[10px] font-medium uppercase ${sourceTypeBadgeClasses('plugin')}`}
+                  >
+                    plugin
+                  </span>
+                  {agent.sourcePlugin?.name && (
+                    <SourceBadge name={agent.sourcePlugin.name} kind="plugin" />
+                  )}
+                </div>
+              )}
+              <Dialog.Description className="sr-only">
+                {t('subagents.viewTitle')}
+              </Dialog.Description>
+            </div>
+            <Dialog.Close
+              className="rounded-sm p-1 text-text-secondary transition-colors hover:bg-hover-bg cursor-pointer"
+              aria-label="Close"
+            >
+              <X className="h-4 w-4" />
+            </Dialog.Close>
+          </div>
+
+          <div className="min-h-0 flex-1 space-y-4 overflow-y-auto px-6 py-5">
+            {agent?.description && (
+              <p className="text-sm text-text-secondary">{agent.description}</p>
+            )}
+
+            {(agent?.skills.length ?? 0) > 0 && (
+              <div>
+                <div className="mb-1.5 text-xs font-medium text-text-tertiary">
+                  {t('subagents.skills')}
+                </div>
+                <div className="flex flex-wrap gap-1">
+                  {agent!.skills.map((s) => (
+                    <span
+                      key={s}
+                      className="rounded-sm bg-accent-primary/10 px-1.5 py-0.5 font-mono text-[10px] text-accent-primary"
+                    >
+                      {s}
+                    </span>
+                  ))}
+                </div>
+              </div>
+            )}
+
+            {(agent?.tools.length ?? 0) > 0 && (
+              <div>
+                <div className="mb-1.5 text-xs font-medium text-text-tertiary">
+                  {t('subagents.tools')}
+                </div>
+                <div className="flex flex-wrap gap-1">
+                  {agent!.tools.map((toolId) => (
+                    <span
+                      key={toolId}
+                      className="rounded-sm bg-bg-secondary px-1.5 py-0.5 font-mono text-[10px] text-text-tertiary"
+                    >
+                      {toolId}
+                    </span>
+                  ))}
+                </div>
+              </div>
+            )}
+
+            <div>
+              <div className="mb-1.5 text-xs font-medium text-text-tertiary">
+                {t('subagents.instructions')}
+              </div>
+              {instructionsHtml ? (
+                <div
+                  className="registry-markdown overflow-hidden text-sm text-text-secondary"
+                  dangerouslySetInnerHTML={{ __html: instructionsHtml }}
+                />
+              ) : (
+                <p className="text-xs text-text-tertiary">{t('subagents.noInstructions')}</p>
+              )}
+            </div>
+          </div>
+        </Dialog.Content>
+      </Dialog.Portal>
+    </Dialog.Root>
   );
 }
 

--- a/web-ui/src/features/projects/components/sourceTypeColors.ts
+++ b/web-ui/src/features/projects/components/sourceTypeColors.ts
@@ -24,6 +24,7 @@ const SOURCE_TYPE_COLORS: Record<string, string> = {
   gitlab: 'bg-orange-500/10 text-orange-400',
   local: 'bg-slate-500/10 text-slate-400',
   installed: 'bg-amber-500/10 text-amber-400',
+  plugin: 'bg-teal-500/10 text-teal-400',
 };
 
 const FALLBACK = 'bg-bg-secondary text-text-tertiary';

--- a/web-ui/src/locales/en/projects.json
+++ b/web-ui/src/locales/en/projects.json
@@ -318,7 +318,9 @@
     "skills": "Skills",
     "tools": "Tools",
     "instructions": "Instructions",
-    "noDescription": "No description"
+    "noDescription": "No description",
+    "viewTitle": "Sub-agent",
+    "noInstructions": "No instructions"
   },
   "rules": {
     "title": "Rules",

--- a/web-ui/src/locales/en/projects.json
+++ b/web-ui/src/locales/en/projects.json
@@ -329,7 +329,10 @@
     "providers": "Providers",
     "appliesTo": "Applies to",
     "alwaysApply": "Always apply",
-    "allProviders": "All providers"
+    "allProviders": "All providers",
+    "viewTitle": "Rule",
+    "content": "Content",
+    "noContent": "No content"
   },
   "hooks": {
     "title": "Hooks",

--- a/web-ui/src/types/api.ts
+++ b/web-ui/src/types/api.ts
@@ -109,6 +109,9 @@ export interface ResolvedPlugin {
   skills?: string[];
   /** Capa server IDs (after `as` rename) the plugin contributed. */
   serverIds?: string[];
+  subagentIds?: string[];
+  hookIds?: string[];
+  ruleIds?: string[];
 }
 
 export interface SubAgent {
@@ -117,6 +120,7 @@ export interface SubAgent {
   skills: string[];
   tools: string[];
   instructions: string | null;
+  sourcePlugin: SourcePlugin | null;
 }
 
 export interface Rule {
@@ -130,6 +134,7 @@ export interface Rule {
   url?: string | null;
   path?: string | null;
   def?: { repo: string } | null;
+  sourcePlugin: SourcePlugin | null;
 }
 
 export interface InstalledHook {
@@ -156,6 +161,7 @@ export interface Hook {
   sourceContent?: string | null;
   /** One row per provider where capa successfully installed this hook. */
   installed: InstalledHook[];
+  sourcePlugin: SourcePlugin | null;
 }
 
 export interface AuthoredPlugin {


### PR DESCRIPTION
## Summary
- Expand Claude/Cursor plugin unpack so plugins contribute rules, subagents, hooks, and legacy commands (as skills), not only skills/MCP — with stable install under `~/.capa/plugins/<projectId>/`.
- Merge sibling Claude/Cursor hook manifests into one canonical capa hook when rewritten commands match (including empty vs provider-specific matchers), and map native events to capa canonical names.
- UI lock/badge parity for plugin-sourced hooks, rules, and subagents; marketplace plugin preview lists full contribution contents; skip `${Var}` credential scans in plugin prose.

## Test plan
- [x] Install a dual-manifest plugin (e.g. superpowers) and confirm one `sessionStart` hook in the project UI (not Claude + Cursor duplicates)
- [x] Confirm plugin rules/subagents appear locked with source badge; view-only subagent dialog works
- [x] Confirm hook commands use forward-slash paths under `~/.capa/plugins/<projectId>/<plugin>/`
- [x] Preview a Claude marketplace plugin and verify Contents lists skills/agents/hooks/rules/MCP
- [x] Run `bun test` for plugin-manifest full-unpack, hook merge, provider-map, and variable-resolver tests