### PR TITLE
feat: extend capa wrap to Cursor agent and other CLI providers

### DIFF
--- a/src/cli/commands/__tests__/wrap-ensure-binary.test.ts
+++ b/src/cli/commands/__tests__/wrap-ensure-binary.test.ts
@@ -1,0 +1,32 @@
+import { describe, it, expect, spyOn } from 'bun:test';
+import * as childProcess from 'child_process';
+import { ensureWrapBinaryOnPath } from '../wrap-ensure-binary';
+
+describe('ensureWrapBinaryOnPath', () => {
+  it('resolves when the binary is on PATH', async () => {
+    const execFileSpy = spyOn(childProcess, 'execFile').mockImplementation(
+      ((_cmd: string, _args: readonly string[] | null | undefined, _opts: object, cb: (err: null, result: { stdout: string; stderr: string }) => void) => {
+        cb(null, { stdout: '/usr/bin/gemini\n', stderr: '' });
+      }) as typeof childProcess.execFile,
+    );
+
+    await ensureWrapBinaryOnPath('gemini', 'gemini-cli');
+    expect(execFileSpy).toHaveBeenCalled();
+    const [, args] = execFileSpy.mock.calls[0] as unknown as [string, string[]];
+    expect(args).toEqual(['gemini']);
+    execFileSpy.mockRestore();
+  });
+
+  it('rejects with a wrap-specific message when missing', async () => {
+    const execFileSpy = spyOn(childProcess, 'execFile').mockImplementation(
+      ((_cmd: string, _args: readonly string[] | null | undefined, _opts: object, cb: (err: Error) => void) => {
+        cb(new Error('not found'));
+      }) as typeof childProcess.execFile,
+    );
+
+    await expect(ensureWrapBinaryOnPath('gemini', 'gemini-cli')).rejects.toThrow(
+      'gemini not found — required by capa wrap gemini-cli',
+    );
+    execFileSpy.mockRestore();
+  });
+});

--- a/src/cli/commands/__tests__/wrap-prompt.test.ts
+++ b/src/cli/commands/__tests__/wrap-prompt.test.ts
@@ -1,0 +1,60 @@
+import { describe, it, expect, spyOn, afterEach } from 'bun:test';
+import * as flags from '../../ui/flags';
+import * as prompts from '../../ui/prompts';
+import { buildWrapSelectOptions, resolveWrapProviderArg } from '../wrap-prompt';
+
+describe('buildWrapSelectOptions', () => {
+  it('includes wrappable providers and wrap aliases', () => {
+    const options = buildWrapSelectOptions();
+    const values = options.map((o) => o.value);
+
+    expect(values).toContain('cursor');
+    expect(values).toContain('agent');
+    expect(values).toContain('claude-code');
+    expect(values).toContain('gemini-cli');
+    expect(values).not.toContain('github-copilot');
+
+    const agent = options.find((o) => o.value === 'agent');
+    expect(agent?.label).toContain('Cursor');
+    expect(agent?.hint).toBe('agent');
+
+    const cursor = options.find((o) => o.value === 'cursor');
+    expect(cursor?.hint).toBe('cursor');
+  });
+});
+
+describe('resolveWrapProviderArg', () => {
+  afterEach(() => {
+    // restore spies created in each test
+  });
+
+  it('returns the provided arg when present', async () => {
+    expect(await resolveWrapProviderArg('gemini-cli')).toBe('gemini-cli');
+    expect(await resolveWrapProviderArg('  agent  ')).toBe('agent');
+  });
+
+  it('errors in non-interactive mode when no provider is given', async () => {
+    const interactive = spyOn(flags, 'isInteractive').mockReturnValue(false);
+    await expect(resolveWrapProviderArg(undefined)).rejects.toThrow(
+      /Missing provider/,
+    );
+    interactive.mockRestore();
+  });
+
+  it('prompts interactively when no provider is given', async () => {
+    const interactive = spyOn(flags, 'isInteractive').mockReturnValue(true);
+    const select = spyOn(prompts.prompt, 'select').mockResolvedValue('agent');
+
+    await expect(resolveWrapProviderArg(undefined)).resolves.toBe('agent');
+    expect(select).toHaveBeenCalled();
+    const [message, options] = select.mock.calls[0] as unknown as [
+      string,
+      Array<{ value: string }>,
+    ];
+    expect(message).toBe('Which provider do you want to wrap?');
+    expect(options.map((o) => o.value)).toContain('agent');
+
+    select.mockRestore();
+    interactive.mockRestore();
+  });
+});

--- a/src/cli/commands/wrap-ensure-binary.ts
+++ b/src/cli/commands/wrap-ensure-binary.ts
@@ -1,0 +1,14 @@
+import { checkRequiredCommand } from './install-tasks/helpers/required-command';
+
+/**
+ * Ensure the wrap launch binary is on PATH before preparing a shadow workspace.
+ */
+export async function ensureWrapBinaryOnPath(
+  binary: string,
+  providerArg: string,
+): Promise<void> {
+  await checkRequiredCommand({
+    cli: binary,
+    description: `required by capa wrap ${providerArg}`,
+  });
+}

--- a/src/cli/commands/wrap-prompt.ts
+++ b/src/cli/commands/wrap-prompt.ts
@@ -1,0 +1,87 @@
+import { prompt, isInteractive, type SelectOption } from '../ui';
+import {
+  formatWrappableProviderList,
+  getWrappableProviders,
+  resolveWrapTarget,
+} from '../../shared/providers';
+import type { ProviderIntegration } from '../../types/providers';
+
+/**
+ * Build select options for `capa wrap`: one entry per wrappable provider id,
+ * plus each `wrap.aliases` token (e.g. Cursor GUI + `agent` CLI).
+ */
+export function buildWrapSelectOptions(
+  providers: ProviderIntegration[] = getWrappableProviders(),
+): SelectOption[] {
+  const options: SelectOption[] = [];
+
+  for (const p of providers) {
+    if (!p.wrap) continue;
+    options.push({
+      value: p.id,
+      label: p.displayName,
+      hint: p.wrap.binary,
+    });
+    for (const [alias, launch] of Object.entries(p.wrap.aliases ?? {})) {
+      if (alias.toLowerCase() === p.id.toLowerCase()) continue;
+      options.push({
+        value: alias,
+        label: `${p.displayName} (${alias})`,
+        hint: launch.binary,
+      });
+    }
+  }
+
+  return options.sort((a, b) => a.label.localeCompare(b.label));
+}
+
+async function detectInstalledWrappableIds(): Promise<Set<string>> {
+  const ids = new Set<string>();
+  for (const p of getWrappableProviders()) {
+    if (!p.detectInstalled) continue;
+    try {
+      if (await p.detectInstalled()) ids.add(p.id);
+    } catch {
+      // ignore detection failures
+    }
+  }
+  return ids;
+}
+
+/**
+ * Resolve the wrap provider token: use the CLI arg when present, otherwise
+ * prompt interactively (TTY) among wrappable providers — same pattern as
+ * `capa install` when no provider is configured.
+ */
+export async function resolveWrapProviderArg(
+  providerArg: string | undefined,
+): Promise<string> {
+  if (providerArg?.trim()) return providerArg.trim();
+
+  const allOptions = buildWrapSelectOptions();
+  if (allOptions.length === 0) {
+    throw new Error('No wrappable providers are registered.');
+  }
+
+  if (!isInteractive()) {
+    throw new Error(
+      `Missing provider. Wrappable providers: ${formatWrappableProviderList() || '(none)'}\n` +
+        '  Pass a provider, e.g. capa wrap cursor',
+    );
+  }
+
+  const detectedIds = await detectInstalledWrappableIds();
+  const preferred =
+    detectedIds.size > 0
+      ? allOptions.filter((o) => {
+          const target = resolveWrapTarget(o.value);
+          return target != null && detectedIds.has(target.provider.id);
+        })
+      : allOptions;
+
+  return prompt.select(
+    'Which provider do you want to wrap?',
+    preferred.length > 0 ? preferred : allOptions,
+    '<provider>',
+  );
+}

--- a/src/cli/commands/wrap.ts
+++ b/src/cli/commands/wrap.ts
@@ -1,7 +1,7 @@
 import { resolve } from 'path';
 import {
-  getWrappableProvider,
-  getWrappableProviders,
+  formatWrappableProviderList,
+  resolveWrapTarget,
 } from '../../shared/providers';
 import { prepareWorkspace, pruneWorkspaces } from '../utils/wrap/workspace';
 import { startWrapWatchers } from '../utils/wrap/watch-project';
@@ -72,20 +72,14 @@ export async function wrapCommand(
   }
 
   if (!providerArg) {
-    const available = getWrappableProviders()
-      .map((p) => p.id)
-      .sort()
-      .join(', ');
+    const available = formatWrappableProviderList();
     error(`Missing provider. Wrappable providers: ${available || '(none)'}`);
     process.exit(1);
   }
 
-  const provider = getWrappableProvider(providerArg);
-  if (!provider || !provider.wrap) {
-    const available = getWrappableProviders()
-      .map((p) => `${p.id}${p.pluginProviderId ? ` (alias: ${p.pluginProviderId})` : ''}`)
-      .sort()
-      .join(', ');
+  const target = resolveWrapTarget(providerArg);
+  if (!target) {
+    const available = formatWrappableProviderList();
     error(
       `Unknown or non-wrappable provider "${providerArg}".\n` +
         `  Available: ${available || '(none)'}`,
@@ -93,6 +87,7 @@ export async function wrapCommand(
     process.exit(1);
   }
 
+  const { provider, wrap } = target;
   const realProjectPath = resolve(options.project ?? process.cwd());
 
   let prepared;
@@ -124,7 +119,7 @@ export async function wrapCommand(
     console.warn('⚠ Could not write wrap session file; clean/delete may not stop this session.');
   }
 
-  if (provider.wrap.kind === 'gui') {
+  if (wrap.kind === 'gui') {
     const watchers = startWrapWatchers({
       realProjectPath: prepared.realProjectPath,
       workspacePath: prepared.workspacePath,
@@ -154,15 +149,15 @@ export async function wrapCommand(
     }
 
     info(
-      `Launching ${provider.wrap.binary} (wrap stops when the window closes, or Ctrl+C / q)`,
+      `Launching ${wrap.binary} (wrap stops when the window closes, or Ctrl+C / q)`,
     );
     let launch;
     try {
-      launch = await launchProvider(provider, prepared.workspacePath, args);
+      launch = await launchProvider(wrap, prepared.workspacePath, args);
     } catch (err) {
       cleanup();
       error(
-        `Failed to launch ${provider.wrap.binary}: ${
+        `Failed to launch ${wrap.binary}: ${
           err instanceof Error ? err.message : String(err)
         }`,
       );
@@ -221,7 +216,7 @@ export async function wrapCommand(
   }
 
   try {
-    const result = await launchProvider(provider, prepared.workspacePath, args);
+    const result = await launchProvider(wrap, prepared.workspacePath, args);
     cleanupCli();
     if (result.exitCode != null && result.exitCode !== 0) {
       process.exit(result.exitCode);
@@ -229,7 +224,7 @@ export async function wrapCommand(
   } catch (err) {
     cleanupCli();
     error(
-      `Failed to launch ${provider.wrap.binary}: ${
+      `Failed to launch ${wrap.binary}: ${
         err instanceof Error ? err.message : String(err)
       }`,
     );

--- a/src/cli/commands/wrap.ts
+++ b/src/cli/commands/wrap.ts
@@ -8,6 +8,8 @@ import { startWrapWatchers } from '../utils/wrap/watch-project';
 import { launchProvider } from '../utils/wrap/launch';
 import { waitForInterrupt } from '../utils/wrap/wait-for-interrupt';
 import { clearWrapSession, writeWrapSession } from '../utils/wrap/session-file';
+import { ensureWrapBinaryOnPath } from './wrap-ensure-binary';
+import { resolveWrapProviderArg } from './wrap-prompt';
 import { info, error } from '../ui';
 
 export interface WrapOptions {
@@ -71,23 +73,34 @@ export async function wrapCommand(
     return;
   }
 
-  if (!providerArg) {
-    const available = formatWrappableProviderList();
-    error(`Missing provider. Wrappable providers: ${available || '(none)'}`);
+  let providerToken: string;
+  try {
+    providerToken = await resolveWrapProviderArg(providerArg);
+  } catch (err) {
+    error(err instanceof Error ? err.message : String(err));
     process.exit(1);
   }
 
-  const target = resolveWrapTarget(providerArg);
+  const target = resolveWrapTarget(providerToken);
   if (!target) {
     const available = formatWrappableProviderList();
     error(
-      `Unknown or non-wrappable provider "${providerArg}".\n` +
+      `Unknown or non-wrappable provider "${providerToken}".\n` +
         `  Available: ${available || '(none)'}`,
     );
     process.exit(1);
   }
 
   const { provider, wrap } = target;
+
+  // Fail fast before shadow workspace install when the launch binary is missing.
+  try {
+    await ensureWrapBinaryOnPath(wrap.binary, providerToken);
+  } catch (err) {
+    error(err instanceof Error ? err.message : String(err));
+    process.exit(1);
+  }
+
   const realProjectPath = resolve(options.project ?? process.cwd());
 
   let prepared;

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -189,7 +189,9 @@ if (process.argv[2] === '__server__') {
 
     program
       .command('wrap [provider] [args...]')
-      .description('Run a provider from a CAPA shadow workspace without modifying in-repo provider configs')
+      .description(
+        'Run a provider from a CAPA shadow workspace without modifying in-repo provider configs (prompts for provider when omitted)',
+      )
       .option('--project <dir>', 'Source project directory (default: cwd)')
       .option('--print-dir', 'Print the workspace path before launching')
       .option('--prune', 'Remove wrap workspaces under ~/.capa/workspaces and exit')

--- a/src/cli/utils/wrap/__tests__/launch.test.ts
+++ b/src/cli/utils/wrap/__tests__/launch.test.ts
@@ -13,13 +13,10 @@ mock.module('node:child_process', () => ({
 }));
 
 import { launchProvider } from '../launch';
-import type { ProviderIntegration } from '../../../../types/providers';
+import type { WrapLaunchConfig } from '../../../../types/providers';
 
-const claude: ProviderIntegration = {
-  id: 'claude-code',
-  displayName: 'Claude Code',
-  wrap: { binary: 'claude', kind: 'cli' },
-} as ProviderIntegration;
+const claudeWrap: WrapLaunchConfig = { binary: 'claude', kind: 'cli' };
+const agentWrap: WrapLaunchConfig = { binary: 'agent', kind: 'cli' };
 
 describe('launchProvider CLI', () => {
   beforeEach(() => {
@@ -31,7 +28,7 @@ describe('launchProvider CLI', () => {
   });
 
   test('uses spawnSync with inherited stdio for a real TTY', async () => {
-    const result = await launchProvider(claude, 'C:\\ws\\proj', ['--help']);
+    const result = await launchProvider(claudeWrap, 'C:\\ws\\proj', ['--help']);
     expect(result.exitCode).toBe(0);
     expect(spawnSyncCalls).toHaveLength(1);
     expect(spawnSyncCalls[0]?.cmd).toBe('claude');
@@ -40,5 +37,12 @@ describe('launchProvider CLI', () => {
     expect(spawnSyncCalls[0]?.opts.cwd).toBe('C:\\ws\\proj');
     expect(spawnSyncCalls[0]?.opts.windowsHide).toBe(false);
     expect(spawnSyncCalls[0]?.opts.shell).toBe(false);
+  });
+
+  test('launches cursor agent CLI binary from wrap config', async () => {
+    const result = await launchProvider(agentWrap, '/tmp/ws', []);
+    expect(result.exitCode).toBe(0);
+    expect(spawnSyncCalls[0]?.cmd).toBe('agent');
+    expect(spawnSyncCalls[0]?.args).toEqual([]);
   });
 });

--- a/src/cli/utils/wrap/launch.ts
+++ b/src/cli/utils/wrap/launch.ts
@@ -1,5 +1,5 @@
 import { spawnSync } from 'node:child_process';
-import type { ProviderIntegration } from '../../../types/providers';
+import type { WrapLaunchConfig } from '../../../types/providers';
 
 export interface LaunchResult {
   /** Exit code for CLI providers after they exit. */
@@ -70,20 +70,15 @@ function ignoreParentSigint(): () => void {
 }
 
 /**
- * Launch the provider binary according to wrap.kind.
+ * Launch according to wrap.kind.
  * CLI: blocking spawnSync with inherited console (real TTY for Claude).
  * GUI: returns immediately with `closed`/`kill` so wrap can race window-close vs interrupt.
  */
 export async function launchProvider(
-  provider: ProviderIntegration,
+  wrap: WrapLaunchConfig,
   workspacePath: string,
   args: string[],
 ): Promise<LaunchResult> {
-  const wrap = provider.wrap;
-  if (!wrap) {
-    throw new Error(`Provider "${provider.id}" is not wrappable.`);
-  }
-
   const wrapArgs = wrap.args ?? [];
 
   if (wrap.kind === 'gui') {

--- a/src/shared/providers/__tests__/wrap.test.ts
+++ b/src/shared/providers/__tests__/wrap.test.ts
@@ -16,11 +16,12 @@ describe('wrap provider helpers', () => {
     expect(ids).toContain('cursor');
     expect(ids).toContain('gemini-cli');
     expect(ids).toContain('opencode');
-    expect(ids).toContain('github-copilot');
     expect(ids).toContain('qwen-code');
     expect(ids).toContain('kiro-cli');
     expect(ids).toContain('iflow-cli');
     expect(ids).toContain('kimi-cli');
+    // Shared top-level dirs (.github / .vscode) — not wrappable until subpath exclusions exist.
+    expect(ids).not.toContain('github-copilot');
   });
 
   it('resolves by registry id', () => {
@@ -39,6 +40,8 @@ describe('wrap provider helpers', () => {
   it('returns undefined for non-wrappable providers', () => {
     expect(getWrappableProvider('amp')).toBeUndefined();
     expect(getWrappableProvider('not-a-provider')).toBeUndefined();
+    expect(getWrappableProvider('github-copilot')).toBeUndefined();
+    expect(resolveWrapTarget('copilot')).toBeUndefined();
   });
 
   it('cursor wrap is gui with wait-until-close args', () => {
@@ -72,12 +75,6 @@ describe('wrap provider helpers', () => {
       binary: 'opencode',
       kind: 'cli',
     });
-    expect(resolveWrapTarget('github-copilot')?.wrap).toEqual({
-      binary: 'copilot',
-      kind: 'cli',
-    });
-    expect(resolveWrapTarget('copilot')?.provider.id).toBe('github-copilot');
-    expect(resolveWrapTarget('copilot')?.wrap.binary).toBe('copilot');
     expect(resolveWrapTarget('qwen-code')?.wrap.binary).toBe('qwen');
     expect(resolveWrapTarget('kiro-cli')?.wrap.binary).toBe('kiro-cli');
     expect(resolveWrapTarget('iflow-cli')?.wrap.binary).toBe('iflow');
@@ -87,8 +84,14 @@ describe('wrap provider helpers', () => {
   it('formatWrappableProviderList includes wrap aliases', () => {
     const list = formatWrappableProviderList();
     expect(list).toContain('cursor (alias: agent)');
-    expect(list).toContain('github-copilot (alias: copilot)');
+    expect(list).not.toContain('github-copilot');
     expect(list).toContain('claude-code (alias: claude)');
+  });
+
+  it('github-copilot owns shared top-level dirs that wrap cannot safely exclude', () => {
+    const owned = getProviderOwnedTopLevelNames(['github-copilot']);
+    expect(owned.has('.github')).toBe(true);
+    expect(owned.has('.vscode')).toBe(true);
   });
 
   it('collectWrapExclusionProviderIds unions wrap target with capabilities providers', () => {

--- a/src/shared/providers/__tests__/wrap.test.ts
+++ b/src/shared/providers/__tests__/wrap.test.ts
@@ -4,6 +4,8 @@ import {
   getWrappableProviders,
   getProviderOwnedTopLevelNames,
   collectWrapExclusionProviderIds,
+  resolveWrapTarget,
+  formatWrappableProviderList,
 } from '../index';
 
 describe('wrap provider helpers', () => {
@@ -12,6 +14,13 @@ describe('wrap provider helpers', () => {
     expect(ids).toContain('claude-code');
     expect(ids).toContain('codex');
     expect(ids).toContain('cursor');
+    expect(ids).toContain('gemini-cli');
+    expect(ids).toContain('opencode');
+    expect(ids).toContain('github-copilot');
+    expect(ids).toContain('qwen-code');
+    expect(ids).toContain('kiro-cli');
+    expect(ids).toContain('iflow-cli');
+    expect(ids).toContain('kimi-cli');
   });
 
   it('resolves by registry id', () => {
@@ -36,6 +45,50 @@ describe('wrap provider helpers', () => {
     const wrap = getWrappableProvider('cursor')?.wrap;
     expect(wrap?.kind).toBe('gui');
     expect(wrap?.args).toEqual(['--new-window', '--wait']);
+  });
+
+  it('resolveWrapTarget maps agent alias to cursor CLI launch', () => {
+    const target = resolveWrapTarget('agent');
+    expect(target?.provider.id).toBe('cursor');
+    expect(target?.wrap.binary).toBe('agent');
+    expect(target?.wrap.kind).toBe('cli');
+    expect(target?.token).toBe('agent');
+  });
+
+  it('resolveWrapTarget keeps cursor as GUI', () => {
+    const target = resolveWrapTarget('cursor');
+    expect(target?.provider.id).toBe('cursor');
+    expect(target?.wrap.binary).toBe('cursor');
+    expect(target?.wrap.kind).toBe('gui');
+    expect(target?.wrap.args).toEqual(['--new-window', '--wait']);
+  });
+
+  it('resolveWrapTarget maps CLI providers to expected binaries', () => {
+    expect(resolveWrapTarget('gemini-cli')?.wrap).toEqual({
+      binary: 'gemini',
+      kind: 'cli',
+    });
+    expect(resolveWrapTarget('opencode')?.wrap).toEqual({
+      binary: 'opencode',
+      kind: 'cli',
+    });
+    expect(resolveWrapTarget('github-copilot')?.wrap).toEqual({
+      binary: 'copilot',
+      kind: 'cli',
+    });
+    expect(resolveWrapTarget('copilot')?.provider.id).toBe('github-copilot');
+    expect(resolveWrapTarget('copilot')?.wrap.binary).toBe('copilot');
+    expect(resolveWrapTarget('qwen-code')?.wrap.binary).toBe('qwen');
+    expect(resolveWrapTarget('kiro-cli')?.wrap.binary).toBe('kiro-cli');
+    expect(resolveWrapTarget('iflow-cli')?.wrap.binary).toBe('iflow');
+    expect(resolveWrapTarget('kimi-cli')?.wrap.binary).toBe('kimi');
+  });
+
+  it('formatWrappableProviderList includes wrap aliases', () => {
+    const list = formatWrappableProviderList();
+    expect(list).toContain('cursor (alias: agent)');
+    expect(list).toContain('github-copilot (alias: copilot)');
+    expect(list).toContain('claude-code (alias: claude)');
   });
 
   it('collectWrapExclusionProviderIds unions wrap target with capabilities providers', () => {

--- a/src/shared/providers/entries/cursor.ts
+++ b/src/shared/providers/entries/cursor.ts
@@ -74,5 +74,12 @@ export const cursor: ProviderIntegration = {
 			stop: { event: "stop" },
 		},
 	},
-	wrap: { binary: "cursor", kind: "gui", args: ["--new-window", "--wait"] },
+	wrap: {
+		binary: "cursor",
+		kind: "gui",
+		args: ["--new-window", "--wait"],
+		aliases: {
+			agent: { binary: "agent", kind: "cli" },
+		},
+	},
 };

--- a/src/shared/providers/entries/gemini-cli.ts
+++ b/src/shared/providers/entries/gemini-cli.ts
@@ -67,4 +67,5 @@ export const geminiCli: ProviderIntegration = {
 			preCompact: { event: "PreCompress" },
 		},
 	},
+	wrap: { binary: "gemini", kind: "cli" },
 };

--- a/src/shared/providers/entries/github-copilot.ts
+++ b/src/shared/providers/entries/github-copilot.ts
@@ -32,4 +32,11 @@ export const githubCopilot: ProviderIntegration = {
 		extension: ".md",
 		format: "markdown-frontmatter",
 	},
+	wrap: {
+		binary: "copilot",
+		kind: "cli",
+		aliases: {
+			copilot: { binary: "copilot", kind: "cli" },
+		},
+	},
 };

--- a/src/shared/providers/entries/github-copilot.ts
+++ b/src/shared/providers/entries/github-copilot.ts
@@ -32,11 +32,8 @@ export const githubCopilot: ProviderIntegration = {
 		extension: ".md",
 		format: "markdown-frontmatter",
 	},
-	wrap: {
-		binary: "copilot",
-		kind: "cli",
-		aliases: {
-			copilot: { binary: "copilot", kind: "cli" },
-		},
-	},
+	// No wrap: owned paths live under shared project dirs (`.github`, `.vscode`).
+	// Wrap's exclusion model is top-level only, so enabling wrap would omit those
+	// entire trees from the shadow workspace. Revisit when wrap supports
+	// subpath-level exclusions/overlays.
 };

--- a/src/shared/providers/entries/opencode.ts
+++ b/src/shared/providers/entries/opencode.ts
@@ -45,4 +45,5 @@ export const opencode: ProviderIntegration = {
 			value: "allow",
 		},
 	},
+	wrap: { binary: "opencode", kind: "cli" },
 };

--- a/src/shared/providers/entries/partial-integration.ts
+++ b/src/shared/providers/entries/partial-integration.ts
@@ -120,6 +120,7 @@ export const partialIntegrationProviders: Record<string, ProviderIntegration> =
 				supportsSubAgentEntries: true,
 			},
 			instructions: { filename: "AGENTS.md" },
+			wrap: { binary: "iflow", kind: "cli" },
 		},
 		junie: {
 			id: "junie",
@@ -196,6 +197,7 @@ export const partialIntegrationProviders: Record<string, ProviderIntegration> =
 				extension: ".md",
 				frontmatter: "none",
 			},
+			wrap: { binary: "kiro-cli", kind: "cli" },
 		},
 		kode: {
 			id: "kode",
@@ -308,6 +310,7 @@ export const partialIntegrationProviders: Record<string, ProviderIntegration> =
 				extension: ".md",
 				format: "markdown-frontmatter",
 			},
+			wrap: { binary: "qwen", kind: "cli" },
 		},
 		roo: {
 			id: "roo",

--- a/src/shared/providers/entries/skills-only.ts
+++ b/src/shared/providers/entries/skills-only.ts
@@ -70,6 +70,7 @@ export const skillsOnlyProviders: Record<string, ProviderIntegration> = {
 		detectInstalled: async () => existsSync(join(home, ".kimi")),
 		// MCP is global-only (~/.kimi/mcp.json); no project-local file.
 		instructions: { filename: "AGENTS.md" },
+		wrap: { binary: "kimi", kind: "cli" },
 	},
 	mcpjam: {
 		id: "mcpjam",

--- a/src/shared/providers/index.ts
+++ b/src/shared/providers/index.ts
@@ -1,5 +1,19 @@
-import type { ProviderIntegration } from "../../types/providers";
+import type {
+	ProviderIntegration,
+	WrapLaunchConfig,
+} from "../../types/providers";
 import { providers } from "./registry";
+
+/**
+ * Resolved target for `capa wrap <token>`: provider entry plus the launch
+ * config to use (primary wrap or a wrap.aliases entry).
+ */
+export interface WrapTarget {
+	provider: ProviderIntegration;
+	wrap: WrapLaunchConfig;
+	/** Token the user passed (registry id, pluginProviderId, or wrap alias). */
+	token: string;
+}
 
 /**
  * Get a provider by id. Returns undefined for unknown providers.
@@ -51,6 +65,7 @@ export function getWrappableProviders(): ProviderIntegration[] {
 /**
  * Resolve a wrappable provider by registry id or pluginProviderId alias
  * (e.g. `claude` → `claude-code`). Returns undefined if unknown or not wrappable.
+ * Does not resolve `wrap.aliases` tokens — use {@link resolveWrapTarget} for that.
  */
 export function getWrappableProvider(
 	id: string,
@@ -61,6 +76,76 @@ export function getWrappableProvider(
 	const byPlugin = getProviderByPluginProviderId(needle);
 	if (byPlugin?.wrap) return byPlugin;
 	return undefined;
+}
+
+function primaryWrapLaunch(wrap: NonNullable<ProviderIntegration["wrap"]>): WrapLaunchConfig {
+	return {
+		binary: wrap.binary,
+		kind: wrap.kind,
+		...(wrap.args ? { args: wrap.args } : {}),
+	};
+}
+
+/**
+ * Resolve `capa wrap <token>` to a provider + launch config.
+ * Matches registry id, pluginProviderId, or a `wrap.aliases` key.
+ */
+export function resolveWrapTarget(token: string): WrapTarget | undefined {
+	const needle = token.trim().toLowerCase();
+	if (!needle) return undefined;
+
+	const byId = getProvider(needle);
+	if (byId?.wrap) {
+		return {
+			provider: byId,
+			wrap: primaryWrapLaunch(byId.wrap),
+			token: needle,
+		};
+	}
+
+	const byPlugin = getProviderByPluginProviderId(needle);
+	if (byPlugin?.wrap) {
+		return {
+			provider: byPlugin,
+			wrap: primaryWrapLaunch(byPlugin.wrap),
+			token: needle,
+		};
+	}
+
+	for (const provider of getWrappableProviders()) {
+		const aliases = provider.wrap?.aliases;
+		if (!aliases) continue;
+		for (const [alias, launch] of Object.entries(aliases)) {
+			if (alias.toLowerCase() === needle) {
+				return { provider, wrap: launch, token: needle };
+			}
+		}
+	}
+
+	return undefined;
+}
+
+/**
+ * Human-readable list of wrappable provider ids plus short aliases
+ * (pluginProviderId and wrap.aliases keys, excluding the registry id itself).
+ */
+export function formatWrappableProviderList(): string {
+	return getWrappableProviders()
+		.map((p) => {
+			const extras = new Set<string>();
+			if (p.pluginProviderId) {
+				extras.add(p.pluginProviderId.toLowerCase());
+			}
+			for (const alias of Object.keys(p.wrap?.aliases ?? {})) {
+				extras.add(alias.toLowerCase());
+			}
+			extras.delete(p.id.toLowerCase());
+			const sorted = [...extras].sort();
+			if (sorted.length === 0) return p.id;
+			return `${p.id} (alias: ${sorted.join(", ")})`;
+		})
+		.sort()
+		.join(", ");
 }
 
 /**
@@ -152,4 +237,5 @@ export type {
 	RulesIntegration,
 	SubagentsIntegration,
 	WrapIntegration,
+	WrapLaunchConfig,
 } from "../../types/providers";

--- a/src/types/providers.ts
+++ b/src/types/providers.ts
@@ -49,10 +49,9 @@ export interface McpIntegration {
 }
 
 /**
- * How `capa wrap <provider>` launches this provider from a shadow workspace.
- * Undefined when the provider is not wrappable.
+ * Launch config for a single `capa wrap` invocation (binary + kind + args).
  */
-export interface WrapIntegration {
+export interface WrapLaunchConfig {
   /** Executable to spawn (must be on PATH). */
   binary: string;
   /** CLI = blocking foreground; GUI = wait for app window (or interrupt). */
@@ -63,6 +62,18 @@ export interface WrapIntegration {
    * CLI: inserted before user passthrough args.
    */
   args?: string[];
+}
+
+/**
+ * How `capa wrap <provider>` launches this provider from a shadow workspace.
+ * Undefined when the provider is not wrappable.
+ */
+export interface WrapIntegration extends WrapLaunchConfig {
+  /**
+   * Extra tokens accepted by `capa wrap <token>` that launch this provider
+   * with an alternate binary/kind (e.g. Cursor GUI vs `agent` CLI).
+   */
+  aliases?: Record<string, WrapLaunchConfig>;
 }
 
 /**


### PR DESCRIPTION
## Summary
- Add `wrap.aliases` and `resolveWrapTarget` so a provider can expose alternate launch binaries (Cursor GUI vs `agent` CLI) while sharing the same shadow workspace/install paths.
- Enable `capa wrap agent` for Cursor CLI, plus wrap for `gemini-cli`, `opencode`, `qwen-code`, `kiro-cli`, `iflow-cli`, and `kimi-cli`.
- Wire `launchProvider` to take an explicit launch config; leave Claude Code and Codex wrap unchanged.
- **Not** wrapping `github-copilot`: its owned paths live under shared `.github` / `.vscode`, and wrap exclusions are top-level only (would hide those entire trees).

## Test plan
- [x] `bun test src/shared/providers/__tests__/wrap.test.ts src/cli/utils/wrap/__tests__/`
- [x] `capa wrap agent` prepares a cursor shadow workspace and launches the `agent` binary
- [x] `capa wrap cursor` still launches GUI (`cursor --new-window --wait`)
- [x] `capa wrap github-copilot` / `capa wrap copilot` are rejected (not wrappable)
- [x] `capa wrap` with a missing provider lists new ids and aliases (`agent`)
- [x] `capa wrap gemini-cli` / `opencode` launch their respective binaries when installed