### PR TITLE
feat(auth): support headless git auth via access tokens

### DIFF
--- a/skills/capabilities-manager/references/commands.md
+++ b/skills/capabilities-manager/references/commands.md
@@ -169,12 +169,18 @@ capa status             # Check server health and uptime
 ## Authentication
 
 ```bash
-capa auth               # Authenticate with the default Git provider
-capa auth github.com    # Authenticate with GitHub
-capa auth gitlab.com    # Authenticate with GitLab
+capa auth               # List connected providers and usage
+capa auth github.com    # OAuth with GitHub (opens browser)
+capa auth gitlab.com    # OAuth with GitLab (opens browser)
+capa auth github.com --access-token <token>   # Headless GitHub PAT
+capa auth gitlab.com --access-token <token>   # Headless GitLab PAT
+capa auth git.corp.com --access-token <token> --type github-enterprise
+capa auth git.corp.com --access-token <token> --type gitlab-self-managed
 ```
 
 Authenticates with Git providers for accessing private repositories (skills, plugins, agent snippets). Credentials are stored securely in the capa database.
+
+`--access-token` skips the browser OAuth flow (for CI / headless environments) and overwrites any existing credential for that host. Self-hosted hosts require `--type github-enterprise` or `--type gitlab-self-managed`.
 
 **When to use**: When you need to access private GitHub or GitLab repositories for skills or plugins.
 

--- a/src/cli/commands/__tests__/auth-command.test.ts
+++ b/src/cli/commands/__tests__/auth-command.test.ts
@@ -102,6 +102,30 @@ describe('authCommand', () => {
     expect(ensureServerMock).toHaveBeenCalled();
   });
 
+  it('lists self-hosted integrations alongside cloud providers', async () => {
+    const { loadSettings, getDatabasePath } = await import('../../../shared/config');
+    const { CapaDatabase } = await import('../../../db/database');
+    const settings = await loadSettings();
+    const db = new CapaDatabase(getDatabasePath(settings));
+    try {
+      db.setGitIntegration('github', {
+        access_token: 'gh',
+        token_type: 'token',
+      });
+      db.setGitIntegration('github-enterprise', {
+        host: 'git.corp.com',
+        access_token: 'ghe',
+        token_type: 'token',
+      });
+    } finally {
+      db.close();
+    }
+
+    const { stdout } = await captureOutput(() => authCommand());
+    expect(stdout).toContain('github.com');
+    expect(stdout).toContain('GitHub Enterprise (git.corp.com)');
+  });
+
   it('exits with a clear error for an invalid provider format', async () => {
     const exitSpy = spyOn(process, 'exit').mockImplementation((() => {}) as typeof process.exit);
     const { stdout } = await captureOutput(() => authCommand('not-a-valid-domain'));

--- a/src/cli/commands/__tests__/auth-command.test.ts
+++ b/src/cli/commands/__tests__/auth-command.test.ts
@@ -118,6 +118,102 @@ describe('authCommand', () => {
     exitSpy.mockRestore();
   });
 
+  describe('access-token path', () => {
+    const originalFetch = globalThis.fetch;
+    let fetchOk = true;
+
+    beforeEach(() => {
+      fetchOk = true;
+      globalThis.fetch = (async () =>
+        new Response(fetchOk ? JSON.stringify({ login: 'u' }) : 'Unauthorized', {
+          status: fetchOk ? 200 : 401,
+          headers: { 'Content-Type': 'application/json' },
+        })) as typeof fetch;
+    });
+
+    afterEach(() => {
+      globalThis.fetch = originalFetch;
+    });
+
+    it('stores a cloud GitHub token without starting the server', async () => {
+      const { stdout } = await captureOutput(() =>
+        authCommand('github.com', { accessToken: 'ghp_test' }),
+      );
+
+      expect(ensureServerMock).not.toHaveBeenCalled();
+      expect(stdout).toContain('Authenticated with github.com using access token');
+
+      const { loadSettings, getDatabasePath } = await import('../../../shared/config');
+      const { CapaDatabase } = await import('../../../db/database');
+      const settings = await loadSettings();
+      const db = new CapaDatabase(getDatabasePath(settings));
+      try {
+        const stored = db.getGitIntegration('github');
+        expect(stored?.access_token).toBe('ghp_test');
+        expect(stored?.host).toBeNull();
+      } finally {
+        db.close();
+      }
+    });
+
+    it('stores a self-hosted token when --type is provided', async () => {
+      const { stdout } = await captureOutput(() =>
+        authCommand('git.corp.com', {
+          accessToken: 'ghe_test',
+          type: 'github-enterprise',
+        }),
+      );
+
+      expect(ensureServerMock).not.toHaveBeenCalled();
+      expect(stdout).toContain('Authenticated with git.corp.com using access token');
+
+      const { loadSettings, getDatabasePath } = await import('../../../shared/config');
+      const { CapaDatabase } = await import('../../../db/database');
+      const settings = await loadSettings();
+      const db = new CapaDatabase(getDatabasePath(settings));
+      try {
+        const stored = db.getGitIntegration('github-enterprise', 'git.corp.com');
+        expect(stored?.access_token).toBe('ghe_test');
+      } finally {
+        db.close();
+      }
+    });
+
+    it('requires --type for unknown self-hosted hosts', async () => {
+      const exitSpy = spyOn(process, 'exit').mockImplementation((() => {}) as typeof process.exit);
+      const { stdout } = await captureOutput(() =>
+        authCommand('git.corp.com', { accessToken: 'tok' }),
+      );
+      expect(stdout).toContain('--type');
+      expect(exitSpy).toHaveBeenCalledWith(1);
+      exitSpy.mockRestore();
+    });
+
+    it('rejects --type on cloud hosts', async () => {
+      const exitSpy = spyOn(process, 'exit').mockImplementation((() => {}) as typeof process.exit);
+      const { stdout } = await captureOutput(() =>
+        authCommand('github.com', {
+          accessToken: 'tok',
+          type: 'github-enterprise',
+        }),
+      );
+      expect(stdout).toContain('--type is not needed');
+      expect(exitSpy).toHaveBeenCalledWith(1);
+      exitSpy.mockRestore();
+    });
+
+    it('exits when the token is invalid', async () => {
+      fetchOk = false;
+      const exitSpy = spyOn(process, 'exit').mockImplementation((() => {}) as typeof process.exit);
+      const { stdout } = await captureOutput(() =>
+        authCommand('github.com', { accessToken: 'bad' }),
+      );
+      expect(stdout).toContain('Invalid Personal Access Token');
+      expect(exitSpy).toHaveBeenCalledWith(1);
+      exitSpy.mockRestore();
+    });
+  });
+
   afterAll(() => {
     mock.restore();
   });

--- a/src/cli/commands/auth.ts
+++ b/src/cli/commands/auth.ts
@@ -2,10 +2,14 @@ import { loadSettings, getDatabasePath } from '../../shared/config';
 import { CapaDatabase } from '../../db/database';
 import { ensureServer } from '../utils/server-manager';
 import { VERSION } from '../../version';
-import { getGitProviderByHost } from '../../shared/git-providers/registry';
+import {
+  getGitProvider,
+  getGitProviderByHost,
+} from '../../shared/git-providers/registry';
 import { GitIntegrationManager } from '../../server/git-integration-manager';
 import { header, footer, success, info, warn, error, runTasks } from '../ui';
 import type { GitPlatform } from '../../types/git-integration';
+import type { GitIntegration } from '../../types/database';
 
 const SELF_HOSTED_TYPES = ['github-enterprise', 'gitlab-self-managed'] as const;
 type SelfHostedType = (typeof SELF_HOSTED_TYPES)[number];
@@ -215,6 +219,7 @@ export async function authCommand(
     error(`Error: ${message}`);
     db.close();
     process.exit(1);
+    return;
   }
 
   db.close();
@@ -281,6 +286,7 @@ async function authenticateWithAccessToken(
     error(`Error: ${message}`);
     db.close();
     process.exit(1);
+    return;
   }
 
   db.close();
@@ -323,18 +329,18 @@ function isSelfHostedType(value: string): value is SelfHostedType {
 function listConnectedProviders(db: CapaDatabase): void {
   info('Connected Git Providers:');
 
-  const tokens = db.getAllGitOAuthTokens();
-  if (tokens.length === 0) {
+  const integrations = db.getAllGitIntegrations();
+  if (integrations.length === 0) {
     info('  No providers connected yet.');
     return;
   }
 
-  for (const token of tokens) {
-    const providerEmoji = getGitProviderByHost(token.provider)?.emoji ?? '🔗';
-    info(`  ${providerEmoji} ${token.provider}`);
+  for (const integration of integrations) {
+    const { emoji, label } = formatIntegrationLabel(integration);
+    info(`  ${emoji} ${label}`);
 
-    if (token.expires_at) {
-      const expiresAt = new Date(token.expires_at);
+    if (integration.expires_at) {
+      const expiresAt = new Date(integration.expires_at);
       const now = new Date();
       const hoursUntilExpiry = Math.floor(
         (expiresAt.getTime() - now.getTime()) / (1000 * 60 * 60),
@@ -355,7 +361,7 @@ function listConnectedProviders(db: CapaDatabase): void {
         );
       }
 
-      if (token.refresh_token) {
+      if (integration.refresh_token) {
         success('    Auto-refresh enabled');
       } else {
         warn('    No refresh token (will need manual re-auth after expiration)');
@@ -364,6 +370,37 @@ function listConnectedProviders(db: CapaDatabase): void {
       success('    No expiration');
     }
   }
+}
+
+function formatIntegrationLabel(integration: GitIntegration): {
+  emoji: string;
+  label: string;
+} {
+  const gp = getGitProvider(integration.platform);
+  if (gp && !integration.host) {
+    return { emoji: gp.emoji, label: gp.host };
+  }
+
+  if (integration.platform === 'github-enterprise') {
+    return {
+      emoji: '🐙',
+      label: `GitHub Enterprise (${integration.host ?? 'unknown host'})`,
+    };
+  }
+
+  if (integration.platform === 'gitlab-self-managed') {
+    return {
+      emoji: '🦊',
+      label: `GitLab Self-Managed (${integration.host ?? 'unknown host'})`,
+    };
+  }
+
+  return {
+    emoji: '🔗',
+    label: integration.host
+      ? `${integration.platform} (${integration.host})`
+      : integration.platform,
+  };
 }
 
 function isValidProvider(provider: string): boolean {

--- a/src/cli/commands/auth.ts
+++ b/src/cli/commands/auth.ts
@@ -3,19 +3,36 @@ import { CapaDatabase } from '../../db/database';
 import { ensureServer } from '../utils/server-manager';
 import { VERSION } from '../../version';
 import { getGitProviderByHost } from '../../shared/git-providers/registry';
+import { GitIntegrationManager } from '../../server/git-integration-manager';
 import { header, footer, success, info, warn, error, runTasks } from '../ui';
-import type { Task } from '../ui';
+import type { GitPlatform } from '../../types/git-integration';
+
+const SELF_HOSTED_TYPES = ['github-enterprise', 'gitlab-self-managed'] as const;
+type SelfHostedType = (typeof SELF_HOSTED_TYPES)[number];
+
+export interface AuthCommandOptions {
+  accessToken?: string;
+  type?: string;
+}
 
 /**
  * Manual authentication command
  * Allows users to authenticate with Git providers preemptively
  */
-export async function authCommand(provider?: string): Promise<void> {
+export async function authCommand(
+  provider?: string,
+  options: AuthCommandOptions = {},
+): Promise<void> {
   header('Git Authentication');
 
   const settings = await loadSettings();
   const dbPath = getDatabasePath(settings);
   const db = new CapaDatabase(dbPath);
+
+  if (options.accessToken) {
+    await authenticateWithAccessToken(db, provider, options);
+    return;
+  }
 
   let serverUrl = '';
 
@@ -41,14 +58,22 @@ export async function authCommand(provider?: string): Promise<void> {
   if (!provider) {
     listConnectedProviders(db);
     info('Usage:');
-    info('  capa auth <provider>  - Authenticate with a Git provider');
+    info('  capa auth <provider>                         - OAuth (browser)');
+    info('  capa auth <provider> --access-token <token>  - PAT / access token');
     info('Examples:');
-    info('  capa auth github.com  - Authenticate with GitHub.com');
-    info('  capa auth gitlab.com  - Authenticate with GitLab.com');
+    info('  capa auth github.com');
+    info('  capa auth github.com --access-token <token>');
+    info('  capa auth gitlab.com --access-token <token>');
     info(
-      'Note: For self-hosted instances (GitHub Enterprise, GitLab Self-Managed),',
+      '  capa auth git.corp.com --access-token <token> --type github-enterprise',
     );
-    info(`      use the web UI at: ${serverUrl}/ui/integrations`);
+    info(
+      '  capa auth git.corp.com --access-token <token> --type gitlab-self-managed',
+    );
+    info(
+      'Note: Self-hosted OAuth is not supported; use --access-token or the web UI:',
+    );
+    info(`      ${serverUrl}/ui/integrations`);
     db.close();
     return;
   }
@@ -90,6 +115,8 @@ export async function authCommand(provider?: string): Promise<void> {
 
       info('To re-authenticate, first disconnect from the provider:');
       info(`  Visit: ${serverUrl}/ui/integrations`);
+      info('Or overwrite with a token:');
+      info(`  capa auth ${provider} --access-token <token>`);
       db.close();
       return;
     }
@@ -103,7 +130,14 @@ export async function authCommand(provider?: string): Promise<void> {
     const gitProvider = getGitProviderByHost(provider);
     if (!gitProvider) {
       error(`Unknown git provider: ${provider}`);
-      error('  For self-hosted instances, use the web UI at:');
+      error('  For self-hosted instances, use an access token:');
+      info(
+        `  capa auth ${provider} --access-token <token> --type github-enterprise`,
+      );
+      info(
+        `  capa auth ${provider} --access-token <token> --type gitlab-self-managed`,
+      );
+      info('  Or use the web UI at:');
       info(`  ${serverUrl}/ui/integrations`);
       db.close();
       process.exit(1);
@@ -184,6 +218,106 @@ export async function authCommand(provider?: string): Promise<void> {
   }
 
   db.close();
+}
+
+async function authenticateWithAccessToken(
+  db: CapaDatabase,
+  provider: string | undefined,
+  options: AuthCommandOptions,
+): Promise<void> {
+  const accessToken = options.accessToken!;
+
+  if (!provider) {
+    error('Provider is required when using --access-token');
+    error('Example: capa auth github.com --access-token <token>');
+    db.close();
+    process.exit(1);
+    return;
+  }
+
+  if (!isValidProvider(provider)) {
+    error(`Invalid provider: ${provider}`);
+    error('Provider must be a domain name (e.g., github.com, gitlab.com)');
+    db.close();
+    process.exit(1);
+    return;
+  }
+
+  let platform: GitPlatform;
+  let host: string | undefined;
+
+  try {
+    ({ platform, host } = resolveTokenAuthTarget(provider, options.type));
+  } catch (err: unknown) {
+    const message = err instanceof Error ? err.message : String(err);
+    error(message);
+    db.close();
+    process.exit(1);
+    return;
+  }
+
+  const displayHost = host ?? provider;
+  info(`Authenticating with access token: ${displayHost}`);
+
+  try {
+    await runTasks([
+      {
+        title: 'Validate and store access token',
+        task: async () => {
+          const manager = new GitIntegrationManager(db);
+          await manager.storePAT({
+            platform,
+            host,
+            token: accessToken,
+          });
+        },
+      },
+    ]);
+
+    success(`Authenticated with ${displayHost} using access token`);
+    footer(`You can now access private repositories from ${displayHost}`);
+  } catch (err: unknown) {
+    const message = err instanceof Error ? err.message : String(err);
+    error(`Error: ${message}`);
+    db.close();
+    process.exit(1);
+  }
+
+  db.close();
+}
+
+function resolveTokenAuthTarget(
+  provider: string,
+  typeOption?: string,
+): { platform: GitPlatform; host?: string } {
+  const gitProvider = getGitProviderByHost(provider);
+
+  if (gitProvider) {
+    if (typeOption) {
+      throw new Error(
+        `--type is not needed for ${provider} (inferred as ${gitProvider.id}). Omit --type for cloud hosts.`,
+      );
+    }
+    return { platform: gitProvider.id as 'github' | 'gitlab' };
+  }
+
+  if (!typeOption) {
+    throw new Error(
+      `Unknown git provider: ${provider}. For self-hosted instances, pass --type github-enterprise or --type gitlab-self-managed.`,
+    );
+  }
+
+  if (!isSelfHostedType(typeOption)) {
+    throw new Error(
+      `Invalid --type: ${typeOption}. Expected github-enterprise or gitlab-self-managed.`,
+    );
+  }
+
+  return { platform: typeOption, host: provider };
+}
+
+function isSelfHostedType(value: string): value is SelfHostedType {
+  return (SELF_HOSTED_TYPES as readonly string[]).includes(value);
 }
 
 function listConnectedProviders(db: CapaDatabase): void {

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -244,9 +244,22 @@ if (process.argv[2] === '__server__') {
     program
       .command('auth [provider]')
       .description('Authenticate with Git providers (github.com, gitlab.com, etc.)')
-      .action(async (provider?: string) => {
-        await authCommand(provider);
-      });
+      .option(
+        '--access-token <token>',
+        'Authenticate with a Personal Access Token (headless / CI)',
+      )
+      .option(
+        '--type <type>',
+        'Self-hosted platform: github-enterprise or gitlab-self-managed',
+      )
+      .action(
+        async (
+          provider?: string,
+          options?: { accessToken?: string; type?: string },
+        ) => {
+          await authCommand(provider, options);
+        },
+      );
 
     program
       .command('upgrade')

--- a/src/server/__tests__/git-integration-manager.test.ts
+++ b/src/server/__tests__/git-integration-manager.test.ts
@@ -68,4 +68,88 @@ describe('GitIntegrationManager', () => {
   it('returns null when no integration exists for a platform', async () => {
     expect(await manager.getAccessToken('gitlab')).toBeNull();
   });
+
+  describe('storePAT', () => {
+    const originalFetch = globalThis.fetch;
+    let fetchCalls: Array<{ url: string; authorization: string | null }>;
+
+    beforeEach(() => {
+      fetchCalls = [];
+      globalThis.fetch = (async (input: RequestInfo | URL, init?: RequestInit) => {
+        const url = typeof input === 'string' ? input : input.toString();
+        const authorization =
+          init?.headers && typeof init.headers === 'object' && !Array.isArray(init.headers)
+            ? ((init.headers as Record<string, string>).Authorization ?? null)
+            : null;
+        fetchCalls.push({ url, authorization });
+
+        if (url.includes('/user') && authorization?.includes('bad-token')) {
+          return new Response('Unauthorized', { status: 401 });
+        }
+        return new Response(JSON.stringify({ login: 'tester' }), {
+          status: 200,
+          headers: { 'Content-Type': 'application/json' },
+        });
+      }) as typeof fetch;
+    });
+
+    afterEach(() => {
+      globalThis.fetch = originalFetch;
+    });
+
+    it('stores a cloud GitHub PAT with null host and clears refresh metadata', async () => {
+      db.setGitIntegration('github', {
+        access_token: 'old-oauth',
+        refresh_token: 'refresh',
+        token_type: 'Bearer',
+        expires_at: Date.now() + 60_000,
+      });
+
+      await manager.storePAT({ platform: 'github', token: 'ghp_valid' });
+
+      const stored = db.getGitIntegration('github');
+      expect(stored?.access_token).toBe('ghp_valid');
+      expect(stored?.host).toBeNull();
+      expect(stored?.refresh_token).toBeNull();
+      expect(stored?.expires_at).toBeNull();
+      expect(stored?.token_type).toBe('token');
+      expect(fetchCalls[0]?.url).toBe('https://api.github.com/user');
+      expect(fetchCalls[0]?.authorization).toBe('token ghp_valid');
+    });
+
+    it('stores a cloud GitLab PAT', async () => {
+      await manager.storePAT({ platform: 'gitlab', token: 'glpat_valid' });
+
+      const stored = db.getGitIntegration('gitlab');
+      expect(stored?.access_token).toBe('glpat_valid');
+      expect(stored?.host).toBeNull();
+      expect(fetchCalls[0]?.url).toBe('https://gitlab.com/api/v4/user');
+      expect(fetchCalls[0]?.authorization).toBe('Bearer glpat_valid');
+    });
+
+    it('stores a GitHub Enterprise PAT at the given host', async () => {
+      await manager.storePAT({
+        platform: 'github-enterprise',
+        host: 'git.example.com',
+        token: 'ghe_valid',
+      });
+
+      const stored = db.getGitIntegration('github-enterprise', 'git.example.com');
+      expect(stored?.access_token).toBe('ghe_valid');
+      expect(stored?.host).toBe('git.example.com');
+      expect(fetchCalls[0]?.url).toBe('https://git.example.com/api/v3/user');
+    });
+
+    it('throws when self-hosted PAT is missing a host', async () => {
+      await expect(
+        manager.storePAT({ platform: 'github-enterprise', token: 'x' }),
+      ).rejects.toThrow(/Host is required/);
+    });
+
+    it('throws when the token fails validation', async () => {
+      await expect(
+        manager.storePAT({ platform: 'github', token: 'bad-token' }),
+      ).rejects.toThrow(/Invalid Personal Access Token/);
+    });
+  });
 });

--- a/src/server/git-integration-manager.ts
+++ b/src/server/git-integration-manager.ts
@@ -195,12 +195,23 @@ export class GitIntegrationManager {
 	}
 
 	/**
-	 * Store Personal Access Token for self-managed instances
+	 * Store a Personal Access Token for cloud or self-hosted Git providers.
+	 * Overwrites any existing credential for the platform/host (including OAuth).
 	 */
 	async storePAT(config: GitPATConfig): Promise<void> {
-		this.logger.info(`Storing PAT for ${config.platform} at ${config.host}`);
+		const isSelfHosted =
+			config.platform === "github-enterprise" ||
+			config.platform === "gitlab-self-managed";
 
-		// Validate the token by making a test API call
+		if (isSelfHosted && !config.host) {
+			throw new Error(
+				`Host is required for ${config.platform} Personal Access Tokens.`,
+			);
+		}
+
+		const hostLabel = config.host ?? "cloud";
+		this.logger.info(`Storing PAT for ${config.platform} at ${hostLabel}`);
+
 		const isValid = await this.validatePAT(
 			config.platform,
 			config.host,
@@ -214,23 +225,33 @@ export class GitIntegrationManager {
 		}
 
 		this.db.setGitIntegration(config.platform, {
-			host: config.host,
+			host: config.host ?? null,
 			access_token: config.token,
+			refresh_token: null,
 			token_type: "token",
+			expires_at: null,
 		});
 
-		this.logger.success(`PAT stored for ${config.platform} at ${config.host}`);
+		this.logger.success(`PAT stored for ${config.platform} at ${hostLabel}`);
 	}
 
 	/**
-	 * Validate a Personal Access Token
+	 * Validate a Personal Access Token against the provider's user API.
 	 */
 	private async validatePAT(
-		platform: "github-enterprise" | "gitlab-self-managed",
-		host: string,
+		platform: GitPlatform,
+		host: string | undefined,
 		token: string,
 	): Promise<boolean> {
 		try {
+			if (platform === "github" || platform === "gitlab") {
+				return await this.testToken(platform, token);
+			}
+
+			if (!host) {
+				return false;
+			}
+
 			const apiUrl =
 				platform === "github-enterprise"
 					? `https://${host}/api/v3/user`

--- a/src/types/git-integration.ts
+++ b/src/types/git-integration.ts
@@ -27,7 +27,8 @@ export interface GitTokenData {
 }
 
 export interface GitPATConfig {
-  platform: 'github-enterprise' | 'gitlab-self-managed';
-  host: string;
+  platform: GitPlatform;
+  /** Required for github-enterprise / gitlab-self-managed; omit for cloud github/gitlab. */
+  host?: string;
   token: string;
 }


### PR DESCRIPTION
## Summary
- Adds `capa auth <host> --access-token <token>` for GitHub.com and GitLab.com without browser OAuth (CI / headless).
- Supports self-hosted instances via `--type github-enterprise` or `--type gitlab-self-managed`.
- Reuses `GitIntegrationManager.storePAT` validation and `git_integrations` storage; token path skips starting the CAPA server and overwrites existing credentials.

Closes #130

## Test plan
- [ ] `bun test src/cli/commands/__tests__/auth-command.test.ts src/server/__tests__/git-integration-manager.test.ts`
- [ ] `capa auth github.com --access-token <valid-pat>` stores token and can fetch a private repo skill
- [ ] `capa auth gitlab.com --access-token <valid-pat>` same for GitLab
- [ ] `capa auth <self-hosted> --access-token <token> --type github-enterprise` (and gitlab-self-managed)
- [ ] Invalid token / missing `--type` / `--type` on cloud host produce clear errors
- [ ] Existing `capa auth github.com` OAuth browser flow still works

Made with [Cursor](https://cursor.com)