### PR TITLE
docs: refresh README and shipped skills for v2

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
   </picture>
 </p>
 
-<h3 align="center">The package manager for AI coding agents</h3>
+<h3 align="center">The package manager and MCP gateway for AI coding agents</h3>
 
 <p align="center">
   <a href="https://github.com/infragate/capa/releases/latest"><img src="https://img.shields.io/github/v/release/infragate/capa?style=flat-square&label=latest&color=6366f1" alt="Latest Release"></a>
@@ -26,7 +26,7 @@
   <a href="#documentation">Docs</a>
 </p>
 
-Declare skills, tools, rules, sub-agents, MCP servers, hooks, and plugins once in `capabilities.yaml`. Run `capa install`. CAPA writes them into Cursor, Claude Code, Codex, Windsurf, GitHub Copilot, and 35+ other agents — native formats, pinned SHAs, zero manual sync.
+Declare skills, tools, rules, sub-agents, MCP servers, hooks, and plugins once in `capabilities.yaml`. Run `capa install`. CAPA writes them into Cursor, Claude Code, Codex, Windsurf, GitHub Copilot, and 35+ other agents — native formats, pinned SHAs, zero manual sync. At runtime it is also the **MCP gateway**: every agent talks to one local endpoint; CAPA proxies upstream servers, lazy-loads tools, and scopes what each sub-agent can call.
 
 https://github.com/user-attachments/assets/98442d19-44c9-43e6-b2c2-88156b189d5e
 
@@ -34,18 +34,19 @@ https://github.com/user-attachments/assets/98442d19-44c9-43e6-b2c2-88156b189d5e
 
 Agent config today is scattered across `CLAUDE.md`, `.cursor/rules/`, `AGENTS.md`, MCP JSON, hooks, and skill folders. No two teammates match. Nothing is pinned. Cloning the repo does not clone the agent setup.
 
-CAPA collapses that into one version-controlled file next to your code:
+CAPA collapses that into one version-controlled file next to your code — and a local MCP gateway in front of every tool:
 
 - **`capabilities.yaml`** — source of truth for every capability
 - **`capabilities.lock`** — SHA pins so tomorrow's clone gets the same bytes
 - **Marker blocks** — surgical writes that leave hand-edited content alone
-- **One MCP endpoint** — agents talk to CAPA; CAPA proxies upstream servers on demand
+- **MCP gateway** — one endpoint per project; CAPA proxies stdio / HTTP / SSE servers, applies formatters, and records activity
 
 The teammate who clones tomorrow gets the exact setup you have today.
 
 ## Features
 
 - **One file → 35+ agents** — write once; CAPA fans out to each provider's native layout (`.cursor/rules/`, `.claude/agents/`, `AGENTS.md`, …)
+- **MCP gateway** — one local endpoint per agent; CAPA proxies upstream MCP servers, lazy-loads tools on demand, and filters tools per sub-agent
 - **Cheaper inference, same quality** — on-demand tool loading instead of front-loading the whole catalog (**19–40%** fewer tokens across 150 trials on claude-opus-4-8)
 - **`capa wrap`** — run Cursor, Claude, Codex, and more from a shadow workspace so provider dirs never touch your real repo
 - **Local Web UI** — interactive capabilities editor with live YAML sync, registry browse, OAuth setup, and drag-to-reorder
@@ -192,7 +193,7 @@ capabilities.yaml  ──►  capa install  ──►  provider files (.cursor/,
         │
         └──► Web UI editor ◄──► file watcher ◄──► disk
 
-Agent ──MCP──► capa server (:5912) ──proxy──► upstream MCP (stdio / HTTP / SSE)
+Agent ──MCP──► capa gateway (:5912) ──proxy──► upstream MCP (stdio / HTTP / SSE)
                      │
                      ├── on-demand tools (setup_tools / call_tool)
                      ├── per-sub-agent filtered endpoints

--- a/README.md
+++ b/README.md
@@ -130,7 +130,7 @@ capa wrap codex
 capa wrap gemini-cli
 capa wrap opencode
 
-capa wrap cursor --print-dir   # print shadow path only
+capa wrap cursor --print-dir   # print shadow path, then launch
 capa wrap --prune              # clean stale workspaces
 capa stop                      # stop server + active wrap sessions
 ```

--- a/README.md
+++ b/README.md
@@ -55,10 +55,6 @@ The teammate who clones tomorrow gets the exact setup you have today.
 - **`capa add --passthrough`** — write provider-native files directly when you want unmanaged one-offs
 - **Sub-agent isolation** — each sub-agent gets a filtered MCP endpoint, so research agents never inherit a `git push` tool
 
-<p align="center">
-  <img width="1305" height="941" alt="CAPA Architecture" src="https://github.com/user-attachments/assets/a4db54a2-6ea5-43df-baa9-c61c189d30c1" />
-</p>
-
 ## Installation
 
 **macOS and Linux:**

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
   </picture>
 </p>
 
-<h3 align="center">Agentic Capabilities and Package Manager</h3>
+<h3 align="center">The package manager for AI coding agents</h3>
 
 <p align="center">
   <a href="https://github.com/infragate/capa/releases/latest"><img src="https://img.shields.io/github/v/release/infragate/capa?style=flat-square&label=latest&color=6366f1" alt="Latest Release"></a>
@@ -16,26 +16,44 @@
   <a href="https://github.com/infragate/capa/releases/latest"><img src="https://img.shields.io/badge/platform-macOS%20%7C%20Linux%20%7C%20Windows-lightgrey?style=flat-square" alt="Platforms"></a>
 </p>
 
-CAPA is the package manager for AI coding agents. Declare your skills, tools, rules, sub-agents, MCP servers, and plugins once in `capabilities.yaml`, run `capa install`, and CAPA writes them into Cursor, Claude Code, Codex, Windsurf, GitHub Copilot, and 35+ other agents.
+<p align="center">
+  <a href="#why-capa">Why</a> ·
+  <a href="#features">Features</a> ·
+  <a href="#installation">Install</a> ·
+  <a href="#quick-start">Quick start</a> ·
+  <a href="#capa-wrap">Wrap</a> ·
+  <a href="#web-ui--observability">Web UI</a> ·
+  <a href="#documentation">Docs</a>
+</p>
 
+Declare skills, tools, rules, sub-agents, MCP servers, hooks, and plugins once in `capabilities.yaml`. Run `capa install`. CAPA writes them into Cursor, Claude Code, Codex, Windsurf, GitHub Copilot, and 35+ other agents — native formats, pinned SHAs, zero manual sync.
 
 https://github.com/user-attachments/assets/98442d19-44c9-43e6-b2c2-88156b189d5e
 
-
-
 ## Why CAPA?
 
-AI coding agents need rules, tools, and conventions — and right now those live scattered across CLAUDE.md, .cursor/rules/, AGENTS.md, MCP configs, and a half-finished internal doc. No two setups match.
+Agent config today is scattered across `CLAUDE.md`, `.cursor/rules/`, `AGENTS.md`, MCP JSON, hooks, and skill folders. No two teammates match. Nothing is pinned. Cloning the repo does not clone the agent setup.
 
-CAPA collapses it into one `capabilities.yaml` next to your code: skills, tools, rules, sub-agents, plugins. capa install fans it out to every provider in its native format — .cursor/rules/ for Cursor, .claude/agents/ and CLAUDE.md for Claude Code, AGENTS.md for Codex, and so on. Capa-managed marker blocks keep your hand-written content untouched.
+CAPA collapses that into one version-controlled file next to your code:
 
-One file, version controlled, pinned by capabilities.lock, cached by SHA. The teammate who clones tomorrow gets the exact bytes you got today.
+- **`capabilities.yaml`** — source of truth for every capability
+- **`capabilities.lock`** — SHA pins so tomorrow's clone gets the same bytes
+- **Marker blocks** — surgical writes that leave hand-edited content alone
+- **One MCP endpoint** — agents talk to CAPA; CAPA proxies upstream servers on demand
 
-## What it does
+The teammate who clones tomorrow gets the exact setup you have today.
 
-- One `capabilities.yaml` manages the content for your agent. Write rules, hooks, and tools once — capa runs them natively, supporting 35+ agents (Cursor, Claude Code, Codex, Windsurf, Copilot, Gemini CLI, and more). No more keeping `.cursor/rules/`, `.claude/settings.json`, and `AGENTS.md` in sync by hand.
-- 19–40% cheaper inference, same quality. One MCP server per agent, tools lazy-load on demand instead of front-loading the whole catalog. Measured across 150 trials on claude-opus-4-8.
-- Sub-agents only see the tools they need. Each gets its own filtered MCP endpoint — so your research sub-agent isn't holding a git push tool it shouldn't touch.
+## Features
+
+- **One file → 35+ agents** — write once; CAPA fans out to each provider's native layout (`.cursor/rules/`, `.claude/agents/`, `AGENTS.md`, …)
+- **Cheaper inference, same quality** — on-demand tool loading instead of front-loading the whole catalog (**19–40%** fewer tokens across 150 trials on claude-opus-4-8)
+- **`capa wrap`** — run Cursor, Claude, Codex, and more from a shadow workspace so provider dirs never touch your real repo
+- **Local Web UI** — interactive capabilities editor with live YAML sync, registry browse, OAuth setup, and drag-to-reorder
+- **Activity traces** — live feed of every MCP call, shell tool, and agent span on the project page
+- **Plugins that unpack** — Claude and Cursor plugins decompose into skills, MCP, rules, sub-agents, and hooks
+- **Registries** — browse skills.sh, Cursor Marketplace, Claude plugins, and Claude marketplace catalogs
+- **`capa add --passthrough`** — write provider-native files directly when you want unmanaged one-offs
+- **Sub-agent isolation** — each sub-agent gets a filtered MCP endpoint, so research agents never inherit a `git push` tool
 
 <p align="center">
   <img width="1305" height="941" alt="CAPA Architecture" src="https://github.com/user-attachments/assets/a4db54a2-6ea5-43df-baa9-c61c189d30c1" />
@@ -44,46 +62,163 @@ One file, version controlled, pinned by capabilities.lock, cached by SHA. The te
 ## Installation
 
 **macOS and Linux:**
+
 ```bash
 curl -LsSf https://capa.infragate.ai/install.sh | sh
 ```
 
 **Windows:**
+
 ```powershell
 powershell -ExecutionPolicy ByPass -c "irm https://capa.infragate.ai/install.ps1 | iex"
 ```
 
 ## Quick start
 
-### 1. Initialize your project
+### 1. Initialize
 
 ```bash
 cd your-project
 capa init
 ```
 
-This creates a `capabilities.yaml` next to your code.
+Creates `capabilities.yaml` and registers the project with the local CAPA server (default `http://localhost:5912`).
 
-### 2. Install
+### 2. Add capabilities
+
+```bash
+capa add vercel-labs/agent-skills@web-researcher
+capa add --server --id brave --cmd npx --arg @brave/brave-search-mcp
+capa registry search skills-sh "research"
+```
+
+### 3. Install
 
 ```bash
 capa install
 ```
 
-### 3. Boostrap (Optional)
-If you are already working on a project, and would like to get all of it's capabilities be managed by CAPA, simply use the `/bootstrap` skill. The agent will scan your project for skills, MCPs, relevant tools, hooks, and rules.
+Resolves SHAs, fills the cache, writes per-provider files, and registers one MCP endpoint with each configured agent. Resolved SHAs land in `capabilities.lock`.
 
-`capa install` resolves SHAs and downloads anything that isn't already in the cache. It then writes the per-provider files (`.cursor/rules/`, `.claude/agents/`, `AGENTS.md`, and so on) and registers one MCP endpoint with each agent on your list. The resolved SHAs land in `capabilities.lock` so the next clone gets the same bytes.
+> [!TIP]
+> Already have skills, MCP configs, and rules in the repo? After `capa init`, use the bundled `/bootstrap` skill — the agent scans the project and drafts the CAPA config for you.
 
-### 4. Use `capa sh`
+### 4. Run tools from the terminal
 
 ```bash
 capa sh                                  # list every configured tool
 capa sh brave                            # list brave subcommands
 capa sh brave search --query "…"         # run a tool directly
+capa sh --raw brave search --query "…"   # skip per-tool formatters
 ```
 
-Every tool you define is also a CLI command under `capa sh`. MCP tools live at `capa sh <server> <tool>`. Shell tools live at the top level (or under whatever `group` you assigned). 
+Every tool you define is also a CLI command under `capa sh`.
+
+### 5. Open the Web UI
+
+```bash
+capa status    # prints the local URL when the server is up
+```
+
+Edit skills, tools, rules, hooks, plugins, and agents in the browser. Changes sync live back to `capabilities.yaml`.
+
+## `capa wrap`
+
+Run an agent **without polluting your repo** with `.cursor/`, `.claude/`, and friends. CAPA builds a shadow workspace under `~/.capa/workspaces/`, symlinks your project (minus provider-owned paths), installs capabilities into the shadow, and launches the agent.
+
+```bash
+capa wrap cursor          # Cursor GUI — stops when the window closes
+capa wrap claude          # Claude Code (aliases: claude-code)
+capa wrap agent           # Cursor CLI
+capa wrap codex
+capa wrap gemini-cli
+capa wrap opencode
+
+capa wrap cursor --print-dir   # print shadow path only
+capa wrap --prune              # clean stale workspaces
+capa stop                      # stop server + active wrap sessions
+```
+
+**Wrappable today:** Claude Code, Codex, Cursor, Gemini CLI, OpenCode, iFlow CLI, Kiro CLI, Qwen Code, Kimi CLI.
+
+> [!NOTE]
+> On Windows, creating the shadow workspace may require [Developer Mode](https://learn.microsoft.com/windows/apps/get-started/enable-your-device-for-development) (or an elevated shell) for symlinks. GitHub Copilot is not wrappable yet — it owns shared `.github/` / `.vscode/` trees that need subpath exclusions.
+
+## Web UI & observability
+
+The embedded React UI (served by the local server) covers the full project lifecycle:
+
+| Area | What you get |
+| --- | --- |
+| **Capabilities editor** | Skills, tools, rules, hooks, sub-agents, plugins, agents — CRUD, local file pickers, drag reorder |
+| **Registries** | Search seeded catalogs (skills.sh, Cursor Marketplace, Claude plugins) and add your own |
+| **Activity** | Live tool-call feed, charts, and run timelines (default-on via `options.agentActivity`) |
+| **Variables / OAuth** | Credential setup when install needs secrets |
+
+Activity is powered by system hooks and the MCP proxy tracer — MCP failures show as error rows, shell tools from `capa sh` are labeled correctly, and secrets in args/results are redacted.
+
+## Plugins & registries
+
+Plugins are not opaque blobs. CAPA clones the repo, reads Claude (`.claude-plugin/`) or Cursor (`.cursor-plugin/`) manifests, and merges skills, MCP servers, rules, sub-agents, and hooks into the same install pipeline as everything else.
+
+```bash
+capa add owner/repo --plugin --install
+capa add cursor-marketplace:some-plugin --plugin
+
+capa registry list
+capa registry add anthropics/claude-plugins-official --type claude-marketplace
+capa registry search skills-sh "typescript"
+```
+
+> [!IMPORTANT]
+> Most registry adapters are executable TypeScript fetched into `~/.capa/registries-managed/`. Review the source before enabling a third-party registry. Claude marketplaces are JSON catalogs only — safer by design.
+
+## Passthrough mode
+
+Need a one-off native write without CAPA managing the file?
+
+```bash
+capa add owner/repo@skill --passthrough --provider cursor
+capa add --rule --id ts-strict --inline "Always use strict TypeScript" --passthrough
+capa install --passthrough
+```
+
+Passthrough skips `capabilities.yaml`, the lockfile, and managed-file tracking. Tool aliases, defaults, and formatters still require managed mode (`capa add --tool … --passthrough` is refused).
+
+## How it fits together
+
+```
+capabilities.yaml  ──►  capa install  ──►  provider files (.cursor/, .claude/, AGENTS.md, …)
+        │                      │
+        │                      ├── capabilities.lock
+        │                      ├── ~/.capa/cache/          (content-addressed snapshots)
+        │                      └── ~/.capa/db.sqlite       (projects, variables, activity)
+        │
+        └──► Web UI editor ◄──► file watcher ◄──► disk
+
+Agent ──MCP──► capa server (:5912) ──proxy──► upstream MCP (stdio / HTTP / SSE)
+                     │
+                     ├── on-demand tools (setup_tools / call_tool)
+                     ├── per-sub-agent filtered endpoints
+                     └── ToolCallTracer → activity feed
+```
+
+## CLI cheat sheet
+
+```bash
+capa init                              # create capabilities.yaml + register project
+capa add <source> [--plugin] [--install]
+capa add --server|--tool|--rule|--hook …
+capa install [-p <provider>] [-e .env] [--no-cache]
+capa wrap <provider> [--project <path>]
+capa sh [tool] [args…] [--raw]
+capa registry search|add|list|refresh|remove …
+capa start|stop|restart|status
+capa clean                             # remove managed artifacts
+capa auth github|gitlab
+capa cache | capa cache clean
+capa upgrade
+```
 
 ## Documentation
 
@@ -91,6 +226,4 @@ Guides, the full schema reference, and the registry catalog:
 
 **[https://capa.infragate.ai](https://capa.infragate.ai/docs/introduction)**
 
-## License
-
-MIT
+Maintainer-oriented internals (install pipeline, provider matrix, lockfile semantics) live in [`docs/`](./docs/README.md).

--- a/skills/bootstrap/SKILL.md
+++ b/skills/bootstrap/SKILL.md
@@ -99,7 +99,7 @@ If the project's own conventions designate `.claude/skills/` (or similar provide
 1. **Which items to migrate into shared dirs**, and what they'll become:
    - `.claude/skills/foo/` → `skills/foo/` referenced as `type: local`, `def.path: ./skills/foo`
    - `.cursor/skills/bar/` → `skills/bar/` (or merged with an existing one of the same name; flag the conflict)
-   - `.cursor/rules/*.mdc` → `rules/*.md` referenced as `type: inline` (small) or moved with a `path:` (for now, capa supports inline/remote/github/gitlab — there is no `type: local` for rules, so the bootstrap default is `type: inline` with the file content embedded; flag this trade-off with the user if files are large)
+   - `.cursor/rules/*.mdc` → `rules/*.md` referenced as `type: local` with `path: ./rules/<id>.md` (preferred for anything non-trivial). Small one-liners can stay `type: inline` with `content:` embedded.
    - `.claude/agents/*.md` → entries in the top-level `subagents:` section (capa regenerates the file on install)
    - Hooks in `.claude/settings.json` / `.cursor/hooks.json` → top-level `hooks:` entries, using canonical event names. For non-trivial hook scripts, move the script under `hooks/<id>.sh` and reference via `source: { type: local, path: ./hooks/<id>.sh }`. Inline one-liners stay inline.
    - MCP servers from `.cursor/mcp.json`, `.claude/settings.json` `mcpServers`, `.codex/config.toml` `mcp_servers` → top-level `servers:` entries. Merge duplicates by id; flag mismatched configs (e.g., two providers point a server with the same id at different commands).
@@ -119,7 +119,7 @@ If the project's own conventions designate `.claude/skills/` (or similar provide
 4. **Conflicts and ambiguities** — call them out explicitly:
    - Two skills with the same name in different provider dirs (likely the same skill installed twice — confirm before merging)
    - A symlinked config dir (user probably wants this preserved, not moved)
-   - A rule with provider-specific frontmatter that won't round-trip into capa's inline form (note the loss and ask)
+   - A rule with provider-specific frontmatter that won't round-trip cleanly into capa's `type: local` / `type: inline` form (note any lost Cursor-only fields like complex globs and ask)
    - A submodule that itself ships skills (probably should become a plugin or a github-typed skill — don't auto-vendor it)
 
 **Wait for confirmation** before Phase 4. The user may want to skip some items, rename others, or change the target layout. Don't move files without sign-off — bootstrap's whole value is being the careful path.
@@ -160,7 +160,7 @@ Rules of composition:
 - **Sort entries by `id`** within each section. Stable order makes future diffs readable.
 - **Don't invent ids.** Use the directory or file basename for discovered items, kebab-cased.
 - **For each MCP server**, prefer the most complete config from any source (e.g., if `.cursor/mcp.json` has env vars and `.claude/settings.json` doesn't, take Cursor's). Replace literal secrets with `${VarName}` placeholders and warn the user that capa will prompt for them on `capa install`.
-- **For rules**, default to `type: inline` with `content:` — capa doesn't currently have a `type: local` for rules. If the rule file is big (> ~100 lines), ask the user whether to keep it inline (simple) or push it to a github repo (cleaner but requires a follow-up).
+- **For rules**, prefer `type: local` with `path:` pointing at the migrated file under `rules/` — capa re-reads it on each install. Use `type: inline` with `content:` only for short one-liners. Remote github/gitlab sources are fine when the rule already lives in another repo.
 - **For hooks**, translate provider event names to canonical names using the table in `references/event-mapping.md`. If a hook's provider event has no canonical mapping, keep the provider-scoped form (`cursor:beforeShellExecution`) — don't drop it.
 - **Don't include empty sections** unless they're useful as placeholders. `servers: []` and `tools: []` belong (so users know where to add things); `subagents: []` only belongs if you actually expect them to add some.
 
@@ -243,7 +243,7 @@ If they say yes: delete the entry (and any trailing comment that explained it), 
 
 Do not auto-remove without asking. The skill never edits `capabilities.yaml` silently after Phase 5 — every change since gets the user's sign-off, and self-removal is no exception.
 
-End with a one-paragraph summary: which branch you're on, what was migrated, what tools got added (and which servers are pending auth), what to do next (commit, `capa restart`, open PR).
+End with a one-paragraph summary: which branch you're on, what was migrated, what tools got added (and which servers are pending auth), what to do next (commit, `capa restart`, open PR). Optionally mention `capa wrap <provider>` if the user wants to try an agent without committing provider dirs, and the Web UI at `http://localhost:5912` for the capabilities editor and Activity feed.
 
 ## What this skill never does
 

--- a/skills/capabilities-manager/SKILL.md
+++ b/skills/capabilities-manager/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: capabilities-manager
-description: Manage capa CLI configuration — `capabilities.yaml` / `capabilities.json`, skills, MCP servers, tools, hooks, sub-agents, rules, plugins, AGENTS.md / CLAUDE.md, security options, and tool exposure modes. Use whenever the user edits the capabilities file, runs any `capa` command (init, install, add, clean, sh, start/stop/restart/status, auth, upgrade, cache, registry), wires up an MCP server, adds a skill from GitHub / GitLab / a registry / a remote URL / a local path, configures secrets via `${VarName}` placeholders, installs lifecycle hooks, defines sub-agents, or troubleshoots a failed install. Use even when the user only names a fragment ("add a skill", "wire up brave search", "block this phrase in skills") without saying "capa" — if a `capabilities.yaml` or `capabilities.json` lives at the project root, this is almost certainly the right skill. If the project does NOT yet have a capabilities file, point at the `bootstrap` skill instead.
+description: Manage capa CLI configuration — `capabilities.yaml` / `capabilities.json`, skills, MCP servers, tools, hooks, sub-agents, rules, plugins, AGENTS.md / CLAUDE.md, security options, tool exposure modes, `capa wrap` shadow workspaces, `--passthrough` native writes, registries (including Claude marketplaces), activity traces, and the local Web UI. Use whenever the user edits the capabilities file, runs any `capa` command (init, install, add, wrap, clean, sh, start/stop/restart/status, auth, upgrade, cache, registry), wires up an MCP server, adds a skill from GitHub / GitLab / a registry / a remote URL / a local path, configures secrets via `${VarName}` placeholders, installs lifecycle hooks, defines sub-agents, or troubleshoots a failed install. Use even when the user only names a fragment ("add a skill", "wire up brave search", "wrap cursor", "block this phrase in skills") without saying "capa" — if a `capabilities.yaml` or `capabilities.json` lives at the project root, this is almost certainly the right skill. If the project does NOT yet have a capabilities file, point at the `bootstrap` skill instead.
 ---
 
 # Capabilities Manager
@@ -12,19 +12,20 @@ This skill is the routing layer for that loop. The actual command reference, sch
 ## How capa works (one screen)
 
 1. **The file is the source of truth.** `capabilities.yaml` declares what gets installed. Capa never auto-discovers anything from `.claude/`, `.cursor/`, etc. — if it's not in the file, capa won't manage it. (Onboarding an already-configured project is the `bootstrap` skill's job.)
-2. **`capa install` writes everything.** Skill directories under each provider, MCP client config (`.mcp.json`, `.cursor/mcp.json`, etc.), `AGENTS.md` / `CLAUDE.md` blocks, hook entries, rules — all rewritten from the file. Anything labeled `name: capa:<id>` is capa's; entries the user authored by hand are left alone.
-3. **`capa clean` removes only what capa wrote.** Safe to run; doesn't touch user-authored files or settings entries.
-4. **A background server at `localhost:5912`** handles credential prompts, tool execution (`capa sh`), and the MCP endpoints providers connect to. Started by `capa install`; lifecycle is `capa start | stop | restart | status`.
+2. **`capa install` writes everything.** Skill directories under each provider, MCP client config (`.mcp.json`, `.cursor/mcp.json`, etc.), `AGENTS.md` / `CLAUDE.md` blocks, hook entries, rules — all rewritten from the file. Anything labeled `name: capa:<id>` is capa's; entries the user authored by hand are left alone. Plugins unpack into the same primitives (skills, servers, rules, sub-agents, hooks).
+3. **`capa clean` removes only what capa wrote.** Safe to run; doesn't touch user-authored files or settings entries. Passthrough writes (`capa add --passthrough` / `capa install --passthrough`) are **not** managed — `capa clean` will not remove them.
+4. **A background server at `localhost:5912`** handles credential prompts, tool execution (`capa sh`), MCP endpoints, the Web UI capabilities editor, registries, and the Activity feed. Started by `capa init` / `capa install`; lifecycle is `capa start | stop | restart | status`.
 5. **Secrets are `${VarName}` placeholders** anywhere in the file. Capa prompts for them via web UI on install, or loads from `.env` with `capa install -e`.
+6. **`capa wrap <provider>`** runs the agent from a shadow workspace under `~/.capa/workspaces/` so provider dirs never pollute the real repo. Mutating commands refuse to run inside a wrap workspace — always edit/install from the real project path.
 
 ## Routing — load the reference that matches the task
 
 | If the user is… | Read first | Then |
 |---|---|---|
-| Running a CLI command (init/install/add/clean/sh/server/auth/cache/registry/upgrade) or asking what flags exist | `references/commands.md` | Run the command and report results |
-| Editing the file — adding a skill, server, tool, hook, sub-agent, rule, plugin, agents block, security setting | `references/capabilities-schema.md` | Edit `capabilities.yaml`; run `capa install` |
-| Asking how to wire up a common pattern (web search, file ops, on-demand mode, plugins, etc.) | `references/workflows-and-examples.md` | Adapt the closest example |
-| Hitting an install error, credential prompt issue, server crash, missing tools, stale cache, TLS error, blocked phrase | `references/troubleshooting.md` | Apply the diagnostic flow listed for that symptom |
+| Running a CLI command (init/install/add/wrap/clean/sh/server/auth/cache/registry/upgrade) or asking what flags exist | `references/commands.md` | Run the command and report results |
+| Editing the file — adding a skill, server, tool, hook, sub-agent, rule, plugin, agents block, security / activity setting | `references/capabilities-schema.md` | Edit `capabilities.yaml`; run `capa install` |
+| Asking how to wire up a common pattern (web search, wrap, passthrough, on-demand mode, plugins, registries, etc.) | `references/workflows-and-examples.md` | Adapt the closest example |
+| Hitting an install error, wrap failure, credential prompt issue, server crash, missing tools, stale cache, TLS error, blocked phrase | `references/troubleshooting.md` | Apply the diagnostic flow listed for that symptom |
 
 The references are sized for selective reads (each ≤ ~600 lines, with table-of-contents at the top of the larger ones). Don't load all four if only one applies.
 
@@ -57,11 +58,15 @@ When binding tools to skills via `requires:`, mismatching the `@` prefix is the 
 
 `options.toolExposure` has three values and they change what `capa install` writes:
 
-- `expose-all` (default): every tool any active skill requires shows up in the MCP `tools/list`. Simplest.
-- `on-demand`: only `setup_tools` and `call_tool` are exposed at startup; the agent activates skills on demand. Keeps the active toolset small for long contexts.
+- `expose-all`: every tool any active skill requires shows up in the MCP `tools/list`. Simplest.
+- `on-demand` (what `capa init` writes by default): only `setup_tools` and `call_tool` are exposed at startup; the agent activates skills on demand. Keeps the active toolset small for long contexts.
 - `none`: capa writes **no** project-local MCP config files at all. The agent is expected to invoke tools via `capa sh <group> <tool>` instead. Useful when policy forbids per-project `.mcp.json` edits.
 
 Pick deliberately — switching modes later cleans up old entries on the next install but the choice colours the install output.
+
+### Activity traces are on by default
+
+`options.agentActivity` defaults to **enabled** (omit or `true`). Capa injects system hooks that report tool calls and agent lifecycle events into the project Activity feed in the Web UI. Set `options.agentActivity: false` to opt out. System activity hooks are managed and hidden from the Hooks editor — don't try to declare them yourself.
 
 ## Conventions that prevent surprises
 
@@ -86,9 +91,9 @@ If an install fails or behaves unexpectedly, jump directly to `references/troubl
 
 | Need | File | Notes |
 |---|---|---|
-| Every `capa` command and flag, with concrete invocations | `references/commands.md` | Includes `.env` flow, provider resolution rules, registry adapters |
-| Field-by-field schema for skills / servers / tools / hooks / sub-agents / rules / plugins / security / `agents` | `references/capabilities-schema.md` | Includes the `@` vs `::` table and the tool exposure matrix |
-| End-to-end YAML examples for the most common patterns | `references/workflows-and-examples.md` | Web research, file ops, on-demand loading, plugins, optional providers |
-| Symptoms → diagnoses for install / server / credential / tool failures | `references/troubleshooting.md` | Indexed by the error message the user sees |
+| Every `capa` command and flag, with concrete invocations | `references/commands.md` | Includes wrap, passthrough, `.env` flow, provider resolution, registry adapters + Claude marketplaces |
+| Field-by-field schema for skills / servers / tools / hooks / sub-agents / rules / plugins / security / activity / `agents` | `references/capabilities-schema.md` | Includes the `@` vs `::` table, tool exposure matrix, plugin unpack |
+| End-to-end YAML examples for the most common patterns | `references/workflows-and-examples.md` | Web research, wrap, passthrough, on-demand loading, plugins, registries |
+| Symptoms → diagnoses for install / wrap / server / credential / tool failures | `references/troubleshooting.md` | Indexed by the error message the user sees |
 
 External: [CAPA on GitHub](https://github.com/infragate/capa) · [skills.sh registry](https://skills.sh) · [MCP protocol](https://modelcontextprotocol.io)

--- a/skills/capabilities-manager/references/capabilities-schema.md
+++ b/skills/capabilities-manager/references/capabilities-schema.md
@@ -1,6 +1,6 @@
 # Capabilities File Schema
 
-Full reference for `capabilities.yaml` / `capabilities.json` structure: basic layout, skills (all seven types), servers, tools, rules, plugins, security, `requiresCommands`, the `agents` section, and sub-agents.
+Full reference for `capabilities.yaml` / `capabilities.json` structure: basic layout, skills (all seven types), servers, tools, rules (including `type: local`), plugins (full unpack), security, `agentActivity`, `requiresCommands`, the `agents` section, and sub-agents.
 
 ## Basic Structure (YAML)
 
@@ -12,7 +12,8 @@ providers:
   - claude-code
 
 options:
-  toolExposure: expose-all  # 'expose-all' | 'on-demand' | 'none' (see notes below)
+  toolExposure: on-demand  # 'expose-all' | 'on-demand' | 'none' (see notes below)
+  # agentActivity: true     # default on — inject system hooks for the Activity feed; set false to opt out
   # security: { blockedPhrases, allowedCharacters }
   # requiresCommands: [ { cli, description? } ]
 
@@ -33,9 +34,10 @@ tools:
     type: mcp|command
     def: { ... }
 
-# rules: [ { id, type, content?, url?, def?, providers?, appliesTo?, alwaysApply?, description? } ]
+# rules: [ { id, type, content?, url?, path?, def?, providers?, appliesTo?, alwaysApply?, description? } ]
 
 # plugins: [ { id?, type: github|gitlab, def: { repo, subpath?, version?, ref?, description? }, servers?: { <manifestKey>: { as?: <serverId> } } } ]
+# Plugins unpack into skills + servers + rules + sub-agents + hooks (Claude/Cursor manifests).
 # `def.repo` mirrors the skill grammar:
 #   - `owner/repo`                    — manifest at the repo root
 #   - `owner/repo@plugin-name`        — recursive search by basename / manifest name
@@ -85,14 +87,28 @@ Controls how capa exposes skill tools to the MCP client. Three modes:
 
 | Mode | `tools/list` returns | Per-install MCP file writes | Agent invocation path |
 |------|----------------------|------------------------------|------------------------|
-| `'expose-all'` (default) | Every tool required by any active skill, with full input schemas | Yes — main `capa` entry + sub-agent `capa-<id>` entries | Direct MCP `tools/call` |
-| `'on-demand'` | Only the meta-tools `setup_tools` and `call_tool` | Yes — same as expose-all | Agent calls `setup_tools(['<skill>'])` (returns compact `name(required, optional?)` signature list), then `call_tool(name, data)`. If the call is invalid the full schema is returned in the error so the agent can self-correct without re-running setup. |
+| `'expose-all'` | Every tool required by any active skill, with full input schemas | Yes — main `capa` entry + sub-agent `capa-<id>` entries | Direct MCP `tools/call` |
+| `'on-demand'` (what `capa init` writes) | Only the meta-tools `setup_tools` and `call_tool` | Yes — same as expose-all | Agent calls `setup_tools(['<skill>'])` (returns compact `name(required, optional?)` signature list), then `call_tool(name, data)`. If the call is invalid the full schema is returned in the error so the agent can self-correct without re-running setup. |
 | `'none'` | Empty list | **No** — capa skips all project-local MCP config files (`.mcp.json`, `.cursor/mcp.json`, `.codex/config.toml` `mcp_servers.capa`, sub-agent `capa-<id>` entries). Any previously-written entries are removed on install. | The agent must use `capa sh <group> <tool> [--args]` (see [`commands.md`](./commands.md)). Sub-agent instruction files are still installed for documentation but their tools are not reachable over MCP. |
 
 Notes on `'none'`:
 - The capa HTTP server still runs and the project endpoints stay live; `tools/list` returns empty so MCP-aware agents don't try to discover tools through capa's MCP endpoint. `tools/call` is **not** gated — that's the path `capa sh` uses to execute tools, and gating it would mean rejecting `capa sh` itself.
 - Useful when the user prefers to keep `.mcp.json` clean or has policy restrictions against writing per-project MCP configs.
 - Switching to `'none'` on a project that previously installed under another mode cleans up the old entries on the next `capa install`.
+
+## Agent Activity (`options.agentActivity`)
+
+When enabled (default — omit the field or set `true`), capa injects **system hooks** (`capa-sys-activity-*`) at install time. Those hooks POST lifecycle and tool events into the project's Activity feed in the Web UI. The MCP proxy also records tool calls (with secret redaction).
+
+- Set `agentActivity: false` to opt out; the next `capa install` removes the system hooks.
+- System hooks are managed and **hidden** from the Hooks editor — do not declare them in `hooks:`.
+- Activity only installs events the target provider actually maps (avoids skip warnings on wrap).
+
+```yaml
+options:
+  toolExposure: on-demand
+  agentActivity: true   # default; set false to disable the Activity feed
+```
 
 ## Security Options (`options.security`)
 
@@ -177,13 +193,14 @@ Defines rules installed into each provider's rules directory or instructions fil
 
 **Fields:**
 - `id` (required): Unique identifier, used as filename stem and capa marker id.
-- `type` (required): `inline`, `remote`, `github`, or `gitlab`.
+- `type` (required): `inline`, `remote`, `github`, `gitlab`, or `local`.
 - `providers` (optional): Restrict this rule to specific providers. When omitted, applies to all.
 - `appliesTo` (optional): Glob patterns for auto-attached rules (maps to Cursor `globs`).
 - `alwaysApply` (optional): When `true`, the rule is always loaded regardless of file context.
 - `description` (optional): Human-readable description used in frontmatter.
 - `content` (inline only): Literal rule content.
 - `url` (remote only): Raw URL to fetch (for private repos prefer `type: github`/`gitlab` so capa uses your OAuth token instead of hitting the raw URL).
+- `path` (local only): Path to a local markdown file, relative to the capabilities file. Re-read on each install.
 - `def.repo` (github/gitlab only): Repository reference using the [repo string format](#repo-string-format--vs-). Use `::` for an exact file path (the common case for rules) or `@<basename>` to let capa search recursively.
 
 ```yaml
@@ -195,6 +212,11 @@ rules:
     content: |
       Use TypeScript strict mode. Prefer const over let.
       Always use explicit return types on exported functions.
+
+  - id: local-conventions
+    type: local
+    path: ./rules/conventions.md
+    alwaysApply: true
 
   - id: test-patterns
     type: inline
@@ -227,7 +249,7 @@ rules:
       repo: my-org/standards@style.md
 ```
 
-`capa clean` removes all capa-installed rules. Rules can be scoped per-provider and support the same source types as skills.
+`capa clean` removes all capa-installed rules. Rules can be scoped per-provider and support the same source types as skills (including `type: local`).
 
 ## Hooks Section
 
@@ -323,7 +345,11 @@ Providers without a hooks integration (most of the rest of the registry) emit a 
 
 ## Plugins Section
 
-Remote plugin packages that bundle skills, servers, and tools from a provider manifest. Plugin tools and skills are NOT auto-exposed — declare the tools you want under the top-level `tools` section and the skills you want under `skills` with `type: plugin`.
+Remote plugin packages that capa **unpacks** into the same primitives as everything else: skills, servers/tools, rules, sub-agents, and hooks. Capa does **not** install plugins as opaque units.
+
+Supported manifests today: **Claude** (`.claude-plugin/`) and **Cursor** (`.cursor-plugin/`). If no manifest is found, discover-mode still scans `skills/`, `commands/`, `agents/`, `hooks/`, `rules/`, and `.mcp.json`. Unsupported artifacts (LSP, themes, monitors, …) produce install warnings and are skipped.
+
+Plugin tools and skills are NOT auto-exposed to the agent — declare the tools you want under the top-level `tools` section and the skills you want under `skills` with `type: plugin`. Plugin-sourced rules / hooks / sub-agents flow through the normal install tasks (shown locked/badged in the Web UI).
 
 **Fields:**
 - `id` (optional): Stable identifier; derived from the `@`/`::` suffix in `def.repo` or from the last repo segment when absent.
@@ -386,7 +412,7 @@ plugins:
       version: v1.0.1
 ```
 
-Plugins are resolved during `capa install`. The plugin manifest is fetched from the repository, skill files are copied onto disk for each provider, and the MCP servers it declares are registered under capa. Plugin tools must be declared explicitly in the top-level `tools` section using `@server-id` references; plugin skills are activated via `type: plugin` skill entries (capa warns when a `type: plugin` skill id does not match any plugin manifest skill).
+Plugins are resolved during `capa install`. The plugin manifest is fetched from the repository; skill files are copied onto disk for each provider; MCP servers are registered; rules / sub-agents / hooks from the plugin are merged into the install pipeline (`${CLAUDE_PLUGIN_ROOT}` in hook scripts is rewritten to the stable plugin copy under `~/.capa/plugins/<projectId>/`). Plugin tools must be declared explicitly in the top-level `tools` section using `@server-id` references; plugin skills are activated via `type: plugin` skill entries (capa warns when a `type: plugin` skill id does not match any plugin manifest skill).
 
 The `servers` field lets you rename plugin servers so skills can `requires:`-bind to plugin tools via stable aliases:
 

--- a/skills/capabilities-manager/references/commands.md
+++ b/skills/capabilities-manager/references/commands.md
@@ -118,12 +118,13 @@ Use `--plugin` to add a plugin entry (skills, MCP, rules, sub-agents, hooks) ins
 ### Servers, tools, rules, hooks
 
 ```bash
-# MCP server (stdio)
+# MCP server (stdio) — quote ${VarName} so the shell does not expand it
 capa add --server --id brave --cmd npx --arg -y --arg @modelcontextprotocol/server-brave-search \
-  --env-var BRAVE_API_KEY=${BraveApiKey}
+  --env-var 'BRAVE_API_KEY=${BraveApiKey}'
 
 # Remote MCP server
-capa add --server --id remote-api --url https://mcp.example.com --header Authorization=Bearer\ ${Token}
+capa add --server --id remote-api --url https://mcp.example.com \
+  --header 'Authorization=Bearer ${Token}'
 
 # Tool alias for an MCP server tool
 capa add --tool --id search --mcp-server @brave --mcp-tool brave_web_search --default count=5
@@ -160,7 +161,7 @@ capa wrap codex
 capa wrap gemini-cli
 capa wrap opencode
 capa wrap cursor --project /path/to/repo
-capa wrap cursor --print-dir  # print shadow path only
+capa wrap cursor --print-dir  # print shadow path, then launch
 capa wrap --prune             # remove stale workspaces under ~/.capa/workspaces
 ```
 

--- a/skills/capabilities-manager/references/commands.md
+++ b/skills/capabilities-manager/references/commands.md
@@ -2,7 +2,7 @@
 
 ## Contents
 
-- Initialize Capabilities · Install Capabilities · Add Skills · Clean Managed Files · Shell / Tool Executor · Server Management · Authentication · Upgrade · Cache Management · Registry Management
+- Initialize Capabilities · Install Capabilities · Add (skills / plugins / servers / tools / rules / hooks) · Wrap · Clean Managed Files · Shell / Tool Executor · Server Management · Authentication · Upgrade · Cache Management · Registry Management
 
 ---
 
@@ -12,7 +12,9 @@
 capa init [--format json|yaml]
 ```
 
-Creates a new capabilities file with default configuration. Defaults to YAML format if not specified.
+Creates a new capabilities file with default configuration (includes the `capabilities-manager` and `bootstrap` skills, `options.toolExposure: on-demand`). Defaults to YAML format if not specified.
+
+Also **registers the project** with the local CAPA server so it appears in the Web UI (`http://localhost:5912`). The server is started if it isn't already running.
 
 **When to use**: First-time setup or starting a new project.
 
@@ -26,6 +28,7 @@ capa install -e             # Load variables from .env file
 capa install -e .prod.env   # Load variables from custom env file
 capa install -p cursor      # Install for a single provider
 capa install --no-cache     # Bypass on-disk cache; re-resolve all remote sources
+capa install --passthrough  # Write provider-native files only (no capa server/proxy)
 ```
 
 Reads the capabilities file and:
@@ -33,10 +36,11 @@ Reads the capabilities file and:
 2. Installs all skills to configured MCP clients (creates skill directories in `.cursor/skills/` and/or `~/Library/Application Support/Claude/skills/`)
 3. Installs/updates `AGENTS.md` (always) and `CLAUDE.md` (when `claude-code` is in providers) if the `agents` section is present (downloads base file, upserts/prunes snippets)
 4. Installs rules into each provider's rules directory or instructions file if the `rules` section is present
-5. Resolves plugins and merges their skills, servers, and tools
-6. Configures the CAPA server with your tools and servers
+5. Resolves plugins and **unpacks** them into skills, servers, tools, rules, sub-agents, and hooks
+6. Configures the CAPA server with your tools and servers (skipped with `--passthrough`)
 7. Prompts for any required credentials via web UI (unless `-e` flag is used)
-8. Registers the project's MCP endpoint in client config files (skipped when no tools or subagents are configured)
+8. Registers the project's MCP endpoint in client config files (skipped when no tools or subagents are configured, or with `--passthrough`)
+9. Injects system activity hooks when `options.agentActivity` is enabled (default)
 
 **Security**: If `options.security` is configured with `blockedPhrases` or `allowedCharacters`, the corresponding checks run during installation. Omit or comment out each property to disable it. If a blocked phrase is found, installation stops immediately and reports which skill and phrase caused the block. When `allowedCharacters` is present, character sanitization runs: the baseline (printable ASCII + standard whitespace) is always preserved, and the value specifies extra Unicode ranges to keep on top of that.
 
@@ -48,6 +52,7 @@ Reads the capabilities file and:
   - All required variables must be present in the env file
 - `-p, --provider <id>`: Install for a single provider (e.g. `cursor`, `claude-code`). Overrides the `providers` field in the capabilities file.
 - `--no-cache`: Bypass the on-disk cache and lockfile; re-resolve every remote source (skills, agents, rules, plugins) from scratch.
+- `--passthrough`: Write provider-native files from the capabilities file **without** registering the project with the capa server / MCP proxy. No lockfile pinning for managed mode, no tool aliases/defaults/formatters via the proxy. Prefer managed install unless the user explicitly wants unmanaged native files.
 
 **Provider resolution** (when `providers` is omitted from the capabilities file):
 1. `--provider` flag (highest priority)
@@ -79,14 +84,14 @@ DatabaseUrl=postgresql://localhost:5432/db
 
 ---
 
-## Add Skills & Plugins
+## Add Skills, Plugins, Servers, Tools, Rules & Hooks
 
 ```bash
-capa add [--plugin|--skill] <source>
-capa add --plugin <source>
+capa add [--skill|--plugin|--server|--tool|--rule|--hook] [source]
+capa add <source> [--install] [--passthrough] [-p <provider>]
 ```
 
-Add a skill (default) or plugin from various sources. Without a flag, `--skill` is assumed for backward compatibility.
+Add an entry to `capabilities.yaml` (default) or write provider-native files immediately (`--passthrough`). Without a kind flag, `--skill` is assumed for backward compatibility when a source looks like a skill/plugin.
 
 ### Skills
 
@@ -102,7 +107,7 @@ Add a skill (default) or plugin from various sources. Without a flag, `--skill` 
 
 ### Plugins
 
-Use `--plugin` to add a plugin entry (MCP server bundles, skills, hooks, etc.) instead of a skill:
+Use `--plugin` to add a plugin entry (skills, MCP, rules, sub-agents, hooks) instead of a skill:
 
 - **GitHub root**: `capa add --plugin slackapi/slack-mcp-plugin`
 - **GitHub subpath**: `capa add --plugin anthropics/claude-plugins-official::plugins/frontend-design`
@@ -110,9 +115,73 @@ Use `--plugin` to add a plugin entry (MCP server bundles, skills, hooks, etc.) i
 - **URL**: `capa add --plugin https://github.com/anthropics/claude-plugins-official/tree/main/plugins/code-review`
 - **Registry**: `capa add claude-plugins:frontend-design` — the registry adapter determines whether the item is a skill or plugin.
 
-The `--plugin` and `--skill` flags are mutually exclusive. When a source matches a registry (`<registryId>:<itemId>`), the registry adapter's resolved capability takes precedence; a conflicting flag emits a warning but install proceeds.
+### Servers, tools, rules, hooks
 
-**When to use**: Quickly adding community skills or plugins without manually editing the capabilities file. Use `<registryId>:<itemId>` to install from a configured third-party registry.
+```bash
+# MCP server (stdio)
+capa add --server --id brave --cmd npx --arg -y --arg @modelcontextprotocol/server-brave-search \
+  --env-var BRAVE_API_KEY=${BraveApiKey}
+
+# Remote MCP server
+capa add --server --id remote-api --url https://mcp.example.com --header Authorization=Bearer\ ${Token}
+
+# Tool alias for an MCP server tool
+capa add --tool --id search --mcp-server @brave --mcp-tool brave_web_search --default count=5
+
+# Inline rule
+capa add --rule --id ts-strict --inline "Always use strict TypeScript" --always-apply
+
+# Hook
+capa add --hook --id audit-shell --on beforeShell --command 'date >> ~/.capa/audit.log'
+```
+
+Kind flags (`--skill`, `--plugin`, `--server`, `--tool`, `--rule`, `--hook`) are mutually exclusive. When a source matches a registry (`<registryId>:<itemId>`), the registry adapter's resolved capability takes precedence; a conflicting flag emits a warning but install proceeds.
+
+### Shared flags
+
+- `--install` — also run `capa install` after updating the capabilities file (ignored with `--passthrough`; files are written immediately)
+- `--passthrough` — write **provider-native** files; skip `capabilities.yaml`, the capa server, lockfile, and managed-files tracking. `--provider` is required in non-TTY. Refuses unsafe overwrites. **`--tool` with `--passthrough` is refused** — tool aliases/defaults/formatters need the managed MCP proxy.
+- `-p, --provider <id>` — provider for install follow-up, or required for passthrough in non-TTY
+- `-e, --env [file]` — load variables when `--install` runs
+- `--no-cache` — re-resolve remotes when installing
+
+**When to use**: Quickly adding community skills, plugins, servers, rules, or hooks without manually editing the capabilities file. Use `<registryId>:<itemId>` to install from a configured third-party registry. Use `--passthrough` only when the user wants unmanaged native files.
+
+---
+
+## Wrap (shadow workspaces)
+
+```bash
+capa wrap [provider] [args...]
+capa wrap cursor
+capa wrap claude              # alias for claude-code
+capa wrap agent               # Cursor CLI
+capa wrap codex
+capa wrap gemini-cli
+capa wrap opencode
+capa wrap cursor --project /path/to/repo
+capa wrap cursor --print-dir  # print shadow path only
+capa wrap --prune             # remove stale workspaces under ~/.capa/workspaces
+```
+
+Runs a provider from a **shadow workspace** under `~/.capa/workspaces/` so `.cursor/`, `.claude/`, etc. never land in the real repo. CAPA symlinks the project (minus provider-owned paths), runs `capa install` into the shadow, launches the agent, and watches for capability changes.
+
+**Wrappable providers**: `claude-code` (aliases: `claude`), `codex`, `cursor` (GUI; CLI alias `agent`), `gemini-cli`, `opencode`, `iflow-cli`, `kiro-cli`, `qwen-code`, `kimi-cli`.
+
+**Not wrappable**: GitHub Copilot (owns shared `.github/` / `.vscode/` trees — subpath exclusions not implemented yet).
+
+**Flags**:
+- `--project <dir>` — source project (default: cwd)
+- `--print-dir` — print the workspace path before launching
+- `--prune` — delete wrap workspaces and exit
+
+**Important**:
+- Mutating commands (`capa install`, `capa add`, `capa clean`, …) **refuse** to run inside a wrap workspace. Edit and install from the real project path.
+- Wrap never registers the shadow path as a CAPA project — the Web UI always lists the real project.
+- On Windows, creating symlinks may require Developer Mode or an elevated shell.
+- `capa stop` also stops active wrap sessions.
+
+**When to use**: Try Cursor / Claude / Codex without committing provider config dirs to the repo.
 
 ---
 
@@ -122,7 +191,9 @@ The `--plugin` and `--skill` flags are mutually exclusive. When a source matches
 capa clean
 ```
 
-Removes all skill directories and MCP client configurations that were installed by CAPA. If the capabilities file has an `agents` section, also removes all capa-managed blocks from `AGENTS.md` and `CLAUDE.md` (each file is deleted if it becomes entirely empty after cleaning). Capa-installed hook entries are stripped from each provider's hooks config (entries you authored by hand are preserved) and any materialised hook scripts under `~/.capa/hooks/<projectId>/` are deleted.
+Removes all skill directories and MCP client configurations that were installed by CAPA. If the capabilities file has an `agents` section, also removes all capa-managed blocks from `AGENTS.md` and `CLAUDE.md` (each file is deleted if it becomes entirely empty after cleaning). Capa-installed hook entries are stripped from each provider's hooks config (entries you authored by hand are preserved) and any materialised hook scripts under `~/.capa/hooks/<projectId>/` are deleted. The project is unregistered from the Web UI.
+
+Does **not** remove `--passthrough` writes (those are unmanaged).
 
 **When to use**: Cleaning up before reinstalling or removing CAPA-managed capabilities.
 
@@ -135,10 +206,13 @@ capa sh                                     # List all available commands
 capa sh <group>                             # List subcommands for an MCP server group
 capa sh <group> <subcommand> [--arg value]  # Run an MCP tool
 capa sh <command> [--arg value]             # Run a top-level command tool
+capa sh --raw <group> <subcommand> …        # Skip per-tool formatters; return raw output
 capa sh <unknown command>                   # Pass through to the OS shell
 ```
 
 `capa sh` converts every configured tool into a CLI command. MCP server tools are grouped under the server ID (e.g. `gitlab`). Command tools appear at the top level, or under a custom `group` if defined. Tool IDs are automatically slugified to kebab-case.
+
+`--raw` may appear anywhere among the args (`capa sh --raw db query` or `capa sh db query --raw`). It bypasses optional `def.formatter` pipelines and returns the tool's raw output. Shell invocations are labeled correctly in the Activity feed (not as MCP).
 
 `capa sh` is **non-interactive** — each invocation executes one command and exits, making it ideal for AI agents. Use `--help` at any level for contextual guidance:
 
@@ -148,7 +222,7 @@ capa sh gitlab --help                       # List gitlab subcommands
 capa sh gitlab list-merge-requests --help   # Show argument details
 ```
 
-**Requires**: a `capabilities.yaml` in the current directory and the CAPA server running (`capa start`). Run `capa install` at least once to register the project.
+**Requires**: a `capabilities.yaml` in the current directory (or inside a wrap workspace — capa resolves the real project path) and the CAPA server running (`capa start`). Run `capa install` at least once to register the project.
 
 ---
 
@@ -157,12 +231,14 @@ capa sh gitlab list-merge-requests --help   # Show argument details
 ```bash
 capa start              # Start the CAPA server (background)
 capa start -f           # Start in foreground (for debugging)
-capa stop               # Stop the CAPA server
+capa stop               # Stop the CAPA server + active wrap sessions
 capa restart            # Restart the CAPA server
-capa status             # Check server health and uptime
+capa status             # Check server health, uptime, and Web UI URL
 ```
 
-**When to use**: Managing the background MCP server that handles tool execution and credential management.
+**When to use**: Managing the background MCP server that handles tool execution, credential management, the Web UI, registries, and activity ingest.
+
+The Web UI lives at `http://localhost:5912` (project editor, Activity feed, Registries, Integrations). Open it after `capa init` / `capa install` / `capa status`.
 
 ---
 
@@ -217,45 +293,59 @@ Capa caches remote sources (GitHub/GitLab repositories) locally to speed up subs
 capa registry                                              # List all configured registries (same as `capa registry list`)
 capa registry list                                         # List all configured registries with status, type, source
 capa registry path                                         # Print the managed registries directory (~/.capa/registries-managed/)
+capa registry search [slug] "query" [--capability skills|plugins] [--limit 20]
 
-capa registry add <source> [slug]                          # Fetch + install a registry adapter
+capa registry add <source> [slug]                          # Fetch + install a registry
 capa registry add infragate/capa@skills-sh                 # GitHub source, search-form (auto type=github)
 capa registry add gitlab/group/proj::registries/internal --type=gitlab
 capa registry add https://example.com/adapter.ts          # HTTPS URL source (type auto-detected from scheme)
-capa registry add owner/repo@my-reg my-reg                 # Explicit slug when the auto-derived one collides or you want a friendlier name
+capa registry add anthropics/claude-plugins-official --type claude-marketplace
+capa registry add owner/repo@my-reg my-reg                 # Explicit slug when the auto-derived one collides
 
 capa registry remove <slug>                                # Delete the registry row and its materialized adapter file
-capa registry refresh <slug>                               # Re-fetch the adapter from the stored source (updates resolved_ref)
+capa registry refresh <slug>                               # Re-fetch the adapter / catalog from the stored source
 capa registry enable <slug>                                # Re-enable a previously-disabled registry
 capa registry disable <slug>                               # Hide a registry without removing it
 ```
 
-Registries let you browse and install skills and plugins from third-party sources (e.g. skills.sh, internal company registries, JFrog). Each registry is tracked in capa's database; the adapter file is materialized into `~/.capa/registries-managed/<slug>/adapter.{ts,js,mjs}` after capa fetches and validates it.
+Registries let you browse and install skills and plugins from third-party sources (e.g. skills.sh, Cursor Marketplace, Claude plugins, Claude marketplaces, internal company registries). Each registry is tracked in capa's database.
+
+**Seeded on first server start:** `skills-sh`, `claude-plugins`, `cursor-marketplace`.
+
+### Registry types
+
+| Type | What it is | Trust model |
+| --- | --- | --- |
+| `github` / `gitlab` / `url` | Executable TypeScript adapter materialized into `~/.capa/registries-managed/<slug>/` | Adapter runs in-process — only add sources you trust; UI shows source preview |
+| `claude-marketplace` | JSON catalog (Claude plugin marketplace) — **no adapter code** | Safer by design; preferred when available |
 
 ### Setting up a registry
 
 1. Run `capa registry add <source>` with one of:
    - `owner/repo@<name>` — GitHub search-form (capa searches the repo for a folder named `<name>` containing `adapter.{ts,js,mjs}`)
    - `owner/repo::path/to/<name>` — GitHub exact-path form
-   - The same forms prefixed with `--type=gitlab` (or autodetected from `gitlab.com/...` style sources)
+   - The same forms with `--type=gitlab`
    - `https://...` — direct HTTPS URL to an adapter file (non-HTTPS URLs are rejected for security)
+   - `--type claude-marketplace` — Claude marketplace JSON catalog (e.g. `anthropics/claude-plugins-official`)
 2. Capa derives a slug from the source (`infragate/capa@skills-sh` → `skills-sh`); pass an explicit slug as the second argument to override.
 3. Run `capa registry list` to verify the registry shows `[ok]`.
-4. Open the capa web UI — the **Registries** nav link is always visible; choose a registry, then browse and install from there, or use `capa add <slug>:<itemId>` from the CLI.
+4. Open the capa web UI — the **Registries** nav link is always visible; choose a registry, then browse and install from there, or use `capa add <slug>:<itemId>` / `capa registry search` from the CLI.
 
 Registry management is also available from the web UI: navigate to **Registries → Manage registries** (or hit `/ui/registries/settings` directly) to add, refresh, enable/disable, or remove registries with a preview of the adapter source before installing.
 
 ### Installing from a registry
 
 ```bash
+capa registry search skills-sh "typescript"
 capa add skills-sh:vercel-labs/skills/find-skills     # Install a skill from skills.sh
 capa add acme-internal:design-system/checkout          # Install from an internal registry
+capa add claude-plugins:frontend-design --plugin
 ```
 
-The syntax is `<slug>:<itemId>` where `slug` is the registry's slug from `capa registry list` and `itemId` is the registry-specific identifier for the item.
+The syntax is `<slug>:<itemId>` where `slug` is the registry's slug from `capa registry list` and `itemId` is the registry-specific identifier for the item. With `--passthrough`, Claude marketplace plugins prefer native `claude plugin install` when available.
 
 ### Security
 
-Registry adapters are executable TypeScript — only add sources you trust. Capa enforces HTTPS for URL sources (except `localhost` for testing) and validates the adapter shape before persisting the row; the UI also offers a "Preview" button that shows the raw adapter source before you confirm. There is no sandbox: the adapter runs in the same process as the capa server.
+Registry adapters (non-marketplace types) are executable TypeScript — only add sources you trust. Capa enforces HTTPS for URL sources (except `localhost` for testing) and validates the adapter shape before persisting the row; the UI also offers a "Preview" button that shows the raw adapter source before you confirm. There is no sandbox: the adapter runs in the same process as the capa server. Claude marketplaces are JSON catalogs only.
 
 **When to use**: When you want to browse, search, and install skills or plugins from public or private registries beyond GitHub/GitLab.

--- a/skills/capabilities-manager/references/troubleshooting.md
+++ b/skills/capabilities-manager/references/troubleshooting.md
@@ -124,3 +124,36 @@ If `capa install` does not register the MCP server in `.cursor/mcp.json` or equi
 - This is expected when no tools or subagents are configured in the capabilities file
 - Add at least one tool or subagent to trigger MCP server registration
 - If the server was previously registered but tools were removed, capa automatically unregisters it
+
+### Cannot Run Command Inside Wrap Workspace
+
+If you see `Cannot run "capa <command>" inside a wrap workspace`:
+
+- You are inside `~/.capa/workspaces/...` (or a symlink into it)
+- `cd` back to the real project path shown in the error (or check `.capa-workspace.json` / the wrap marker for `realProjectPath`)
+- Run `capa install` / `capa add` / `capa clean` from the real project; then re-launch with `capa wrap <provider>` if needed
+
+### Wrap Symlink Failures (Windows)
+
+If `capa wrap` fails creating the shadow workspace on Windows:
+
+- Enable [Developer Mode](https://learn.microsoft.com/windows/apps/get-started/enable-your-device-for-development) so symlinks work without elevation, **or** run an elevated shell
+- Confirm the project path is not already a wrap workspace
+- Try `capa wrap --prune` then retry
+
+### Passthrough Wrote Files but `capa clean` Did Not Remove Them
+
+- Expected — `--passthrough` writes unmanaged provider-native files
+- Delete the files manually, or re-add them via managed `capa add` (without `--passthrough`) so future cleans track them
+
+### Activity Feed Empty / Missing Events
+
+- Confirm `options.agentActivity` is not set to `false`
+- Re-run `capa install` so system activity hooks are injected
+- Open the project page in the Web UI (`capa status` for the URL) — Activity lives there, not in the CLI
+- Providers without hook support will not emit lifecycle events (tool calls via the MCP proxy still appear)
+
+### `--tool` Refused With `--passthrough`
+
+- Tool aliases, defaults, and formatters require the managed MCP proxy
+- Drop `--passthrough` and use a normal `capa add --tool …` + `capa install`

--- a/skills/capabilities-manager/references/workflows-and-examples.md
+++ b/skills/capabilities-manager/references/workflows-and-examples.md
@@ -2,8 +2,8 @@
 
 ## Contents
 
-- **Workflows**: 1. Starting a New Project · 2. Adding a Community Skill · 3. Adding a Local Skill · 4. Creating a Custom Skill (inline) · 5. Running Tools with `capa sh` · 6. Managing Server Lifecycle · 7. Installing Without a Providers Section · 8. Bypassing the Cache
-- **Examples**: 1. Web Research Setup · 2. File Operations · 3. Mixed Command and MCP Tools · 4. On-Demand Tool Loading · 5. CLI Prerequisites · 6. Rules · 7. Plugins · 8. Optional Providers
+- **Workflows**: 1. Starting a New Project · 2. Adding a Community Skill · 3. Adding a Local Skill · 4. Creating a Custom Skill (inline) · 5. Running Tools with `capa sh` · 6. Managing Server Lifecycle · 7. Installing Without a Providers Section · 8. Bypassing the Cache · 9. Wrap (shadow workspaces) · 10. Passthrough native writes · 11. Browse registries
+- **Examples**: 1. Web Research Setup · 2. File Operations · 3. Mixed Command and MCP Tools · 4. On-Demand Tool Loading · 5. CLI Prerequisites · 6. Rules · 7. Plugins · 8. Optional Providers · 9. Tool formatter
 
 ---
 
@@ -12,15 +12,16 @@
 ### 1. Starting a New Project
 
 ```bash
-# Initialize capabilities file (defaults to YAML)
+# Initialize capabilities file (defaults to YAML) + register project in Web UI
 capa init
 
 # Edit capabilities.yaml to add your skills and tools
+# Or open http://localhost:5912 and use the capabilities editor
 
 # Install the capabilities
 capa install
 
-# Server starts automatically - check status
+# Server starts automatically - check status / Web UI URL
 capa status
 ```
 
@@ -30,7 +31,11 @@ capa status
 # Option 1: Use capa add command
 capa add vercel-labs/agent-skills
 
-# Option 2: Manually add to capabilities.yaml:
+# Option 2: From a registry
+capa registry search skills-sh "research"
+capa add skills-sh:vercel-labs/skills/find-skills --install
+
+# Option 3: Manually add to capabilities.yaml:
 skills:
   - id: web-researcher
     type: github
@@ -109,6 +114,9 @@ capa sh gitlab list-merge-requests --help
 # Execute a tool
 capa sh gitlab list-merge-requests --project-id 123 --state opened
 
+# Skip optional formatters
+capa sh --raw gitlab list-merge-requests --project-id 123
+
 # Top-level command tool
 capa sh find-skills --query "git automation"
 
@@ -121,10 +129,10 @@ Tool IDs are slugified automatically: `list_merge_requests` → `list-merge-requ
 ### 6. Managing Server Lifecycle
 
 ```bash
-# Check server status
+# Check server status + Web UI URL
 capa status
 
-# Stop server
+# Stop server (also stops active wrap sessions)
 capa stop
 
 # Start server (background)
@@ -165,6 +173,43 @@ capa install --no-cache
 capa cache clean
 capa install
 ```
+
+### 9. Wrap (shadow workspaces)
+
+Run an agent without writing provider dirs into the real repo:
+
+```bash
+capa wrap cursor          # Cursor GUI
+capa wrap claude          # Claude Code
+capa wrap codex
+capa wrap --prune         # clean stale ~/.capa/workspaces entries
+```
+
+Edit `capabilities.yaml` and run `capa install` from the **real** project path (mutating commands refuse wrap workspaces). The shadow workspace reinstalls automatically when capabilities change.
+
+### 10. Passthrough native writes
+
+One-off provider-native files without capa management:
+
+```bash
+capa add owner/repo@skill --passthrough --provider cursor
+capa add --rule --id ts-strict --inline "Always use strict TypeScript" --passthrough -p cursor
+capa install --passthrough -p cursor
+```
+
+Do **not** use `--tool … --passthrough` — tool aliases need the managed MCP proxy. Prefer managed mode (`capa add` without `--passthrough`) for anything that should be reproducible via `capabilities.lock`.
+
+### 11. Browse registries
+
+```bash
+capa registry list
+capa registry search "typescript"
+capa registry search skills-sh "research" --capability skills
+capa registry add anthropics/claude-plugins-official --type claude-marketplace
+capa add skills-sh:vercel-labs/skills/find-skills --install
+```
+
+Or open the Web UI → **Registries**.
 
 ---
 
@@ -528,7 +573,7 @@ skills:
 servers: []
 ```
 
-During `capa install`, the plugin manifest is fetched, its SKILL.md files are copied to each provider's skills folder, and its MCP servers are registered. The plugin contributes only the tools you declare in `tools:` and the skills you activate with `type: plugin`. Capa warns when a `type: plugin` skill id has no matching plugin manifest skill, and when a plugin server has no user-declared tool pointing at it.
+During `capa install`, the plugin manifest is fetched and **unpacked**: SKILL.md files are copied to each provider's skills folder, MCP servers are registered, and any rules / sub-agents / hooks from the plugin are merged into the same install pipeline. The plugin contributes only the tools you declare in `tools:` and the skills you activate with `type: plugin`. Capa warns when a `type: plugin` skill id has no matching plugin manifest skill, and when a plugin server has no user-declared tool pointing at it.
 
 ### Example 8: Optional Providers
 
@@ -571,3 +616,21 @@ capa install
 ```
 
 This pattern is ideal for shared `capabilities.yaml` files where different team members use different agents.
+
+### Example 9: Tool formatter
+
+Pipe MCP tool JSON through `jq` before the agent (or `capa sh`) sees it:
+
+```yaml
+tools:
+  - id: search
+    type: mcp
+    def:
+      server: "@brave"
+      tool: brave_web_search
+      formatter:
+        cmd: jq -r '.[] | [.title, .url] | @tsv'
+        timeout: 3000
+```
+
+Use `capa sh --raw brave search --query "…"` to skip the formatter. Do not use formatters that re-execute stdin (`eval`, `xargs sh -c`).


### PR DESCRIPTION
## Summary
- Rewrite the top-level README around the v2 surface: `capa wrap`, Web UI editor, activity traces, plugin unpack, registries (including Claude marketplaces), and passthrough mode.
- Update shipped `capabilities-manager` and `bootstrap` skills so agents get accurate commands, schema (`agentActivity`, local rules, plugin unpack), workflows, and troubleshooting for those features.

## Test plan
- [ ] Skim README on GitHub for rendering (badges, admonitions, architecture diagram, demo embed)
- [ ] Spot-check `skills/capabilities-manager/references/commands.md` against `capa wrap --help` / `capa add --help` / `capa registry --help`
- [ ] Confirm bootstrap guidance for `type: local` rules matches current schema