### PR TITLE
fix(wrap): never mutate the real project during shadow install

### DIFF
--- a/src/cli/commands/install-tasks/check-removed-skills.ts
+++ b/src/cli/commands/install-tasks/check-removed-skills.ts
@@ -5,6 +5,9 @@ import { cleanupRemovedSkills } from './helpers/cleanup-removed-skills';
 export function checkRemovedSkillsTask(): Task<InstallCtx> {
   return {
     title: 'Checking for removed skills',
+    // Wrap shares project identity with the real install — never delete
+    // managed skill/rule paths that may live outside the shadow workspace.
+    enabled: (ctx) => !ctx.isWrapInstall,
     task: async (ctx) => {
       const providers = ctx.capabilitiesToUse.providers ?? ctx.resolvedProviders;
       const stats = await cleanupRemovedSkills(

--- a/src/cli/commands/install-tasks/context.ts
+++ b/src/cli/commands/install-tasks/context.ts
@@ -27,6 +27,12 @@ export interface InstallCtx {
    * in-memory provider set or triggers server-side writes for that provider.
    */
   configureProviders: string[];
+  /**
+   * True when writing into a wrap shadow workspace under a different identity
+   * path. Install prune/cleanup must not mutate the real project: only paths
+   * under `projectPath` (the shadow) may be written or deleted.
+   */
+  isWrapInstall: boolean;
   lockBuilder: LockfileBuilder;
   configureResult?: Record<string, unknown>;
   mcpUrl: string;

--- a/src/cli/commands/install-tasks/context.ts
+++ b/src/cli/commands/install-tasks/context.ts
@@ -29,8 +29,8 @@ export interface InstallCtx {
   configureProviders: string[];
   /**
    * True when writing into a wrap shadow workspace under a different identity
-   * path. Install prune/cleanup must not mutate the real project: only paths
-   * under `projectPath` (the shadow) may be written or deleted.
+   * path. Wrap installs only materialize the wrap provider into the shadow;
+   * they never run orphan prune/cleanup against the shared project identity.
    */
   isWrapInstall: boolean;
   lockBuilder: LockfileBuilder;

--- a/src/cli/commands/install-tasks/helpers/__tests__/cleanup-removed-skills.test.ts
+++ b/src/cli/commands/install-tasks/helpers/__tests__/cleanup-removed-skills.test.ts
@@ -1,0 +1,88 @@
+import { describe, it, expect, beforeEach, afterEach } from 'bun:test';
+import { mkdtempSync, mkdirSync, writeFileSync, existsSync, rmSync } from 'fs';
+import { join } from 'path';
+import { tmpdir } from 'os';
+import { CapaDatabase } from '../../../../../db/database';
+import {
+  cleanupRemovedSkills,
+  isProviderSkillManagedPath,
+} from '../cleanup-removed-skills';
+
+describe('cleanupRemovedSkills', () => {
+  let tempDir: string;
+  let realProject: string;
+  let shadowProject: string;
+  let db: CapaDatabase;
+  const projectId = 'wrap-proj';
+
+  beforeEach(() => {
+    tempDir = mkdtempSync(join(tmpdir(), 'capa-cleanup-skills-'));
+    realProject = join(tempDir, 'real');
+    shadowProject = join(tempDir, 'shadow');
+    mkdirSync(realProject, { recursive: true });
+    mkdirSync(shadowProject, { recursive: true });
+    db = new CapaDatabase(join(tempDir, 'capa.db'));
+    db.upsertProject({ id: projectId, path: realProject });
+  });
+
+  afterEach(() => {
+    db.close();
+    rmSync(tempDir, { recursive: true, force: true });
+  });
+
+  it('isProviderSkillManagedPath matches only skill dirs under projectPath', () => {
+    const skillDir = join(realProject, '.cursor', 'skills', 'hello');
+    expect(isProviderSkillManagedPath(realProject, skillDir, ['cursor'])).toBe(true);
+    expect(
+      isProviderSkillManagedPath(realProject, join(realProject, '.cursor', 'rules', 'r.mdc'), [
+        'cursor',
+      ]),
+    ).toBe(false);
+    expect(isProviderSkillManagedPath(shadowProject, skillDir, ['claude-code'])).toBe(false);
+  });
+
+  it('does not delete real-project cursor rules during a wrap shadow cleanup', async () => {
+    const rulePath = join(realProject, '.cursor', 'rules', 'style-guide.mdc');
+    mkdirSync(join(realProject, '.cursor', 'rules'), { recursive: true });
+    writeFileSync(rulePath, '---\ndescription: style\n---\nBe consistent.\n');
+    db.addManagedFile(projectId, rulePath);
+
+    const skillPath = join(realProject, '.cursor', 'skills', 'kept-skill');
+    mkdirSync(skillPath, { recursive: true });
+    writeFileSync(join(skillPath, 'SKILL.md'), '# kept\n');
+    db.addManagedFile(projectId, skillPath);
+
+    const stats = await cleanupRemovedSkills(
+      shadowProject,
+      projectId,
+      [{ id: 'kept-skill', def: { path: './skills/kept-skill' } } as any],
+      ['claude-code'],
+      db,
+    );
+
+    expect(stats.removed).toBe(0);
+    expect(existsSync(rulePath)).toBe(true);
+    expect(existsSync(skillPath)).toBe(true);
+    expect(db.getManagedFiles(projectId)).toContain(rulePath);
+    expect(db.getManagedFiles(projectId)).toContain(skillPath);
+  });
+
+  it('still removes orphan skill dirs for the active provider under projectPath', async () => {
+    const orphan = join(shadowProject, '.claude', 'skills', 'gone-skill');
+    mkdirSync(orphan, { recursive: true });
+    writeFileSync(join(orphan, 'SKILL.md'), '# gone\n');
+    db.addManagedFile(projectId, orphan);
+
+    const stats = await cleanupRemovedSkills(
+      shadowProject,
+      projectId,
+      [],
+      ['claude-code'],
+      db,
+    );
+
+    expect(stats.removed).toBe(1);
+    expect(existsSync(orphan)).toBe(false);
+    expect(db.getManagedFiles(projectId)).not.toContain(orphan);
+  });
+});

--- a/src/cli/commands/install-tasks/helpers/cleanup-removed-skills.ts
+++ b/src/cli/commands/install-tasks/helpers/cleanup-removed-skills.ts
@@ -1,8 +1,37 @@
 import { existsSync, rmSync } from 'fs';
-import { basename } from 'path';
+import { basename, relative, resolve, sep } from 'path';
 import type { Skill } from '../../../../types/capabilities';
 import type { CapaDatabase } from '../../../../db/database';
-import { isProviderRulesManagedPath } from '../../../utils/rules-installer';
+import { getProvider } from '../../../../shared/providers';
+import { isPathInside } from '../../../../shared/paths';
+
+/**
+ * True when `filePath` is a skill install directory for one of `providers`
+ * under `projectPath` (e.g. `<project>/.cursor/skills/<id>`).
+ *
+ * Restricting cleanup to these paths avoids:
+ * - deleting rule files that share `managed_files` (basename `foo.mdc` ≠ skill id)
+ * - deleting another provider's skills during a scoped install (e.g. wrap)
+ * - deleting the real project's managed paths when `projectPath` is a wrap shadow
+ */
+export function isProviderSkillManagedPath(
+  projectPath: string,
+  filePath: string,
+  providers: string[],
+): boolean {
+  const resolvedFile = resolve(filePath);
+  for (const pid of providers) {
+    const provider = getProvider(pid);
+    if (!provider?.skillsDir) continue;
+    const skillsDir = resolve(projectPath, provider.skillsDir);
+    if (!isPathInside(resolvedFile, skillsDir)) continue;
+    const rel = relative(skillsDir, resolvedFile);
+    // Managed skill entries are the skill directory itself (one level under skillsDir).
+    if (!rel || rel === '' || rel.split(sep).length !== 1) continue;
+    return true;
+  }
+  return false;
+}
 
 // Clean up skill directories for skills that have been removed from capabilities.
 export async function cleanupRemovedSkills(
@@ -21,8 +50,9 @@ export async function cleanupRemovedSkills(
   const dirsToRemove: string[] = [];
 
   for (const managedPath of managedFiles) {
-    // Rule files share the managed-files table but are pruned in step 3.5
-    if (isProviderRulesManagedPath(projectPath, managedPath, clients)) {
+    // Only touch skill dirs for providers in this install under projectPath.
+    // Rule files and other-provider / real-project paths are left alone.
+    if (!isProviderSkillManagedPath(projectPath, managedPath, clients)) {
       continue;
     }
 

--- a/src/cli/commands/install-tasks/install-system-activity-hooks.ts
+++ b/src/cli/commands/install-tasks/install-system-activity-hooks.ts
@@ -22,6 +22,7 @@ export function installSystemActivityHooksTask(): Task<InstallCtx> {
 					capabilities: ctx.capabilitiesToUse,
 					providers,
 					db: ctx.db,
+					skipPrune: ctx.isWrapInstall,
 				});
 				for (const w of result.warnings) ctx.warnings.push(w);
 				if (!result.enabled) {

--- a/src/cli/commands/install-tasks/prune-orphan-hooks.ts
+++ b/src/cli/commands/install-tasks/prune-orphan-hooks.ts
@@ -12,6 +12,10 @@ import type { InstallCtx } from './context';
  * `capabilities.hooks` (plus capa system activity hooks when enabled)
  * or whose provider is no longer in the active set.
  *
+ * On wrap installs (`ctx.isWrapInstall`), only the providers being installed
+ * into the shadow workspace are pruned — other providers' managed hooks on
+ * the shared project identity (e.g. cursor after `capa wrap claude`) are kept.
+ *
  * Runs *before* `install-hooks` so installs always converge on the
  * requested state — a hook moved from `cursor` to `claude-code` results
  * in a removal on cursor and an install on claude-code in the same run.
@@ -37,6 +41,9 @@ export function pruneOrphanHooksTask(): Task<InstallCtx> {
           desiredHooks,
           providers,
           ctx.db,
+          ctx.isWrapInstall
+            ? { onlyDesiredProviders: true, mutateRoot: ctx.projectPath }
+            : {},
         );
         for (const w of warnings) ctx.warnings.push(w);
         if (removed > 0) {

--- a/src/cli/commands/install-tasks/prune-orphan-hooks.ts
+++ b/src/cli/commands/install-tasks/prune-orphan-hooks.ts
@@ -12,9 +12,9 @@ import type { InstallCtx } from './context';
  * `capabilities.hooks` (plus capa system activity hooks when enabled)
  * or whose provider is no longer in the active set.
  *
- * On wrap installs (`ctx.isWrapInstall`), only the providers being installed
- * into the shadow workspace are pruned — other providers' managed hooks on
- * the shared project identity (e.g. cursor after `capa wrap claude`) are kept.
+ * Skipped entirely on wrap shadow installs — wrap must only *add* provider
+ * config under the shadow workspace and must never prune shared project
+ * identity state (e.g. Cursor hooks on the real project).
  *
  * Runs *before* `install-hooks` so installs always converge on the
  * requested state — a hook moved from `cursor` to `claude-code` results
@@ -23,7 +23,9 @@ import type { InstallCtx } from './context';
 export function pruneOrphanHooksTask(): Task<InstallCtx> {
   return {
     title: 'Pruning orphan hooks',
-    enabled: (ctx) => (ctx.capabilitiesToUse.providers ?? ctx.resolvedProviders).length > 0,
+    enabled: (ctx) =>
+      !ctx.isWrapInstall &&
+      (ctx.capabilitiesToUse.providers ?? ctx.resolvedProviders).length > 0,
     task: async (ctx) => {
       const providers = ctx.capabilitiesToUse.providers ?? ctx.resolvedProviders;
       const rawHooks = ctx.capabilitiesToUse.hooks ?? [];
@@ -41,9 +43,6 @@ export function pruneOrphanHooksTask(): Task<InstallCtx> {
           desiredHooks,
           providers,
           ctx.db,
-          ctx.isWrapInstall
-            ? { onlyDesiredProviders: true, mutateRoot: ctx.projectPath }
-            : {},
         );
         for (const w of warnings) ctx.warnings.push(w);
         if (removed > 0) {

--- a/src/cli/commands/install-tasks/prune-orphan-rules.ts
+++ b/src/cli/commands/install-tasks/prune-orphan-rules.ts
@@ -5,7 +5,9 @@ import type { InstallCtx } from './context';
 export function pruneOrphanRulesTask(): Task<InstallCtx> {
   return {
     title: 'Pruning orphan rules',
-    enabled: (ctx) => (ctx.capabilitiesToUse.providers ?? ctx.resolvedProviders).length > 0,
+    enabled: (ctx) =>
+      !ctx.isWrapInstall &&
+      (ctx.capabilitiesToUse.providers ?? ctx.resolvedProviders).length > 0,
     task: async (ctx) => {
       const providers = ctx.capabilitiesToUse.providers ?? ctx.resolvedProviders;
       const currentRules = ctx.capabilitiesToUse.rules ?? [];

--- a/src/cli/commands/install.ts
+++ b/src/cli/commands/install.ts
@@ -164,6 +164,7 @@ async function installCommandBody(opts: {
 
   let resolvedProviders: string[];
   let configureProviders: string[];
+  let isWrapInstall = false;
   try {
     // Always store the real project path for MCP tool cwd / identity.
     db.upsertProject({ id: projectId, path: idPath });
@@ -185,7 +186,7 @@ async function installCommandBody(opts: {
     // Shadow wrap: local file writes use `resolvedProviders` (e.g. claude-code),
     // but POST /configure must keep the identity project's authored providers
     // so the real repo / live session stay on cursor (or whatever the file says).
-    const isWrapInstall =
+    isWrapInstall =
       !!identityPath &&
       (process.platform === 'win32'
         ? resolve(identityPath).toLowerCase() !== resolve(projectPath).toLowerCase()
@@ -224,6 +225,7 @@ async function installCommandBody(opts: {
     serverStatus: { running: true, url: serverStatus.url },
     resolvedProviders,
     configureProviders,
+    isWrapInstall,
     lockBuilder,
     mcpUrl,
     resolvedRepos: new Map(),

--- a/src/cli/utils/__tests__/hooks-installer.test.ts
+++ b/src/cli/utils/__tests__/hooks-installer.test.ts
@@ -548,4 +548,49 @@ describe('hooks-installer — pruneOrphanHooks / cleanHooks', () => {
     expect(db.getManagedHooks(projectId)).toHaveLength(1);
     expect(readFileSync(realSettings, 'utf-8')).toBe(before);
   });
+
+  it('preserves shared materialized scripts when only one provider row is pruned (wrap)', async () => {
+    // Remote/source hooks materialize once under ~/.capa/hooks/<projectId>/<hookId>
+    // and both provider rows reference that same scriptPath.
+    await installHooks({
+      projectPath,
+      projectId,
+      capabilitiesFilePath: join(projectPath, 'capabilities.yaml'),
+      hooks: [
+        {
+          id: 'shared-remote',
+          on: 'beforeShell',
+          type: 'command',
+          source: { type: 'remote', url: 'https://example.com/hook.sh' },
+        },
+      ],
+      providers: ['cursor', 'claude-code'],
+      db,
+      authFetch: makeAuthFetch(),
+      getRepoSnapshot: stubGetRepoSnapshot,
+    });
+
+    const rows = db.getManagedHooks(projectId);
+    expect(rows).toHaveLength(2);
+    const scriptPath = rows[0].scriptPath;
+    expect(scriptPath).toBeTruthy();
+    expect(rows.every((r) => r.scriptPath === scriptPath)).toBe(true);
+    expect(existsSync(scriptPath!)).toBe(true);
+
+    // Scoped prune: drop claude's orphaned row, keep cursor's row.
+    const result = pruneOrphanHooks(
+      projectPath,
+      projectId,
+      [],
+      ['claude-code'],
+      db,
+      { onlyDesiredProviders: true },
+    );
+    expect(result.removed).toBe(1);
+    const remaining = db.getManagedHooks(projectId);
+    expect(remaining).toHaveLength(1);
+    expect(remaining[0].providerId).toBe('cursor');
+    expect(remaining[0].scriptPath).toBe(scriptPath);
+    expect(existsSync(scriptPath!)).toBe(true);
+  });
 });

--- a/src/cli/utils/__tests__/hooks-installer.test.ts
+++ b/src/cli/utils/__tests__/hooks-installer.test.ts
@@ -462,4 +462,90 @@ describe('hooks-installer — pruneOrphanHooks / cleanHooks', () => {
     ) as any;
     expect(settings.hooks).toBeUndefined();
   });
+
+  it('onlyDesiredProviders leaves other providers managed hooks untouched (wrap)', async () => {
+    // Simulate: capa install for cursor, then wrap install for claude-code
+    // sharing the same projectId — must not strip cursor hooks from the real project.
+    await installHooks({
+      projectPath,
+      projectId,
+      capabilitiesFilePath: join(projectPath, 'capabilities.yaml'),
+      hooks: [{ id: 'keep-me', on: 'sessionStart', command: 'echo cursor' }],
+      providers: ['cursor'],
+      db,
+      authFetch: makeAuthFetch(),
+      getRepoSnapshot: stubGetRepoSnapshot,
+    });
+    expect(db.getManagedHooks(projectId).some((r) => r.providerId === 'cursor')).toBe(true);
+
+    const result = pruneOrphanHooks(
+      join(tempDir, 'shadow-workspace'),
+      projectId,
+      [{ id: 'keep-me', on: 'sessionStart', command: 'echo cursor' }],
+      ['claude-code'],
+      db,
+      { onlyDesiredProviders: true },
+    );
+    expect(result.removed).toBe(0);
+    const rows = db.getManagedHooks(projectId);
+    expect(rows).toHaveLength(1);
+    expect(rows[0].providerId).toBe('cursor');
+    expect(rows[0].hookId).toBe('keep-me');
+
+    const hooksJson = JSON.parse(
+      readFileSync(join(projectPath, '.cursor', 'hooks.json'), 'utf-8'),
+    ) as { hooks?: Record<string, unknown[]> };
+    expect(hooksJson.hooks?.sessionStart?.length).toBeGreaterThan(0);
+  });
+
+  it('without onlyDesiredProviders, other providers are still pruned (normal install)', async () => {
+    await installHooks({
+      projectPath,
+      projectId,
+      capabilitiesFilePath: join(projectPath, 'capabilities.yaml'),
+      hooks: [{ id: 'drop-me', on: 'sessionStart', command: 'echo cursor' }],
+      providers: ['cursor'],
+      db,
+      authFetch: makeAuthFetch(),
+      getRepoSnapshot: stubGetRepoSnapshot,
+    });
+
+    const result = pruneOrphanHooks(
+      projectPath,
+      projectId,
+      [{ id: 'drop-me', on: 'sessionStart', command: 'echo cursor' }],
+      ['claude-code'],
+      db,
+    );
+    expect(result.removed).toBe(1);
+    expect(db.getManagedHooks(projectId)).toEqual([]);
+  });
+
+  it('mutateRoot refuses to touch hook configs outside the shadow workspace', async () => {
+    await installHooks({
+      projectPath,
+      projectId,
+      capabilitiesFilePath: join(projectPath, 'capabilities.yaml'),
+      hooks: [{ id: 'real-claude', on: 'beforeShell', command: 'echo real' }],
+      providers: ['claude-code'],
+      db,
+      authFetch: makeAuthFetch(),
+      getRepoSnapshot: stubGetRepoSnapshot,
+    });
+    const realSettings = join(projectPath, '.claude', 'settings.json');
+    const before = readFileSync(realSettings, 'utf-8');
+
+    const shadow = join(tempDir, 'shadow-workspace');
+    const result = pruneOrphanHooks(
+      shadow,
+      projectId,
+      [],
+      ['claude-code'],
+      db,
+      { onlyDesiredProviders: true, mutateRoot: shadow },
+    );
+    expect(result.removed).toBe(0);
+    expect(db.getManagedHooks(projectId)).toHaveLength(1);
+    expect(readFileSync(realSettings, 'utf-8')).toBe(before);
+  });
 });

--- a/src/cli/utils/hooks-installer.ts
+++ b/src/cli/utils/hooks-installer.ts
@@ -10,5 +10,6 @@ export {
   type InstallHooksOptions,
   type InstallHooksResult,
   type PruneOrphanHooksResult,
+  type PruneOrphanHooksOptions,
   type SnapshotResolver,
 } from './hooks';

--- a/src/cli/utils/hooks/config-apply.ts
+++ b/src/cli/utils/hooks/config-apply.ts
@@ -69,10 +69,15 @@ export function applyHookEntryToConfig(args: ApplyEntryArgs): { configPath: stri
  * Errors propagate to the caller — pruneOrphanHooks/cleanHooks catch them
  * and surface as warnings so a malformed config never aborts the install.
  */
-export function removeManagedHookEntry(projectPath: string, row: ManagedHookRow): void {
+export function removeManagedHookEntry(
+  projectPath: string,
+  row: ManagedHookRow,
+  options: { preserveScript?: boolean } = {},
+): void {
+  const preserveScript = !!options.preserveScript;
   const provider = getProvider(row.providerId);
   if (!provider?.hooks) {
-    if (row.scriptPath && existsSync(row.scriptPath)) {
+    if (!preserveScript && row.scriptPath && existsSync(row.scriptPath)) {
       try { unlinkSync(row.scriptPath); } catch {}
     }
     return;
@@ -89,7 +94,7 @@ export function removeManagedHookEntry(projectPath: string, row: ManagedHookRow)
   }
 
   if (!existsSync(configPath)) {
-    if (row.scriptPath && existsSync(row.scriptPath)) {
+    if (!preserveScript && row.scriptPath && existsSync(row.scriptPath)) {
       try { unlinkSync(row.scriptPath); } catch {}
     }
     return;
@@ -136,7 +141,7 @@ export function removeManagedHookEntry(projectPath: string, row: ManagedHookRow)
     writeJsonFile(configPath, config);
   }
 
-  if (row.scriptPath && existsSync(row.scriptPath)) {
+  if (!preserveScript && row.scriptPath && existsSync(row.scriptPath)) {
     try { unlinkSync(row.scriptPath); } catch {}
   }
 }

--- a/src/cli/utils/hooks/index.ts
+++ b/src/cli/utils/hooks/index.ts
@@ -16,6 +16,8 @@
  *     hook combination is no longer requested by the current capabilities
  *     file. Stale config entries are removed surgically using the stored
  *     locator; the row is dropped from the DB.
+ *   • With `onlyDesiredProviders: true` (wrap shadow installs), rows for
+ *     providers outside the current install set are left untouched.
  *
  * `cleanHooks`:
  *   • Used by `capa clean` to remove every capa-installed hook entry for
@@ -33,6 +35,7 @@ export {
   pruneOrphanHooks,
   cleanHooks,
   type PruneOrphanHooksResult,
+  type PruneOrphanHooksOptions,
 } from './prune';
 
 export { resolveProviderEventName as _resolveProviderEventName } from './provider-map';

--- a/src/cli/utils/hooks/prune.ts
+++ b/src/cli/utils/hooks/prune.ts
@@ -1,11 +1,33 @@
 import type { CapaDatabase } from '../../../db/database';
 import type { Hook } from '../../../types/hooks';
+import { isPathInside } from '../../../shared/paths';
 import { scopeHookForProvider } from './provider-map';
 import { removeManagedHookEntry } from './config-apply';
 
 export interface PruneOrphanHooksResult {
   removed: number;
   warnings: string[];
+}
+
+export interface PruneOrphanHooksOptions {
+  /**
+   * When true, only prune within `desiredProviders`. Managed hooks for other
+   * providers are left alone (DB + on-disk).
+   *
+   * Used by `capa wrap` shadow installs: they share the real project's
+   * `projectId` / `managed_hooks` rows but install for a single provider into
+   * a shadow workspace. Without this, cursor hooks would be treated as orphans
+   * and removed via their stored absolute `configPath` in the real project.
+   */
+  onlyDesiredProviders?: boolean;
+  /**
+   * When set, never mutate (or drop DB rows for) managed hooks whose
+   * `configPath` lies outside this directory.
+   *
+   * Wrap installs pass the shadow workspace path so capa wrap cannot touch
+   * the real project's hook configs — even for the same provider id.
+   */
+  mutateRoot?: string;
 }
 
 /**
@@ -18,6 +40,7 @@ export function pruneOrphanHooks(
   desiredHooks: Hook[],
   desiredProviders: string[],
   db: CapaDatabase,
+  options: PruneOrphanHooksOptions = {},
 ): PruneOrphanHooksResult {
   const warnings: string[] = [];
   let removed = 0;
@@ -36,6 +59,15 @@ export function pruneOrphanHooks(
   for (const row of existing) {
     const desired = desiredByProvider.get(row.providerId);
     if (desired && desired.has(row.hookId)) continue;
+    // Wrap / scoped installs: other providers' rows are still desired on the
+    // identity project — do not treat them as orphans.
+    if (options.onlyDesiredProviders && !desiredByProvider.has(row.providerId)) {
+      continue;
+    }
+    // Hard invariant for wrap: never write outside the shadow workspace.
+    if (options.mutateRoot && !isPathInside(row.configPath, options.mutateRoot)) {
+      continue;
+    }
 
     try {
       removeManagedHookEntry(projectPath, row);

--- a/src/cli/utils/hooks/prune.ts
+++ b/src/cli/utils/hooks/prune.ts
@@ -56,21 +56,39 @@ export function pruneOrphanHooks(
   }
 
   const existing = db.getManagedHooks(projectId);
+  const toRemove: typeof existing = [];
+  const toKeep: typeof existing = [];
   for (const row of existing) {
     const desired = desiredByProvider.get(row.providerId);
-    if (desired && desired.has(row.hookId)) continue;
+    if (desired && desired.has(row.hookId)) {
+      toKeep.push(row);
+      continue;
+    }
     // Wrap / scoped installs: other providers' rows are still desired on the
     // identity project — do not treat them as orphans.
     if (options.onlyDesiredProviders && !desiredByProvider.has(row.providerId)) {
+      toKeep.push(row);
       continue;
     }
     // Hard invariant for wrap: never write outside the shadow workspace.
     if (options.mutateRoot && !isPathInside(row.configPath, options.mutateRoot)) {
+      toKeep.push(row);
       continue;
     }
+    toRemove.push(row);
+  }
 
+  // Materialized scripts live at ~/.capa/hooks/<projectId>/<hookId> and are
+  // shared across providers for the same hookId. Only unlink when no kept row
+  // still references that path.
+  const retainedScripts = new Set(
+    toKeep.map((r) => r.scriptPath).filter((p): p is string => !!p),
+  );
+
+  for (const row of toRemove) {
     try {
-      removeManagedHookEntry(projectPath, row);
+      const preserveScript = !!(row.scriptPath && retainedScripts.has(row.scriptPath));
+      removeManagedHookEntry(projectPath, row, { preserveScript });
       removed++;
       db.removeManagedHook(row.projectId, row.providerId, row.hookId);
     } catch (err: unknown) {

--- a/src/cli/utils/wrap/marker.ts
+++ b/src/cli/utils/wrap/marker.ts
@@ -1,11 +1,12 @@
 import { existsSync } from 'fs';
-import { dirname, join, relative, resolve, sep } from 'path';
+import { dirname, join, resolve } from 'path';
 import {
   WORKSPACE_MARKER,
   getWorkspacesDir,
   isUnderWrapWorkspacesDir,
   type WorkspaceMarker,
 } from '../../../shared/workspaces/paths';
+import { isPathInside } from '../../../shared/paths';
 
 async function tryReadMarker(markerPath: string): Promise<WorkspaceMarker | null> {
   if (!existsSync(markerPath)) return null;
@@ -16,11 +17,6 @@ async function tryReadMarker(markerPath: string): Promise<WorkspaceMarker | null
   } catch {
     return null;
   }
-}
-
-function isPathInside(child: string, parent: string): boolean {
-  const rel = relative(resolve(parent), resolve(child));
-  return rel === '' || (!rel.startsWith('..') && !rel.startsWith(`..${sep}`));
 }
 
 /**

--- a/src/cli/utils/wrap/watch-project.ts
+++ b/src/cli/utils/wrap/watch-project.ts
@@ -12,7 +12,10 @@ import {
 import { applyWrapShadowExtras } from './shadow-extras';
 import { installCommand } from '../../commands/install';
 import { parseCapabilitiesFile } from '../../../shared/capabilities';
-import { collectWrapExclusionProviderIds } from '../../../shared/providers';
+import {
+  collectWrapExclusionProviderIds,
+  detectProviderIdsFromProjectTree,
+} from '../../../shared/providers';
 import { isVerbose } from '../../ui';
 
 /** Coalesce burst writes only — keep sync as close to real-time as possible. */
@@ -228,7 +231,14 @@ export function startWrapWatchers(opts: WatchOpts): WrapWatchers {
       const capsPath = resolve(opts.capabilitiesPath);
       const format = capsPath.endsWith('.json') ? 'json' : 'yaml';
       const capabilities = await parseCapabilitiesFile(capsPath, format);
-      providerIds = collectWrapExclusionProviderIds(opts.providerId, capabilities.providers);
+      // Re-detect on-disk provider dirs + keep any extras already in the
+      // session exclusion set (e.g. DB-stored providers from prepareWorkspace).
+      const detected = detectProviderIdsFromProjectTree(realRoot);
+      providerIds = collectWrapExclusionProviderIds(
+        opts.providerId,
+        capabilities.providers,
+        [...opts.exclusionProviderIds, ...detected],
+      );
       excluded = getWrapExclusionSet(providerIds);
     } catch {
       // Keep last good exclusion set.

--- a/src/cli/utils/wrap/workspace.ts
+++ b/src/cli/utils/wrap/workspace.ts
@@ -17,7 +17,10 @@ import {
   type WorkspaceMarker,
 } from '../../../shared/workspaces/paths';
 import { parseCapabilitiesFile } from '../../../shared/capabilities';
-import { collectWrapExclusionProviderIds } from '../../../shared/providers';
+import {
+  collectWrapExclusionProviderIds,
+  detectProviderIdsFromProjectTree,
+} from '../../../shared/providers';
 import { buildSymlinkWorkspace, syncTopLevelSymlinks } from './symlink-workspace';
 import { applyWrapShadowExtras } from './shadow-extras';
 import { installCommand } from '../../commands/install';
@@ -197,6 +200,31 @@ async function dbHasProject(realProjectPath: string): Promise<boolean> {
   }
 }
 
+async function loadWrapExclusionProviderIds(
+  realProjectPath: string,
+  wrapProviderId: string,
+  capabilitiesProviders?: string[] | null,
+): Promise<string[]> {
+  const extras: string[] = detectProviderIdsFromProjectTree(realProjectPath);
+  try {
+    const settings = await loadSettings();
+    const db = new CapaDatabase(getDatabasePath(settings));
+    try {
+      const id = generateProjectId(realProjectPath);
+      extras.push(...db.getProjectProviders(id));
+    } finally {
+      db.close();
+    }
+  } catch {
+    // DB unavailable — on-disk detection still covers existing provider dirs.
+  }
+  return collectWrapExclusionProviderIds(
+    wrapProviderId,
+    capabilitiesProviders,
+    extras,
+  );
+}
+
 function cacheLooksLikeWrap(cachePath: string): boolean {
   // Marker lives on the cache root (above the nested working dir).
   return existsSync(join(cachePath, WORKSPACE_MARKER));
@@ -260,7 +288,8 @@ export async function prepareWorkspace(
   const workspacePath = join(cachePath, workName);
 
   const capabilities = await parseCapabilitiesFile(caps.path, caps.format);
-  const exclusionProviderIds = collectWrapExclusionProviderIds(
+  const exclusionProviderIds = await loadWrapExclusionProviderIds(
+    real,
     provider.id,
     capabilities.providers,
   );

--- a/src/cli/utils/wrap/workspace.ts
+++ b/src/cli/utils/wrap/workspace.ts
@@ -208,6 +208,9 @@ async function runWrapInstall(
   providerId: string,
   exclusionProviderIds: Iterable<string>,
 ): Promise<void> {
+  // Invariant: wrap install may only write under `workspacePath`. The real
+  // project is identity-only (projectId / credentials) — never a mutate target
+  // for hooks, rules, skills, or MCP config.
   await installCommand({
     projectPath: workspacePath,
     identityPath: realProjectPath,

--- a/src/shared/agent-activity-sync.ts
+++ b/src/shared/agent-activity-sync.ts
@@ -32,6 +32,12 @@ export async function syncSystemActivityHooks(opts: {
 	db: CapaDatabase;
 	/** Suppress CLI-style install logs (server / API callers). */
 	quiet?: boolean;
+	/**
+	 * When true, skip orphan prune and only install/update activity hooks for
+	 * `providers`. Used by wrap shadow installs so shared project identity
+	 * (e.g. Cursor hooks) is never cleaned up.
+	 */
+	skipPrune?: boolean;
 }): Promise<SyncSystemActivityHooksResult> {
 	const warnings: string[] = [];
 	const enabled = isAgentActivityEnabled(opts.capabilities.options);
@@ -43,20 +49,24 @@ export async function syncSystemActivityHooks(opts: {
 		warnings.push(`${prefix}${issue.message} (skipped from activity sync)`);
 	}
 
-	const systemHooks = enabled
-		? // Ids only for prune desired-set (command text is per-provider below).
-			buildSystemActivityHooks(opts.projectId)
-		: [];
-	const desiredHooks = [...userHooks, ...systemHooks];
+	let removed = 0;
+	if (!opts.skipPrune) {
+		const systemHooks = enabled
+			? // Ids only for prune desired-set (command text is per-provider below).
+				buildSystemActivityHooks(opts.projectId)
+			: [];
+		const desiredHooks = [...userHooks, ...systemHooks];
 
-	const prune = pruneOrphanHooks(
-		opts.projectPath,
-		opts.projectId,
-		desiredHooks,
-		opts.providers,
-		opts.db,
-	);
-	warnings.push(...prune.warnings);
+		const prune = pruneOrphanHooks(
+			opts.projectPath,
+			opts.projectId,
+			desiredHooks,
+			opts.providers,
+			opts.db,
+		);
+		warnings.push(...prune.warnings);
+		removed = prune.removed;
+	}
 
 	let installed = 0;
 	if (enabled && opts.providers.length > 0) {
@@ -84,7 +94,7 @@ export async function syncSystemActivityHooks(opts: {
 	return {
 		enabled,
 		installed,
-		removed: prune.removed,
+		removed,
 		warnings,
 	};
 }

--- a/src/shared/paths.ts
+++ b/src/shared/paths.ts
@@ -1,5 +1,5 @@
 import { createHash } from "crypto";
-import { basename, resolve } from "path";
+import { basename, relative, resolve, sep } from "path";
 
 /**
  * Generate a project ID from a directory path.
@@ -23,6 +23,17 @@ export function generateProjectId(projectPath: string): string {
 		.replace(/^-|-$/g, "");
 
 	return `${sanitizedName}-${hash}`;
+}
+
+/**
+ * True when `child` is `parent` or a path under it.
+ * Uses path.relative so Windows drive-letter case is handled.
+ */
+export function isPathInside(child: string, parent: string): boolean {
+	const rel = relative(resolve(parent), resolve(child));
+	return (
+		rel === "" || (!rel.startsWith("..") && !rel.startsWith(`..${sep}`))
+	);
 }
 
 /**

--- a/src/shared/providers/__tests__/wrap.test.ts
+++ b/src/shared/providers/__tests__/wrap.test.ts
@@ -1,9 +1,13 @@
 import { describe, it, expect } from 'bun:test';
+import { mkdtempSync, mkdirSync, rmSync } from 'fs';
+import { join } from 'path';
+import { tmpdir } from 'os';
 import {
   getWrappableProvider,
   getWrappableProviders,
   getProviderOwnedTopLevelNames,
   collectWrapExclusionProviderIds,
+  detectProviderIdsFromProjectTree,
   resolveWrapTarget,
   formatWrappableProviderList,
 } from '../index';
@@ -101,6 +105,23 @@ describe('wrap provider helpers', () => {
       'cursor',
     ]);
     expect(collectWrapExclusionProviderIds('cursor', undefined)).toEqual(['cursor']);
+  });
+
+  it('collectWrapExclusionProviderIds merges extraProviderIds (DB / on-disk)', () => {
+    expect(
+      collectWrapExclusionProviderIds('claude-code', undefined, ['cursor']).sort(),
+    ).toEqual(['claude-code', 'cursor']);
+  });
+
+  it('detectProviderIdsFromProjectTree finds cursor when .cursor exists', () => {
+    const dir = mkdtempSync(join(tmpdir(), 'capa-detect-prov-'));
+    try {
+      mkdirSync(join(dir, '.cursor'));
+      expect(detectProviderIdsFromProjectTree(dir)).toContain('cursor');
+      expect(detectProviderIdsFromProjectTree(dir)).not.toContain('claude-code');
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
   });
 
   it('getProviderOwnedTopLevelNames is scoped to the given providers', () => {

--- a/src/shared/providers/index.ts
+++ b/src/shared/providers/index.ts
@@ -1,3 +1,5 @@
+import { readdirSync } from "fs";
+import { resolve } from "path";
 import type {
 	ProviderIntegration,
 	WrapLaunchConfig,
@@ -194,22 +196,59 @@ export function resolveProviderId(raw: string): string | undefined {
 
 /**
  * Provider ids whose owned paths wrap should shadow (not symlink):
- * the launched wrap provider plus every entry in `capabilities.providers`.
+ * the launched wrap provider, every entry in `capabilities.providers`,
+ * and any extra ids (e.g. DB-stored install providers, providers detected
+ * from existing project dirs like `.cursor`).
  */
 export function collectWrapExclusionProviderIds(
 	wrapProviderId: string,
 	capabilitiesProviders?: string[] | null,
+	extraProviderIds?: string[] | null,
 ): string[] {
 	const ids = new Set<string>();
 	const wrapId =
 		resolveProviderId(wrapProviderId) ?? wrapProviderId.toLowerCase();
 	ids.add(wrapId);
-	for (const raw of capabilitiesProviders ?? []) {
+	for (const raw of [...(capabilitiesProviders ?? []), ...(extraProviderIds ?? [])]) {
 		if (typeof raw !== "string") continue;
 		const id = resolveProviderId(raw);
 		if (id) ids.add(id);
 	}
 	return [...ids];
+}
+
+/**
+ * Providers that already own a top-level path present in `projectPath`
+ * (e.g. `.cursor` → cursor). Used so wrap never junctions another agent's
+ * config tree into the shadow workspace just because `capabilities.providers`
+ * was left empty after an interactive install.
+ */
+export function detectProviderIdsFromProjectTree(projectPath: string): string[] {
+	const root = resolve(projectPath);
+	let entries: string[];
+	try {
+		entries = readdirSync(root);
+	} catch {
+		return [];
+	}
+	const present = new Set(
+		process.platform === "win32"
+			? entries.map((e) => e.toLowerCase())
+			: entries,
+	);
+	const found = new Set<string>();
+	for (const p of getAllProviders()) {
+		const owned = new Set<string>();
+		addProviderOwnedTopLevelNames(p, owned);
+		for (const name of owned) {
+			const key = process.platform === "win32" ? name.toLowerCase() : name;
+			if (present.has(key)) {
+				found.add(p.id);
+				break;
+			}
+		}
+	}
+	return [...found];
 }
 
 /**


### PR DESCRIPTION
## Summary
- Cold `capa wrap` install shared the real project identity, so orphan hook/rule cleanup deleted Cursor hooks and rules in the original folder via absolute `managed_hooks` / `managed_files` paths.
- Scope wrap prune to the install provider set and refuse to mutate any managed hook `configPath` outside the shadow workspace (`mutateRoot`).
- Restrict skill cleanup to skill dirs under the shadow `projectPath` so real-project rules/skills are never treated as orphans.

## Test plan
- [x] `capa install` for cursor (hooks + rules present)
- [x] Delete wrap cache for the project (or use a fresh project) so the next wrap is cold
- [x] `capa wrap claude` and confirm real `.cursor/hooks.json` and `.cursor/rules` are unchanged
- [x] Confirm shadow workspace still gets Claude hooks/rules installed
- [x] Warm `capa wrap claude` still reuses the workspace without touching the real project
- [x] `bun test src/cli/utils/__tests__/hooks-installer.test.ts src/cli/commands/install-tasks/helpers/__tests__/cleanup-removed-skills.test.ts`
