### PR TITLE
fix: isolate plugin resolve failures

### DIFF
--- a/src/cli/commands/__tests__/plugin-resolve-isolate.test.ts
+++ b/src/cli/commands/__tests__/plugin-resolve-isolate.test.ts
@@ -1,0 +1,198 @@
+import { describe, expect, it, beforeEach, afterEach } from 'bun:test';
+import {
+  mkdtempSync,
+  mkdirSync,
+  writeFileSync,
+  rmSync,
+  existsSync,
+} from 'fs';
+import { join } from 'path';
+import { tmpdir } from 'os';
+import { Database } from 'bun:sqlite';
+import { CapaDatabase } from '../../../db/database';
+import { initSchema } from '../../../db/schema';
+import { LockfileBuilder } from '../../../shared/lockfile';
+import { resolvePlugins } from '../plugin-install';
+import type { Capabilities } from '../../../types/capabilities';
+
+function writeMinimalClaudePlugin(root: string, name = 'good-plugin'): void {
+  mkdirSync(join(root, '.claude-plugin'), { recursive: true });
+  writeFileSync(
+    join(root, '.claude-plugin', 'plugin.json'),
+    JSON.stringify({ name, version: '1.0.0' }),
+  );
+  mkdirSync(join(root, 'skills', 'hello-skill'), { recursive: true });
+  writeFileSync(
+    join(root, 'skills', 'hello-skill', 'SKILL.md'),
+    '---\nname: hello-skill\ndescription: hi\n---\n\nHello.\n',
+  );
+}
+
+/** Marketplace-style repo: catalog at root, no plugin.json. */
+function writeMarketplaceCatalogRoot(root: string): void {
+  mkdirSync(join(root, '.cursor-plugin'), { recursive: true });
+  writeFileSync(
+    join(root, '.cursor-plugin', 'marketplace.json'),
+    JSON.stringify({ name: 'demo-market', plugins: [] }),
+  );
+}
+
+describe('resolvePlugins isolates per-plugin failures', () => {
+  let dir: string;
+  let db: CapaDatabase;
+  let goodSnapshot: string;
+  let badSnapshot: string;
+  let pluginsBase: string;
+  let projectPath: string;
+
+  beforeEach(() => {
+    dir = mkdtempSync(join(tmpdir(), 'capa-plugin-isolate-'));
+    goodSnapshot = join(dir, 'good-snapshot');
+    badSnapshot = join(dir, 'bad-snapshot');
+    pluginsBase = join(dir, 'plugins-base');
+    projectPath = join(dir, 'project');
+    mkdirSync(pluginsBase, { recursive: true });
+    mkdirSync(projectPath, { recursive: true });
+    writeMinimalClaudePlugin(goodSnapshot);
+    writeMarketplaceCatalogRoot(badSnapshot);
+    writeFileSync(join(projectPath, 'capabilities.yaml'), 'providers: [claude-code]\n');
+
+    const dbPath = join(dir, 'test.db');
+    const sqlite = new Database(dbPath, { create: true });
+    initSchema(sqlite);
+    sqlite.close();
+    db = new CapaDatabase(dbPath);
+    db.upsertProject({ id: 'proj-isolate', path: projectPath });
+  });
+
+  afterEach(() => {
+    db.close();
+    rmSync(dir, { recursive: true, force: true });
+  });
+
+  it('keeps healthy plugins when another plugin has no manifest', async () => {
+    const caps: Capabilities = {
+      providers: ['claude-code'],
+      skills: [],
+      servers: [],
+      tools: [],
+      plugins: [
+        {
+          id: 'good-plugin',
+          type: 'github',
+          def: { repo: 'owner/good-plugin' },
+        },
+        {
+          id: 'broken-market',
+          type: 'github',
+          def: { repo: 'owner/broken-market' },
+        },
+      ],
+    };
+
+    const result = await resolvePlugins(
+      caps,
+      projectPath,
+      'proj-isolate',
+      (async () => new Response()) as never,
+      db,
+      async (_platform, repoPath) => {
+        if (repoPath.includes('broken')) {
+          return {
+            snapshotDir: badSnapshot,
+            resolvedSha: 'b'.repeat(40),
+            resolvedVersion: null,
+          };
+        }
+        return {
+          snapshotDir: goodSnapshot,
+          resolvedSha: 'a'.repeat(40),
+          resolvedVersion: null,
+        };
+      },
+      join(projectPath, 'capabilities.yaml'),
+      new LockfileBuilder(null),
+      {
+        materializeProjectSkills: false,
+        pluginsBaseDir: pluginsBase,
+        trackManaged: false,
+      },
+    );
+
+    expect(
+      result.mergedCapabilities.skills.some((s) => s.id === 'hello-skill'),
+    ).toBe(true);
+    expect(
+      result.mergedCapabilities.resolvedPlugins?.some((p) => p.id === 'good-plugin'),
+    ).toBe(true);
+    expect(
+      result.mergedCapabilities.resolvedPlugins?.some((p) => p.id === 'broken-market'),
+    ).toBe(false);
+    expect(existsSync(join(pluginsBase, 'good-plugin'))).toBe(true);
+    expect(
+      result.warnings.some(
+        (w) =>
+          w.includes('broken-market') &&
+          w.includes('failed to resolve') &&
+          w.includes('No plugin manifest found'),
+      ),
+    ).toBe(true);
+  });
+
+  it('keeps healthy plugins when another plugin fails to clone', async () => {
+    const caps: Capabilities = {
+      providers: ['claude-code'],
+      skills: [],
+      servers: [],
+      tools: [],
+      plugins: [
+        {
+          id: 'good-plugin',
+          type: 'github',
+          def: { repo: 'owner/good-plugin' },
+        },
+        {
+          id: 'missing-repo',
+          type: 'github',
+          def: { repo: 'owner/missing-repo' },
+        },
+      ],
+    };
+
+    const result = await resolvePlugins(
+      caps,
+      projectPath,
+      'proj-isolate',
+      (async () => new Response()) as never,
+      db,
+      async (_platform, repoPath) => {
+        if (repoPath.includes('missing')) {
+          throw new Error('Repository not found');
+        }
+        return {
+          snapshotDir: goodSnapshot,
+          resolvedSha: 'a'.repeat(40),
+          resolvedVersion: null,
+        };
+      },
+      join(projectPath, 'capabilities.yaml'),
+      new LockfileBuilder(null),
+      {
+        materializeProjectSkills: false,
+        pluginsBaseDir: pluginsBase,
+        trackManaged: false,
+      },
+    );
+
+    expect(
+      result.mergedCapabilities.skills.some((s) => s.id === 'hello-skill'),
+    ).toBe(true);
+    expect(
+      result.warnings.some(
+        (w) =>
+          w.includes('missing-repo') &&
+          w.includes('Failed to clone plugin'),
+      ),
+    ).toBe(true);
+  });
+});

--- a/src/cli/commands/__tests__/plugin-resolve-isolate.test.ts
+++ b/src/cli/commands/__tests__/plugin-resolve-isolate.test.ts
@@ -195,4 +195,81 @@ describe('resolvePlugins isolates per-plugin failures', () => {
       ),
     ).toBe(true);
   });
+
+  it('rolls back partial state when a plugin fails after lock upsert begins', async () => {
+    const caps: Capabilities = {
+      providers: ['claude-code'],
+      skills: [],
+      servers: [],
+      tools: [],
+      plugins: [
+        {
+          id: 'good-plugin',
+          type: 'github',
+          def: { repo: 'owner/good-plugin' },
+        },
+        {
+          id: 'fail-late',
+          type: 'github',
+          def: { repo: 'owner/fail-late' },
+        },
+      ],
+    };
+
+    const lockBuilder = new LockfileBuilder(null);
+    const origUpsert = lockBuilder.upsertPlugin.bind(lockBuilder);
+    lockBuilder.upsertPlugin = (entry) => {
+      if (entry.id === 'fail-late') {
+        throw new Error('simulated late lock failure');
+      }
+      return origUpsert(entry);
+    };
+
+    const result = await resolvePlugins(
+      caps,
+      projectPath,
+      'proj-isolate',
+      (async () => new Response()) as never,
+      db,
+      async (_platform, repoPath) => {
+        // Both plugins resolve to the same valid snapshot; fail-late dies at upsert.
+        void repoPath;
+        return {
+          snapshotDir: goodSnapshot,
+          resolvedSha: 'a'.repeat(40),
+          resolvedVersion: null,
+        };
+      },
+      join(projectPath, 'capabilities.yaml'),
+      lockBuilder,
+      {
+        materializeProjectSkills: false,
+        pluginsBaseDir: pluginsBase,
+        trackManaged: false,
+      },
+    );
+
+    expect(
+      result.mergedCapabilities.skills.some((s) => s.id === 'hello-skill'),
+    ).toBe(true);
+    expect(
+      result.mergedCapabilities.resolvedPlugins?.some((p) => p.id === 'good-plugin'),
+    ).toBe(true);
+    expect(
+      result.mergedCapabilities.resolvedPlugins?.some((p) => p.id === 'fail-late'),
+    ).toBe(false);
+    expect(existsSync(join(pluginsBase, 'fail-late'))).toBe(false);
+    expect(
+      result.warnings.some(
+        (w) =>
+          w.includes('fail-late') &&
+          w.includes('simulated late lock failure'),
+      ),
+    ).toBe(true);
+
+    const built = lockBuilder.build();
+    expect(built.plugins.some((p) => p.id === 'good-plugin')).toBe(true);
+    expect(built.plugins.some((p) => p.id === 'fail-late')).toBe(false);
+  });
+
 });

--- a/src/cli/commands/plugin-install.ts
+++ b/src/cli/commands/plugin-install.ts
@@ -267,44 +267,43 @@ export async function resolvePlugins(
     if (!getGitProvider(pluginRef.type)) continue;
     if (!pluginRef.def?.repo) continue;
 
-    const validated = validatePluginDef(pluginRef);
-    if ('error' in validated) {
-      // The user explicitly listed this plugin — fail loudly rather than skip
-      // it silently and report "install succeeded" with the plugin missing.
-      throw new Error(
-        `Invalid plugin entry ${pluginRef.id ?? pluginRef.def.repo}: ${validated.error}`
-      );
-    }
-
-    const { platform, repoPath, subpath, search, version, ref } = validated;
-
-    let snapshot: GetSnapshotResult;
+    const pluginLabel = pluginRef.id ?? pluginRef.def.repo;
+    // Isolate per-plugin failures so one bad entry (marketplace repo root,
+    // missing manifest, clone error, …) cannot wipe expansions from the rest.
     try {
-      const lockEntry = noCache
-        ? null
-        : lockBuilder.findPlugin({
-            source: platform,
-            repo: repoPath,
-            subpath: subpath || null,
-            requestedSearchName: search ?? null,
-            requestedVersion: version ?? null,
-            requestedRef: ref ?? null,
-          });
-      const pinnedSha = lockEntry?.resolvedRef;
-      snapshot = await getRepoSnapshot(platform, repoPath, authFetch, {
-        version,
-        ref,
-        pinnedSha,
-        noCache,
-      });
-    } catch (err: any) {
-      // Surface auth / 404 / network failures from `explainGitError` so that
-      // disconnected git integrations and typo'd repo paths fail the install
-      // instead of being silently skipped.
-      throw new Error(
-        `Failed to clone plugin ${repoPath}: ${err.message}`
-      );
-    }
+      const validated = validatePluginDef(pluginRef);
+      if ('error' in validated) {
+        throw new Error(
+          `Invalid plugin entry ${pluginLabel}: ${validated.error}`
+        );
+      }
+
+      const { platform, repoPath, subpath, search, version, ref } = validated;
+
+      let snapshot: GetSnapshotResult;
+      try {
+        const lockEntry = noCache
+          ? null
+          : lockBuilder.findPlugin({
+              source: platform,
+              repo: repoPath,
+              subpath: subpath || null,
+              requestedSearchName: search ?? null,
+              requestedVersion: version ?? null,
+              requestedRef: ref ?? null,
+            });
+        const pinnedSha = lockEntry?.resolvedRef;
+        snapshot = await getRepoSnapshot(platform, repoPath, authFetch, {
+          version,
+          ref,
+          pinnedSha,
+          noCache,
+        });
+      } catch (err: any) {
+        throw new Error(
+          `Failed to clone plugin ${repoPath}: ${err.message}`
+        );
+      }
 
     // Resolve the manifest root. Three modes:
     //   • `search`  — walk the snapshot for a manifest dir matching the name.
@@ -662,6 +661,15 @@ export async function resolvePlugins(
           );
         }
       }
+    }
+    } catch (err: unknown) {
+      if (err instanceof BlockedPhraseError) {
+        throw err;
+      }
+      const message = err instanceof Error ? err.message : String(err);
+      warnings.push(
+        `Plugin "${pluginLabel}" failed to resolve and was skipped: ${message}`,
+      );
     }
   }
 

--- a/src/cli/commands/plugin-install.ts
+++ b/src/cli/commands/plugin-install.ts
@@ -270,6 +270,16 @@ export async function resolvePlugins(
     const pluginLabel = pluginRef.id ?? pluginRef.def.repo;
     // Isolate per-plugin failures so one bad entry (marketplace repo root,
     // missing manifest, clone error, …) cannot wipe expansions from the rest.
+    let pluginInstallId: string | undefined;
+    const mergeSnap = {
+      skills: mergedSkills.length,
+      servers: mergedServers.length,
+      tools: mergedTools.length,
+      subagents: mergedSubagents.length,
+      hooks: mergedHooks.length,
+      rules: mergedRules.length,
+      resolved: resolvedPlugins.length,
+    };
     try {
       const validated = validatePluginDef(pluginRef);
       if ('error' in validated) {
@@ -346,7 +356,7 @@ export async function resolvePlugins(
       }
     }
 
-    const pluginInstallId = getPluginInstallId(pluginRef.id ?? manifest.name);
+    pluginInstallId = getPluginInstallId(pluginRef.id ?? manifest.name);
     currentPluginIds.add(pluginInstallId);
 
     const pluginStablePath = resolve(join(pluginsBase, pluginInstallId));
@@ -667,6 +677,38 @@ export async function resolvePlugins(
         throw err;
       }
       const message = err instanceof Error ? err.message : String(err);
+      if (pluginInstallId) {
+        currentPluginIds.delete(pluginInstallId);
+        lockBuilder.removePlugin(pluginInstallId);
+        mergedSkills.length = mergeSnap.skills;
+        mergedServers.length = mergeSnap.servers;
+        mergedTools.length = mergeSnap.tools;
+        mergedSubagents.length = mergeSnap.subagents;
+        mergedHooks.length = mergeSnap.hooks;
+        mergedRules.length = mergeSnap.rules;
+        resolvedPlugins.length = mergeSnap.resolved;
+        for (const skill of mergedSkills) {
+          if (skill.sourcePlugin?.id === pluginInstallId) {
+            delete skill.sourcePlugin;
+          }
+        }
+        registeredServerIds.clear();
+        for (const server of mergedServers) registeredServerIds.add(server.id);
+        registeredSubagentIds.clear();
+        for (const agent of mergedSubagents) registeredSubagentIds.add(agent.id);
+        registeredHookIds.clear();
+        for (const hook of mergedHooks) registeredHookIds.add(hook.id);
+        registeredRuleIds.clear();
+        for (const rule of mergedRules) registeredRuleIds.add(rule.id);
+        const partialDir = resolve(join(pluginsBase, pluginInstallId));
+        if (existsSync(partialDir)) {
+          try {
+            rmSync(partialDir, { recursive: true, force: true });
+          } catch {
+            // best-effort cleanup of a partially copied plugin tree
+          }
+        }
+      }
       warnings.push(
         `Plugin "${pluginLabel}" failed to resolve and was skipped: ${message}`,
       );

--- a/src/server/resolve-effective-capabilities.ts
+++ b/src/server/resolve-effective-capabilities.ts
@@ -54,6 +54,7 @@ export function resolveProvidersForServer(
  * copy skills into the project's `.claude/` / `.cursor/` dirs — that only
  * happens during `capa install` / wrap shadow-workspace install.
  * Returns the authored capabilities unchanged when there are no plugins or providers.
+ * Individual plugin failures are collected as warnings; healthy plugins still expand.
  */
 export async function resolveEffectiveCapabilities(
 	authored: Capabilities,

--- a/src/shared/lockfile.ts
+++ b/src/shared/lockfile.ts
@@ -350,6 +350,11 @@ export class LockfileBuilder {
 		this.plugins.set(entry.id, entry);
 	}
 
+	/** Drop a plugin pin (used when per-plugin resolve fails after upsert). */
+	removePlugin(id: string): void {
+		this.plugins.delete(id);
+	}
+
 	upsertHook(entry: LockHookEntry): void {
 		this.hooks.set(entry.id, entry);
 	}


### PR DESCRIPTION
## Summary
One faulty plugin (e.g. a Cursor marketplace repo root with only `marketplace.json`) previously aborted `resolvePlugins` entirely. Effective capabilities then fell back to authored YAML, so **every** plugin’s skills/servers disappeared from the UI.

## Changes
- Wrap each plugin iteration in `resolvePlugins` with try/catch
- Record a warning and continue; rethrow `BlockedPhraseError` only
- Tests: healthy plugin still expands when a sibling has no manifest or fails to clone

## Test plan
- [x] `bun test src/cli/commands/__tests__/plugin-resolve-isolate.test.ts src/cli/commands/__tests__/plugin-materialize.test.ts`
- [ ] Add a bad marketplace-root plugin alongside a good one in the UI; confirm good plugin skills/servers remain