### PR TITLE
fix: resolve Cursor marketplace monorepo plugins

### DIFF
--- a/registries/cursor-marketplace/adapter.test.ts
+++ b/registries/cursor-marketplace/adapter.test.ts
@@ -1,5 +1,5 @@
-﻿import { describe, expect, it } from 'bun:test';
-import { pluginDef } from './adapter.ts';
+import { describe, expect, it } from 'bun:test';
+import { pluginDef } from './adapter';
 
 describe('cursor-marketplace pluginDef', () => {
   it('maps a root-level GitHub plugin without gitPath', () => {

--- a/registries/cursor-marketplace/adapter.test.ts
+++ b/registries/cursor-marketplace/adapter.test.ts
@@ -1,0 +1,40 @@
+﻿import { describe, expect, it } from 'bun:test';
+import { pluginDef } from './adapter.ts';
+
+describe('cursor-marketplace pluginDef', () => {
+  it('maps a root-level GitHub plugin without gitPath', () => {
+    expect(pluginDef('https://github.com/acme/single-plugin')).toEqual({
+      type: 'github',
+      def: { repo: 'acme/single-plugin' },
+    });
+  });
+
+  it('pins gitPath with ::subpath for monorepo listings', () => {
+    expect(
+      pluginDef('https://github.com/acme/plugins', 'nested/widget', 'abc123'),
+    ).toEqual({
+      type: 'github',
+      def: { repo: 'acme/plugins::nested/widget', ref: 'abc123' },
+    });
+  });
+
+  it('normalizes gitPath separators and trims slashes', () => {
+    expect(pluginDef('https://github.com/acme/plugins', '\\foo\\bar\\')).toEqual({
+      type: 'github',
+      def: { repo: 'acme/plugins::foo/bar' },
+    });
+  });
+
+  it('rejects traversal in gitPath', () => {
+    expect(pluginDef('https://github.com/acme/plugins', '../escape')).toBeUndefined();
+    expect(pluginDef('https://github.com/acme/plugins', 'ok/../nope')).toBeUndefined();
+  });
+
+  it('supports GitLab URLs', () => {
+    expect(pluginDef('https://gitlab.com/group/proj.git', 'pkg')).toEqual({
+      type: 'gitlab',
+      def: { repo: 'group/proj::pkg' },
+    });
+  });
+});
+

--- a/registries/cursor-marketplace/adapter.ts
+++ b/registries/cursor-marketplace/adapter.ts
@@ -62,6 +62,10 @@ interface CursorMarketplacePlugin {
   logoUrl?: string;
   publisher?: unknown;
   gitUrl?: string;
+  /** Path inside the git repo when the listing is a multi-plugin monorepo. */
+  gitPath?: string;
+  /** Optional commit/tag/branch pin from the marketplace listing. */
+  gitRef?: string;
   skills?: CursorMarketplaceSkill[];
   mcpServers?: CursorMarketplaceMcpServer[];
   curatedCategoryKeys?: unknown;
@@ -89,13 +93,54 @@ function strArr(v: unknown): string[] | undefined {
   return v.map((x) => typeof x === 'string' ? x : str(x) ?? '').filter(Boolean);
 }
 
-function pluginDef(gitUrl: string | undefined): { type: 'github' | 'gitlab'; def: { repo: string } } | undefined {
+export type CursorPluginInstallDef = {
+  type: 'github' | 'gitlab';
+  def: { repo: string; ref?: string };
+};
+
+/**
+ * Build a capa plugin install def from Cursor marketplace git coordinates.
+ * Multi-plugin monorepos expose `gitPath`; pin it with capa's `::subpath`
+ * form so resolve finds the plugin manifest inside that directory instead of
+ * failing on a root marketplace catalog (e.g. `.cursor-plugin/marketplace.json`).
+ */
+export function pluginDef(
+  gitUrl: string | undefined,
+  gitPath?: string | undefined,
+  gitRef?: string | undefined,
+): CursorPluginInstallDef | undefined {
   if (!gitUrl) return undefined;
-  const m = gitUrl.match(/github\.com\/([^/]+)\/([^/]+?)(?:\.git)?$/);
-  if (m) return { type: 'github', def: { repo: `${m[1]}/${m[2]}` } };
-  const g = gitUrl.match(/gitlab\.com\/([^/]+)\/([^/]+?)(?:\.git)?$/);
-  if (g) return { type: 'gitlab', def: { repo: `${g[1]}/${g[2]}` } };
-  return undefined;
+  let ownerRepo: string | undefined;
+  let type: 'github' | 'gitlab' | undefined;
+  const gh = gitUrl.match(/github\.com\/([^/]+)\/([^/]+?)(?:\.git)?$/);
+  if (gh) {
+    type = 'github';
+    ownerRepo = `${gh[1]}/${gh[2]}`;
+  } else {
+    const gl = gitUrl.match(/gitlab\.com\/([^/]+)\/([^/]+?)(?:\.git)?$/);
+    if (gl) {
+      type = 'gitlab';
+      ownerRepo = `${gl[1]}/${gl[2]}`;
+    }
+  }
+  if (!type || !ownerRepo) return undefined;
+
+  const cleanedPath = (gitPath ?? '')
+    .replace(/\\/g, '/')
+    .replace(/^\/+/, '')
+    .replace(/\/+$/, '');
+  if (
+    cleanedPath &&
+    cleanedPath.split('/').some((seg) => !seg || seg === '.' || seg === '..')
+  ) {
+    return undefined;
+  }
+
+  const repo = cleanedPath ? `${ownerRepo}::${cleanedPath}` : ownerRepo;
+  const def: { repo: string; ref?: string } = { repo };
+  const ref = typeof gitRef === 'string' ? gitRef.trim() : '';
+  if (ref) def.ref = ref;
+  return { type, def };
 }
 
 function formatCategory(key: string): string {
@@ -197,7 +242,7 @@ const adapter: RegistryAdapter = {
     const publisherName = str(p.publisher) ?? '';
     const description = str(p.description) ?? '';
     const itemId = p.name ?? String(p.id);
-    const resolved = pluginDef(p.gitUrl);
+    const resolved = pluginDef(p.gitUrl, p.gitPath, p.gitRef);
     if (!resolved) {
       throw new Error(
         `Cursor marketplace plugin "${itemId}" does not expose a supported GitHub or GitLab repository URL.`

--- a/src/cli/commands/__tests__/plugin-monorepo-id-fallback.test.ts
+++ b/src/cli/commands/__tests__/plugin-monorepo-id-fallback.test.ts
@@ -1,0 +1,109 @@
+﻿import { describe, expect, it, beforeEach, afterEach } from 'bun:test';
+import {
+  mkdtempSync,
+  mkdirSync,
+  writeFileSync,
+  rmSync,
+} from 'fs';
+import { join } from 'path';
+import { tmpdir } from 'os';
+import { Database } from 'bun:sqlite';
+import { CapaDatabase } from '../../../db/database';
+import { initSchema } from '../../../db/schema';
+import { LockfileBuilder } from '../../../shared/lockfile';
+import { resolvePlugins } from '../plugin-install';
+import type { Capabilities } from '../../../types/capabilities';
+
+function writeNestedCursorPlugin(repoRoot: string, pluginDir: string, name: string): void {
+  mkdirSync(join(repoRoot, '.cursor-plugin'), { recursive: true });
+  writeFileSync(
+    join(repoRoot, '.cursor-plugin', 'marketplace.json'),
+    JSON.stringify({ name: 'demo-market', plugins: [{ name, source: pluginDir }] }),
+  );
+  const root = join(repoRoot, pluginDir);
+  mkdirSync(join(root, '.cursor-plugin'), { recursive: true });
+  writeFileSync(
+    join(root, '.cursor-plugin', 'plugin.json'),
+    JSON.stringify({ name, version: '1.0.0' }),
+  );
+  mkdirSync(join(root, 'skills', 'nested-skill'), { recursive: true });
+  writeFileSync(
+    join(root, 'skills', 'nested-skill', 'SKILL.md'),
+    '---\nname: nested-skill\ndescription: hi\n---\n\nHello.\n',
+  );
+}
+
+describe('resolvePlugins monorepo id fallback', () => {
+  let dir: string;
+  let db: CapaDatabase;
+  let snapshotDir: string;
+  let pluginsBase: string;
+  let projectPath: string;
+
+  beforeEach(() => {
+    dir = mkdtempSync(join(tmpdir(), 'capa-plugin-mono-'));
+    snapshotDir = join(dir, 'snapshot');
+    pluginsBase = join(dir, 'plugins-base');
+    projectPath = join(dir, 'project');
+    mkdirSync(pluginsBase, { recursive: true });
+    mkdirSync(projectPath, { recursive: true });
+    writeNestedCursorPlugin(snapshotDir, 'widget', 'widget');
+    writeFileSync(join(projectPath, 'capabilities.yaml'), 'providers: [cursor]\n');
+
+    const dbPath = join(dir, 'test.db');
+    const sqlite = new Database(dbPath, { create: true });
+    initSchema(sqlite);
+    sqlite.close();
+    db = new CapaDatabase(dbPath);
+    db.upsertProject({ id: 'proj-mono', path: projectPath });
+  });
+
+  afterEach(() => {
+    db.close();
+    rmSync(dir, { recursive: true, force: true });
+  });
+
+  it('resolves a nested plugin when only the entry id is set (no ::/@)', async () => {
+    const caps: Capabilities = {
+      providers: ['cursor'],
+      skills: [],
+      servers: [],
+      tools: [],
+      plugins: [
+        {
+          id: 'widget',
+          type: 'github',
+          def: { repo: 'acme/plugins-monorepo' },
+        },
+      ],
+    };
+
+    const result = await resolvePlugins(
+      caps,
+      projectPath,
+      'proj-mono',
+      (async () => new Response()) as never,
+      db,
+      async () => ({
+        snapshotDir,
+        resolvedSha: 'a'.repeat(40),
+        resolvedVersion: null,
+      }),
+      join(projectPath, 'capabilities.yaml'),
+      new LockfileBuilder(null),
+      {
+        materializeProjectSkills: false,
+        pluginsBaseDir: pluginsBase,
+        trackManaged: false,
+      },
+    );
+
+    expect(
+      result.mergedCapabilities.skills.some((s) => s.id === 'nested-skill'),
+    ).toBe(true);
+    expect(
+      result.mergedCapabilities.resolvedPlugins?.some((p) => p.id === 'widget'),
+    ).toBe(true);
+    expect(result.warnings).toEqual([]);
+  });
+});

--- a/src/cli/commands/__tests__/plugin-monorepo-id-fallback.test.ts
+++ b/src/cli/commands/__tests__/plugin-monorepo-id-fallback.test.ts
@@ -1,4 +1,4 @@
-﻿import { describe, expect, it, beforeEach, afterEach } from 'bun:test';
+import { describe, expect, it, beforeEach, afterEach } from 'bun:test';
 import {
   mkdtempSync,
   mkdirSync,

--- a/src/cli/commands/plugin-install.ts
+++ b/src/cli/commands/plugin-install.ts
@@ -315,10 +315,12 @@ export async function resolvePlugins(
         );
       }
 
-    // Resolve the manifest root. Three modes:
+    // Resolve the manifest root:
     //   • `search`  — walk the snapshot for a manifest dir matching the name.
     //   • `subpath` — exact path inside the repo (already provided by the user).
-    //   • neither   — the repo root itself is the plugin.
+    //   • neither   — the repo root itself is the plugin; if that has no
+    //                 manifest and the entry has an id, search the tree by id
+    //                 (multi-plugin marketplace monorepos).
     let manifestRoot: string;
     let resolvedSubpath: string;
     let manifest: UnifiedPluginManifest | null;
@@ -348,10 +350,30 @@ export async function resolvePlugins(
       }
       resolvedSubpath = subpath;
       manifest = detectAndParseManifest(manifestRoot, providers);
+      // Multi-plugin monorepos often only have a marketplace catalog at the
+      // repo root. When the capa entry has an id, search the tree for a
+      // nested plugin whose directory or manifest name matches that id.
+      if (!manifest && !subpath && pluginRef.id) {
+        const located = findPluginInDirectory(
+          snapshot.snapshotDir,
+          pluginRef.id,
+          providers,
+        );
+        if (located) {
+          manifestRoot = located.entry.subpath
+            ? join(snapshot.snapshotDir, located.entry.subpath)
+            : snapshot.snapshotDir;
+          resolvedSubpath = located.entry.subpath;
+          manifest = located.manifest;
+        }
+      }
       if (!manifest) {
         throw new Error(
           `No plugin manifest found in ${repoPath}${subpath ? `/${subpath}` : ''}.\n` +
-          `    Expected one of: .claude-plugin/plugin.json, .cursor-plugin/plugin.json.`
+          `    Expected one of: .claude-plugin/plugin.json, .cursor-plugin/plugin.json.` +
+          (pluginRef.id
+            ? `\n    Tip: for monorepos, pin the plugin with "${repoPath}@${pluginRef.id}" or "${repoPath}::${pluginRef.id}".`
+            : '')
         );
       }
     }

--- a/src/cli/commands/plugin-install.ts
+++ b/src/cli/commands/plugin-install.ts
@@ -11,6 +11,7 @@ import {
   detectAndParseManifest,
   discoverPluginEntries,
   findPluginInDirectory,
+  resolveNestedPluginById,
   resolvePluginServerDef,
   resolvePluginRootInString,
   materializeCommandAsSkill,
@@ -351,10 +352,10 @@ export async function resolvePlugins(
       resolvedSubpath = subpath;
       manifest = detectAndParseManifest(manifestRoot, providers);
       // Multi-plugin monorepos often only have a marketplace catalog at the
-      // repo root. When the capa entry has an id, search the tree for a
-      // nested plugin whose directory or manifest name matches that id.
+      // repo root. When the capa entry has an id, resolve via direct child
+      // path or root marketplace.json (bounded — no full-tree walk).
       if (!manifest && !subpath && pluginRef.id) {
-        const located = findPluginInDirectory(
+        const located = resolveNestedPluginById(
           snapshot.snapshotDir,
           pluginRef.id,
           providers,

--- a/src/shared/plugin-manifest/detect.ts
+++ b/src/shared/plugin-manifest/detect.ts
@@ -401,3 +401,85 @@ export function findPluginInDirectory(
 	if (!manifest) return null;
 	return { entry: target, manifest };
 }
+
+/**
+ * Bounded lookup for a nested plugin by capa entry id when the repo root has
+ * no plugin manifest (typical marketplace monorepo). Avoids a full-tree walk:
+ * 1) try `<repoRoot>/<id>` as a direct child
+ * 2) read Cursor/Claude marketplace catalogs at the root and map name → source
+ */
+export function resolveNestedPluginById(
+	repoRoot: string,
+	pluginId: string,
+	preferredProviders: string[],
+): { entry: DiscoveredPluginEntry; manifest: UnifiedPluginManifest } | null {
+	if (
+		!pluginId ||
+		pluginId.includes("/") ||
+		pluginId.includes("\\") ||
+		pluginId.includes("..")
+	) {
+		return null;
+	}
+
+	const tryAt = (
+		relPath: string,
+	): { entry: DiscoveredPluginEntry; manifest: UnifiedPluginManifest } | null => {
+		const cleaned = relPath
+			.replace(/\\/g, "/")
+			.replace(/^\/+/, "")
+			.replace(/\/+$/, "");
+		if (
+			!cleaned ||
+			cleaned.split("/").some((seg) => !seg || seg === "." || seg === "..")
+		) {
+			return null;
+		}
+		const pluginRoot = join(repoRoot, cleaned);
+		if (!existsSync(pluginRoot)) return null;
+		const manifest = detectAndParseManifest(pluginRoot, preferredProviders);
+		if (!manifest) return null;
+		const dirName = cleaned.split("/").filter(Boolean).pop() ?? cleaned;
+		return {
+			entry: {
+				subpath: cleaned,
+				manifestName: manifest.name || dirName,
+				dirName,
+				manifestFile: "",
+			},
+			manifest,
+		};
+	};
+
+	const direct = tryAt(pluginId);
+	if (direct) return direct;
+
+	const catalogRels = [
+		".cursor-plugin/marketplace.json",
+		".claude-plugin/marketplace.json",
+	];
+	for (const catalogRel of catalogRels) {
+		const catalogPath = join(repoRoot, catalogRel);
+		if (!existsSync(catalogPath)) continue;
+		try {
+			const data = JSON.parse(readFileSync(catalogPath, "utf8")) as {
+				plugins?: unknown;
+			};
+			const plugins = Array.isArray(data.plugins) ? data.plugins : [];
+			for (const raw of plugins) {
+				if (!raw || typeof raw !== "object") continue;
+				const p = raw as { name?: unknown; source?: unknown };
+				const name = typeof p.name === "string" ? p.name : "";
+				const source = typeof p.source === "string" ? p.source : "";
+				if (name !== pluginId && source !== pluginId) continue;
+				if (!source) continue;
+				const located = tryAt(source);
+				if (located) return located;
+			}
+		} catch {
+			// ignore malformed catalogs
+		}
+	}
+
+	return null;
+}

--- a/src/shared/plugin-manifest/index.ts
+++ b/src/shared/plugin-manifest/index.ts
@@ -3,6 +3,7 @@ export {
 	detectAndParseManifest,
 	discoverPluginEntries,
 	findPluginInDirectory,
+	resolveNestedPluginById,
 } from "./detect";
 
 export { resolvePluginServerDef, resolvePluginRootInString } from "./mcp-parser";


### PR DESCRIPTION
## Summary
Cursor marketplace listings often point at a multi-plugin git repo (`gitUrl`) with the actual plugin under `gitPath`. capa previously installed `owner/repo` at the root, hit only a marketplace catalog (no `plugin.json`), and failed to expand the plugin.

## Changes
- **cursor-marketplace adapter**: include `gitPath` as `owner/repo::path` and optional `gitRef` in the install snippet
- **resolvePlugins**: if the repo root has no plugin manifest and the entry has an `id`, search the tree for a nested plugin matching that id (helps already-authored entries without `::`/`@`)
- Reject `gitPath` traversal (`..`) from marketplace data
- Unit tests for `pluginDef` and monorepo id fallback

## Test plan
- [x] `bun test registries/cursor-marketplace/adapter.test.ts src/cli/commands/__tests__/plugin-monorepo-id-fallback.test.ts`
- [x] Add a Cursor marketplace monorepo plugin from the UI; confirm skills/servers expand
- [x] Re-add / reconfigure an existing root-only monorepo entry that has a matching `id`