### PR TITLE
Fix plugin skill content loading before capa install

### DIFF
--- a/src/server/__tests__/skill-content-plugin.test.ts
+++ b/src/server/__tests__/skill-content-plugin.test.ts
@@ -1,0 +1,125 @@
+import { describe, it, expect, beforeEach, afterEach } from "bun:test";
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "fs";
+import { tmpdir } from "os";
+import { join } from "path";
+import type { Capabilities, Skill } from "../../types/capabilities";
+import {
+	resolveSkillContent,
+	resolveSkillContentById,
+	resolveSkillDescription,
+} from "../skill-content";
+
+describe("resolveSkillContent plugin unpack", () => {
+	let dir: string;
+	let projectPath: string;
+	let pluginsBase: string;
+	const projectId = "proj-test";
+	const pluginId = "fixture-plugin";
+
+	beforeEach(() => {
+		dir = mkdtempSync(join(tmpdir(), "capa-skill-content-"));
+		projectPath = join(dir, "project");
+		pluginsBase = join(dir, "plugins", projectId);
+		mkdirSync(projectPath, { recursive: true });
+
+		const skillDir = join(pluginsBase, pluginId, "skills", "hello-skill");
+		mkdirSync(skillDir, { recursive: true });
+		writeFileSync(
+			join(skillDir, "SKILL.md"),
+			"---\nname: hello-skill\ndescription: From plugin unpack\n---\n\nPlugin body.\n",
+		);
+	});
+
+	afterEach(() => {
+		rmSync(dir, { recursive: true, force: true });
+	});
+
+	const pluginSkill: Skill = {
+		id: "hello-skill",
+		type: "plugin",
+		def: {},
+		sourcePlugin: {
+			id: pluginId,
+			name: "Fixture Plugin",
+			provider: "claude",
+		},
+	};
+
+	it("loads plugin skill content from the unpacked plugin tree without install", () => {
+		const result = resolveSkillContent(projectPath, pluginSkill, ["claude-code"], {
+			projectId,
+			pluginsBaseDir: pluginsBase,
+		});
+
+		expect(result).not.toBeNull();
+		expect(result!.content).toContain("Plugin body.");
+		expect(result!.metadata.description).toBe("From plugin unpack");
+	});
+
+	it("resolveSkillContentById finds plugin skills via unpack dir", async () => {
+		const caps: Capabilities = {
+			providers: ["claude-code"],
+			skills: [pluginSkill],
+			tools: [],
+			servers: [],
+			plugins: [
+				{
+					id: pluginId,
+					type: "github",
+					def: { repo: "owner/fixture-plugin" },
+				},
+			],
+		};
+
+		const result = await resolveSkillContentById(
+			projectPath,
+			caps,
+			"hello-skill",
+			undefined,
+			{ projectId, pluginsBaseDir: pluginsBase },
+		);
+
+		expect(result).not.toBeNull();
+		expect(result!.content).toContain("Plugin body.");
+	});
+
+	it("resolveSkillDescription reads frontmatter from unpack dir", () => {
+		const { description, descriptionSource } = resolveSkillDescription(
+			projectPath,
+			pluginSkill,
+			["claude-code"],
+			{ projectId, pluginsBaseDir: pluginsBase },
+		);
+
+		expect(description).toBe("From plugin unpack");
+		expect(descriptionSource).toBe("frontmatter");
+	});
+
+	it("loads command-materialized skills under .capa-commands", () => {
+		const cmdDir = join(pluginsBase, pluginId, ".capa-commands", "slash-cmd");
+		mkdirSync(cmdDir, { recursive: true });
+		writeFileSync(
+			join(cmdDir, "SKILL.md"),
+			"---\nname: slash-cmd\ndescription: Command skill\n---\n\nCmd body.\n",
+		);
+
+		const skill: Skill = {
+			id: "slash-cmd",
+			type: "plugin",
+			def: {},
+			sourcePlugin: {
+				id: pluginId,
+				name: "Fixture Plugin",
+				provider: "claude",
+			},
+		};
+
+		const result = resolveSkillContent(projectPath, skill, ["claude-code"], {
+			projectId,
+			pluginsBaseDir: pluginsBase,
+		});
+
+		expect(result).not.toBeNull();
+		expect(result!.content).toContain("Cmd body.");
+	});
+});

--- a/src/server/__tests__/skill-content-plugin.test.ts
+++ b/src/server/__tests__/skill-content-plugin.test.ts
@@ -122,4 +122,55 @@ describe("resolveSkillContent plugin unpack", () => {
 		expect(result).not.toBeNull();
 		expect(result!.content).toContain("Cmd body.");
 	});
+it("prefers installed provider copy over unpacked plugin tree after install", () => {
+		const installedDir = join(projectPath, ".claude", "skills", "hello-skill");
+		mkdirSync(installedDir, { recursive: true });
+		writeFileSync(
+			join(installedDir, "SKILL.md"),
+			"---\nname: hello-skill\ndescription: Installed sanitized\n---\n\nInstalled body.\n",
+		);
+
+		const result = resolveSkillContent(projectPath, pluginSkill, ["claude-code"], {
+			projectId,
+			pluginsBaseDir: pluginsBase,
+		});
+
+		expect(result).not.toBeNull();
+		expect(result!.content).toContain("Installed body.");
+		expect(result!.content).not.toContain("Plugin body.");
+		expect(result!.metadata.description).toBe("Installed sanitized");
+	});
+
+	it("finds nested nonstandard skill layouts via cached plugin scan", () => {
+		const nestedDir = join(pluginsBase, pluginId, "extras", "nested-skill");
+		mkdirSync(nestedDir, { recursive: true });
+		writeFileSync(
+			join(nestedDir, "SKILL.md"),
+			"---\nname: nested-skill\ndescription: Nested\n---\n\nNested body.\n",
+		);
+
+		const skill: Skill = {
+			id: "nested-skill",
+			type: "plugin",
+			def: {},
+			sourcePlugin: {
+				id: pluginId,
+				name: "Fixture Plugin",
+				provider: "claude",
+			},
+		};
+
+		const first = resolveSkillContent(projectPath, skill, ["claude-code"], {
+			projectId,
+			pluginsBaseDir: pluginsBase,
+		});
+		const second = resolveSkillContent(projectPath, skill, ["claude-code"], {
+			projectId,
+			pluginsBaseDir: pluginsBase,
+		});
+
+		expect(first).not.toBeNull();
+		expect(first!.content).toContain("Nested body.");
+		expect(second!.content).toContain("Nested body.");
+	});
 });

--- a/src/server/mcp-meta-routes.ts
+++ b/src/server/mcp-meta-routes.ts
@@ -112,6 +112,7 @@ export async function handleGetSkillContent(
 			capabilities,
 			skillId,
 			authFetch,
+			{ projectId },
 		);
 		if (!resolved) {
 			return new Response(

--- a/src/server/project-routes.ts
+++ b/src/server/project-routes.ts
@@ -142,6 +142,7 @@ export async function handleGetProject(
 									project.path,
 									s,
 									capabilities.providers || [],
+									{ projectId },
 								);
 							return {
 								id: s.id,

--- a/src/server/skill-content.ts
+++ b/src/server/skill-content.ts
@@ -10,6 +10,7 @@ import {
 } from "../cli/commands/install-tasks/helpers/skill-discovery";
 import type { AuthenticatedFetch } from "../shared/authenticated-fetch";
 import { type CachePlatform, getOrCreateSnapshot } from "../shared/cache";
+import { getProjectPluginsDir } from "../shared/plugin-paths";
 import { getProvider } from "../shared/providers";
 import { assertSafeRepoPath } from "../shared/repo-file";
 import { parseRepoString } from "../shared/repo-string";
@@ -23,6 +24,13 @@ export interface SkillContentResult {
 	content: string;
 	metadata: SkillMetadata;
 	files: string[];
+}
+
+/** Options for locating unpacked plugin trees under `~/.capa/plugins/<projectId>/`. */
+export interface SkillContentResolveOptions {
+	projectId?: string;
+	/** Override for tests; defaults to `getProjectPluginsDir(projectId)`. */
+	pluginsBaseDir?: string;
 }
 
 function stripSurroundingQuotes(value: string): string {
@@ -142,6 +150,71 @@ export function resolveSkillSourceUrl(
 }
 
 /**
+ * Locate SKILL.md for a skill id inside an unpacked plugin tree.
+ * Checks common layouts, then falls back to a recursive scan.
+ */
+function findPluginSkillMd(
+	pluginRoot: string,
+	skillId: string,
+): string | null {
+	const candidates = [
+		join(pluginRoot, skillId, "SKILL.md"),
+		join(pluginRoot, "skills", skillId, "SKILL.md"),
+		join(pluginRoot, ".capa-commands", skillId, "SKILL.md"),
+	];
+	for (const candidate of candidates) {
+		if (existsSync(candidate)) return candidate;
+	}
+
+	const found = findSkillsInDirectory(pluginRoot);
+	const fromScan = found.get(skillId);
+	if (fromScan) return fromScan;
+
+	return null;
+}
+
+function resolvePluginSkillContent(
+	skill: Skill,
+	options?: SkillContentResolveOptions,
+): SkillContentResult | null {
+	if (skill.type !== "plugin" && !skill.sourcePlugin) return null;
+	const pluginId = skill.sourcePlugin?.id;
+	if (
+		!pluginId ||
+		!isSafeCapabilityId(skill.id) ||
+		!isSafeCapabilityId(pluginId)
+	) {
+		return null;
+	}
+
+	const pluginsBase =
+		options?.pluginsBaseDir ??
+		(options?.projectId ? getProjectPluginsDir(options.projectId) : null);
+	if (!pluginsBase) return null;
+
+	let pluginRoot: string;
+	try {
+		pluginRoot = assertSafeRepoPath(pluginsBase, pluginId);
+	} catch {
+		return null;
+	}
+	if (!existsSync(pluginRoot)) return null;
+
+	const skillMdPath = findPluginSkillMd(pluginRoot, skill.id);
+	if (!skillMdPath) return null;
+
+	try {
+		const skillRoot = skillMdPath.replace(/[/\\]SKILL\.md$/i, "");
+		return tryParse(
+			readFileSync(skillMdPath, "utf-8"),
+			collectFiles(skillRoot),
+		);
+	} catch {
+		return null;
+	}
+}
+
+/**
  * Resolve SKILL.md content for a skill from inline content, a local path,
  * or an installed copy under a provider's skillsDir.
  */
@@ -149,6 +222,7 @@ export function resolveSkillContent(
 	projectPath: string,
 	skill: Skill,
 	providers: string[],
+	options?: SkillContentResolveOptions,
 ): SkillContentResult | null {
 	// Inline skills embed SKILL.md in def.content
 	if (skill.type === "inline" && skill.def?.content) {
@@ -171,6 +245,11 @@ export function resolveSkillContent(
 			}
 		}
 	}
+
+	// Plugin skills: read from the unpacked tree under ~/.capa/plugins/<projectId>/
+	// (populated when the plugin is added / effective caps are resolved — before install).
+	const fromPlugin = resolvePluginSkillContent(skill, options);
+	if (fromPlugin) return fromPlugin;
 
 	// Installed / github / gitlab / remote / plugin: look under provider skillsDirs
 	if (!isSafeCapabilityId(skill.id)) {
@@ -214,11 +293,12 @@ export async function resolveSkillContentById(
 	capabilities: Capabilities,
 	skillId: string,
 	authFetch?: AuthenticatedFetch,
+	options?: SkillContentResolveOptions,
 ): Promise<SkillContentResult | null> {
 	const skill = (capabilities.skills ?? []).find((s) => s.id === skillId);
 	if (!skill) return null;
 	const providers = capabilities.providers ?? [];
-	const local = resolveSkillContent(projectPath, skill, providers);
+	const local = resolveSkillContent(projectPath, skill, providers, options);
 	if (local) return local;
 	if (authFetch) {
 		return fetchUninstalledSkillContent(skill, authFetch);
@@ -299,6 +379,7 @@ export function resolveSkillDescription(
 	projectPath: string,
 	skill: Skill,
 	providers: string[],
+	options?: SkillContentResolveOptions,
 ): {
 	description: string | null;
 	descriptionSource: "capabilities" | "frontmatter" | null;
@@ -308,7 +389,7 @@ export function resolveSkillDescription(
 		return { description: fromCaps, descriptionSource: "capabilities" };
 	}
 
-	const resolved = resolveSkillContent(projectPath, skill, providers);
+	const resolved = resolveSkillContent(projectPath, skill, providers, options);
 	const fromFrontmatter = resolved?.metadata?.description?.trim();
 	if (fromFrontmatter) {
 		return { description: fromFrontmatter, descriptionSource: "frontmatter" };

--- a/src/server/skill-content.ts
+++ b/src/server/skill-content.ts
@@ -149,9 +149,67 @@ export function resolveSkillSourceUrl(
 	return null;
 }
 
+/** In-memory skill index for unpacked plugin trees (avoids re-scanning per skill). */
+const pluginSkillIndexCache = new Map<
+	string,
+	{ mtimeMs: number; index: Map<string, string> }
+>();
+
+function readPluginRootMtime(pluginRoot: string): number | null {
+	try {
+		return statSync(pluginRoot).mtimeMs;
+	} catch {
+		return null;
+	}
+}
+
+/**
+ * Build (or reuse) an id → SKILL.md path index for an unpacked plugin tree.
+ * Prefer `skills/` then `.capa-commands/`, then a full-tree scan for odd layouts.
+ */
+function getCachedPluginSkillIndex(pluginRoot: string): Map<string, string> {
+	const mtimeMs = readPluginRootMtime(pluginRoot);
+	if (mtimeMs == null) return new Map();
+
+	const cached = pluginSkillIndexCache.get(pluginRoot);
+	if (cached && cached.mtimeMs === mtimeMs) return cached.index;
+
+	const index = new Map<string, string>();
+
+	const skillsSub = join(pluginRoot, "skills");
+	if (existsSync(skillsSub)) {
+		for (const [id, skillMdPath] of findSkillsInDirectory(skillsSub)) {
+			index.set(id, skillMdPath);
+		}
+	}
+
+	const commandsRoot = join(pluginRoot, ".capa-commands");
+	if (existsSync(commandsRoot)) {
+		try {
+			for (const entry of readdirSync(commandsRoot, { withFileTypes: true })) {
+				if (!entry.isDirectory()) continue;
+				const skillMdPath = join(commandsRoot, entry.name, "SKILL.md");
+				if (existsSync(skillMdPath) && !index.has(entry.name)) {
+					index.set(entry.name, skillMdPath);
+				}
+			}
+		} catch {
+			// ignore unreadable command dirs
+		}
+	}
+
+	// Odd layouts (e.g. nested non-skills paths) — fill gaps only.
+	for (const [id, skillMdPath] of findSkillsInDirectory(pluginRoot)) {
+		if (!index.has(id)) index.set(id, skillMdPath);
+	}
+
+	pluginSkillIndexCache.set(pluginRoot, { mtimeMs, index });
+	return index;
+}
+
 /**
  * Locate SKILL.md for a skill id inside an unpacked plugin tree.
- * Checks common layouts, then falls back to a recursive scan.
+ * Checks common layouts, then falls back to a cached recursive scan.
  */
 function findPluginSkillMd(
 	pluginRoot: string,
@@ -166,11 +224,7 @@ function findPluginSkillMd(
 		if (existsSync(candidate)) return candidate;
 	}
 
-	const found = findSkillsInDirectory(pluginRoot);
-	const fromScan = found.get(skillId);
-	if (fromScan) return fromScan;
-
-	return null;
+	return getCachedPluginSkillIndex(pluginRoot).get(skillId) ?? null;
 }
 
 function resolvePluginSkillContent(
@@ -246,12 +300,7 @@ export function resolveSkillContent(
 		}
 	}
 
-	// Plugin skills: read from the unpacked tree under ~/.capa/plugins/<projectId>/
-	// (populated when the plugin is added / effective caps are resolved — before install).
-	const fromPlugin = resolvePluginSkillContent(skill, options);
-	if (fromPlugin) return fromPlugin;
-
-	// Installed / github / gitlab / remote / plugin: look under provider skillsDirs
+	// Prefer provider-installed copies (may include install-time sanitization).
 	if (!isSafeCapabilityId(skill.id)) {
 		return null;
 	}
@@ -280,7 +329,9 @@ export function resolveSkillContent(
 		}
 	}
 
-	return null;
+	// Pre-install fallback: unpacked plugin tree under ~/.capa/plugins/<projectId>/
+	// (populated when the plugin is added / effective caps are resolved).
+	return resolvePluginSkillContent(skill, options);
 }
 
 /**


### PR DESCRIPTION
## Summary
- Plugin skills listed in the UI after add could not load SKILL.md until `capa install`, because content resolution only checked provider skill dirs.
- Resolve plugin skill content (and descriptions) from the already-unpacked tree under `~/.capa/plugins/<projectId>/`.
- Add regression tests for unpack-dir and `.capa-commands` layouts.

## Test plan
- [x] Add a new plugin via the UI without running `capa install`
- [x] Confirm plugin skills appear and opening one shows SKILL.md content
- [x] Confirm skill description frontmatter appears in the project skills list
- [x] Run `bun test src/server/__tests__/skill-content-plugin.test.ts`
- [x] After `capa install`, content still loads as before
