### PR TITLE
Fix Cursor CLI activity trace grouping

### DIFF
--- a/src/server/__tests__/skill-content-plugin.test.ts
+++ b/src/server/__tests__/skill-content-plugin.test.ts
@@ -122,7 +122,8 @@ describe("resolveSkillContent plugin unpack", () => {
 		expect(result).not.toBeNull();
 		expect(result!.content).toContain("Cmd body.");
 	});
-it("prefers installed provider copy over unpacked plugin tree after install", () => {
+
+	it("prefers installed provider copy over unpacked plugin tree after install", () => {
 		const installedDir = join(projectPath, ".claude", "skills", "hello-skill");
 		mkdirSync(installedDir, { recursive: true });
 		writeFileSync(
@@ -139,6 +140,30 @@ it("prefers installed provider copy over unpacked plugin tree after install", ()
 		expect(result!.content).toContain("Installed body.");
 		expect(result!.content).not.toContain("Plugin body.");
 		expect(result!.metadata.description).toBe("Installed sanitized");
+	});
+
+	it("does not resolve inline skills via plugin unpack when type is not plugin", () => {
+		const inlineWithPluginMeta: Skill = {
+			id: "hello-skill",
+			type: "inline",
+			def: { content: "Inline only." },
+			sourcePlugin: {
+				id: pluginId,
+				name: "Fixture Plugin",
+				provider: "claude",
+			},
+		};
+
+		const result = resolveSkillContent(
+			projectPath,
+			inlineWithPluginMeta,
+			["claude-code"],
+			{ projectId, pluginsBaseDir: pluginsBase },
+		);
+
+		expect(result).not.toBeNull();
+		expect(result!.content).toContain("Inline only.");
+		expect(result!.content).not.toContain("Plugin body.");
 	});
 
 	it("finds nested nonstandard skill layouts via cached plugin scan", () => {

--- a/src/server/skill-content.ts
+++ b/src/server/skill-content.ts
@@ -231,7 +231,7 @@ function resolvePluginSkillContent(
 	skill: Skill,
 	options?: SkillContentResolveOptions,
 ): SkillContentResult | null {
-	if (skill.type !== "plugin" && !skill.sourcePlugin) return null;
+	if (skill.type !== "plugin" || !skill.sourcePlugin) return null;
 	const pluginId = skill.sourcePlugin?.id;
 	if (
 		!pluginId ||

--- a/src/shared/__tests__/activity-attributes.test.ts
+++ b/src/shared/__tests__/activity-attributes.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from "bun:test";
 import {
+	ACTIVITY_ATTRIBUTES_MAX_JSON_CHARS,
 	extractActivityAttributes,
 	serializeActivityAttributes,
 } from "../activity-attributes";
@@ -58,6 +59,20 @@ describe("serializeActivityAttributes", () => {
 	it("round-trips a small bag", () => {
 		expect(serializeActivityAttributes({ model: "x", duration_ms: 1 })).toBe(
 			JSON.stringify({ model: "x", duration_ms: 1 }),
+		);
+	});
+
+	it("returns valid JSON or null when over the size cap", () => {
+		const huge = "x".repeat(ACTIVITY_ATTRIBUTES_MAX_JSON_CHARS + 500);
+		const serialized = serializeActivityAttributes({
+			model: "small",
+			dump: huge,
+			keep: "yes",
+		});
+		if (serialized === null) return;
+		expect(() => JSON.parse(serialized)).not.toThrow();
+		expect(serialized.length).toBeLessThanOrEqual(
+			ACTIVITY_ATTRIBUTES_MAX_JSON_CHARS,
 		);
 	});
 });

--- a/src/shared/__tests__/activity-correlation-reconcile.test.ts
+++ b/src/shared/__tests__/activity-correlation-reconcile.test.ts
@@ -76,6 +76,35 @@ describe("reconcileCursorActivityConversationIds", () => {
 		expect(out[1]!.conversation_id).toBe(chatId);
 	});
 
+	it("does not rewrite when the same generation_id maps to conflicting chat ids", () => {
+		const generationId = "gen-1";
+		const rows = [
+			{
+				source: "cursor",
+				kind: "prompt",
+				conversation_id: "chat-a",
+				generation_id: generationId,
+				attributes_json: null,
+			},
+			{
+				source: "cursor",
+				kind: "prompt",
+				conversation_id: "chat-b",
+				generation_id: generationId,
+				attributes_json: null,
+			},
+			{
+				source: "cursor",
+				kind: "agent_tool",
+				conversation_id: "agent-session",
+				generation_id: generationId,
+				attributes_json: null,
+			},
+		];
+		const out = reconcileCursorActivityConversationIds(rows);
+		expect(out[2]!.conversation_id).toBe("agent-session");
+	});
+
 	it("does not rewrite non-cursor sources", () => {
 		const rows = [
 			{

--- a/src/shared/__tests__/activity-correlation-reconcile.test.ts
+++ b/src/shared/__tests__/activity-correlation-reconcile.test.ts
@@ -1,0 +1,93 @@
+import { describe, expect, it } from "bun:test";
+import {
+	chatConversationIdFromTranscriptPath,
+	reconcileCursorActivityConversationIds,
+} from "../activity-correlation-reconcile";
+
+describe("chatConversationIdFromTranscriptPath", () => {
+	it("parses Cursor agent transcript paths", () => {
+		const path =
+			"/Users/me/.cursor/projects/foo/agent-transcripts/5838f384-e543-41e8-be49-57fb1de0d433/5838f384.jsonl";
+		expect(chatConversationIdFromTranscriptPath(path)).toBe(
+			"5838f384-e543-41e8-be49-57fb1de0d433",
+		);
+	});
+});
+
+describe("reconcileCursorActivityConversationIds", () => {
+	it("rewrites tool rows to the prompt chat id for the same generation", () => {
+		const chatId = "5838f384-e543-41e8-be49-57fb1de0d433";
+		const agentSessionId = "6b74a2c7-5d30-4160-8b01-e8106e144ff3";
+		const generationId = "e972af4d-ba8b-4d82-a839-b3b0a9b2aafd";
+
+		const rows = [
+			{
+				source: "cursor",
+				kind: "prompt",
+				conversation_id: chatId,
+				generation_id: generationId,
+				attributes_json: null,
+			},
+			{
+				source: "cursor",
+				kind: "agent_tool",
+				conversation_id: agentSessionId,
+				generation_id: generationId,
+				attributes_json: null,
+			},
+			{
+				source: "cursor",
+				kind: "shell",
+				conversation_id: agentSessionId,
+				generation_id: generationId,
+				attributes_json: null,
+			},
+		];
+
+		const out = reconcileCursorActivityConversationIds(rows);
+		expect(out[0]!.conversation_id).toBe(chatId);
+		expect(out[1]!.conversation_id).toBe(chatId);
+		expect(out[2]!.conversation_id).toBe(chatId);
+	});
+
+	it("learns chat id from transcript_path on stop when prompt is absent", () => {
+		const chatId = "5838f384-e543-41e8-be49-57fb1de0d433";
+		const generationId = "gen-1";
+		const transcript = `/home/.cursor/projects/p/agent-transcripts/${chatId}/t.jsonl`;
+
+		const rows = [
+			{
+				source: "cursor",
+				kind: "stop",
+				conversation_id: chatId,
+				generation_id: generationId,
+				attributes_json: JSON.stringify({ transcript_path: transcript }),
+			},
+			{
+				source: "cursor",
+				kind: "agent_tool",
+				conversation_id: "agent-session",
+				generation_id: generationId,
+				attributes_json: null,
+			},
+		];
+
+		const out = reconcileCursorActivityConversationIds(rows);
+		expect(out[1]!.conversation_id).toBe(chatId);
+	});
+
+	it("does not rewrite non-cursor sources", () => {
+		const rows = [
+			{
+				source: "claude-code",
+				kind: "shell",
+				conversation_id: "sess-a",
+				generation_id: "gen-1",
+				attributes_json: null,
+			},
+		];
+		expect(reconcileCursorActivityConversationIds(rows)[0]!.conversation_id).toBe(
+			"sess-a",
+		);
+	});
+});

--- a/src/shared/__tests__/agent-activity.test.ts
+++ b/src/shared/__tests__/agent-activity.test.ts
@@ -18,7 +18,7 @@ describe("agent-activity helpers", () => {
 	it("builds portable capa activity-ingest commands", () => {
 		const hooks = buildSystemActivityHooks("my-project", "cursor");
 		expect(hooks.length).toBeGreaterThan(5);
-		expect(hooks.some((h) => h.on === "beforeTool")).toBe(false);
+		expect(hooks.some((h) => h.on === "beforeTool")).toBe(true);
 		expect(hooks.some((h) => h.on === "beforeShell")).toBe(false);
 		expect(hooks.some((h) => h.on === "afterShell")).toBe(true);
 		expect(hooks.some((h) => h.on === "afterTool")).toBe(true);
@@ -44,10 +44,54 @@ describe("agent-activity helpers", () => {
 		for (const h of hooks) {
 			expect(h.command).toContain("--provider claude-code");
 		}
+		expect(hooks.some((h) => h.on === "beforeTool")).toBe(false);
 	});
 });
 
 describe("normalizeActivityHookPayload", () => {
+	it("traces Cursor WebSearch via preToolUse CallDynamicTool wrapper", () => {
+		const out = normalizeActivityHookPayload(
+			"beforeTool",
+			{
+				tool_name: "CallDynamicTool",
+				tool_input: {
+					namespace: "cursor",
+					toolName: "WebSearch",
+					arguments: { search_term: "mermaid links" },
+				},
+				conversation_id: "conv-1",
+				generation_id: "gen-1",
+			},
+			"cursor",
+		);
+		expect(out.skip).toBe(false);
+		expect(out.kind).toBe("agent_tool");
+		expect(out.toolName).toBe("WebSearch");
+	});
+
+	it("still skips Cursor preToolUse for Read (postToolUse covers it)", () => {
+		expect(
+			normalizeActivityHookPayload(
+				"beforeTool",
+				{ tool_name: "Read", tool_input: { path: "/a.ts" } },
+				"cursor",
+			).skip,
+		).toBe(true);
+	});
+
+	it("traces Cursor Glob at preToolUse", () => {
+		const out = normalizeActivityHookPayload(
+			"beforeTool",
+			{
+				tool_name: "Glob",
+				tool_input: { glob_pattern: "**/*.md" },
+			},
+			"cursor",
+		);
+		expect(out.skip).toBe(false);
+		expect(out.toolName).toBe("Glob");
+	});
+
 	it("maps shell events", () => {
 		const out = normalizeActivityHookPayload(
 			"afterShell",

--- a/src/shared/activity-attributes.ts
+++ b/src/shared/activity-attributes.ts
@@ -65,9 +65,15 @@ export function serializeActivityAttributes(
 ): string | null {
 	if (!attributes || Object.keys(attributes).length === 0) return null;
 	try {
-		const json = JSON.stringify(attributes);
-		if (json.length <= ACTIVITY_ATTRIBUTES_MAX_JSON_CHARS) return json;
-		return `${json.slice(0, ACTIVITY_ATTRIBUTES_MAX_JSON_CHARS - 1)}…`;
+		const working: ActivityAttributes = { ...attributes };
+		const dropOrder = Object.keys(working);
+		while (dropOrder.length > 0) {
+			const json = JSON.stringify(working);
+			if (json.length <= ACTIVITY_ATTRIBUTES_MAX_JSON_CHARS) return json;
+			const key = dropOrder.pop();
+			if (key) delete working[key];
+		}
+		return null;
 	} catch {
 		return null;
 	}
@@ -108,7 +114,10 @@ function readAttribute(
 		) {
 			return raw;
 		}
-		if (Array.isArray(raw) || (typeof raw === "object" && raw !== null)) {
+		if (Array.isArray(raw)) {
+			return raw;
+		}
+		if (typeof raw === "object") {
 			return raw;
 		}
 	}

--- a/src/shared/activity-correlation-reconcile.ts
+++ b/src/shared/activity-correlation-reconcile.ts
@@ -38,7 +38,9 @@ function parseAttributesJson(
 }
 
 function transcriptPathFromRow(row: ActivityCorrelationRow): string | null {
-	const attrs = parseAttributesJson(row.attributes_json);
+	const raw = row.attributes_json;
+	if (!raw?.trim() || !raw.includes("transcript_path")) return null;
+	const attrs = parseAttributesJson(raw);
 	const path = attrs?.transcript_path;
 	return typeof path === "string" ? path : null;
 }
@@ -74,7 +76,7 @@ export function reconcileCursorActivityConversationIds<
 		if (call.kind === "prompt" && call.conversation_id?.trim()) {
 			chatId = call.conversation_id.trim();
 		}
-		if (!chatId) {
+		if (!chatId && call.kind === "stop") {
 			chatId = chatConversationIdFromTranscriptPath(
 				transcriptPathFromRow(call),
 			);

--- a/src/shared/activity-correlation-reconcile.ts
+++ b/src/shared/activity-correlation-reconcile.ts
@@ -1,0 +1,96 @@
+/**
+ * Reconcile provider activity rows whose conversation_id disagrees within the
+ * same generation (Cursor Agent CLI sends chat id on prompts and a separate
+ * agent-session id on tool/shell hooks).
+ */
+
+export type ActivityCorrelationRow = {
+	source: string | null;
+	kind: string;
+	conversation_id: string | null;
+	generation_id: string | null;
+	attributes_json?: string | null;
+};
+
+const TRANSCRIPT_CHAT_ID_RE = /agent-transcripts\/([^/]+)\//;
+
+export function chatConversationIdFromTranscriptPath(
+	path: string | null | undefined,
+): string | null {
+	if (!path?.trim()) return null;
+	const match = TRANSCRIPT_CHAT_ID_RE.exec(path.replace(/\\/g, "/"));
+	const id = match?.[1]?.trim();
+	return id || null;
+}
+
+function parseAttributesJson(
+	json: string | null | undefined,
+): Record<string, unknown> | null {
+	if (!json?.trim()) return null;
+	try {
+		const value = JSON.parse(json) as unknown;
+		return value && typeof value === "object" && !Array.isArray(value)
+			? (value as Record<string, unknown>)
+			: null;
+	} catch {
+		return null;
+	}
+}
+
+function transcriptPathFromRow(row: ActivityCorrelationRow): string | null {
+	const attrs = parseAttributesJson(row.attributes_json);
+	const path = attrs?.transcript_path;
+	return typeof path === "string" ? path : null;
+}
+
+/**
+ * Rewrite `conversation_id` on Cursor rows so a generation's prompt, tools,
+ * and stops share the composer/chat id used in transcript paths.
+ */
+export function reconcileCursorActivityConversationIds<
+	T extends ActivityCorrelationRow,
+>(calls: readonly T[]): T[] {
+	const chatByGeneration = new Map<string, string>();
+	const chatByAgentSession = new Map<string, string>();
+
+	for (const call of calls) {
+		if (call.source !== "cursor") continue;
+		const generationId = call.generation_id?.trim();
+		if (!generationId) continue;
+
+		let chatId: string | null = null;
+		if (call.kind === "prompt" && call.conversation_id?.trim()) {
+			chatId = call.conversation_id.trim();
+		}
+		if (!chatId) {
+			chatId = chatConversationIdFromTranscriptPath(
+				transcriptPathFromRow(call),
+			);
+		}
+		if (chatId) chatByGeneration.set(generationId, chatId);
+	}
+
+	if (chatByGeneration.size === 0) return [...calls];
+
+	const reconciled = calls.map((call) => {
+		if (call.source !== "cursor") return call;
+		const generationId = call.generation_id?.trim();
+		if (!generationId) return call;
+		const chatId = chatByGeneration.get(generationId);
+		if (!chatId || call.conversation_id === chatId) return call;
+		const priorSession = call.conversation_id?.trim();
+		if (priorSession) chatByAgentSession.set(priorSession, chatId);
+		return { ...call, conversation_id: chatId };
+	});
+
+	if (chatByAgentSession.size === 0) return reconciled;
+
+	return reconciled.map((call) => {
+		if (call.source !== "cursor") return call;
+		const sessionId = call.conversation_id?.trim();
+		if (!sessionId) return call;
+		const chatId = chatByAgentSession.get(sessionId);
+		if (!chatId || sessionId === chatId) return call;
+		return { ...call, conversation_id: chatId };
+	});
+}

--- a/src/shared/activity-correlation-reconcile.ts
+++ b/src/shared/activity-correlation-reconcile.ts
@@ -51,7 +51,19 @@ export function reconcileCursorActivityConversationIds<
 	T extends ActivityCorrelationRow,
 >(calls: readonly T[]): T[] {
 	const chatByGeneration = new Map<string, string>();
+	const ambiguousGenerations = new Set<string>();
 	const chatByAgentSession = new Map<string, string>();
+
+	const noteChatForGeneration = (generationId: string, chatId: string) => {
+		if (ambiguousGenerations.has(generationId)) return;
+		const existing = chatByGeneration.get(generationId);
+		if (existing && existing !== chatId) {
+			chatByGeneration.delete(generationId);
+			ambiguousGenerations.add(generationId);
+			return;
+		}
+		chatByGeneration.set(generationId, chatId);
+	};
 
 	for (const call of calls) {
 		if (call.source !== "cursor") continue;
@@ -67,7 +79,7 @@ export function reconcileCursorActivityConversationIds<
 				transcriptPathFromRow(call),
 			);
 		}
-		if (chatId) chatByGeneration.set(generationId, chatId);
+		if (chatId) noteChatForGeneration(generationId, chatId);
 	}
 
 	if (chatByGeneration.size === 0) return [...calls];
@@ -75,7 +87,7 @@ export function reconcileCursorActivityConversationIds<
 	const reconciled = calls.map((call) => {
 		if (call.source !== "cursor") return call;
 		const generationId = call.generation_id?.trim();
-		if (!generationId) return call;
+		if (!generationId || ambiguousGenerations.has(generationId)) return call;
 		const chatId = chatByGeneration.get(generationId);
 		if (!chatId || call.conversation_id === chatId) return call;
 		const priorSession = call.conversation_id?.trim();

--- a/src/shared/agent-activity-normalize.ts
+++ b/src/shared/agent-activity-normalize.ts
@@ -78,22 +78,29 @@ export function normalizeActivityHookPayload(
 		};
 	}
 
-	// Outcome-only: ignore lifecycle "before" noise.
-	// Kept even though SYSTEM_ACTIVITY_EVENTS omits these — CLI may still receive them.
+	// Outcome-only: ignore lifecycle "before" noise (except Cursor tools with no postToolUse).
 	if (
 		event === "beforeTool" ||
 		event === "beforeShell" ||
 		event === "beforeMcpCall" ||
 		event === "beforeFileRead"
 	) {
-		return {
-			kind: "agent_tool",
-			toolName: event,
-			status: "ok",
-			source: provider,
-			skip: true,
-			skipReason: "before-hook (outcome-only activity)",
-		};
+		if (
+			event === "beforeTool" &&
+			provider === "cursor" &&
+			cursorPreToolShouldTrace(obj)
+		) {
+			// fall through — traced at preToolUse because postToolUse never fires
+		} else {
+			return {
+				kind: "agent_tool",
+				toolName: event,
+				status: "ok",
+				source: provider,
+				skip: true,
+				skipReason: "before-hook (outcome-only activity)",
+			};
+		}
 	}
 
 	const kind = kindForEvent(event, obj);
@@ -151,8 +158,8 @@ function kindForEvent(
 		return isSkillMdPath(extractPath(obj)) ? "skill" : "file";
 	}
 	if (event === "beforeMcpCall" || event === "afterMcpCall") return "agent_mcp";
+	if (event === "beforeTool") return "agent_tool";
 	if (
-		event === "beforeTool" ||
 		event === "afterTool" ||
 		event === "afterToolFailure"
 	) {
@@ -202,7 +209,42 @@ function nameForEvent(
 	}
 	if (kind === "compact" || kind === "stop") return event;
 
+	const fromProvider = displayToolNameFrom(obj);
+	if (fromProvider) return fromProvider;
 	return toolNameFrom(obj) || stringField(obj, "tool") || event;
+}
+
+/** Cursor tools that already emit `postToolUse` — skip preToolUse to avoid dupes. */
+const CURSOR_POST_TOOL_USE_NAMES = new Set([
+	"Shell",
+	"Read",
+	"Write",
+	"Grep",
+	"Delete",
+	"Task",
+	"ApplyPatch",
+	"EditNotebook",
+]);
+
+export function cursorPreToolShouldTrace(obj: Record<string, unknown>): boolean {
+	const name = toolNameFrom(obj)?.trim();
+	if (!name) return false;
+	if (CURSOR_POST_TOOL_USE_NAMES.has(name)) return false;
+	if (/^mcp:/i.test(name)) return false;
+	return true;
+}
+
+function displayToolNameFrom(obj: Record<string, unknown>): string | null {
+	const wrapper = toolNameFrom(obj)?.trim();
+	if (wrapper === "CallDynamicTool") {
+		const inner =
+			nestedString(obj, ["tool_input", "toolName"]) ||
+			nestedString(obj, ["tool_input", "tool_name"]) ||
+			nestedString(obj, ["input", "toolName"]) ||
+			nestedString(obj, ["input", "tool_name"]);
+		if (inner?.trim()) return inner.trim();
+	}
+	return null;
 }
 
 function statusForEvent(

--- a/src/shared/agent-activity.ts
+++ b/src/shared/agent-activity.ts
@@ -40,6 +40,14 @@ export const SYSTEM_ACTIVITY_EVENTS: readonly CanonicalHookEvent[] = [
 	"stop",
 ] as const;
 
+/**
+ * Cursor CLI fires `postToolUse` only for a subset of tools (Read, Shell, …).
+ * Dynamic tools (`CallDynamicTool` → WebSearch/WebFetch) and Glob are visible
+ * on `preToolUse` instead — ingest those without doubling covered tools.
+ */
+export const CURSOR_SUPPLEMENTAL_ACTIVITY_EVENTS: readonly CanonicalHookEvent[] =
+	["beforeTool"];
+
 export function isSystemActivityHookId(id: string): boolean {
 	return id.startsWith(SYSTEM_ACTIVITY_HOOK_PREFIX);
 }
@@ -67,11 +75,21 @@ export function buildSystemActivityHooks(
 	providerId?: string,
 ): Hook[] {
 	const providerArg = providerId ? ` --provider ${shellQuote(providerId)}` : "";
-	const events = providerId
+	let events: CanonicalHookEvent[] = providerId
 		? SYSTEM_ACTIVITY_EVENTS.filter((event) =>
 				providerMapsActivityEvent(providerId, event),
 			)
-		: SYSTEM_ACTIVITY_EVENTS;
+		: [...SYSTEM_ACTIVITY_EVENTS];
+	if (providerId === "cursor") {
+		for (const event of CURSOR_SUPPLEMENTAL_ACTIVITY_EVENTS) {
+			if (
+				providerMapsActivityEvent(providerId, event) &&
+				!events.includes(event)
+			) {
+				events.push(event);
+			}
+		}
+	}
 	return events.map((event) => ({
 		id: systemActivityHookId(event),
 		on: event,

--- a/src/shared/plugin-manifest/detect.ts
+++ b/src/shared/plugin-manifest/detect.ts
@@ -440,12 +440,20 @@ export function resolveNestedPluginById(
 		const manifest = detectAndParseManifest(pluginRoot, preferredProviders);
 		if (!manifest) return null;
 		const dirName = cleaned.split("/").filter(Boolean).pop() ?? cleaned;
+		let manifestFile = "";
+		for (const { path } of getManifestSearchOrder(preferredProviders)) {
+			const candidate = join(pluginRoot, path);
+			if (existsSync(candidate)) {
+				manifestFile = candidate;
+				break;
+			}
+		}
 		return {
 			entry: {
 				subpath: cleaned,
 				manifestName: manifest.name || dirName,
 				dirName,
-				manifestFile: "",
+				manifestFile,
 			},
 			manifest,
 		};

--- a/src/shared/workspaces/__tests__/remap-shadow-path.test.ts
+++ b/src/shared/workspaces/__tests__/remap-shadow-path.test.ts
@@ -1,0 +1,29 @@
+import { describe, expect, it } from "bun:test";
+import { remapWrapShadowPath } from "../remap-shadow-path";
+
+describe("remapWrapShadowPath", () => {
+  const real = "/Users/me/Documents/Projects/odin";
+
+  it("maps nested shadow workspace paths to the real project", () => {
+    const shadow =
+      "/Users/me/.capa/workspaces/odin-5415-cursor/odin/src/foo.ts";
+    expect(remapWrapShadowPath(shadow, real)).toBe(
+      "/Users/me/Documents/Projects/odin/src/foo.ts",
+    );
+  });
+
+  it("maps shadow project root to real project root", () => {
+    const shadow = "/Users/me/.capa/workspaces/odin-5415-cursor/odin";
+    expect(remapWrapShadowPath(shadow, real)).toBe(real);
+  });
+
+  it("leaves non-shadow paths unchanged", () => {
+    const p = "/Users/me/Documents/Projects/odin/src/foo.ts";
+    expect(remapWrapShadowPath(p, real)).toBe(p);
+  });
+
+  it("returns input when real project path is missing", () => {
+    const shadow = "/Users/me/.capa/workspaces/x/y/file.ts";
+    expect(remapWrapShadowPath(shadow, null)).toBe(shadow);
+  });
+});

--- a/src/shared/workspaces/remap-shadow-path.ts
+++ b/src/shared/workspaces/remap-shadow-path.ts
@@ -1,0 +1,52 @@
+/** Normalize to posix slashes (no trailing slash except root). */
+export function normalizePosixPath(raw: string): string {
+  return raw.replace(/\\/g, "/").replace(/\/+/g, "/");
+}
+
+const CAPA_WORKSPACES_MARKER = "/.capa/workspaces/";
+
+/**
+ * If `filePath` lives under a capa wrap shadow workspace, map it to the real
+ * project tree. Nested layout:
+ *   ~/.capa/workspaces/<cache-slug>/<projectBasename>/… → <realProjectPath>/…
+ *
+ * Shadow roots and `.capa/workspaces` segments never appear in the result.
+ */
+export function remapWrapShadowPath(
+  filePath: string,
+  realProjectPath: string | null | undefined,
+): string {
+  const path = normalizePosixPath(filePath.trim());
+  if (!path || !realProjectPath?.trim()) return path;
+
+  const realBase = normalizePosixPath(realProjectPath.trim()).replace(/\/+$/, "");
+  if (!realBase) return path;
+
+  const idx = path.indexOf(CAPA_WORKSPACES_MARKER);
+  if (idx === -1) return path;
+
+  const after = path.slice(idx + CAPA_WORKSPACES_MARKER.length);
+  const parts = after.split("/").filter(Boolean);
+  if (parts.length === 0) return realBase;
+
+  const projectBasename =
+    realBase.split("/").filter(Boolean).pop()?.toLowerCase() ?? "";
+
+  // Nested cwd: <cache>/<basename>/rest…
+  if (parts.length >= 2 && projectBasename) {
+    const nested = parts[1]!.toLowerCase();
+    if (nested === projectBasename) {
+      const rest = parts.slice(2);
+      return rest.length === 0 ? realBase : `${realBase}/${rest.join("/")}`;
+    }
+    return path;
+  }
+
+  // Legacy flat cache: <cache>/rest…
+  if (parts.length >= 1) {
+    const rest = parts.slice(1);
+    return rest.length === 0 ? realBase : `${realBase}/${rest.join("/")}`;
+  }
+
+  return path;
+}

--- a/web-ui/src/components/common/FileTree.test.ts
+++ b/web-ui/src/components/common/FileTree.test.ts
@@ -1,0 +1,29 @@
+import { describe, expect, it } from 'bun:test';
+import {
+  buildFilePathTree,
+  treeNodeIsDirectory,
+  treeNodeIsFileLeaf,
+} from './FileTree';
+
+describe('buildFilePathTree', () => {
+  it('renders strict prefix paths as folders when deeper paths exist', () => {
+    const root = buildFilePathTree([
+      'domains',
+      'domains/attn-platform/AGENTS.md',
+    ]);
+    expect(treeNodeIsDirectory(root, 'domains')).toBe(true);
+    expect(treeNodeIsFileLeaf(root, 'domains')).toBe(false);
+    expect(treeNodeIsFileLeaf(root, 'domains/attn-platform/AGENTS.md')).toBe(true);
+  });
+
+  it('renders extensionless Grep roots as folders', () => {
+    const root = buildFilePathTree(['domains/attn-platform/platform-core']);
+    expect(treeNodeIsDirectory(root, 'domains/attn-platform/platform-core')).toBe(true);
+    expect(treeNodeIsFileLeaf(root, 'domains/attn-platform/platform-core')).toBe(false);
+  });
+
+  it('keeps normal files as file leaves', () => {
+    const root = buildFilePathTree(['src/foo.ts']);
+    expect(treeNodeIsFileLeaf(root, 'src/foo.ts')).toBe(true);
+  });
+});

--- a/web-ui/src/components/common/FileTree.tsx
+++ b/web-ui/src/components/common/FileTree.tsx
@@ -1,34 +1,104 @@
-import { useMemo, useState } from 'react';
-import { ChevronRight, File, Folder } from 'lucide-react';
+import { useEffect, useMemo, useRef, useState } from 'react';
+import { ChevronRight, Eye, File, FilePenLine, Folder, Trash2 } from 'lucide-react';
+import { cn } from '../../lib/utils';
+
+export type FileTreeFileMeta = {
+  read?: boolean;
+  modified?: boolean;
+  deleted?: boolean;
+};
 
 interface TreeNode {
   name: string;
   children: Map<string, TreeNode>;
   isFile: boolean;
+  pathKey: string | null;
 }
 
 function buildTree(paths: string[]): TreeNode {
-  const root: TreeNode = { name: '', children: new Map(), isFile: false };
+  const root: TreeNode = { name: '', children: new Map(), isFile: false, pathKey: null };
   for (const p of paths) {
     const segments = p.replace(/\\/g, '/').split('/').filter(Boolean);
     let node = root;
+    let pathSoFar = '';
     for (let i = 0; i < segments.length; i++) {
       const seg = segments[i];
+      pathSoFar = pathSoFar ? `${pathSoFar}/${seg}` : seg;
       if (!node.children.has(seg)) {
         node.children.set(seg, {
           name: seg,
           children: new Map(),
           isFile: i === segments.length - 1,
+          pathKey: i === segments.length - 1 ? pathSoFar : null,
         });
       }
       node = node.children.get(seg)!;
+      if (i === segments.length - 1) {
+        node.isFile = true;
+        node.pathKey = pathSoFar;
+      }
     }
   }
   return root;
 }
 
-function FileTreeNode({ node, depth = 0 }: { node: TreeNode; depth?: number }) {
-  const [open, setOpen] = useState(false);
+function FileMetaBadges({ meta }: { meta: FileTreeFileMeta }) {
+  const items: { key: string; icon: typeof Eye; className: string }[] = [];
+  if (meta.deleted) {
+    items.push({ key: 'deleted', icon: Trash2, className: 'text-error-text' });
+  }
+  if (meta.modified) {
+    items.push({
+      key: 'modified',
+      icon: FilePenLine,
+      className: 'text-amber-600 dark:text-amber-400',
+    });
+  }
+  if (meta.read) {
+    items.push({ key: 'read', icon: Eye, className: 'text-accent-primary' });
+  }
+  if (items.length === 0) return null;
+  return (
+    <span className="ml-auto flex shrink-0 items-center gap-0.5">
+      {items.map(({ key, icon: Icon, className }) => (
+        <Icon key={key} size={12} className={cn(className, 'opacity-90')} aria-hidden />
+      ))}
+    </span>
+  );
+}
+
+function pathKeySelected(
+  pathKey: string | null,
+  selectedPathKeys?: ReadonlySet<string> | readonly string[],
+): boolean {
+  if (pathKey == null || selectedPathKeys == null) return false;
+  if (selectedPathKeys instanceof Set) return selectedPathKeys.has(pathKey);
+  return selectedPathKeys.includes(pathKey);
+}
+
+function FileTreeNode({
+  node,
+  depth = 0,
+  annotations,
+  defaultExpanded = false,
+  treeExpansion,
+  selectedPathKeys,
+  searchQuery,
+  onFileSelect,
+  scrollPathKey,
+}: {
+  node: TreeNode;
+  depth?: number;
+  annotations?: Record<string, FileTreeFileMeta>;
+  defaultExpanded?: boolean;
+  treeExpansion?: 'all' | 'none';
+  selectedPathKeys?: ReadonlySet<string> | readonly string[];
+  searchQuery?: string;
+  onFileSelect?: (pathKey: string) => void;
+  scrollPathKey?: string | null;
+}) {
+  const [open, setOpen] = useState(defaultExpanded);
+  const rowRef = useRef<HTMLButtonElement>(null);
   const hasChildren = node.children.size > 0;
   const sorted = useMemo(
     () =>
@@ -39,23 +109,70 @@ function FileTreeNode({ node, depth = 0 }: { node: TreeNode; depth?: number }) {
     [node.children],
   );
 
+  useEffect(() => {
+    if (treeExpansion === 'all' && hasChildren) setOpen(true);
+    if (treeExpansion === 'none' && hasChildren) setOpen(false);
+  }, [treeExpansion, hasChildren]);
+
+  useEffect(() => {
+    const q = searchQuery?.trim().toLowerCase();
+    if (!q || !hasChildren) return;
+    const childMatches = sorted.some((child) => treeNodeMatchesSearch(child, q));
+    if (childMatches) setOpen(true);
+  }, [searchQuery, hasChildren, sorted]);
+
+  const isSelected = pathKeySelected(node.pathKey, selectedPathKeys);
+
+  useEffect(() => {
+    if (isSelected && node.pathKey && node.pathKey === scrollPathKey) {
+      rowRef.current?.scrollIntoView({ block: 'nearest', behavior: 'smooth' });
+    }
+  }, [isSelected, node.pathKey, scrollPathKey]);
+
   if (!node.name) {
     return (
       <>
         {sorted.map((child) => (
-          <FileTreeNode key={child.name} node={child} depth={0} />
+          <FileTreeNode
+            key={child.name}
+            node={child}
+            depth={0}
+            annotations={annotations}
+            defaultExpanded={defaultExpanded}
+            treeExpansion={treeExpansion}
+            selectedPathKeys={selectedPathKeys}
+            searchQuery={searchQuery}
+            onFileSelect={onFileSelect}
+            scrollPathKey={scrollPathKey}
+          />
         ))}
       </>
     );
   }
 
+  const meta =
+    node.isFile && node.pathKey ? annotations?.[node.pathKey] : undefined;
+
   return (
     <div>
       <button
+        ref={rowRef}
         type="button"
-        className="flex w-full items-center gap-1.5 rounded-sm px-1 py-0.5 text-left text-xs hover:bg-hover-bg"
+        className={cn(
+          'flex w-full min-w-0 items-center gap-1.5 rounded-sm px-1 py-0.5 text-left text-xs hover:bg-hover-bg',
+          isSelected && 'bg-accent-primary/15 ring-1 ring-inset ring-accent-primary/35',
+          node.isFile && onFileSelect && 'cursor-pointer',
+        )}
         style={{ paddingLeft: `${depth * 16 + 4}px` }}
-        onClick={() => hasChildren && setOpen((v) => !v)}
+        onClick={() => {
+          if (node.isFile && node.pathKey) {
+            onFileSelect?.(node.pathKey);
+            return;
+          }
+          if (hasChildren) setOpen((v) => !v);
+        }}
+        title={node.pathKey ?? undefined}
+        aria-current={isSelected ? 'true' : undefined}
       >
         {hasChildren ? (
           <ChevronRight
@@ -63,7 +180,7 @@ function FileTreeNode({ node, depth = 0 }: { node: TreeNode; depth?: number }) {
             data-open={open ? 'true' : 'false'}
           />
         ) : (
-          <span className="inline-block w-3" />
+          <span className="inline-block w-3 shrink-0" />
         )}
         {node.isFile ? (
           <File className="h-3.5 w-3.5 shrink-0 text-text-tertiary" />
@@ -71,15 +188,31 @@ function FileTreeNode({ node, depth = 0 }: { node: TreeNode; depth?: number }) {
           <Folder className="h-3.5 w-3.5 shrink-0 text-accent-primary" />
         )}
         <span
-          className={`truncate ${node.isFile ? 'text-text-secondary' : 'font-medium text-text-primary'}`}
+          className={cn(
+            'min-w-0 flex-1 truncate',
+            node.isFile ? 'text-text-secondary' : 'font-medium text-text-primary',
+            isSelected && 'text-text-primary',
+          )}
         >
           {node.name}
         </span>
+        {meta ? <FileMetaBadges meta={meta} /> : null}
       </button>
       {open && (
         <div className="ui-panel-enter">
           {sorted.map((child) => (
-            <FileTreeNode key={child.name} node={child} depth={depth + 1} />
+            <FileTreeNode
+              key={child.name}
+              node={child}
+              depth={depth + 1}
+              annotations={annotations}
+              defaultExpanded={defaultExpanded}
+              treeExpansion={treeExpansion}
+              selectedPathKeys={selectedPathKeys}
+              searchQuery={searchQuery}
+              onFileSelect={onFileSelect}
+              scrollPathKey={scrollPathKey}
+            />
           ))}
         </div>
       )}
@@ -87,12 +220,57 @@ function FileTreeNode({ node, depth = 0 }: { node: TreeNode; depth?: number }) {
   );
 }
 
-export function FileTree({ files }: { files: string[] }) {
+function treeNodeMatchesSearch(node: TreeNode, q: string): boolean {
+  if (node.pathKey?.toLowerCase().includes(q)) return true;
+  if (node.name.toLowerCase().includes(q)) return true;
+  for (const child of node.children.values()) {
+    if (treeNodeMatchesSearch(child, q)) return true;
+  }
+  return false;
+}
+
+export function FileTree({
+  files,
+  annotations,
+  variant = 'card',
+  defaultExpanded = false,
+  treeExpansion,
+  selectedPathKeys,
+  searchQuery,
+  onFileSelect,
+  scrollPathKey,
+}: {
+  files: string[];
+  annotations?: Record<string, FileTreeFileMeta>;
+  variant?: 'card' | 'plain';
+  defaultExpanded?: boolean;
+  treeExpansion?: 'all' | 'none';
+  selectedPathKeys?: ReadonlySet<string> | readonly string[];
+  searchQuery?: string;
+  onFileSelect?: (pathKey: string) => void;
+  /** When set, the matching selected file row scrolls into view. */
+  scrollPathKey?: string | null;
+}) {
   const tree = useMemo(() => buildTree(files), [files]);
   if (files.length === 0) return null;
+  const inner = (
+    <FileTreeNode
+      node={tree}
+      annotations={annotations}
+      defaultExpanded={defaultExpanded}
+      treeExpansion={treeExpansion}
+      selectedPathKeys={selectedPathKeys}
+      searchQuery={searchQuery}
+      onFileSelect={onFileSelect}
+      scrollPathKey={scrollPathKey}
+    />
+  );
+  if (variant === 'plain') {
+    return <div className="font-mono">{inner}</div>;
+  }
   return (
     <div className="rounded-lg border border-border-primary bg-bg-secondary p-3">
-      <FileTreeNode node={tree} />
+      {inner}
     </div>
   );
 }

--- a/web-ui/src/components/common/FileTree.tsx
+++ b/web-ui/src/components/common/FileTree.tsx
@@ -72,8 +72,8 @@ function pathKeySelected(
   selectedPathKeys?: ReadonlySet<string> | readonly string[],
 ): boolean {
   if (pathKey == null || selectedPathKeys == null) return false;
-  if (selectedPathKeys instanceof Set) return selectedPathKeys.has(pathKey);
-  return selectedPathKeys.includes(pathKey);
+  if (Array.isArray(selectedPathKeys)) return selectedPathKeys.includes(pathKey);
+  return (selectedPathKeys as ReadonlySet<string>).has(pathKey);
 }
 
 function FileTreeNode({

--- a/web-ui/src/components/common/FileTree.tsx
+++ b/web-ui/src/components/common/FileTree.tsx
@@ -15,31 +15,98 @@ interface TreeNode {
   pathKey: string | null;
 }
 
+const EXTENSIONLESS_FILE_NAMES =
+  /^(Makefile|Dockerfile|LICENSE|README|CHANGELOG|CODEOWNERS)$/i;
+
+function basenameLooksLikeFile(displayPath: string): boolean {
+  const base = displayPath.split('/').filter(Boolean).pop() ?? '';
+  if (!base) return false;
+  if (base.includes('.')) return true;
+  return EXTENSIONLESS_FILE_NAMES.test(base);
+}
+
+function isStrictPathPrefix(full: string, pathSet: Set<string>): boolean {
+  for (const other of pathSet) {
+    if (other !== full && other.startsWith(`${full}/`)) return true;
+  }
+  return false;
+}
+
+function normalizeDirectoryNodes(node: TreeNode): void {
+  for (const child of node.children.values()) {
+    normalizeDirectoryNodes(child);
+  }
+  if (node.children.size > 0) {
+    node.isFile = false;
+  }
+}
+
 function buildTree(paths: string[]): TreeNode {
   const root: TreeNode = { name: '', children: new Map(), isFile: false, pathKey: null };
-  for (const p of paths) {
-    const segments = p.replace(/\\/g, '/').split('/').filter(Boolean);
+  const pathSet = new Set(
+    paths.map((p) => p.replace(/\\/g, '/').replace(/\/+$/, '')).filter(Boolean),
+  );
+
+  for (const raw of paths) {
+    const normalized = raw.replace(/\\/g, '/').replace(/\/+$/, '');
+    const segments = normalized.split('/').filter(Boolean);
+    if (segments.length === 0) continue;
+
     let node = root;
     let pathSoFar = '';
     for (let i = 0; i < segments.length; i++) {
-      const seg = segments[i];
+      const seg = segments[i]!;
       pathSoFar = pathSoFar ? `${pathSoFar}/${seg}` : seg;
       if (!node.children.has(seg)) {
         node.children.set(seg, {
           name: seg,
           children: new Map(),
-          isFile: i === segments.length - 1,
-          pathKey: i === segments.length - 1 ? pathSoFar : null,
+          isFile: false,
+          pathKey: pathSoFar,
         });
       }
       node = node.children.get(seg)!;
+      node.pathKey = pathSoFar;
       if (i === segments.length - 1) {
-        node.isFile = true;
-        node.pathKey = pathSoFar;
+        node.isFile =
+          !isStrictPathPrefix(pathSoFar, pathSet) &&
+          basenameLooksLikeFile(pathSoFar);
       }
     }
   }
+
+  normalizeDirectoryNodes(root);
   return root;
+}
+
+/** @internal Exported for unit tests. */
+export function buildFilePathTree(paths: string[]): TreeNode {
+  return buildTree(paths);
+}
+
+function findTreeNode(root: TreeNode, pathKey: string): TreeNode | null {
+  const segments = pathKey.split('/').filter(Boolean);
+  let node = root;
+  for (const seg of segments) {
+    const next = node.children.get(seg);
+    if (!next) return null;
+    node = next;
+  }
+  return node;
+}
+
+/** @internal */
+export function treeNodeIsFileLeaf(root: TreeNode, pathKey: string): boolean {
+  const node = findTreeNode(root, pathKey);
+  if (!node) return false;
+  return node.isFile && node.children.size === 0;
+}
+
+/** @internal */
+export function treeNodeIsDirectory(root: TreeNode, pathKey: string): boolean {
+  const node = findTreeNode(root, pathKey);
+  if (!node) return false;
+  return !node.isFile || node.children.size > 0;
 }
 
 function FileMetaBadges({ meta }: { meta: FileTreeFileMeta }) {
@@ -150,8 +217,8 @@ function FileTreeNode({
     );
   }
 
-  const meta =
-    node.isFile && node.pathKey ? annotations?.[node.pathKey] : undefined;
+  const meta = node.pathKey ? annotations?.[node.pathKey] : undefined;
+  const showAsFile = node.isFile && !hasChildren;
 
   return (
     <div>
@@ -161,11 +228,11 @@ function FileTreeNode({
         className={cn(
           'flex w-full min-w-0 items-center gap-1.5 rounded-sm px-1 py-0.5 text-left text-xs hover:bg-hover-bg',
           isSelected && 'bg-accent-primary/15 ring-1 ring-inset ring-accent-primary/35',
-          node.isFile && onFileSelect && 'cursor-pointer',
+          showAsFile && onFileSelect && 'cursor-pointer',
         )}
         style={{ paddingLeft: `${depth * 16 + 4}px` }}
         onClick={() => {
-          if (node.isFile && node.pathKey) {
+          if (showAsFile && node.pathKey) {
             onFileSelect?.(node.pathKey);
             return;
           }
@@ -182,7 +249,7 @@ function FileTreeNode({
         ) : (
           <span className="inline-block w-3 shrink-0" />
         )}
-        {node.isFile ? (
+        {showAsFile ? (
           <File className="h-3.5 w-3.5 shrink-0 text-text-tertiary" />
         ) : (
           <Folder className="h-3.5 w-3.5 shrink-0 text-accent-primary" />
@@ -190,7 +257,7 @@ function FileTreeNode({
         <span
           className={cn(
             'min-w-0 flex-1 truncate',
-            node.isFile ? 'text-text-secondary' : 'font-medium text-text-primary',
+            showAsFile ? 'text-text-secondary' : 'font-medium text-text-primary',
             isSelected && 'text-text-primary',
           )}
         >

--- a/web-ui/src/features/projects/components/activity/ActivityFeed.tsx
+++ b/web-ui/src/features/projects/components/activity/ActivityFeed.tsx
@@ -21,6 +21,7 @@ interface ActivityFeedProps {
   loadingMore: boolean;
   onLoadMore: () => void;
   live?: boolean;
+  projectPath?: string | null;
 }
 
 function RunRow({
@@ -144,6 +145,7 @@ export function ActivityFeed({
   loadingMore,
   onLoadMore,
   live = false,
+  projectPath = null,
 }: ActivityFeedProps) {
   const { t } = useTranslation('projects');
   const conversations = useMemo(
@@ -213,6 +215,7 @@ export function ActivityFeed({
           if (!next) setSelectedId(null);
         }}
         live={live}
+        projectPath={projectPath}
       />
     </>
   );

--- a/web-ui/src/features/projects/components/activity/ActivityRunDialog.tsx
+++ b/web-ui/src/features/projects/components/activity/ActivityRunDialog.tsx
@@ -11,6 +11,13 @@ import {
   sumRunTokenUsage,
 } from './groupActivityRuns';
 import { ActivitySpanRow } from './ActivitySpanRow';
+import { ActivityRunFileTree } from './ActivityRunFileTree';
+import { ActivityRunSplitPane } from './ActivityRunSplitPane';
+import {
+  collectRunFileChanges,
+  displayPathKeyFromSpan,
+  spanIdsForDisplayPathKey,
+} from './buildRunFileTree';
 import { sourceLabelText, TokenUsageLabel } from './ActivityShared';
 
 interface ActivityRunDialogProps {
@@ -18,6 +25,7 @@ interface ActivityRunDialogProps {
   open: boolean;
   onOpenChange: (open: boolean) => void;
   live?: boolean;
+  projectPath?: string | null;
 }
 
 function runEvents(run: ActivityRun): ToolCallRecord[] {
@@ -58,11 +66,15 @@ export function ActivityRunDialog({
   open,
   onOpenChange,
   live = false,
+  projectPath = null,
 }: ActivityRunDialogProps) {
   const { t } = useTranslation('projects');
   const scrollRef = useRef<HTMLDivElement>(null);
   const bottomRef = useRef<HTMLDivElement>(null);
   const [followLatest, setFollowLatest] = useState(true);
+  const [expandedSpanIds, setExpandedSpanIds] = useState<Set<string>>(() => new Set());
+  const [pickedFilePathKey, setPickedFilePathKey] = useState<string | null>(null);
+  const [scrollTreePathKey, setScrollTreePathKey] = useState<string | null>(null);
   const eventCount = run ? runEvents(run).length : 0;
   const prevCountRef = useRef(eventCount);
   const seenIdsRef = useRef<Set<string>>(new Set());
@@ -78,6 +90,75 @@ export function ActivityRunDialog({
   const running = run ? runIsLive(run) : false;
   const tokenTotals = useMemo(() => sumRunTokenUsage(events), [events]);
 
+  const fileEntries = useMemo(
+    () => collectRunFileChanges(events, { realProjectPath: projectPath }),
+    [events, projectPath],
+  );
+
+  const pathOptions = useMemo(
+    () => ({ realProjectPath: projectPath }),
+    [projectPath],
+  );
+
+  const selectedPathKeys = useMemo(() => {
+    if (pickedFilePathKey) return new Set([pickedFilePathKey]);
+    const keys = new Set<string>();
+    for (const id of expandedSpanIds) {
+      const ev = events.find((e) => e.id === id);
+      if (!ev) continue;
+      const key = displayPathKeyFromSpan(ev, fileEntries, pathOptions);
+      if (key) keys.add(key);
+    }
+    return keys;
+  }, [pickedFilePathKey, expandedSpanIds, events, fileEntries, pathOptions]);
+
+  const fileLinkedSpanIds = useMemo(() => {
+    if (!pickedFilePathKey) return new Set<string>();
+    return new Set(
+      spanIdsForDisplayPathKey(
+        pickedFilePathKey,
+        events,
+        fileEntries,
+        pathOptions,
+      ),
+    );
+  }, [pickedFilePathKey, events, fileEntries, pathOptions]);
+
+  function onSpanExpandedChange(nextOpen: boolean, call: ToolCallRecord) {
+    setPickedFilePathKey(null);
+    setExpandedSpanIds((prev) => {
+      const next = new Set(prev);
+      if (nextOpen) next.add(call.id);
+      else next.delete(call.id);
+      return next;
+    });
+    if (nextOpen) {
+      setFollowLatest(false);
+      const key = displayPathKeyFromSpan(call, fileEntries, pathOptions);
+      if (key) setScrollTreePathKey(key);
+    }
+  }
+
+  function onFileSelect(pathKey: string) {
+    setPickedFilePathKey(pathKey);
+    setScrollTreePathKey(pathKey);
+    setFollowLatest(false);
+    const spanIds = spanIdsForDisplayPathKey(
+      pathKey,
+      events,
+      fileEntries,
+      pathOptions,
+    );
+    requestAnimationFrame(() => {
+      const first = spanIds[0];
+      if (first) {
+        document
+          .getElementById(`activity-span-${first}`)
+          ?.scrollIntoView({ block: 'nearest', behavior: 'smooth' });
+      }
+    });
+  }
+
   function clearFreshTimers() {
     for (const timer of freshTimersRef.current.values()) {
       window.clearTimeout(timer);
@@ -89,6 +170,9 @@ export function ActivityRunDialog({
   useEffect(() => {
     if (!open || !run) return;
     setFollowLatest(true);
+    setExpandedSpanIds(new Set());
+    setPickedFilePathKey(null);
+    setScrollTreePathKey(null);
     prevCountRef.current = eventCount;
     const ids = new Set(runEvents(run).map((e) => e.id));
     seenIdsRef.current = ids;
@@ -163,7 +247,7 @@ export function ActivityRunDialog({
         <Dialog.Overlay className="ui-overlay fixed inset-0 z-40 bg-black/45" />
         <Dialog.Content
           className={cn(
-            'ui-dialog fixed z-50 flex w-[min(1180px,98vw)] flex-col',
+            'ui-dialog fixed z-50 flex w-[min(1320px,98vw)] flex-col',
             'max-h-[min(92vh,880px)] overflow-hidden rounded-lg',
             'border border-border-primary bg-bg-secondary shadow-lg',
           )}
@@ -244,33 +328,49 @@ export function ActivityRunDialog({
                 </div>
               </div>
 
-              <div
-                ref={scrollRef}
-                onScroll={onScroll}
-                className="min-h-0 flex-1 overflow-y-auto"
-              >
-                <div className="sticky top-0 z-[1] flex items-center gap-2.5 border-b border-border-secondary bg-bg-secondary/95 px-3 py-1.5 text-[10px] font-medium uppercase tracking-[0.07em] text-text-tertiary backdrop-blur-sm">
-                  <span className="w-4 shrink-0" />
-                  <span className="min-w-0 flex-1">{t('activity.colName')}</span>
-                  <span className="hidden md:inline w-32 shrink-0 text-center">
-                    {t('activity.colTimeline')}
-                  </span>
-                  <span className="w-12 shrink-0 text-right">{t('activity.colLatency')}</span>
-                  <span className="w-[4.75rem] shrink-0 text-right">{t('activity.colTime')}</span>
-                </div>
-                {events.map((ev) => (
-                  <ActivitySpanRow
-                    key={ev.id}
-                    call={ev}
-                    runStart={timeline.start}
-                    runEnd={timeline.end}
-                    nestedPayload
-                    fresh={freshIds.has(ev.id)}
-                    onInspect={() => setFollowLatest(false)}
+              <ActivityRunSplitPane
+                left={
+                  <ActivityRunFileTree
+                    events={events}
+                    runId={run.id}
+                    projectPath={projectPath}
+                    selectedPathKeys={selectedPathKeys}
+                    scrollPathKey={scrollTreePathKey}
+                    onFileSelect={onFileSelect}
                   />
-                ))}
-                <div ref={bottomRef} className="h-2" aria-hidden />
-              </div>
+                }
+                right={
+                <div
+                  ref={scrollRef}
+                  onScroll={onScroll}
+                  className="min-h-0 h-full overflow-y-auto"
+                >
+                  <div className="sticky top-0 z-[1] flex items-center gap-2.5 border-b border-border-secondary bg-bg-secondary/95 px-3 py-1.5 text-[10px] font-medium uppercase tracking-[0.07em] text-text-tertiary backdrop-blur-sm">
+                    <span className="w-4 shrink-0" />
+                    <span className="min-w-0 flex-1">{t('activity.colName')}</span>
+                    <span className="hidden md:inline w-32 shrink-0 text-center">
+                      {t('activity.colTimeline')}
+                    </span>
+                    <span className="w-12 shrink-0 text-right">{t('activity.colLatency')}</span>
+                    <span className="w-[4.75rem] shrink-0 text-right">{t('activity.colTime')}</span>
+                  </div>
+                  {events.map((ev) => (
+                    <ActivitySpanRow
+                      key={ev.id}
+                      call={ev}
+                      runStart={timeline.start}
+                      runEnd={timeline.end}
+                      nestedPayload
+                      fresh={freshIds.has(ev.id)}
+                      fileLinked={fileLinkedSpanIds.has(ev.id)}
+                      onInspect={() => setFollowLatest(false)}
+                      onExpandedChange={onSpanExpandedChange}
+                    />
+                  ))}
+                  <div ref={bottomRef} className="h-2" aria-hidden />
+                </div>
+                }
+              />
             </>
           ) : null}
         </Dialog.Content>

--- a/web-ui/src/features/projects/components/activity/ActivityRunFileTree.tsx
+++ b/web-ui/src/features/projects/components/activity/ActivityRunFileTree.tsx
@@ -1,0 +1,141 @@
+import { useEffect, useMemo, useState } from 'react';
+import { useTranslation } from 'react-i18next';
+import { Eye, FilePenLine, Search, Trash2 } from 'lucide-react';
+import type { ToolCallRecord } from '../../../../types/api';
+import { FileTree } from '../../../../components/common/FileTree';
+import {
+  collectRunFileChanges,
+  runFilesForFileTreeFiltered,
+} from './buildRunFileTree';
+
+interface ActivityRunFileTreeProps {
+  events: ToolCallRecord[];
+  runId: string;
+  projectPath: string | null;
+  selectedPathKeys: ReadonlySet<string>;
+  scrollPathKey?: string | null;
+  onFileSelect?: (pathKey: string) => void;
+}
+
+export function ActivityRunFileTree({
+  events,
+  runId,
+  projectPath,
+  selectedPathKeys,
+  scrollPathKey = null,
+  onFileSelect,
+}: ActivityRunFileTreeProps) {
+  const { t } = useTranslation('projects');
+  const [search, setSearch] = useState('');
+  const [treeExpansion, setTreeExpansion] = useState<'all' | 'none'>('all');
+
+  useEffect(() => {
+    setSearch('');
+    setTreeExpansion('all');
+  }, [runId]);
+
+  const entries = useMemo(
+    () => collectRunFileChanges(events, { realProjectPath: projectPath }),
+    [events, projectPath],
+  );
+
+  const { files, annotations, fileCount } = useMemo(() => {
+    const { files: treeFiles, annotations: treeAnnotations } =
+      runFilesForFileTreeFiltered(entries, search, { realProjectPath: projectPath });
+    return {
+      files: treeFiles,
+      annotations: treeAnnotations,
+      fileCount: entries.length,
+    };
+  }, [entries, search]);
+
+  return (
+    <aside
+      className="flex min-h-0 h-full flex-col bg-bg-tertiary/30"
+      aria-label={t('activity.runFiles.aria')}
+    >
+      <div className="shrink-0 space-y-2 border-b border-border-secondary px-3 py-2">
+        <div>
+          <h3 className="text-[10px] font-semibold uppercase tracking-[0.06em] text-text-secondary">
+            {t('activity.runFiles.heading')}
+          </h3>
+          <p className="mt-0.5 text-[10px] leading-snug text-text-tertiary">
+            {fileCount === 0
+              ? t('activity.runFiles.empty')
+              : t('activity.runFiles.count', { count: fileCount })}
+          </p>
+        </div>
+        <div className="relative">
+          <Search
+            size={12}
+            className="pointer-events-none absolute left-2 top-1/2 -translate-y-1/2 text-text-tertiary"
+            aria-hidden
+          />
+          <input
+            type="search"
+            value={search}
+            onChange={(e) => setSearch(e.target.value)}
+            placeholder={t('activity.runFiles.searchPlaceholder')}
+            className="w-full rounded-md border border-border-secondary bg-bg-secondary py-1.5 pl-7 pr-2 text-[11px] text-text-primary placeholder:text-text-tertiary focus:border-accent-primary/50 focus:outline-none"
+          />
+        </div>
+        <div className="flex gap-1">
+          <button
+            type="button"
+            onClick={() => setTreeExpansion('all')}
+            className="rounded px-2 py-0.5 text-[10px] font-medium text-text-secondary hover:bg-hover-bg"
+          >
+            {t('activity.runFiles.expandAll')}
+          </button>
+          <button
+            type="button"
+            onClick={() => setTreeExpansion('none')}
+            className="rounded px-2 py-0.5 text-[10px] font-medium text-text-secondary hover:bg-hover-bg"
+          >
+            {t('activity.runFiles.collapseAll')}
+          </button>
+        </div>
+      </div>
+      <div className="min-h-0 flex-1 overflow-y-auto px-2 py-2">
+        {fileCount === 0 ? (
+          <p className="px-1 text-[10px] text-text-tertiary">
+            {t('activity.runFiles.emptyHint')}
+          </p>
+        ) : files.length === 0 ? (
+          <p className="px-1 text-[10px] text-text-tertiary">
+            {t('activity.runFiles.noSearchResults')}
+          </p>
+        ) : (
+          <FileTree
+            key={runId}
+            files={files}
+            annotations={annotations}
+            variant="plain"
+            defaultExpanded
+            treeExpansion={treeExpansion}
+            selectedPathKeys={selectedPathKeys}
+            searchQuery={search}
+            onFileSelect={onFileSelect}
+            scrollPathKey={scrollPathKey}
+          />
+        )}
+      </div>
+      <div className="shrink-0 border-t border-border-secondary px-3 py-2 text-[9px] text-text-tertiary">
+        <div className="flex flex-wrap gap-x-3 gap-y-1">
+          <span className="inline-flex items-center gap-1">
+            <Eye size={10} className="text-accent-primary" />
+            {t('activity.runFiles.read')}
+          </span>
+          <span className="inline-flex items-center gap-1">
+            <FilePenLine size={10} className="text-amber-600 dark:text-amber-400" />
+            {t('activity.runFiles.modified')}
+          </span>
+          <span className="inline-flex items-center gap-1">
+            <Trash2 size={10} className="text-error-text" />
+            {t('activity.runFiles.deleted')}
+          </span>
+        </div>
+      </div>
+    </aside>
+  );
+}

--- a/web-ui/src/features/projects/components/activity/ActivityRunSplitPane.tsx
+++ b/web-ui/src/features/projects/components/activity/ActivityRunSplitPane.tsx
@@ -1,0 +1,82 @@
+import { useCallback, useEffect, useRef, useState, type ReactNode } from 'react';
+import { cn } from '../../../../lib/utils';
+
+interface ActivityRunSplitPaneProps {
+  left: ReactNode;
+  right: ReactNode;
+  defaultLeftWidth?: number;
+  minLeftWidth?: number;
+  maxLeftWidth?: number;
+  className?: string;
+}
+
+export function ActivityRunSplitPane({
+  left,
+  right,
+  defaultLeftWidth = 280,
+  minLeftWidth = 200,
+  maxLeftWidth = 560,
+  className,
+}: ActivityRunSplitPaneProps) {
+  const [leftWidth, setLeftWidth] = useState(defaultLeftWidth);
+  const draggingRef = useRef(false);
+  const startXRef = useRef(0);
+  const startWidthRef = useRef(defaultLeftWidth);
+
+  const onPointerMove = useCallback(
+    (e: PointerEvent) => {
+      if (!draggingRef.current) return;
+      const delta = e.clientX - startXRef.current;
+      const next = Math.min(
+        maxLeftWidth,
+        Math.max(minLeftWidth, startWidthRef.current + delta),
+      );
+      setLeftWidth(next);
+    },
+    [maxLeftWidth, minLeftWidth],
+  );
+
+  const endDrag = useCallback(() => {
+    draggingRef.current = false;
+    document.body.style.cursor = '';
+    document.body.style.userSelect = '';
+    window.removeEventListener('pointermove', onPointerMove);
+    window.removeEventListener('pointerup', endDrag);
+  }, [onPointerMove]);
+
+  function onHandlePointerDown(e: React.PointerEvent) {
+    e.preventDefault();
+    draggingRef.current = true;
+    startXRef.current = e.clientX;
+    startWidthRef.current = leftWidth;
+    document.body.style.cursor = 'col-resize';
+    document.body.style.userSelect = 'none';
+    window.addEventListener('pointermove', onPointerMove);
+    window.addEventListener('pointerup', endDrag);
+  }
+
+  useEffect(() => () => endDrag(), [endDrag]);
+
+  return (
+    <div className={cn('flex min-h-0 flex-1 overflow-hidden', className)}>
+      <div
+        className="flex min-h-0 shrink-0 flex-col overflow-hidden"
+        style={{ width: leftWidth }}
+      >
+        {left}
+      </div>
+      <div
+        role="separator"
+        aria-orientation="vertical"
+        aria-valuenow={leftWidth}
+        onPointerDown={onHandlePointerDown}
+        className={cn(
+          'w-1 shrink-0 cursor-col-resize bg-border-secondary',
+          'hover:bg-accent-primary/40 active:bg-accent-primary/55',
+          'transition-colors',
+        )}
+      />
+      <div className="min-h-0 min-w-0 flex-1 overflow-hidden">{right}</div>
+    </div>
+  );
+}

--- a/web-ui/src/features/projects/components/activity/ActivitySection.tsx
+++ b/web-ui/src/features/projects/components/activity/ActivitySection.tsx
@@ -2,7 +2,7 @@ import { useTranslation } from 'react-i18next';
 import { Activity as ActivityIcon } from 'lucide-react';
 import { Spinner } from '../../../../components/common/Spinner';
 import { Alert } from '../../../../components/common/Alert';
-import { useProjectActivity } from '../../hooks';
+import { useProjectActivity, useProject } from '../../hooks';
 import { ActivityChart } from './ActivityChart';
 import { ActivityFeed } from './ActivityFeed';
 import { ActivityStatsBar } from './ActivityStats';
@@ -23,6 +23,7 @@ export function ActivitySection({ projectId }: ActivitySectionProps) {
     loadingMore,
     loadMore,
   } = useProjectActivity(projectId);
+  const { data: project } = useProject(projectId);
 
   return (
     <div
@@ -59,6 +60,7 @@ export function ActivitySection({ projectId }: ActivitySectionProps) {
           loadingMore={loadingMore}
           onLoadMore={() => void loadMore()}
           live={live}
+          projectPath={project?.path ?? null}
         />
       )}
     </div>

--- a/web-ui/src/features/projects/components/activity/ActivitySpanRow.tsx
+++ b/web-ui/src/features/projects/components/activity/ActivitySpanRow.tsx
@@ -26,10 +26,14 @@ interface ActivitySpanRowProps {
   runEnd: number;
   /** Called when the user expands a span (e.g. to pause follow-latest). */
   onInspect?: () => void;
+  /** Fired when inline payload is expanded or collapsed. */
+  onExpandedChange?: (open: boolean, call: ToolCallRecord) => void;
   /** Nested payload dialogs sit above the run dialog. */
   nestedPayload?: boolean;
   /** Soft amber highlight that fades out (new live spans). */
   fresh?: boolean;
+  /** Linked from a file selection in the run file tree. */
+  fileLinked?: boolean;
 }
 
 export function ActivitySpanRow({
@@ -37,8 +41,10 @@ export function ActivitySpanRow({
   runStart,
   runEnd,
   onInspect,
+  onExpandedChange,
   nestedPayload = false,
   fresh = false,
+  fileLinked = false,
 }: ActivitySpanRowProps) {
   const { t } = useTranslation('projects');
   const [open, setOpen] = useState(false);
@@ -49,13 +55,14 @@ export function ActivitySpanRow({
   const showUsage = hasTokenUsage(call);
 
   return (
-    <div className="group/span">
+    <div className="group/span" id={`activity-span-${call.id}`}>
       <button
         type="button"
         onClick={() => {
           setOpen((v) => {
             const next = !v;
             if (next) onInspect?.();
+            onExpandedChange?.(next, call);
             return next;
           });
         }}
@@ -64,6 +71,9 @@ export function ActivitySpanRow({
           'flex w-full items-center gap-2.5 px-3 py-1.5 text-left cursor-pointer',
           'transition-colors duration-100',
           fresh && 'activity-span-fresh',
+          fileLinked &&
+            'ring-1 ring-inset ring-accent-primary/25',
+          fileLinked && !open && 'bg-accent-primary/[0.08]',
           errored && 'bg-error-bg hover:bg-error-bg',
           capa
             ? cn(

--- a/web-ui/src/features/projects/components/activity/buildRunFileTree.test.ts
+++ b/web-ui/src/features/projects/components/activity/buildRunFileTree.test.ts
@@ -1,0 +1,201 @@
+import { describe, expect, it } from 'bun:test';
+import type { ToolCallRecord } from '../../../../types/api';
+import {
+  buildRunFileTree,
+  collectRunFileChanges,
+  commonPathPrefix,
+  runFilesForFileTree,
+  spanIdsForDisplayPathKey,
+} from './buildRunFileTree';
+
+function call(
+  partial: Partial<ToolCallRecord> & Pick<ToolCallRecord, 'id' | 'kind' | 'tool_name'>,
+): ToolCallRecord {
+  return {
+    project_id: 'p',
+    session_id: null,
+    started_at: 1,
+    duration_ms: 1,
+    status: 'ok',
+    source: 'cursor',
+    meta_tool: null,
+    args_json: null,
+    result_preview: null,
+    result_bytes: null,
+    result_tokens: null,
+    input_tokens: null,
+    output_tokens: null,
+    cache_read_tokens: null,
+    cache_write_tokens: null,
+    error_message: null,
+    agent_id: null,
+    conversation_id: null,
+    generation_id: null,
+    model: null,
+    attributes_json: null,
+    ...partial,
+  };
+}
+
+describe('collectRunFileChanges', () => {
+  it('merges read and write on the same path', () => {
+    const events = [
+      call({
+        id: '1',
+        kind: 'agent_tool',
+        tool_name: 'Read',
+        args_json: JSON.stringify({ file_path: '/proj/src/a.ts' }),
+      }),
+      call({
+        id: '2',
+        kind: 'agent_tool',
+        tool_name: 'StrReplace',
+        args_json: JSON.stringify({ path: '/proj/src/a.ts' }),
+      }),
+    ];
+    const entries = collectRunFileChanges(events);
+    expect(entries).toHaveLength(1);
+    expect(entries[0]).toMatchObject({
+      path: '/proj/src/a.ts',
+      read: true,
+      modified: true,
+      deleted: false,
+    });
+  });
+
+  it('tracks file edits and deletes', () => {
+    const events = [
+      call({
+        id: '1',
+        kind: 'file',
+        tool_name: '/proj/README.md',
+        args_json: JSON.stringify({ path: '/proj/README.md' }),
+      }),
+      call({
+        id: '2',
+        kind: 'agent_tool',
+        tool_name: 'Delete',
+        args_json: JSON.stringify({ path: '/proj/old.ts' }),
+      }),
+    ];
+    const entries = collectRunFileChanges(events);
+    expect(entries.map((e) => e.path).sort()).toEqual(['/proj/README.md', '/proj/old.ts']);
+    const readme = entries.find((e) => e.path.endsWith('README.md'));
+    const old = entries.find((e) => e.path.endsWith('old.ts'));
+    expect(readme?.modified).toBe(true);
+    expect(old?.deleted).toBe(true);
+  });
+
+  it('ignores prompts and shell', () => {
+    const events = [
+      call({ id: '1', kind: 'prompt', tool_name: 'hi' }),
+      call({ id: '2', kind: 'shell', tool_name: 'ls -la' }),
+    ];
+    expect(collectRunFileChanges(events)).toHaveLength(0);
+  });
+
+  it('remaps wrap shadow paths to the real project path', () => {
+    const real = '/Users/me/Documents/Projects/odin';
+    const shadow =
+      '/Users/me/.capa/workspaces/odin-5415-cursor/odin/src/foo.ts';
+    const events = [
+      call({
+        id: '1',
+        kind: 'agent_tool',
+        tool_name: 'Read',
+        args_json: JSON.stringify({ path: shadow }),
+      }),
+    ];
+    const entries = collectRunFileChanges(events, { realProjectPath: real });
+    expect(entries).toHaveLength(1);
+    expect(entries[0]!.path).toBe(`${real}/src/foo.ts`);
+    const { files } = runFilesForFileTree(entries, { realProjectPath: real });
+    expect(files).toEqual(['src/foo.ts']);
+  });
+});
+
+describe('buildRunFileTree', () => {
+  it('nests paths under a common prefix', () => {
+    const entries = collectRunFileChanges([
+      call({
+        id: '1',
+        kind: 'agent_tool',
+        tool_name: 'Read',
+        args_json: JSON.stringify({ file_path: '/proj/src/foo.ts' }),
+      }),
+      call({
+        id: '2',
+        kind: 'agent_tool',
+        tool_name: 'Write',
+        args_json: JSON.stringify({ path: '/proj/src/bar.ts' }),
+      }),
+    ]);
+    const { roots, displayPrefix } = buildRunFileTree(entries);
+    expect(displayPrefix).toBe('/proj/src/');
+    expect(roots.map((r) => r.name).sort()).toEqual(['bar.ts', 'foo.ts']);
+    expect(roots.every((r) => r.filePath)).toBe(true);
+  });
+});
+
+describe('runFilesForFileTree', () => {
+  it('returns display paths and annotations for FileTree', () => {
+    const entries = collectRunFileChanges([
+      call({
+        id: '1',
+        kind: 'agent_tool',
+        tool_name: 'Read',
+        args_json: JSON.stringify({ file_path: '/proj/src/foo.ts' }),
+      }),
+      call({
+        id: '2',
+        kind: 'agent_tool',
+        tool_name: 'Write',
+        args_json: JSON.stringify({ path: '/proj/src/bar.ts' }),
+      }),
+    ]);
+    const { files, annotations } = runFilesForFileTree(entries);
+    expect(files.sort()).toEqual(['bar.ts', 'foo.ts']);
+    expect(annotations['foo.ts']).toEqual({
+      read: true,
+      modified: false,
+      deleted: false,
+    });
+  });
+});
+
+describe('spanIdsForDisplayPathKey', () => {
+  it('returns spans that touch the same display path', () => {
+    const real = '/Users/me/Documents/Projects/odin';
+    const events = [
+      call({
+        id: 'read-1',
+        kind: 'agent_tool',
+        tool_name: 'Read',
+        args_json: JSON.stringify({ path: `${real}/src/foo.ts` }),
+      }),
+      call({
+        id: 'write-1',
+        kind: 'agent_tool',
+        tool_name: 'Write',
+        args_json: JSON.stringify({ path: `${real}/src/foo.ts` }),
+      }),
+      call({
+        id: 'other',
+        kind: 'agent_tool',
+        tool_name: 'Read',
+        args_json: JSON.stringify({ path: `${real}/src/bar.ts` }),
+      }),
+    ];
+    const entries = collectRunFileChanges(events, { realProjectPath: real });
+    const ids = spanIdsForDisplayPathKey('src/foo.ts', events, entries, {
+      realProjectPath: real,
+    });
+    expect(ids.sort()).toEqual(['read-1', 'write-1']);
+  });
+});
+
+describe('commonPathPrefix', () => {
+  it('returns shared directory prefix', () => {
+    expect(commonPathPrefix(['/a/b/c.ts', '/a/b/d.ts'])).toBe('/a/b/');
+  });
+});

--- a/web-ui/src/features/projects/components/activity/buildRunFileTree.ts
+++ b/web-ui/src/features/projects/components/activity/buildRunFileTree.ts
@@ -1,0 +1,386 @@
+import type { ToolCallRecord } from '../../../../types/api';
+import { remapWrapShadowPath } from '../../../../../../src/shared/workspaces/remap-shadow-path';
+
+export type RunFileChangeFlags = {
+  read: boolean;
+  modified: boolean;
+  deleted: boolean;
+};
+
+export type RunFileEntry = RunFileChangeFlags & {
+  /** Normalized absolute or project-relative path (posix slashes). */
+  path: string;
+};
+
+const READ_TOOLS = new Set(['Read', 'read', 'read_file', 'ReadFile']);
+const WRITE_TOOLS = new Set([
+  'Write',
+  'write',
+  'StrReplace',
+  'str_replace',
+  'StrReplaceEditor',
+  'ApplyPatch',
+  'apply_patch',
+  'EditNotebook',
+  'Delete',
+  'delete',
+]);
+
+function parseArgs(argsJson: string | null): Record<string, unknown> | null {
+  if (!argsJson?.trim()) return null;
+  try {
+    const parsed: unknown = JSON.parse(argsJson);
+    if (parsed && typeof parsed === 'object' && !Array.isArray(parsed)) {
+      return parsed as Record<string, unknown>;
+    }
+  } catch {
+    /* ignore */
+  }
+  return null;
+}
+
+function pathFromArgs(args: Record<string, unknown> | null): string | null {
+  if (!args) return null;
+  for (const key of ['path', 'file_path', 'filePath', 'target_file', 'targetFile']) {
+    const v = args[key];
+    if (typeof v === 'string' && v.trim()) return normalizePath(v.trim());
+  }
+  return null;
+}
+
+function looksLikePath(value: string): boolean {
+  return (
+    value.startsWith('/') ||
+    value.startsWith('~') ||
+    /^[A-Za-z]:[\\/]/.test(value) ||
+    value.includes('/') ||
+    value.includes('\\')
+  );
+}
+
+export function normalizePath(raw: string): string {
+  return raw.replace(/\\/g, '/').replace(/\/+/g, '/');
+}
+
+function mergeFlags(
+  map: Map<string, RunFileEntry>,
+  filePath: string,
+  patch: Partial<RunFileChangeFlags>,
+  realProjectPath?: string | null,
+): void {
+  let path = normalizePath(filePath);
+  path = remapWrapShadowPath(path, realProjectPath);
+  if (!path) return;
+  const prev = map.get(path) ?? {
+    path,
+    read: false,
+    modified: false,
+    deleted: false,
+  };
+  map.set(path, {
+    ...prev,
+    read: prev.read || !!patch.read,
+    modified: prev.modified || !!patch.modified,
+    deleted: prev.deleted || !!patch.deleted,
+  });
+}
+
+/**
+ * Derive touched files from provider activity spans in one generation run.
+ * Uses Read/Write/StrReplace/Delete tool spans and `kind: file` edit rows.
+ */
+export function collectRunFileChanges(
+  events: ToolCallRecord[],
+  options?: { realProjectPath?: string | null },
+): RunFileEntry[] {
+  const map = new Map<string, RunFileEntry>();
+  const realProjectPath = options?.realProjectPath;
+
+  for (const ev of events) {
+    if (ev.kind === 'prompt' || ev.kind === 'stop' || ev.kind === 'session') {
+      continue;
+    }
+
+    const args = parseArgs(ev.args_json);
+    const tool = ev.tool_name?.trim() ?? '';
+
+    if (ev.kind === 'file' || ev.kind === 'skill') {
+      const p =
+        pathFromArgs(args) ||
+        (looksLikePath(tool) ? normalizePath(tool) : null);
+      if (!p) continue;
+      if (ev.kind === 'skill') mergeFlags(map, p, { read: true }, realProjectPath);
+      else mergeFlags(map, p, { modified: true }, realProjectPath);
+      continue;
+    }
+
+    if (ev.kind !== 'agent_tool') continue;
+
+    const fromArgs = pathFromArgs(args);
+
+    if (READ_TOOLS.has(tool)) {
+      if (fromArgs) mergeFlags(map, fromArgs, { read: true }, realProjectPath);
+      else if (looksLikePath(tool)) mergeFlags(map, tool, { read: true }, realProjectPath);
+      continue;
+    }
+
+    if (tool === 'Grep' || tool === 'grep') {
+      if (fromArgs) mergeFlags(map, fromArgs, { read: true }, realProjectPath);
+      continue;
+    }
+
+    if (tool === 'Delete' || tool === 'delete') {
+      if (fromArgs) mergeFlags(map, fromArgs, { deleted: true }, realProjectPath);
+      else if (looksLikePath(tool)) mergeFlags(map, tool, { deleted: true }, realProjectPath);
+      continue;
+    }
+
+    if (WRITE_TOOLS.has(tool)) {
+      if (fromArgs) mergeFlags(map, fromArgs, { modified: true }, realProjectPath);
+      else if (looksLikePath(tool)) mergeFlags(map, tool, { modified: true }, realProjectPath);
+    }
+  }
+
+  return [...map.values()].sort((a, b) => a.path.localeCompare(b.path));
+}
+
+export interface RunFileTreeNode {
+  name: string;
+  /** Set only for file nodes. */
+  filePath: string | null;
+  children: RunFileTreeNode[];
+  flags: RunFileChangeFlags;
+}
+
+function mergeNodeFlags(
+  a: RunFileChangeFlags,
+  b: RunFileChangeFlags,
+): RunFileChangeFlags {
+  return {
+    read: a.read || b.read,
+    modified: a.modified || b.modified,
+    deleted: a.deleted || b.deleted,
+  };
+}
+
+/** Longest shared directory prefix (ends with `/`), for display trimming. */
+export function commonPathPrefix(paths: string[]): string {
+  if (paths.length === 0) return '';
+  const normalized = paths.map((p) => normalizePath(p));
+  const absolute = normalized.every((p) => p.startsWith('/'));
+  const split = normalized.map((p) => p.split('/').filter(Boolean));
+  const first = split[0]!;
+  let i = 0;
+  outer: while (i < first.length) {
+    for (let j = 1; j < split.length; j++) {
+      if (split[j]![i] !== first[i]) break outer;
+    }
+    i++;
+  }
+  if (i === 0) return '';
+  const joined = first.slice(0, i).join('/');
+  return absolute ? `/${joined}/` : `${joined}/`;
+}
+
+function displayPath(fullPath: string, prefix: string): string {
+  if (prefix && fullPath.startsWith(prefix)) {
+    return fullPath.slice(prefix.length);
+  }
+  return fullPath;
+}
+
+function resolveDisplayPrefix(
+  paths: string[],
+  realProjectPath?: string | null,
+): string {
+  let prefix = commonPathPrefix(paths);
+  const realBase = realProjectPath?.trim();
+  if (realBase) {
+    const base = `${normalizePath(realBase).replace(/\/+$/, '')}/`;
+    if (paths.every((p) => normalizePath(p).startsWith(base))) {
+      prefix = base;
+    }
+  }
+  return prefix;
+}
+
+/** Paths and metadata for the shared {@link FileTree} component. */
+export function runFilesForFileTree(
+  entries: RunFileEntry[],
+  options?: { realProjectPath?: string | null },
+): {
+  files: string[];
+  annotations: Record<string, RunFileChangeFlags>;
+} {
+  if (entries.length === 0) {
+    return { files: [], annotations: {} };
+  }
+  const paths = entries.map((e) => e.path);
+  const prefix = resolveDisplayPrefix(paths, options?.realProjectPath);
+  const files: string[] = [];
+  const annotations: Record<string, RunFileChangeFlags> = {};
+  for (const entry of entries) {
+    const rel = displayPath(entry.path, prefix);
+    files.push(rel);
+    annotations[rel] = {
+      read: entry.read,
+      modified: entry.modified,
+      deleted: entry.deleted,
+    };
+  }
+  return { files, annotations };
+}
+
+/** Canonical project path touched by a span, if any. */
+export function filePathFromActivitySpan(
+  ev: ToolCallRecord,
+  realProjectPath?: string | null,
+): string | null {
+  const entries = collectRunFileChanges([ev], { realProjectPath });
+  return entries[0]?.path ?? null;
+}
+
+/** Display path key used by {@link runFilesForFileTree} for a canonical path. */
+export function displayPathKeyForFile(
+  canonicalPath: string,
+  entries: RunFileEntry[],
+  options?: { realProjectPath?: string | null },
+): string | null {
+  if (!canonicalPath || entries.length === 0) return null;
+  const normalized = normalizePath(canonicalPath);
+  const match = entries.find((e) => e.path === normalized);
+  if (!match) return null;
+  const prefix = resolveDisplayPrefix(
+    entries.map((e) => e.path),
+    options?.realProjectPath,
+  );
+  return displayPath(match.path, prefix);
+}
+
+/** Tree path key for a span, if it touches a file. */
+export function displayPathKeyFromSpan(
+  ev: ToolCallRecord,
+  entries: RunFileEntry[],
+  options?: { realProjectPath?: string | null },
+): string | null {
+  const canonical = filePathFromActivitySpan(ev, options?.realProjectPath);
+  if (!canonical) return null;
+  return displayPathKeyForFile(canonical, entries, options);
+}
+
+/** Span ids in `events` that read or wrote `pathKey`. */
+export function spanIdsForDisplayPathKey(
+  pathKey: string,
+  events: ToolCallRecord[],
+  entries: RunFileEntry[],
+  options?: { realProjectPath?: string | null },
+): string[] {
+  if (!pathKey.trim()) return [];
+  const ids: string[] = [];
+  for (const ev of events) {
+    if (ev.kind === 'prompt' || ev.kind === 'stop' || ev.kind === 'session') continue;
+    const key = displayPathKeyFromSpan(ev, entries, options);
+    if (key === pathKey) ids.push(ev.id);
+  }
+  return ids;
+}
+
+function filterFilesBySearch(files: string[], searchQuery: string): string[] {
+  const q = searchQuery.trim().toLowerCase();
+  if (!q) return files;
+  return files.filter((f) => f.toLowerCase().includes(q));
+}
+
+export function runFilesForFileTreeFiltered(
+  entries: RunFileEntry[],
+  searchQuery: string,
+  options?: { realProjectPath?: string | null },
+): ReturnType<typeof runFilesForFileTree> {
+  const base = runFilesForFileTree(entries, options);
+  const filtered = filterFilesBySearch(base.files, searchQuery);
+  const annotations: Record<string, RunFileChangeFlags> = {};
+  for (const f of filtered) {
+    if (base.annotations[f]) annotations[f] = base.annotations[f]!;
+  }
+  return { files: filtered, annotations };
+}
+
+/**
+ * Build a fully-expanded directory tree from flat file entries.
+ */
+export function buildRunFileTree(entries: RunFileEntry[]): {
+  roots: RunFileTreeNode[];
+  displayPrefix: string;
+} {
+  if (entries.length === 0) {
+    return { roots: [], displayPrefix: '' };
+  }
+
+  const prefix = commonPathPrefix(entries.map((e) => e.path));
+  type MutableNode = {
+    name: string;
+    filePath: string | null;
+    children: Map<string, MutableNode>;
+    flags: RunFileChangeFlags;
+  };
+
+  const root: MutableNode = {
+    name: '',
+    filePath: null,
+    children: new Map(),
+    flags: { read: false, modified: false, deleted: false },
+  };
+
+  for (const entry of entries) {
+    const rel = displayPath(entry.path, prefix);
+    const segments = rel.split('/').filter(Boolean);
+    if (segments.length === 0) continue;
+
+    let node = root;
+    for (let i = 0; i < segments.length; i++) {
+      const seg = segments[i]!;
+      const isFile = i === segments.length - 1;
+      let child = node.children.get(seg);
+      if (!child) {
+        child = {
+          name: seg,
+          filePath: isFile ? entry.path : null,
+          children: new Map(),
+          flags: { read: false, modified: false, deleted: false },
+        };
+        node.children.set(seg, child);
+      }
+      if (isFile) {
+        child.filePath = entry.path;
+        child.flags = { ...entry };
+      }
+      node = child;
+    }
+  }
+
+  function sortChildren(a: MutableNode, b: MutableNode): number {
+    const aDir = a.filePath === null;
+    const bDir = b.filePath === null;
+    if (aDir !== bDir) return aDir ? -1 : 1;
+    return a.name.localeCompare(b.name);
+  }
+
+  function toPublic(node: MutableNode): RunFileTreeNode {
+    const children = [...node.children.values()]
+      .sort(sortChildren)
+      .map(toPublic);
+    let flags = { ...node.flags };
+    for (const c of children) {
+      flags = mergeNodeFlags(flags, c.flags);
+    }
+    return {
+      name: node.name,
+      filePath: node.filePath,
+      children,
+      flags,
+    };
+  }
+
+  const roots = [...root.children.values()].sort(sortChildren).map(toPublic);
+  return { roots, displayPrefix: prefix };
+}

--- a/web-ui/src/features/projects/components/activity/groupActivityRuns.test.ts
+++ b/web-ui/src/features/projects/components/activity/groupActivityRuns.test.ts
@@ -181,6 +181,48 @@ describe('groupActivityRuns', () => {
     expect(run.prompt?.id).toBe('prompt-1');
     expect(run.spans.map((s) => s.id)).toEqual(['tool-1']);
     expect(run.title).toBe('fix the alert');
+    expect(run.id).toBe(`${chatId}:${generationId}`);
+  });
+
+  it('namespaces run ids when generation_id collides across conversations', () => {
+    const sharedGen = 'gen-shared';
+    const calls = [
+      call({
+        id: 'b-tool',
+        kind: 'agent_tool',
+        tool_name: 'Read',
+        started_at: 200,
+        conversation_id: 'conv-b',
+        generation_id: sharedGen,
+      }),
+      call({
+        id: 'b-prompt',
+        kind: 'prompt',
+        tool_name: 'chat b',
+        started_at: 190,
+        conversation_id: 'conv-b',
+        generation_id: sharedGen,
+      }),
+      call({
+        id: 'a-tool',
+        kind: 'agent_tool',
+        tool_name: 'Grep',
+        started_at: 100,
+        conversation_id: 'conv-a',
+        generation_id: sharedGen,
+      }),
+      call({
+        id: 'a-prompt',
+        kind: 'prompt',
+        tool_name: 'chat a',
+        started_at: 90,
+        conversation_id: 'conv-a',
+        generation_id: sharedGen,
+      }),
+    ];
+    const runs = groupActivityConversations(calls).flatMap((c) => c.generations);
+    expect(runs.find((r) => r.id === 'conv-a:gen-shared')?.title).toBe('chat a');
+    expect(runs.find((r) => r.id === 'conv-b:gen-shared')?.title).toBe('chat b');
   });
 });
 

--- a/web-ui/src/features/projects/components/activity/groupActivityRuns.test.ts
+++ b/web-ui/src/features/projects/components/activity/groupActivityRuns.test.ts
@@ -150,6 +150,38 @@ describe('groupActivityRuns', () => {
     expect(conversations[1]!.generations[0]!.title).toBe('second turn');
     expect(conversations[1]!.generations[1]!.title).toBe('first turn');
   });
+
+  it('merges Cursor CLI tool spans into the prompt conversation for one generation', () => {
+    const chatId = '5838f384-e543-41e8-be49-57fb1de0d433';
+    const agentSessionId = '6b74a2c7-5d30-4160-8b01-e8106e144ff3';
+    const generationId = 'e972af4d-ba8b-4d82-a839-b3b0a9b2aafd';
+    const calls = [
+      call({
+        id: 'tool-1',
+        kind: 'agent_tool',
+        tool_name: 'Grep',
+        started_at: 300,
+        conversation_id: agentSessionId,
+        generation_id: generationId,
+      }),
+      call({
+        id: 'prompt-1',
+        kind: 'prompt',
+        tool_name: 'fix the alert',
+        started_at: 100,
+        conversation_id: chatId,
+        generation_id: generationId,
+      }),
+    ];
+    const conversations = groupActivityConversations(calls);
+    expect(conversations).toHaveLength(1);
+    expect(conversations[0]!.id).toBe(chatId);
+    expect(conversations[0]!.generations).toHaveLength(1);
+    const run = conversations[0]!.generations[0]!;
+    expect(run.prompt?.id).toBe('prompt-1');
+    expect(run.spans.map((s) => s.id)).toEqual(['tool-1']);
+    expect(run.title).toBe('fix the alert');
+  });
 });
 
 describe('isCapaToolCall', () => {

--- a/web-ui/src/features/projects/components/activity/groupActivityRuns.ts
+++ b/web-ui/src/features/projects/components/activity/groupActivityRuns.ts
@@ -5,6 +5,18 @@ import {
   isActivityRunOpener,
 } from '../../../../../../src/shared/activity-run-boundary';
 
+/** Stable run key for feed selection (unique across conversations). */
+export function activityRunSelectionId(
+  conversationId: string | null,
+  generationId: string | null,
+  fallbackId: string,
+): string {
+  if (conversationId?.trim() && generationId?.trim()) {
+    return `${conversationId.trim()}:${generationId.trim()}`;
+  }
+  return generationId?.trim() || fallbackId;
+}
+
 /** One turn / generation: optional prompt + spans (dialog payload). */
 export interface ActivityRun {
   id: string;
@@ -204,7 +216,7 @@ function buildRunFromCalls(
   const spans = chronological.filter((c) => c !== prompt);
   const first = chronological[0]!;
   const run: ActivityRun = {
-    id: generationId || first.id,
+    id: activityRunSelectionId(conversationId, generationId, first.id),
     conversationId,
     generationId,
     title: prompt?.tool_name || first.tool_name,

--- a/web-ui/src/features/projects/components/activity/groupActivityRuns.ts
+++ b/web-ui/src/features/projects/components/activity/groupActivityRuns.ts
@@ -1,4 +1,5 @@
 import type { ToolCallRecord } from '../../../../types/api';
+import { reconcileCursorActivityConversationIds } from '../../../../../../src/shared/activity-correlation-reconcile';
 import {
   isActivityRunCloser,
   isActivityRunOpener,
@@ -37,9 +38,10 @@ export interface ActivityConversation {
 export function groupActivityConversations(
   calls: ToolCallRecord[],
 ): ActivityConversation[] {
+  const normalized = reconcileCursorActivityConversationIds(calls);
   const correlated: ToolCallRecord[] = [];
   const uncorrelated: ToolCallRecord[] = [];
-  for (const call of calls) {
+  for (const call of normalized) {
     if (call.conversation_id) correlated.push(call);
     else uncorrelated.push(call);
   }

--- a/web-ui/src/locales/en/projects.json
+++ b/web-ui/src/locales/en/projects.json
@@ -295,7 +295,22 @@
     "followLatest": "Follow latest",
     "followingLatest": "Following",
     "closeRun": "Close run",
-    "runOk": "ok"
+    "runOk": "ok",
+    "runFiles": {
+      "aria": "Files touched in this run",
+      "heading": "Files",
+      "empty": "No file reads or edits detected in this run yet.",
+      "emptyHint": "Read, Write, and edit spans will appear here as they arrive.",
+      "count": "{{count}} file",
+      "count_other": "{{count}} files",
+      "read": "Read",
+      "modified": "Modified",
+      "deleted": "Deleted",
+      "searchPlaceholder": "Filter files…",
+      "expandAll": "Expand all",
+      "collapseAll": "Collapse all",
+      "noSearchResults": "No files match your filter."
+    }
   },
   "tool": {
     "from": "from",


### PR DESCRIPTION
## Summary
- Reconcile Cursor CLI activity rows so prompts and tool spans stay in one run during live SSE updates (chat vs agent-session `conversation_id` mismatch).
- **PR #168 review fixes:** valid JSON (or null) for oversized `attributes_json`; plugin skill fallback only for `type: plugin`; composite run ids (`conversation:generation`); real `manifestFile` in nested plugin lookup; test formatting.
- Skip Cursor conversation reconcile when the same `generation_id` maps to conflicting chat ids.

## Test plan
- [x] `bun test src/shared/__tests__/activity-correlation-reconcile.test.ts src/shared/__tests__/activity-attributes.test.ts web-ui/src/features/projects/components/activity/groupActivityRuns.test.ts src/server/__tests__/skill-content-plugin.test.ts`
- [ ] Cursor Agent CLI: opening prompt remains visible as tools stream in
- [ ] Activity run dialog: two conversations with the same `generation_id` open distinct runs