### PR TITLE
fix(cli): keep activity-ingest stdout JSON-only for Cursor gate hooks

### DIFF
--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -53,8 +53,13 @@ if (process.argv[2] === '__server__') {
   (async () => {
     try {
     // Start version check in the background while the command runs
-    const isUpgradeCommand = process.argv[2] === 'upgrade';
-    const updateCheckPromise = isUpgradeCommand ? Promise.resolve(null) : checkForUpdates();
+    const subcommand = process.argv[2];
+    // Hook subprocesses (activity-ingest) must own stdout — only valid JSON for gate events.
+    const skipVersionCheck =
+      subcommand === 'upgrade' || subcommand === 'activity-ingest';
+    const updateCheckPromise = skipVersionCheck
+      ? Promise.resolve(null)
+      : checkForUpdates();
 
     const program = new Command();
 
@@ -436,7 +441,7 @@ if (process.argv[2] === '__server__') {
 
     // Show update notice after the command completes (if a newer version is available)
     const updateInfo = await updateCheckPromise;
-    if (updateInfo?.hasUpdate) {
+    if (!skipVersionCheck && updateInfo?.hasUpdate) {
       console.log(`\n  A new version of capa is available: ${updateInfo.latestVersion} (current: ${updateInfo.currentVersion})`);
       console.log('  Run "capa upgrade" to update.\n');
     }

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -26,6 +26,10 @@ import {
 import type { RegistrySourceType } from '../types/database';
 import type { RegistryCapability } from '../types/registry';
 import { checkForUpdates } from './utils/version-check';
+import {
+  cliSubcommandFromArgv,
+  shouldSkipVersionCheck,
+} from './utils/cli-subcommand';
 import { VERSION } from '../version';
 import { setFlags, ExitCode, error } from './ui';
 
@@ -53,10 +57,9 @@ if (process.argv[2] === '__server__') {
   (async () => {
     try {
     // Start version check in the background while the command runs
-    const subcommand = process.argv[2];
+    const subcommand = cliSubcommandFromArgv(process.argv);
     // Hook subprocesses (activity-ingest) must own stdout — only valid JSON for gate events.
-    const skipVersionCheck =
-      subcommand === 'upgrade' || subcommand === 'activity-ingest';
+    const skipVersionCheck = shouldSkipVersionCheck(subcommand);
     const updateCheckPromise = skipVersionCheck
       ? Promise.resolve(null)
       : checkForUpdates();

--- a/src/cli/utils/__tests__/cli-subcommand.test.ts
+++ b/src/cli/utils/__tests__/cli-subcommand.test.ts
@@ -1,0 +1,36 @@
+import { describe, expect, it } from 'bun:test';
+import {
+	cliSubcommandFromArgv,
+	shouldSkipVersionCheck,
+} from '../cli-subcommand';
+
+describe('cliSubcommandFromArgv', () => {
+	it('returns the first non-option token', () => {
+		expect(cliSubcommandFromArgv(['bun', 'capa', 'activity-ingest'])).toBe(
+			'activity-ingest',
+		);
+		expect(
+			cliSubcommandFromArgv([
+				'bun',
+				'capa',
+				'--no-color',
+				'activity-ingest',
+				'--event',
+				'beforeFileRead',
+			]),
+		).toBe('activity-ingest');
+		expect(cliSubcommandFromArgv(['bun', 'capa', '-q', 'upgrade'])).toBe(
+			'upgrade',
+		);
+		expect(cliSubcommandFromArgv(['bun', 'capa', 'install'])).toBe('install');
+	});
+});
+
+describe('shouldSkipVersionCheck', () => {
+	it('skips for upgrade and activity-ingest only', () => {
+		expect(shouldSkipVersionCheck('upgrade')).toBe(true);
+		expect(shouldSkipVersionCheck('activity-ingest')).toBe(true);
+		expect(shouldSkipVersionCheck('install')).toBe(false);
+		expect(shouldSkipVersionCheck(undefined)).toBe(false);
+	});
+});

--- a/src/cli/utils/cli-subcommand.ts
+++ b/src/cli/utils/cli-subcommand.ts
@@ -1,0 +1,13 @@
+/**
+ * Resolve the CLI subcommand from raw argv (after `node` / `bun` and script path).
+ * Global root flags may precede the command token (`capa --no-color activity-ingest`).
+ */
+export function cliSubcommandFromArgv(argv: string[]): string | undefined {
+	const rest = argv.slice(2);
+	return rest.find((token) => token.length > 0 && !token.startsWith('-'));
+}
+
+/** Subcommands that must not append human-readable text to stdout after they run. */
+export function shouldSkipVersionCheck(subcommand: string | undefined): boolean {
+	return subcommand === 'upgrade' || subcommand === 'activity-ingest';
+}


### PR DESCRIPTION
## Summary
- Skip the background version check and post-command upgrade banner when the subcommand is `activity-ingest`.
- Cursor gate hooks (`beforeReadFile`, `beforeSubmitPrompt`, `subagentStart`, etc.) require stdout to be valid JSON only; appending the upgrade notice caused hook failures and blocked file reads.

## Test plan
- [x] `bun test src/cli/commands/__tests__/activity-ingest.test.ts`
- [x] `bun src/cli/index.ts activity-ingest --event beforeFileRead --provider cursor` — stdout parses as `{"permission":"allow"}` with no trailing text when a newer release exists on GitHub


Made with [Cursor](https://cursor.com)