### PR TITLE
Release: v2.0.3

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -32,7 +32,12 @@ jobs:
         run: bun run build:web
       
       - name: Run tests
+        run: bun test --timeout 20000
+        if: matrix.os == 'windows-latest'
+
+      - name: Run tests
         run: bun test
+        if: matrix.os != 'windows-latest'
       
       - name: Run tests with coverage
         if: matrix.os == 'ubuntu-latest'

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -53,8 +53,13 @@ if (process.argv[2] === '__server__') {
   (async () => {
     try {
     // Start version check in the background while the command runs
-    const isUpgradeCommand = process.argv[2] === 'upgrade';
-    const updateCheckPromise = isUpgradeCommand ? Promise.resolve(null) : checkForUpdates();
+    const subcommand = process.argv[2];
+    // Hook subprocesses (activity-ingest) must own stdout — only valid JSON for gate events.
+    const skipVersionCheck =
+      subcommand === 'upgrade' || subcommand === 'activity-ingest';
+    const updateCheckPromise = skipVersionCheck
+      ? Promise.resolve(null)
+      : checkForUpdates();
 
     const program = new Command();
 
@@ -436,7 +441,7 @@ if (process.argv[2] === '__server__') {
 
     // Show update notice after the command completes (if a newer version is available)
     const updateInfo = await updateCheckPromise;
-    if (updateInfo?.hasUpdate) {
+    if (!skipVersionCheck && updateInfo?.hasUpdate) {
       console.log(`\n  A new version of capa is available: ${updateInfo.latestVersion} (current: ${updateInfo.currentVersion})`);
       console.log('  Run "capa upgrade" to update.\n');
     }

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -26,6 +26,10 @@ import {
 import type { RegistrySourceType } from '../types/database';
 import type { RegistryCapability } from '../types/registry';
 import { checkForUpdates } from './utils/version-check';
+import {
+  cliSubcommandFromArgv,
+  shouldSkipVersionCheck,
+} from './utils/cli-subcommand';
 import { VERSION } from '../version';
 import { setFlags, ExitCode, error } from './ui';
 
@@ -53,10 +57,9 @@ if (process.argv[2] === '__server__') {
   (async () => {
     try {
     // Start version check in the background while the command runs
-    const subcommand = process.argv[2];
+    const subcommand = cliSubcommandFromArgv(process.argv);
     // Hook subprocesses (activity-ingest) must own stdout — only valid JSON for gate events.
-    const skipVersionCheck =
-      subcommand === 'upgrade' || subcommand === 'activity-ingest';
+    const skipVersionCheck = shouldSkipVersionCheck(subcommand);
     const updateCheckPromise = skipVersionCheck
       ? Promise.resolve(null)
       : checkForUpdates();

--- a/src/cli/utils/__tests__/cli-subcommand.test.ts
+++ b/src/cli/utils/__tests__/cli-subcommand.test.ts
@@ -1,0 +1,36 @@
+import { describe, expect, it } from 'bun:test';
+import {
+	cliSubcommandFromArgv,
+	shouldSkipVersionCheck,
+} from '../cli-subcommand';
+
+describe('cliSubcommandFromArgv', () => {
+	it('returns the first non-option token', () => {
+		expect(cliSubcommandFromArgv(['bun', 'capa', 'activity-ingest'])).toBe(
+			'activity-ingest',
+		);
+		expect(
+			cliSubcommandFromArgv([
+				'bun',
+				'capa',
+				'--no-color',
+				'activity-ingest',
+				'--event',
+				'beforeFileRead',
+			]),
+		).toBe('activity-ingest');
+		expect(cliSubcommandFromArgv(['bun', 'capa', '-q', 'upgrade'])).toBe(
+			'upgrade',
+		);
+		expect(cliSubcommandFromArgv(['bun', 'capa', 'install'])).toBe('install');
+	});
+});
+
+describe('shouldSkipVersionCheck', () => {
+	it('skips for upgrade and activity-ingest only', () => {
+		expect(shouldSkipVersionCheck('upgrade')).toBe(true);
+		expect(shouldSkipVersionCheck('activity-ingest')).toBe(true);
+		expect(shouldSkipVersionCheck('install')).toBe(false);
+		expect(shouldSkipVersionCheck(undefined)).toBe(false);
+	});
+});

--- a/src/cli/utils/cli-subcommand.ts
+++ b/src/cli/utils/cli-subcommand.ts
@@ -1,0 +1,13 @@
+/**
+ * Resolve the CLI subcommand from raw argv (after `node` / `bun` and script path).
+ * Global root flags may precede the command token (`capa --no-color activity-ingest`).
+ */
+export function cliSubcommandFromArgv(argv: string[]): string | undefined {
+	const rest = argv.slice(2);
+	return rest.find((token) => token.length > 0 && !token.startsWith('-'));
+}
+
+/** Subcommands that must not append human-readable text to stdout after they run. */
+export function shouldSkipVersionCheck(subcommand: string | undefined): boolean {
+	return subcommand === 'upgrade' || subcommand === 'activity-ingest';
+}

--- a/src/cli/utils/wrap/__tests__/sessions.test.ts
+++ b/src/cli/utils/wrap/__tests__/sessions.test.ts
@@ -1,6 +1,10 @@
+import { mkdtempSync, rmSync } from 'fs';
+import { join } from 'path';
+import { tmpdir } from 'os';
 import { describe, it, expect } from 'bun:test';
 import {
   findWrapPids,
+  findWrapPidsForProject,
   isPidRunning,
   stopAllWrapSessions,
   commandLineMatchesProject,
@@ -16,6 +20,18 @@ describe('wrap process discovery', () => {
   it('findWrapPids does not include the current (non-wrap) process', async () => {
     const pids = await findWrapPids();
     expect(pids.includes(process.pid)).toBe(false);
+  });
+
+  it('findWrapPidsForProject skips process scan when project has no wrap workspace', async () => {
+    const dir = mkdtempSync(join(tmpdir(), 'capa-wrap-scan-skip-'));
+    try {
+      const pids = await findWrapPidsForProject(dir);
+      expect(pids).toEqual([]);
+    } finally {
+      try {
+        rmSync(dir, { recursive: true, force: true });
+      } catch {}
+    }
   });
 
   it('stopAllWrapSessions is a no-op when nothing is wrapping', async () => {

--- a/src/cli/utils/wrap/sessions.ts
+++ b/src/cli/utils/wrap/sessions.ts
@@ -234,6 +234,12 @@ export async function findWrapPidsForProject(realProjectPath: string): Promise<n
   const real = resolve(realProjectPath);
   const fromSessions = await pidsFromSessionFiles(real);
   const workspacePaths = await listWorkspacePathsForProject(real);
+  // No capa wrap workspace for this project — skip a full process-table scan
+  // (notably slow on Windows via PowerShell/CIM). Session files + workspace
+  // markers are the normal sources of truth once wrap has run.
+  if (fromSessions.length === 0 && workspacePaths.length === 0) {
+    return [];
+  }
   const procs = await listWrapProcesses();
   const fromArgv = procs
     .filter((p) => commandLineMatchesProject(p.commandLine, real, workspacePaths))

--- a/src/db/__tests__/database.test.ts
+++ b/src/db/__tests__/database.test.ts
@@ -4,6 +4,26 @@ import { mkdtempSync, rmSync } from 'fs';
 import { join } from 'path';
 import { tmpdir } from 'os';
 
+/** Windows CI can briefly keep SQLite files open after close(). */
+function removeTempDirWithRetry(dir: string, attempts = 8): void {
+  for (let i = 0; i < attempts; i++) {
+    try {
+      rmSync(dir, { recursive: true, force: true });
+      return;
+    } catch (error: unknown) {
+      const code =
+        error && typeof error === 'object' && 'code' in error
+          ? String((error as { code: unknown }).code)
+          : '';
+      if (code !== 'EBUSY' && code !== 'EPERM' && code !== 'ENOTEMPTY') {
+        throw error;
+      }
+      if (i === attempts - 1) return;
+      Bun.sleepSync(50 * (i + 1));
+    }
+  }
+}
+
 describe('CapaDatabase', () => {
   let db: CapaDatabase;
   let tempDir: string;
@@ -17,11 +37,7 @@ describe('CapaDatabase', () => {
 
   afterEach(() => {
     db.close();
-    try {
-      rmSync(tempDir, { recursive: true, force: true });
-    } catch (error: any) {
-      if (error?.code !== 'EBUSY') throw error;
-    }
+    removeTempDirWithRetry(tempDir);
   });
 
   describe('Project operations', () => {


### PR DESCRIPTION
This pull request refactors how the CLI determines when to perform version checks and display update notices. It introduces utility functions to more accurately detect the current subcommand and skip version checks for specific commands, and adds tests to ensure this logic is robust.

**CLI Version Check Logic Improvements:**

- Added `cliSubcommandFromArgv` and `shouldSkipVersionCheck` utilities to reliably identify the invoked subcommand and decide if the version check should be skipped (for `upgrade` and `activity-ingest` commands). [[1]](diffhunk://#diff-4d541c08814159239e881c2a46bef2cbdcfe49e433ed188bca1f23d7e8d789e1R1-R13) [[2]](diffhunk://#diff-2304ffbbb1cb4987906a47b08b7c3b590fc542f4247b733844049776fd8591f2R29-R32)
- Updated `src/cli/index.ts` to use these utilities, ensuring version checks are only performed when appropriate and update notices are not shown for commands that must produce machine-readable output. [[1]](diffhunk://#diff-2304ffbbb1cb4987906a47b08b7c3b590fc542f4247b733844049776fd8591f2L56-R65) [[2]](diffhunk://#diff-2304ffbbb1cb4987906a47b08b7c3b590fc542f4247b733844049776fd8591f2L439-R447)

**Testing Enhancements:**

- Added comprehensive tests for the new CLI subcommand detection and version check skipping logic in `cli-subcommand.test.ts`.