### PR TITLE
Prevent capa install from escaping shadow workspaces via symlinks

### DIFF
--- a/src/cli/commands/install-tasks/helpers/install-one-skill.ts
+++ b/src/cli/commands/install-tasks/helpers/install-one-skill.ts
@@ -8,6 +8,7 @@ import { getProvider, getAllProviders } from '../../../../shared/providers';
 import { getGitProvider } from '../../../../shared/git-providers/registry';
 import { LockfileBuilder } from '../../../../shared/lockfile';
 import { assertSafeRepoPath } from '../../../../shared/repo-file';
+import { assertCapaOwnedInstallPath } from '../../../../shared/install-path-guard';
 import {
   describeUnsafeCapabilityId,
   isSafeCapabilityId,
@@ -312,6 +313,7 @@ export async function installOneSkill(
     const skillsBaseDir = join(projectPath, providerEntry.skillsDir);
     const skillDir = assertSafeRepoPath(skillsBaseDir, skill.id);
     const skillMdPath = join(skillDir, 'SKILL.md');
+    assertCapaOwnedInstallPath(projectPath, skillDir);
 
     if (existsSync(skillDir)) {
       if (trackManaged) {

--- a/src/cli/commands/install-tasks/index.ts
+++ b/src/cli/commands/install-tasks/index.ts
@@ -3,6 +3,7 @@ import type { RequiredCommand } from '../../../types/capabilities';
 import type { InstallCtx } from './context';
 
 import { verifyPrerequisitesTask } from './verify-prerequisites';
+import { validateInstallPathsTask } from './validate-install-paths';
 import { resolvePluginsTask } from './resolve-plugins';
 import { validatePluginConfigTask } from './validate-plugin-config';
 import { loadEnvTask } from './load-env';
@@ -36,6 +37,7 @@ export function buildInstallTasks(
   tasks.push(
     resolvePluginsTask(),
     validatePluginConfigTask(),
+    validateInstallPathsTask(),
     loadEnvTask(),
     checkRemovedSkillsTask(),
     installSkillsTask(),

--- a/src/cli/commands/install-tasks/validate-install-paths.ts
+++ b/src/cli/commands/install-tasks/validate-install-paths.ts
@@ -1,0 +1,13 @@
+import type { Task } from '../../ui';
+import { validateProviderInstallRoots } from '../../../shared/install-path-guard';
+import type { InstallCtx } from './context';
+
+export function validateInstallPathsTask(): Task<InstallCtx> {
+  return {
+    id: 'validate-install-paths',
+    title: 'Validate install paths',
+    run: async (ctx) => {
+      validateProviderInstallRoots(ctx.projectPath, ctx.resolvedProviders);
+    },
+  };
+}

--- a/src/cli/commands/install-tasks/validate-install-paths.ts
+++ b/src/cli/commands/install-tasks/validate-install-paths.ts
@@ -4,9 +4,8 @@ import type { InstallCtx } from './context';
 
 export function validateInstallPathsTask(): Task<InstallCtx> {
   return {
-    id: 'validate-install-paths',
-    title: 'Validate install paths',
-    run: async (ctx) => {
+    title: 'Validating install paths',
+    task: async (ctx) => {
       validateProviderInstallRoots(ctx.projectPath, ctx.resolvedProviders);
     },
   };

--- a/src/cli/commands/plugin-install.ts
+++ b/src/cli/commands/plugin-install.ts
@@ -20,6 +20,7 @@ import { getProjectPluginsDir } from '../../shared/plugin-paths';
 import { getProvider } from '../../shared/providers';
 import { getGitProvider } from '../../shared/git-providers/registry';
 import { assertSafeRepoPath } from '../../shared/repo-file';
+import { assertCapaOwnedInstallPath } from '../../shared/install-path-guard';
 import {
   describeUnsafeCapabilityId,
   isSafeCapabilityId,
@@ -220,6 +221,7 @@ export async function resolvePlugins(
         continue;
       }
       try {
+        assertCapaOwnedInstallPath(projectPath, destSkillDir);
         if (existsSync(destSkillDir)) {
           if (!trackManaged) {
             warnings.push(

--- a/src/cli/utils/__tests__/subagents-path-guard.test.ts
+++ b/src/cli/utils/__tests__/subagents-path-guard.test.ts
@@ -1,0 +1,71 @@
+import { describe, it, expect, beforeEach, afterEach } from 'bun:test';
+import {
+  existsSync,
+  mkdirSync,
+  mkdtempSync,
+  readFileSync,
+  rmSync,
+  symlinkSync,
+  writeFileSync,
+} from 'fs';
+import { join } from 'path';
+import { tmpdir } from 'os';
+import type { Capabilities, SubAgent } from '../../../types/capabilities';
+import {
+  installSubAgentInstructions,
+  removeSubAgentInstructions,
+} from '../agents-file';
+
+describe('subagents install path guard', () => {
+  let projectPath: string;
+  const capabilities: Capabilities = { skills: [], tools: [], servers: [] };
+  const subAgent: SubAgent = {
+    id: 'helper',
+    description: 'Test helper',
+    instructions: 'Do helpful things.',
+    skills: [],
+    tools: [],
+  };
+
+  beforeEach(() => {
+    projectPath = mkdtempSync(join(tmpdir(), 'capa-subagents-guard-'));
+    mkdirSync(join(projectPath, '.claude', 'agents'), { recursive: true });
+    mkdirSync(join(projectPath, 'src'), { recursive: true });
+    writeFileSync(join(projectPath, 'src', 'secret.txt'), 'keep');
+  });
+
+  afterEach(() => {
+    rmSync(projectPath, { recursive: true, force: true });
+  });
+
+  it('refuses to write through a leaf subagent symlink', () => {
+    symlinkSync(
+      join(projectPath, 'src', 'secret.txt'),
+      join(projectPath, '.claude', 'agents', 'helper.md'),
+    );
+
+    expect(() =>
+      installSubAgentInstructions(
+        projectPath,
+        subAgent,
+        capabilities,
+        ['claude-code'],
+      ),
+    ).toThrow(/symlink/i);
+    expect(readFileSync(join(projectPath, 'src', 'secret.txt'), 'utf8')).toBe(
+      'keep',
+    );
+  });
+
+  it('refuses to delete through a leaf subagent symlink', () => {
+    symlinkSync(
+      join(projectPath, 'src', 'secret.txt'),
+      join(projectPath, '.claude', 'agents', 'helper.md'),
+    );
+
+    expect(() =>
+      removeSubAgentInstructions(projectPath, 'helper', ['claude-code']),
+    ).toThrow(/symlink/i);
+    expect(existsSync(join(projectPath, 'src', 'secret.txt'))).toBe(true);
+  });
+});

--- a/src/cli/utils/agents-file/md-io.ts
+++ b/src/cli/utils/agents-file/md-io.ts
@@ -1,5 +1,6 @@
 import { existsSync, mkdirSync, readFileSync, writeFileSync, unlinkSync } from 'fs';
 import { join, dirname } from 'path';
+import { assertCapaOwnedInstallPath } from '../../../shared/install-path-guard';
 
 export function readMdFile(projectPath: string, filename: string): string {
   const filePath = join(projectPath, filename);
@@ -7,9 +8,11 @@ export function readMdFile(projectPath: string, filename: string): string {
 }
 
 export function writeMdFile(projectPath: string, filename: string, content: string): void {
-  const dir = dirname(join(projectPath, filename));
+  const target = join(projectPath, filename);
+  assertCapaOwnedInstallPath(projectPath, target);
+  const dir = dirname(target);
   if (!existsSync(dir)) mkdirSync(dir, { recursive: true });
-  writeFileSync(join(projectPath, filename), content, 'utf8');
+  writeFileSync(target, content, 'utf8');
 }
 
 export function deleteMdFile(projectPath: string, filename: string): void {

--- a/src/cli/utils/agents-file/subagents.ts
+++ b/src/cli/utils/agents-file/subagents.ts
@@ -101,6 +101,7 @@ function writeSubAgentFile(
   }
 
   const content = buildSubAgentFileContent(provider, subAgent, capabilities, skillDescriptions);
+  assertCapaOwnedInstallPath(projectPath, filePath);
   writeFileSync(filePath, content, 'utf8');
 
   taskLog(`  ✓ ${sa.dir}/${subAgent.id}${sa.extension} written`);
@@ -122,6 +123,7 @@ function removeSubAgentFile(projectPath: string, providerId: string, agentId: st
     return;
   }
   if (existsSync(filePath)) {
+    assertCapaOwnedInstallPath(projectPath, filePath);
     unlinkSync(filePath);
     taskLog(`  ✓ Removed ${sa.dir}/${agentId}${sa.extension}`);
   }

--- a/src/cli/utils/agents-file/subagents.ts
+++ b/src/cli/utils/agents-file/subagents.ts
@@ -7,6 +7,7 @@ import {
   renderSubAgentSkillsAndTools,
 } from '../../../shared/providers/handlers';
 import { assertSafeRepoPath } from '../../../shared/repo-file';
+import { assertCapaOwnedInstallPath } from '../../../shared/install-path-guard';
 import {
   describeUnsafeCapabilityId,
   isSafeCapabilityId,
@@ -86,6 +87,7 @@ function writeSubAgentFile(
 
   const { subagents: sa } = provider;
   const agentsDir = join(projectPath, sa.dir);
+  assertCapaOwnedInstallPath(projectPath, agentsDir);
   mkdirSync(agentsDir, { recursive: true });
 
   let filePath: string;

--- a/src/cli/utils/rules-installer.ts
+++ b/src/cli/utils/rules-installer.ts
@@ -5,6 +5,7 @@ import type { Rule } from '../../types/rules';
 import { getAllProviders, getProvider } from '../../shared/providers';
 import { buildRuleFrontmatter } from '../../shared/providers/handlers';
 import { assertSafeRepoPath } from '../../shared/repo-file';
+import { assertCapaOwnedInstallPath } from '../../shared/install-path-guard';
 import {
   describeUnsafeCapabilityId,
   isSafeCapabilityId,
@@ -235,6 +236,7 @@ export function installRules(
 
     if (provider.rules) {
       const rulesDir = join(projectPath, provider.rules.dir);
+      assertCapaOwnedInstallPath(projectPath, rulesDir);
       mkdirSync(rulesDir, { recursive: true });
 
       for (const rule of applicableRules) {
@@ -277,6 +279,7 @@ export function installRules(
           rulesDir,
           `${rule.id}${provider.rules.extension}`,
         );
+        assertCapaOwnedInstallPath(projectPath, filePath);
         writeFileSync(filePath, fileContent, 'utf-8');
         if (!options.quiet) {
           taskLog(`  ✓ ${provider.rules.dir}/${rule.id}${provider.rules.extension} written (${provider.displayName})`);

--- a/src/cli/utils/wrap/__tests__/provider-noise-rule.test.ts
+++ b/src/cli/utils/wrap/__tests__/provider-noise-rule.test.ts
@@ -26,6 +26,8 @@ describe('provider-noise-rule', () => {
     expect(body).toContain('`.claude`');
     expect(body).toContain('`AGENTS.md`');
     expect(body).toContain('`CLAUDE.md`');
+    expect(body).toContain('Git works normally');
+    expect(body).toContain('capa install');
   });
 
   it('installs an always-apply cursor rule', () => {

--- a/src/cli/utils/wrap/__tests__/validate-shadow-workspace.test.ts
+++ b/src/cli/utils/wrap/__tests__/validate-shadow-workspace.test.ts
@@ -1,0 +1,73 @@
+import { describe, it, expect, beforeEach, afterEach } from 'bun:test';
+import {
+  existsSync,
+  lstatSync,
+  mkdirSync,
+  mkdtempSync,
+  rmSync,
+  symlinkSync,
+  writeFileSync,
+} from 'fs';
+import { join } from 'path';
+import { tmpdir } from 'os';
+import { validateAndRepairShadowWorkspace } from '../validate-shadow-workspace';
+import { WORKSPACE_MARKER } from '../../../../shared/workspaces/paths';
+import { LOCKFILE_NAME } from '../../../../shared/lockfile';
+
+const CURSOR_ONLY = ['cursor'];
+
+describe('validateAndRepairShadowWorkspace', () => {
+  let realDir: string;
+  let wsDir: string;
+
+  beforeEach(() => {
+    realDir = mkdtempSync(join(tmpdir(), 'capa-wrap-real-'));
+    wsDir = mkdtempSync(join(tmpdir(), 'capa-wrap-ws-'));
+    mkdirSync(join(realDir, 'src'));
+    writeFileSync(join(realDir, 'src', 'a.ts'), 'export {}');
+    writeFileSync(join(realDir, 'capabilities.yaml'), 'skills: []\n');
+    writeFileSync(join(realDir, LOCKFILE_NAME), 'version: 1\nskills: []\nplugins: []\n');
+    mkdirSync(join(realDir, '.cursor'));
+    writeFileSync(join(realDir, '.cursor', 'mcp.json'), '{}');
+  });
+
+  afterEach(() => {
+    rmSync(realDir, { recursive: true, force: true });
+    rmSync(wsDir, { recursive: true, force: true });
+  });
+
+  it('symlinks new top-level files from the real project', () => {
+    writeFileSync(join(realDir, 'NEW.md'), 'hello');
+    const result = validateAndRepairShadowWorkspace(realDir, wsDir, CURSOR_ONLY);
+    expect(result.needsReinstall).toBe(true);
+    expect(existsSync(join(wsDir, 'NEW.md'))).toBe(true);
+  });
+
+  it('removes provider dirs that symlink to the real project', () => {
+    symlinkSync(join(realDir, '.cursor'), join(wsDir, '.cursor'));
+    const result = validateAndRepairShadowWorkspace(realDir, wsDir, CURSOR_ONLY);
+    expect(result.repaired).toContain('.cursor');
+    expect(result.needsReinstall).toBe(true);
+    expect(existsSync(join(wsDir, '.cursor'))).toBe(false);
+  });
+
+  it('removes nested provider install symlinks', () => {
+    mkdirSync(join(wsDir, '.cursor'), { recursive: true });
+    symlinkSync(join(realDir, 'src'), join(wsDir, '.cursor', 'skills'));
+    const result = validateAndRepairShadowWorkspace(realDir, wsDir, CURSOR_ONLY);
+    expect(result.repaired).toContain('.cursor/skills');
+    expect(result.needsReinstall).toBe(true);
+    expect(existsSync(join(wsDir, '.cursor', 'skills'))).toBe(false);
+  });
+
+  it('leaves materialized provider dirs intact', () => {
+    mkdirSync(join(wsDir, '.cursor', 'skills', 'demo'), { recursive: true });
+    writeFileSync(join(wsDir, '.cursor', 'skills', 'demo', 'SKILL.md'), '# demo');
+    writeFileSync(join(wsDir, '.cursor', 'mcp.json'), '{}');
+    writeFileSync(join(wsDir, 'AGENTS.md'), '# agents');
+    const result = validateAndRepairShadowWorkspace(realDir, wsDir, CURSOR_ONLY);
+    expect(result.repaired).toEqual([]);
+    expect(result.needsReinstall).toBe(false);
+    expect(lstatSync(join(wsDir, '.cursor')).isSymbolicLink()).toBe(false);
+  });
+});

--- a/src/cli/utils/wrap/__tests__/workspace.test.ts
+++ b/src/cli/utils/wrap/__tests__/workspace.test.ts
@@ -115,6 +115,10 @@ describe('prepareWorkspace', () => {
     expect(first.installed).toBe(true);
     expect(installMock).toHaveBeenCalledTimes(1);
 
+    // Simulate provider materialization from a real install run.
+    mkdirSync(join(first.workspacePath, '.claude'), { recursive: true });
+    writeFileSync(join(first.workspacePath, 'CLAUDE.md'), '# claude');
+
     installMock.mockClear();
     const second = await prepareWorkspace(realDir, provider);
     expect(second.cold).toBe(false);

--- a/src/cli/utils/wrap/provider-noise-rule.ts
+++ b/src/cli/utils/wrap/provider-noise-rule.ts
@@ -4,7 +4,7 @@ import { installRules } from '../rules-installer';
 
 export const WRAP_PROVIDER_NOISE_RULE_ID = 'capa-wrap-provider-noise';
 
-/** Body telling the wrap agent to ignore provider-owned session files in VCS. */
+/** Body telling the wrap agent how the shadow workspace is set up. */
 export function buildWrapProviderNoiseRuleBody(providerIds: Iterable<string>): string {
   const names = [...getProviderOwnedTopLevelNames(providerIds)].sort((a, b) =>
     a.localeCompare(b),
@@ -15,15 +15,27 @@ export function buildWrapProviderNoiseRuleBody(providerIds: Iterable<string>): s
       : '- (provider-owned config and instruction paths for this session)';
 
   return [
-    'This session runs inside a capa wrap shadow workspace.',
+    'This session runs inside a **capa wrap shadow workspace** — an isolated working copy of the project for agent work.',
     '',
-    'Version control may show uncommitted files under provider-owned paths that belong to this agent session (capa-generated config, rules, hooks, instruction files) — not the user\'s project source.',
+    '## How this workspace is set up',
+    '',
+    '- Project source (e.g. `src/`, `docs/`, user config) is symlinked from the real project. Edits through those paths update the real project normally.',
+    '- Provider/agent paths listed below are **shadow-only**. They exist only in this workspace and are not part of the user\'s source tree.',
+    '- **Git works normally** — status, diff, commit, and branch operations apply to the real repository. Ignore capa-generated paths when deciding what to commit.',
+    '',
+    '## Ignore these paths in version control',
     '',
     'Do not review, edit for the user\'s project, commit, or treat as project source anything under:',
     '',
     list,
     '',
     'When summarizing version-control status, reviewing diffs, or deciding what to commit, ignore those paths.',
+    '',
+    '## Commands and paths',
+    '',
+    '- Run shell commands from this workspace root as usual — paths like `src/` resolve to the real project.',
+    '- Do **not** run `capa install`, `capa add`, or `capa clean` from this shadow workspace.',
+    '- Never write skills, MCP config, rules, or hooks into the real project tree — only into the shadow provider paths above.',
   ].join('\n');
 }
 

--- a/src/cli/utils/wrap/validate-shadow-workspace.ts
+++ b/src/cli/utils/wrap/validate-shadow-workspace.ts
@@ -1,0 +1,96 @@
+import { existsSync, lstatSync, rmSync } from 'fs';
+import { join, resolve } from 'path';
+import { collectProviderInstallRelativePaths } from '../../../shared/install-path-guard';
+import { getProvider, resolveProviderId } from '../../../shared/providers';
+import {
+  ALWAYS_EXCLUDE,
+  getWrapExclusionSet,
+  isLinkedToReal,
+  removeTopLevelEntry,
+  syncTopLevelSymlinks,
+} from './symlink-workspace';
+
+export interface ShadowWorkspaceRepairResult {
+  /** Human-readable paths that were removed or repaired. */
+  repaired: string[];
+  /** When true, provider materialization should be re-run (capa install). */
+  needsReinstall: boolean;
+}
+
+/**
+ * Validate and repair a wrap shadow workspace before each session.
+ *
+ * - Top-level provider dirs (`.cursor`, `.claude`, …) must be real directories
+ *   owned by the shadow workspace — never symlinks/junctions into the real project.
+ * - Nested provider install paths (e.g. `.cursor/skills`) must not be symlinks
+ *   that collapse writes into the real tree.
+ * - Missing top-level project entries are symlinked from the real project.
+ */
+function getRequiredMaterializedTopLevelNames(
+  providerIds: Iterable<string>,
+): Set<string> {
+  const names = new Set<string>();
+  for (const raw of providerIds) {
+    const id = resolveProviderId(raw) ?? raw.trim().toLowerCase();
+    const p = getProvider(id);
+    if (!p) continue;
+    if (p.skillsDir) {
+      const top = p.skillsDir.replace(/\\/g, '/').replace(/^\.\//, '').split('/')[0];
+      if (top) names.add(top);
+    }
+    if (p.instructions?.filename && !p.instructions.filename.includes('/')) {
+      names.add(p.instructions.filename);
+    }
+  }
+  return names;
+}
+
+export function validateAndRepairShadowWorkspace(
+  realProjectPath: string,
+  workspacePath: string,
+  providerIds: Iterable<string>,
+): ShadowWorkspaceRepairResult {
+  const excluded = getWrapExclusionSet(providerIds);
+  const required = getRequiredMaterializedTopLevelNames(providerIds);
+  const wsRoot = resolve(workspacePath);
+  const realRoot = resolve(realProjectPath);
+  const repaired: string[] = [];
+  let needsReinstall = false;
+
+  for (const name of excluded) {
+    if (ALWAYS_EXCLUDE.has(name)) continue;
+    const wsEntry = join(wsRoot, name);
+    try {
+      if (!existsSync(wsEntry)) {
+        if (required.has(name)) needsReinstall = true;
+        continue;
+      }
+      const st = lstatSync(wsEntry);
+      if (st.isSymbolicLink() || isLinkedToReal(realRoot, wsRoot, name)) {
+        removeTopLevelEntry(wsRoot, name);
+        repaired.push(name);
+        needsReinstall = true;
+      }
+    } catch {
+      needsReinstall = true;
+    }
+  }
+
+  for (const rel of collectProviderInstallRelativePaths(providerIds)) {
+    const wsPath = join(wsRoot, rel);
+    if (!existsSync(wsPath)) continue;
+    try {
+      const st = lstatSync(wsPath);
+      if (!st.isSymbolicLink()) continue;
+      rmSync(wsPath, { recursive: true, force: true });
+      repaired.push(rel);
+      needsReinstall = true;
+    } catch {
+      // best-effort
+    }
+  }
+
+  syncTopLevelSymlinks(realProjectPath, workspacePath, providerIds);
+
+  return { repaired, needsReinstall };
+}

--- a/src/cli/utils/wrap/workspace.ts
+++ b/src/cli/utils/wrap/workspace.ts
@@ -21,7 +21,8 @@ import {
   collectWrapExclusionProviderIds,
   detectProviderIdsFromProjectTree,
 } from '../../../shared/providers';
-import { buildSymlinkWorkspace, syncTopLevelSymlinks } from './symlink-workspace';
+import { buildSymlinkWorkspace } from './symlink-workspace';
+import { validateAndRepairShadowWorkspace } from './validate-shadow-workspace';
 import { applyWrapShadowExtras } from './shadow-extras';
 import { installCommand } from '../../commands/install';
 import type { ProviderIntegration } from '../../../types/providers';
@@ -301,13 +302,30 @@ export async function prepareWorkspace(
   const workspaceReady = !!marker && existsSync(workspacePath);
   const projectKnown = await dbHasProject(real);
 
-  // Warm: same layout + same capabilities/lock pins → symlink sync only.
+  // Warm: same layout + same capabilities/lock pins → validate, sync, reuse.
   if (
     workspaceReady &&
     projectKnown &&
     marker!.capabilitiesFingerprint === fingerprint
   ) {
-    syncTopLevelSymlinks(real, workspacePath, exclusionProviderIds);
+    const repair = validateAndRepairShadowWorkspace(
+      real,
+      workspacePath,
+      exclusionProviderIds,
+    );
+    if (repair.needsReinstall) {
+      await runWrapInstall(workspacePath, real, provider.id, exclusionProviderIds);
+      await writeMarker(cachePath, real, provider.id, workName, fingerprint);
+      return {
+        cachePath,
+        workspacePath,
+        realProjectPath: real,
+        capabilitiesPath: caps.path,
+        exclusionProviderIds,
+        cold: false,
+        installed: true,
+      };
+    }
     applyWrapShadowExtras(workspacePath, real, provider.id, exclusionProviderIds);
     return {
       cachePath,
@@ -322,7 +340,7 @@ export async function prepareWorkspace(
 
   // Existing workspace, capabilities/lock changed → reinstall in place.
   if (workspaceReady) {
-    syncTopLevelSymlinks(real, workspacePath, exclusionProviderIds);
+    validateAndRepairShadowWorkspace(real, workspacePath, exclusionProviderIds);
     await runWrapInstall(workspacePath, real, provider.id, exclusionProviderIds);
     await writeMarker(cachePath, real, provider.id, workName, fingerprint);
     return {

--- a/src/shared/__tests__/install-path-guard.test.ts
+++ b/src/shared/__tests__/install-path-guard.test.ts
@@ -7,10 +7,11 @@ import {
 	rmSync,
 	symlinkSync,
 } from "fs";
-import { join } from "path";
+import { join, win32 } from "path";
 import { tmpdir } from "os";
 import {
 	assertCapaOwnedInstallPath,
+	assertInsideProjectRoot,
 	validateProviderInstallRoots,
 } from "../install-path-guard";
 
@@ -69,5 +70,18 @@ describe("install-path-guard", () => {
 			),
 		).not.toThrow();
 		expect(existsSync(join(projectDir, ".cursor", "skills"))).toBe(false);
+	});
+
+	it("rejects cross-drive destinations on Windows paths", () => {
+		const ops = {
+			resolve: win32.resolve,
+			relative: win32.relative,
+			isAbsolute: win32.isAbsolute,
+			parse: win32.parse,
+			sep: win32.sep,
+		};
+		expect(() =>
+			assertInsideProjectRoot("C:\\capa\\project", "D:\\outside\\file.md", ops),
+		).toThrow(/outside the project root/i);
 	});
 });

--- a/src/shared/__tests__/install-path-guard.test.ts
+++ b/src/shared/__tests__/install-path-guard.test.ts
@@ -1,0 +1,73 @@
+import { describe, it, expect, beforeEach, afterEach } from "bun:test";
+import {
+	existsSync,
+	lstatSync,
+	mkdirSync,
+	mkdtempSync,
+	rmSync,
+	symlinkSync,
+} from "fs";
+import { join } from "path";
+import { tmpdir } from "os";
+import {
+	assertCapaOwnedInstallPath,
+	validateProviderInstallRoots,
+} from "../install-path-guard";
+
+describe("install-path-guard", () => {
+	let projectDir: string;
+
+	beforeEach(() => {
+		projectDir = mkdtempSync(join(tmpdir(), "capa-install-guard-"));
+		mkdirSync(join(projectDir, ".cursor"), { recursive: true });
+	});
+
+	afterEach(() => {
+		rmSync(projectDir, { recursive: true, force: true });
+	});
+
+	it("allows writes under real provider directories", () => {
+		mkdirSync(join(projectDir, ".cursor", "skills"), { recursive: true });
+		expect(() =>
+			assertCapaOwnedInstallPath(
+				projectDir,
+				join(projectDir, ".cursor", "skills", "demo"),
+			),
+		).not.toThrow();
+	});
+
+	it("refuses writes through a symlink in the parent chain", () => {
+		mkdirSync(join(projectDir, "skills"), { recursive: true });
+		symlinkSync(
+			join(projectDir, "skills"),
+			join(projectDir, ".cursor", "skills"),
+		);
+		expect(() =>
+			assertCapaOwnedInstallPath(
+				projectDir,
+				join(projectDir, ".cursor", "skills", "demo"),
+			),
+		).toThrow(/symlink/i);
+	});
+
+	it("refuses when provider install root is a symlink", () => {
+		mkdirSync(join(projectDir, "skills"), { recursive: true });
+		symlinkSync(
+			join(projectDir, "skills"),
+			join(projectDir, ".cursor", "skills"),
+		);
+		expect(() =>
+			validateProviderInstallRoots(projectDir, ["cursor"]),
+		).toThrow(/symlink/i);
+	});
+
+	it("allows paths that do not exist yet when parents are safe", () => {
+		expect(() =>
+			assertCapaOwnedInstallPath(
+				projectDir,
+				join(projectDir, ".cursor", "skills", "new-skill"),
+			),
+		).not.toThrow();
+		expect(existsSync(join(projectDir, ".cursor", "skills"))).toBe(false);
+	});
+});

--- a/src/shared/install-path-guard.ts
+++ b/src/shared/install-path-guard.ts
@@ -1,0 +1,131 @@
+import { existsSync, lstatSync, realpathSync } from "fs";
+import { dirname, join, relative, resolve, sep } from "path";
+import { getProvider, resolveProviderId } from "./providers";
+
+/**
+ * Relative project paths that `capa install` may write (skills, rules, MCP,
+ * hooks, subagents, instruction files, plugin manifests).
+ */
+export function collectProviderInstallRelativePaths(
+	providerIds: Iterable<string>,
+): string[] {
+	const paths = new Set<string>();
+	for (const raw of providerIds) {
+		const id = resolveProviderId(raw) ?? raw.trim().toLowerCase();
+		const p = getProvider(id);
+		if (!p) continue;
+		if (p.skillsDir) paths.add(p.skillsDir.replace(/\\/g, "/"));
+		if (p.instructions?.filename) {
+			paths.add(p.instructions.filename.replace(/\\/g, "/"));
+		}
+		if (p.mcp?.configPath) paths.add(p.mcp.configPath.replace(/\\/g, "/"));
+		if (p.mcp?.defaultMcpFallbackPath) {
+			paths.add(p.mcp.defaultMcpFallbackPath.replace(/\\/g, "/"));
+		}
+		if (p.rules?.dir) paths.add(p.rules.dir.replace(/\\/g, "/"));
+		if (p.subagents?.dir) paths.add(p.subagents.dir.replace(/\\/g, "/"));
+		if (p.hooks?.storage) {
+			const storage = p.hooks.storage;
+			if (storage.kind === "directory") {
+				paths.add(storage.dir.replace(/\\/g, "/"));
+			} else if ("configPath" in storage) {
+				paths.add(storage.configPath.replace(/\\/g, "/"));
+			}
+		}
+		for (const manifest of p.pluginManifestPaths ?? []) {
+			paths.add(manifest.replace(/\\/g, "/"));
+		}
+	}
+	return [...paths];
+}
+
+function formatRel(projectRoot: string, absPath: string): string {
+	const root = resolve(projectRoot);
+	const rel = relative(root, absPath);
+	return rel.split(sep).join("/") || ".";
+}
+
+/** Relative path from the real project root — stable across /var vs /private/var. */
+function relativeFromProjectReal(projectRoot: string, absPath: string): string {
+	const rootReal = realpathSync(resolve(projectRoot));
+	const pathReal = realpathSync(absPath);
+	const rel = relative(rootReal, pathReal);
+	if (rel.startsWith("..") || rel === "") {
+		throw new Error(
+			`Refusing to install outside the project root: ${formatRel(projectRoot, absPath)}`,
+		);
+	}
+	return rel.split(sep).join("/");
+}
+
+/**
+ * Ensure `destPath` sits under `projectRoot` and no existing path component
+ * on the way is a symlink. Symlinks can redirect capa writes outside the
+ * logical provider tree (e.g. `.cursor/skills` → `../skills`).
+ */
+export function assertCapaOwnedInstallPath(
+	projectRoot: string,
+	destPath: string,
+): void {
+	const root = resolve(projectRoot);
+	const dest = resolve(destPath);
+	const rel = relative(root, dest);
+	if (rel.startsWith("..") || rel === "") {
+		throw new Error(
+			`Refusing to install outside the project root: ${formatRel(root, dest)}`,
+		);
+	}
+
+	const parts = rel.split(/[/\\]/).filter(Boolean);
+	let current = root;
+	for (const part of parts) {
+		current = join(current, part);
+		if (!existsSync(current)) break;
+
+		let st;
+		try {
+			st = lstatSync(current);
+		} catch {
+			break;
+		}
+
+		if (st.isSymbolicLink()) {
+			let targetHint = "";
+			try {
+				targetHint = ` (resolves to ${relativeFromProjectReal(root, current)})`;
+			} catch {
+				// dangling link
+			}
+			throw new Error(
+				`Refusing to install through symlink at "${formatRel(root, current)}"${targetHint}. ` +
+					`capa can only write to paths it owns directly.`,
+			);
+		}
+
+		try {
+			const relViaLogical = formatRel(root, current);
+			const relViaReal = relativeFromProjectReal(root, current);
+			if (relViaLogical !== relViaReal) {
+				throw new Error(
+					`Refusing to install: "${relViaLogical}" resolves through a symlink to "${relViaReal}". ` +
+						`capa can only write to paths it owns directly.`,
+				);
+			}
+		} catch (err: unknown) {
+			if (err instanceof Error && err.message.startsWith("Refusing to install")) {
+				throw err;
+			}
+			// realpath failure on race — parent symlink check above is enough.
+		}
+	}
+}
+
+/** Validate every provider install root before a full install run. */
+export function validateProviderInstallRoots(
+	projectRoot: string,
+	providerIds: Iterable<string>,
+): void {
+	for (const rel of collectProviderInstallRelativePaths(providerIds)) {
+		assertCapaOwnedInstallPath(projectRoot, join(projectRoot, rel));
+	}
+}

--- a/src/shared/install-path-guard.ts
+++ b/src/shared/install-path-guard.ts
@@ -1,6 +1,62 @@
 import { existsSync, lstatSync, realpathSync } from "fs";
-import { dirname, join, relative, resolve, sep } from "path";
+import {
+	isAbsolute,
+	join,
+	parse,
+	relative,
+	resolve,
+	sep,
+	win32,
+} from "path";
 import { getProvider, resolveProviderId } from "./providers";
+
+type PathOps = {
+	resolve: (path: string) => string;
+	relative: (from: string, to: string) => string;
+	isAbsolute: (path: string) => boolean;
+	parse: (path: string) => { root: string };
+	sep: string;
+};
+
+function pathOps(): PathOps {
+	return process.platform === "win32"
+		? {
+				resolve: win32.resolve,
+				relative: win32.relative,
+				isAbsolute: win32.isAbsolute,
+				parse: win32.parse,
+				sep: win32.sep,
+			}
+		: { resolve, relative, isAbsolute, parse, sep };
+}
+
+/** @internal Exported for cross-platform containment regression tests. */
+export function assertInsideProjectRoot(
+	projectRoot: string,
+	destPath: string,
+	ops: PathOps = pathOps(),
+): string {
+	const root = ops.resolve(projectRoot);
+	const dest = ops.resolve(destPath);
+	const rootDrive = ops.parse(root).root;
+	const destDrive = ops.parse(dest).root;
+	if (
+		rootDrive &&
+		destDrive &&
+		rootDrive.toLowerCase() !== destDrive.toLowerCase()
+	) {
+		throw new Error(
+			`Refusing to install outside the project root: ${formatRel(root, dest, ops)}`,
+		);
+	}
+	const rel = ops.relative(root, dest);
+	if (ops.isAbsolute(rel) || rel.startsWith("..") || rel === "") {
+		throw new Error(
+			`Refusing to install outside the project root: ${formatRel(root, dest, ops)}`,
+		);
+	}
+	return rel.split(ops.sep).join("/");
+}
 
 /**
  * Relative project paths that `capa install` may write (skills, rules, MCP,
@@ -39,10 +95,14 @@ export function collectProviderInstallRelativePaths(
 	return [...paths];
 }
 
-function formatRel(projectRoot: string, absPath: string): string {
-	const root = resolve(projectRoot);
-	const rel = relative(root, absPath);
-	return rel.split(sep).join("/") || ".";
+function formatRel(
+	projectRoot: string,
+	absPath: string,
+	ops: PathOps = pathOps(),
+): string {
+	const root = ops.resolve(projectRoot);
+	const rel = ops.relative(root, ops.resolve(absPath));
+	return rel.split(ops.sep).join("/") || ".";
 }
 
 /** Relative path from the real project root — stable across /var vs /private/var. */
@@ -50,7 +110,7 @@ function relativeFromProjectReal(projectRoot: string, absPath: string): string {
 	const rootReal = realpathSync(resolve(projectRoot));
 	const pathReal = realpathSync(absPath);
 	const rel = relative(rootReal, pathReal);
-	if (rel.startsWith("..") || rel === "") {
+	if (isAbsolute(rel) || rel.startsWith("..") || rel === "") {
 		throw new Error(
 			`Refusing to install outside the project root: ${formatRel(projectRoot, absPath)}`,
 		);
@@ -69,14 +129,9 @@ export function assertCapaOwnedInstallPath(
 ): void {
 	const root = resolve(projectRoot);
 	const dest = resolve(destPath);
-	const rel = relative(root, dest);
-	if (rel.startsWith("..") || rel === "") {
-		throw new Error(
-			`Refusing to install outside the project root: ${formatRel(root, dest)}`,
-		);
-	}
+	const rel = assertInsideProjectRoot(root, dest);
 
-	const parts = rel.split(/[/\\]/).filter(Boolean);
+	const parts = rel.split("/").filter(Boolean);
 	let current = root;
 	for (const part of parts) {
 		current = join(current, part);


### PR DESCRIPTION
## Summary
- Refuse `capa install` writes when provider paths collapse through symlinks (e.g. `.cursor/skills` → `skills/`), with upfront validation and per-write guards across skills, rules, agents, and plugins.
- On each `capa wrap`, validate and repair the shadow workspace: remove provider dirs that link into the real project, fix nested install-path symlinks, and sync missing top-level project entries.
- Expand the built-in wrap agent rule so agents understand shadow vs real layout, that git works normally, and that capa install commands must not run from the shadow workspace.

## Test plan
- [x] `bun test src/shared/__tests__/install-path-guard.test.ts`
- [x] `bun test src/cli/utils/wrap/__tests__/validate-shadow-workspace.test.ts`
- [x] `bun test src/cli/utils/wrap/__tests__/workspace.test.ts`
- [x] Full suite: `bun test` (1518 pass)
- [ ] Manual: wrap a project whose provider skill dirs symlink to a shared folder; confirm install is refused on the real project and shadow install stays isolated


Made with [Cursor](https://cursor.com)