### PR TITLE
security: harden local API, install, registries, and credentials

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -129,6 +129,10 @@ jobs:
     name: Create Release
     needs: build
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      id-token: write
+      attestations: write
     steps:
       - name: Checkout code
         uses: actions/checkout@v7
@@ -144,7 +148,17 @@ jobs:
       - name: Generate SHA256SUMS.txt
         run: |
           find artifacts -name '*.sha256' -type f -exec cat {} \; | LC_ALL=C sort -k2 > SHA256SUMS.txt
+          sha256sum install.sh install.ps1 >> SHA256SUMS.txt
+          LC_ALL=C sort -k2 -o SHA256SUMS.txt SHA256SUMS.txt
           cat SHA256SUMS.txt
+
+      - name: Attest build provenance
+        uses: actions/attest-build-provenance@v3
+        with:
+          subject-path: |
+            SHA256SUMS.txt
+            install.sh
+            install.ps1
 
       - name: Create Release
         uses: softprops/action-gh-release@v3
@@ -152,17 +166,10 @@ jobs:
           files: |
             artifacts/**/*
             SHA256SUMS.txt
+            install.sh
+            install.ps1
           draft: false
           prerelease: false
           generate_release_notes: true
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-
-      - name: Upload install scripts
-        uses: softprops/action-gh-release@v3
-        with:
-          files: |
-            install.sh
-            install.ps1
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/README.md
+++ b/README.md
@@ -92,10 +92,15 @@ capa registry search skills-sh "research"
 ### 3. Install
 
 ```bash
-capa install
+capa install              # interactive: confirms executable surface, then installs
+capa install --yes        # CI / scripts: skip confirmation
+capa install --dry-run    # preview MCP servers, hooks, and commands without changes
 ```
 
 Resolves SHAs, fills the cache, writes per-provider files, and registers one MCP endpoint with each configured agent. Resolved SHAs land in `capabilities.lock`.
+
+> [!NOTE]
+> Non-interactive shells (CI, scripts) must pass `--yes`. The first install prints the executable surface (MCP stdio servers, hooks, command tools, plugins) and asks for confirmation; unchanged surfaces skip the prompt on re-run.
 
 > [!TIP]
 > Already have skills, MCP configs, and rules in the repo? After `capa init`, use the bundled `/bootstrap` skill — the agent scans the project and drafts the CAPA config for you.
@@ -206,7 +211,7 @@ Agent ──MCP──► capa gateway (:5912) ──proxy──► upstream MCP 
 capa init                              # create capabilities.yaml + register project
 capa add <source> [--plugin] [--install]
 capa add --server|--tool|--rule|--hook …
-capa install [-p <provider>] [-e .env] [--no-cache]
+capa install [-p <provider>] [-e .env] [--no-cache] [--yes] [--dry-run]
 capa wrap <provider> [--project <path>]
 capa sh [tool] [args…] [--raw]
 capa registry search|add|list|refresh|remove …
@@ -214,7 +219,7 @@ capa start|stop|restart|status
 capa clean                             # remove managed artifacts
 capa auth github|gitlab
 capa cache | capa cache clean
-capa upgrade
+capa upgrade [--yes]                   # pin GitHub release + verify installer checksum
 ```
 
 ## Documentation

--- a/bun.lock
+++ b/bun.lock
@@ -24,10 +24,10 @@
         "highlight.js": "^11.11.1",
         "i18next": "^26.0.10",
         "js-yaml": "^5.0.0",
-        "listr2": "^10.2.1",
+        "listr2": "^11.0.0",
         "lucide-react": "^1.14.0",
         "marked": "^18.0.3",
-        "nanoid": "^5.0.8",
+        "nanoid": "^6.0.0",
         "picocolors": "^1.1.1",
         "react": "^19.2.6",
         "react-dom": "^19.2.6",
@@ -270,7 +270,7 @@
 
     "cli-cursor": ["cli-cursor@5.0.0", "", { "dependencies": { "restore-cursor": "^5.0.0" } }, "sha512-aCj4O5wKyszjMmDT4tZj93kxyydN/K5zPWSCe6/0AV/AA1pqe5ZBIw0a2ZfPQV7lL5/yb5HsUreJ6UFAF1tEQw=="],
 
-    "cli-truncate": ["cli-truncate@5.2.0", "", { "dependencies": { "slice-ansi": "^8.0.0", "string-width": "^8.2.0" } }, "sha512-xRwvIOMGrfOAnM1JYtqQImuaNtDEv9v6oIYAs4LIHwTiKee8uwvIi363igssOC0O5U04i4AlENs79LQLu9tEMw=="],
+    "cli-truncate": ["cli-truncate@6.1.1", "", { "dependencies": { "slice-ansi": "^9.0.0", "string-width": "^8.2.0" } }, "sha512-06p9vyLahLa4zkGcgsGxU6iEkSOiuI4fhCH6Emhe2lPAcoUv73n72DnODsnHA+5wwXGnV0n9M9/qOQJSjYhFhw=="],
 
     "clsx": ["clsx@2.1.1", "", {}, "sha512-eYm0QWBtUrBWZWG0d386OGAw16Z995PiOVo2B7bjWSbHedGl5e0ZWaq65kOGgUSNesEIDkB9ISbTg/JK9dhCZA=="],
 
@@ -304,8 +304,6 @@
 
     "ee-first": ["ee-first@1.1.1", "", {}, "sha512-WMwm9LhRUo+WUaRN+vRuETqG89IgZphVSNkdFgeb6sS/E4OrDIN7t48CAewSHXc6C8lefD8KKfr5vY61brQlow=="],
 
-    "emoji-regex": ["emoji-regex@10.6.0", "", {}, "sha512-toUI84YS5YmxW219erniWD0CIVOo46xGKColeNQRgOzDorgBi1v4D71/OFzgD9GO2UGKIv1C3Sp8DAn0+j5w7A=="],
-
     "encodeurl": ["encodeurl@2.0.0", "", {}, "sha512-Q0n9HRi4m6JuGIV1eFlmvJB7ZEVxu93IrMyiMsGC0lrMJMWzRgx6WGquyfQgZVb31vhGgXnfmPNNXmxnOkRBrg=="],
 
     "enhanced-resolve": ["enhanced-resolve@5.21.2", "", { "dependencies": { "graceful-fs": "^4.2.4", "tapable": "^2.3.3" } }, "sha512-xe9vQb5kReirPUxgQrXA3ihgbCqssmTiM7cOZ+Gzu+VeGWgpV98lLZvp0dl4yriyAePcewxGUs9UpKD8PET9KQ=="],
@@ -321,8 +319,6 @@
     "escape-html": ["escape-html@1.0.3", "", {}, "sha512-NiSupZ4OeuGwr68lGIeym/ksIZMJodUGOSCZ/FSnTxcrekbvqrgdUxlJOMpijaKZVjAJrWrGs/6Jy8OMuyj9ow=="],
 
     "etag": ["etag@1.8.1", "", {}, "sha512-aIL5Fx7mawVa300al2BnEE4iNvo1qETxLrPI/o05L7z6go7fCw1J6EQmbK4FmJ2AS7kgVF/KEZWufBfdClMcPg=="],
-
-    "eventemitter3": ["eventemitter3@5.0.4", "", {}, "sha512-mlsTRyGaPBjPedk6Bvw+aqbsXDtoAyAzm5MO7JgU+yVRyMQ5O8bD4Kcci7BS85f93veegeCPkL8R4GLClnjLFw=="],
 
     "eventsource": ["eventsource@3.0.7", "", { "dependencies": { "eventsource-parser": "^3.0.1" } }, "sha512-CRT1WTyuQoD771GW56XEZFQ/ZoSfWid1alKGDYMmkt2yl8UXrVR4pspqWNEcqKvVIzg6PAltWjxcSSPrboA4iA=="],
 
@@ -428,9 +424,9 @@
 
     "lightningcss-win32-x64-msvc": ["lightningcss-win32-x64-msvc@1.32.0", "", { "os": "win32", "cpu": "x64" }, "sha512-Amq9B/SoZYdDi1kFrojnoqPLxYhQ4Wo5XiL8EVJrVsB8ARoC1PWW6VGtT0WKCemjy8aC+louJnjS7U18x3b06Q=="],
 
-    "listr2": ["listr2@10.2.1", "", { "dependencies": { "cli-truncate": "^5.2.0", "eventemitter3": "^5.0.4", "log-update": "^6.1.0", "rfdc": "^1.4.1", "wrap-ansi": "^10.0.0" } }, "sha512-7I5knELsJKTUjXG+A6BkKAiGkW1i25fNa/xlUl9hFtk15WbE9jndA89xu5FzQKrY5llajE1hfZZFMILXkDHk/Q=="],
+    "listr2": ["listr2@11.0.0", "", { "dependencies": { "cli-truncate": "^6.1.1", "log-update": "^8.0.0", "wrap-ansi": "^10.0.0" } }, "sha512-8K88S0aSrcSXdJfiZtEy5BQMnR+TyjrCGLcgAvQs6ta0NEnIm0RJ72/Pv67Jvg07cfBhDbuN74V81lSSVYEFEw=="],
 
-    "log-update": ["log-update@6.1.0", "", { "dependencies": { "ansi-escapes": "^7.0.0", "cli-cursor": "^5.0.0", "slice-ansi": "^7.1.0", "strip-ansi": "^7.1.0", "wrap-ansi": "^9.0.0" } }, "sha512-9ie8ItPR6tjY5uYJh8K/Zrv/RMZ5VOlOWvtZdEHYSTFKZfIBPQa9tOAEeAWhd+AnIneLJ22w5fjOYtoutpWq5w=="],
+    "log-update": ["log-update@8.0.0", "", { "dependencies": { "ansi-escapes": "^7.3.0", "cli-cursor": "^5.0.0", "slice-ansi": "^9.0.0", "string-width": "^8.2.0", "strip-ansi": "^7.2.0", "wrap-ansi": "^10.0.0" } }, "sha512-lddSgOt3bPASrylL54ZSpy8nBHns+vBVSoILlVOx+dei300pnLRN958rj/EdlVLKuWlSESU3qdnDZdAI7FXYGg=="],
 
     "lucide-react": ["lucide-react@1.14.0", "", { "peerDependencies": { "react": "^16.5.1 || ^17.0.0 || ^18.0.0 || ^19.0.0" } }, "sha512-+1mdWcfSJVUsaTIjN9zoezmUhfXo5l0vP7ekBMPo3jcS/aIkxHnXqAPsByszMZx/Y8oQBRJxJx5xg+RH3urzxA=="],
 
@@ -454,7 +450,7 @@
 
     "ms": ["ms@2.1.3", "", {}, "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA=="],
 
-    "nanoid": ["nanoid@5.1.6", "", { "bin": "bin/nanoid.js" }, "sha512-c7+7RQ+dMB5dPwwCp4ee1/iV/q2P6aK1mTZcfr1BTuVlyW9hJYiMPybJCcnBlQtuSmTIWNeazm/zqNoZSSElBg=="],
+    "nanoid": ["nanoid@6.0.1", "", { "bin": { "nanoid": "bin/nanoid.js" } }, "sha512-3wVS3i51pE2pi1k5FFL/95BGfVS0kSsvDVuGXHOtxox/TywUmtgq+3qiTOTbs9J7KfHaXPiN171k/A6dBnaXFw=="],
 
     "negotiator": ["negotiator@1.0.0", "", {}, "sha512-8Ofs/AUQh8MaEcrlq5xOX0CQ9ypTF5dl78mjlMNfOK08fzpgTHQRQPBxcPlEtIw0yRpws+Zo/3r+5WRby7u3Gg=="],
 
@@ -512,8 +508,6 @@
 
     "restore-cursor": ["restore-cursor@5.1.0", "", { "dependencies": { "onetime": "^7.0.0", "signal-exit": "^4.1.0" } }, "sha512-oMA2dcrw6u0YfxJQXm342bFKX/E4sG9rbTzO9ptUcR/e8A33cHuvStiYOwH7fszkZlZ1z/ta9AAoPk2F4qIOHA=="],
 
-    "rfdc": ["rfdc@1.4.1", "", {}, "sha512-q1b3N5QkRUWUl7iyylaaj3kOpIT0N2i9MqIEQXP73GVsN9cw3fdx8X63cEmWhJGi2PPCF23Ijp7ktmd39rawIA=="],
-
     "router": ["router@2.2.0", "", { "dependencies": { "debug": "^4.4.0", "depd": "^2.0.0", "is-promise": "^4.0.0", "parseurl": "^1.3.3", "path-to-regexp": "^8.0.0" } }, "sha512-nLTrUKm2UyiL7rlhapu/Zl45FwNgkZGaCpZbIHajDYgwlJCOzLSk+cIPAnsEqV955GjILJnKbdQC1nVPz+gAYQ=="],
 
     "safer-buffer": ["safer-buffer@2.1.2", "", {}, "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg=="],
@@ -544,7 +538,7 @@
 
     "sisteransi": ["sisteransi@1.0.5", "", {}, "sha512-bLGGlR1QxBcynn2d5YmDX4MGjlZvy2MRBDRNHLJ8VI6l6+9FUiyTFNJ0IveOSP0bcXgVDPRcfGqA0pjaqUpfVg=="],
 
-    "slice-ansi": ["slice-ansi@8.0.0", "", { "dependencies": { "ansi-styles": "^6.2.3", "is-fullwidth-code-point": "^5.1.0" } }, "sha512-stxByr12oeeOyY2BlviTNQlYV5xOj47GirPr4yA1hE9JCtxfQN0+tVbkxwCtYDQWhEKWFHsEK48ORg5jrouCAg=="],
+    "slice-ansi": ["slice-ansi@9.0.0", "", { "dependencies": { "ansi-styles": "^6.2.3", "is-fullwidth-code-point": "^5.1.0" } }, "sha512-SO/3iYL5S3W57LLEniscOGPZgOqZUPCx6d3dB+52B80yJ0XstzsC/eV8gnA4tM3MHDrKz+OCFSLNjswdSC+/bA=="],
 
     "source-map-js": ["source-map-js@1.2.1", "", {}, "sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA=="],
 
@@ -624,14 +618,8 @@
 
     "bun-types/@types/node": ["@types/node@22.19.10", "", { "dependencies": { "undici-types": "~6.21.0" } }, "sha512-tF5VOugLS/EuDlTBijk0MqABfP8UxgYazTLo3uIn3b4yJgg26QRbVYJYsDtHrjdDUIRfP70+VfhTTc+CE1yskw=="],
 
-    "log-update/slice-ansi": ["slice-ansi@7.1.2", "", { "dependencies": { "ansi-styles": "^6.2.1", "is-fullwidth-code-point": "^5.0.0" } }, "sha512-iOBWFgUX7caIZiuutICxVgX1SdxwAVFFKwt1EvMYYec/NWO5meOJ6K5uQxhrYBdQJne4KxiqZc+KptFOWFSI9w=="],
-
-    "log-update/wrap-ansi": ["wrap-ansi@9.0.2", "", { "dependencies": { "ansi-styles": "^6.2.1", "string-width": "^7.0.0", "strip-ansi": "^7.1.0" } }, "sha512-42AtmgqjV+X1VpdOfyTGOYRi0/zsoLqtXQckTmqTeybT+BDIbM/Guxo7x3pE2vtpr1ok6xRqM9OpBe+Jyoqyww=="],
-
     "react-router/cookie": ["cookie@1.1.1", "", {}, "sha512-ei8Aos7ja0weRpFzJnEA9UHJ/7XQmqglbRwnf2ATjcB9Wq874VKH9kfjjirM6UhU2/E5fFYadylyhFldcqSidQ=="],
 
     "bun-types/@types/node/undici-types": ["undici-types@6.21.0", "", {}, "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ=="],
-
-    "log-update/wrap-ansi/string-width": ["string-width@7.2.0", "", { "dependencies": { "emoji-regex": "^10.3.0", "get-east-asian-width": "^1.0.0", "strip-ansi": "^7.1.0" } }, "sha512-tsaTIkKW9b4N+AEj+SVA+WhJzV7/zMhcSu78mLKWSk7cXMOSHsBKFWUs0fWwq8QyK3MgJBQRX6Gbi4kYbdvGkQ=="],
   }
 }

--- a/install.ps1
+++ b/install.ps1
@@ -239,7 +239,11 @@ function Add-ToPath {
 
 function Install-Capa {
     # Fetch the latest version
-    $APP_VERSION = Get-LatestVersion
+    if ($env:CAPA_VERSION) {
+        $APP_VERSION = $env:CAPA_VERSION -replace '^v', ''
+    } else {
+        $APP_VERSION = Get-LatestVersion
+    }
     
     $bannerInner = 39
     $bannerTitle = "  CAPA Installer v$APP_VERSION"

--- a/install.sh
+++ b/install.sh
@@ -99,14 +99,17 @@ ENVIRONMENT VARIABLES:
     CAPA_PRINT_QUIET        Set to 1 for quiet output
 
 EXAMPLES:
-    # Install with defaults
+    # Recommended: download a tagged installer, verify SHA256, then run
+    curl -fsSL -O https://github.com/infragate/capa/releases/download/vX.Y.Z/install.sh
+    curl -fsSL -O https://github.com/infragate/capa/releases/download/vX.Y.Z/SHA256SUMS.txt
+    sha256sum -c SHA256SUMS.txt --ignore-missing
+    sh ./install.sh
+
+    # Existing installs: capa upgrade --yes  (downloads the tagged installer,
+    # verifies SHA256 against SHA256SUMS.txt, then runs the local file)
+
+    # Convenience only — does not verify the installer script itself:
     curl -LsSf https://capa.infragate.ai/install.sh | sh
-
-    # Install to custom directory
-    CAPA_INSTALL_DIR=~/bin curl -LsSf https://capa.infragate.ai/install.sh | sh
-
-    # Install without modifying PATH
-    CAPA_NO_MODIFY_PATH=1 curl -LsSf https://capa.infragate.ai/install.sh | sh
 EOF
 }
 
@@ -405,8 +408,12 @@ EOF
 # Main installation function
 install_capa() {
     # Fetch the latest version first
-    get_latest_version
-    APP_VERSION="$RETVAL"
+    if [ -n "${CAPA_VERSION:-}" ]; then
+        APP_VERSION="${CAPA_VERSION#v}"
+    else
+        get_latest_version
+        APP_VERSION="$RETVAL"
+    fi
     
     local _box_inner=39
     local _banner="  CAPA Installer v${APP_VERSION}"
@@ -508,6 +515,12 @@ install_capa() {
         err "checksum verification failed for ${_binary_name} (expected ${_expected_hash}, got ${_computed_hash})"
     fi
     success "Verified binary integrity"
+
+    if check_cmd gh; then
+        if gh attestation verify "$_temp_file" --repo "${GITHUB_REPO}" >/dev/null 2>&1; then
+            success "Verified build provenance"
+        fi
+    fi
 
     # Install binary
     info "Installing to ${_install_dir}/capa..."

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "dev": "bun run src/cli/index.ts",
     "build:web": "bun run scripts/build-web.ts",
     "prebuild": "bun run scripts/generate-version.ts && bun run scripts/build-web.ts",
-    "build": "bun build src/cli/index.ts --compile --outfile dist/capa --icon logo.ico",
+    "build": "bun build src/cli/index.ts --compile --outfile dist/capa --icon logo.ico && cp -R registries dist/registries",
     "build:win": "bun build src/cli/index.ts --compile --windows-icon=./logo.ico --outfile dist/capa --icon logo.ico",
     "preserver": "bun run build:web",
     "server": "bun run src/server/index.ts",

--- a/skills/capabilities-manager/references/commands.md
+++ b/skills/capabilities-manager/references/commands.md
@@ -29,6 +29,8 @@ capa install -e .prod.env   # Load variables from custom env file
 capa install -p cursor      # Install for a single provider
 capa install --no-cache     # Bypass on-disk cache; re-resolve all remote sources
 capa install --passthrough  # Write provider-native files only (no capa server/proxy)
+capa install --dry-run      # Print executable surface (MCP, hooks, commands) and exit
+capa install --yes          # Skip confirmation (required in CI / non-interactive shells)
 ```
 
 Reads the capabilities file and:
@@ -44,6 +46,10 @@ Reads the capabilities file and:
 
 **Security**: If `options.security` is configured with `blockedPhrases` or `allowedCharacters`, the corresponding checks run during installation. Omit or comment out each property to disable it. If a blocked phrase is found, installation stops immediately and reports which skill and phrase caused the block. When `allowedCharacters` is present, character sanitization runs: the baseline (printable ASCII + standard whitespace) is always preserved, and the value specifies extra Unicode ranges to keep on top of that.
 
+Before any changes run, capa prints the **executable surface** (MCP stdio servers, hooks, command tools, plugins) and asks for confirmation. Re-running install with an unchanged surface skips the prompt. In CI or other non-interactive environments, pass `--yes`. Use `--dry-run` to preview the surface without installing.
+
+Project secrets (`${VarName}`) are encrypted at rest in `~/.capa/capa.db`. The Web UI and HTTP API return `{ isSet, hint }` metadata only — never raw values.
+
 **Flags**:
 - `-e, --env [file]`: Load variables from a `.env` file instead of using the web UI
   - Without filename: Uses `.env` in the project directory
@@ -53,6 +59,8 @@ Reads the capabilities file and:
 - `-p, --provider <id>`: Install for a single provider (e.g. `cursor`, `claude-code`). Overrides the `providers` field in the capabilities file.
 - `--no-cache`: Bypass the on-disk cache and lockfile; re-resolve every remote source (skills, agents, rules, plugins) from scratch.
 - `--passthrough`: Write provider-native files from the capabilities file **without** registering the project with the capa server / MCP proxy. No lockfile pinning for managed mode, no tool aliases/defaults/formatters via the proxy. Prefer managed install unless the user explicitly wants unmanaged native files.
+- `--dry-run`: Print the executable surface and exit without installing.
+- `-y, --yes`: Accept the executable-surface confirmation without prompting (required in non-interactive / CI environments).
 
 **Provider resolution** (when `providers` is omitted from the capabilities file):
 1. `--provider` flag (highest priority)
@@ -267,9 +275,10 @@ Authenticates with Git providers for accessing private repositories (skills, plu
 
 ```bash
 capa upgrade
+capa upgrade --yes    # Skip confirmation (required in non-interactive / CI)
 ```
 
-Upgrades capa to the latest published version.
+Upgrades capa to the latest published version. Prints the pinned release, installer URL, and SHA-256 checksum before downloading. Non-interactive environments must pass `--yes`.
 
 **When to use**: When a new version of capa is available (capa will notify you after commands when an update is available).
 
@@ -297,6 +306,7 @@ capa registry path                                         # Print the managed r
 capa registry search [slug] "query" [--capability skills|plugins] [--limit 20]
 
 capa registry add <source> [slug]                          # Fetch + install a registry
+capa registry add <source> [slug] --yes                  # Skip execute-adapter confirmation (CI)
 capa registry add infragate/capa@skills-sh                 # GitHub source, search-form (auto type=github)
 capa registry add gitlab/group/proj::registries/internal --type=gitlab
 capa registry add https://example.com/adapter.ts          # HTTPS URL source (type auto-detected from scheme)

--- a/src/cli/commands/__tests__/add-install-flag.test.ts
+++ b/src/cli/commands/__tests__/add-install-flag.test.ts
@@ -1,15 +1,11 @@
-import { describe, it, expect, beforeEach, afterEach, mock } from 'bun:test';
+import { describe, it, expect, beforeEach, afterEach, mock, spyOn } from 'bun:test';
 import { mkdtempSync, rmSync, writeFileSync, readFileSync } from 'fs';
 import { join } from 'path';
 import { tmpdir } from 'os';
+import * as install from '../install';
+import { addCommand } from '../add';
 
 const installMock = mock(async () => {});
-
-mock.module('../install', () => ({
-  installCommand: installMock,
-}));
-
-const { addCommand } = await import('../add');
 
 function isolateHome(): { restore: () => void } {
   const home = mkdtempSync(join(tmpdir(), 'capa-add-home-'));
@@ -32,6 +28,7 @@ describe('addCommand install flag (github skill)', () => {
   let projectDir: string;
   let homeCtx: { restore: () => void };
   let originalCwd: string;
+  let installSpy: ReturnType<typeof spyOn>;
 
   beforeEach(() => {
     projectDir = mkdtempSync(join(tmpdir(), 'capa-add-proj-'));
@@ -43,9 +40,11 @@ describe('addCommand install flag (github skill)', () => {
       'skills: []\nplugins: []\nservers: []\ntools: []\n',
     );
     installMock.mockClear();
+    installSpy = spyOn(install, 'installCommand').mockImplementation(installMock);
   });
 
   afterEach(() => {
+    installSpy.mockRestore();
     process.chdir(originalCwd);
     homeCtx.restore();
     rmSync(projectDir, { recursive: true, force: true });

--- a/src/cli/commands/__tests__/auth-command.test.ts
+++ b/src/cli/commands/__tests__/auth-command.test.ts
@@ -2,6 +2,7 @@ import { describe, it, expect, mock, beforeEach, afterEach, afterAll, spyOn } fr
 import { mkdtempSync, rmSync } from 'fs';
 import { join } from 'path';
 import { tmpdir } from 'os';
+import { setFlags } from '../../ui';
 
 const ensureServerMock = mock(async () => ({
   running: true,
@@ -90,6 +91,7 @@ describe('authCommand', () => {
 
   afterEach(() => {
     homeCtx.restore();
+    setFlags({ headless: false });
   });
 
   it('module loads and exports a callable authCommand', () => {
@@ -278,6 +280,58 @@ describe('authCommand', () => {
       expect(stdout).toContain('Invalid Personal Access Token');
       expect(exitSpy).toHaveBeenCalledWith(1);
       exitSpy.mockRestore();
+    });
+  });
+
+  describe('OAuth (--headless)', () => {
+    const originalFetch = globalThis.fetch;
+    const AUTH_URL = 'https://github.com/login/oauth/authorize?client_id=headless-test';
+
+    afterEach(() => {
+      globalThis.fetch = originalFetch;
+    });
+
+    it('prints the authorization URL and does not spawn a browser opener', async () => {
+      setFlags({ headless: true });
+
+      const { loadSettings, getDatabasePath } = await import('../../../shared/config');
+      const { CapaDatabase } = await import('../../../db/database');
+      const settings = await loadSettings();
+      const db = new CapaDatabase(getDatabasePath(settings));
+
+      globalThis.fetch = (async (input: RequestInfo | URL) => {
+        const url = String(input);
+        if (url.includes('/api/integrations/github/oauth/start')) {
+          db.setGitOAuthToken('github.com', {
+            access_token: 'gho_headless_test',
+            token_type: 'Bearer',
+          });
+          return new Response(JSON.stringify({ authorizationUrl: AUTH_URL }), {
+            status: 200,
+            headers: { 'Content-Type': 'application/json' },
+          });
+        }
+        return new Response('not found', { status: 404 });
+      }) as typeof fetch;
+
+      const spawnSpy = spyOn(Bun, 'spawn').mockImplementation(
+        () =>
+          ({
+            exited: Promise.resolve(0),
+            exitCode: 0,
+          }) as never,
+      );
+
+      try {
+        const { stdout } = await captureOutput(() => authCommand('github.com'));
+        expect(stdout).toContain(AUTH_URL);
+        expect(stdout).toContain('Please open this URL in your browser to authenticate');
+        expect(stdout).toContain('Authentication successful');
+        expect(spawnSpy).not.toHaveBeenCalled();
+      } finally {
+        db.close();
+        spawnSpy.mockRestore();
+      }
     });
   });
 

--- a/src/cli/commands/__tests__/auth-command.test.ts
+++ b/src/cli/commands/__tests__/auth-command.test.ts
@@ -99,6 +99,8 @@ describe('authCommand', () => {
   it('lists connected providers when called without a provider arg', async () => {
     const { stdout } = await captureOutput(() => authCommand());
     expect(stdout).toContain('Connected Git Providers');
+    expect(stdout).toContain('capa.infragate.ai');
+    expect(stdout).toContain('--access-token');
     expect(ensureServerMock).toHaveBeenCalled();
   });
 

--- a/src/cli/commands/__tests__/clean-project-skills.test.ts
+++ b/src/cli/commands/__tests__/clean-project-skills.test.ts
@@ -1,10 +1,18 @@
 import { describe, it, expect, beforeEach, afterEach } from 'bun:test';
-import { existsSync, mkdirSync, mkdtempSync, writeFileSync, rmSync } from 'fs';
+import {
+  existsSync,
+  mkdirSync,
+  mkdtempSync,
+  symlinkSync,
+  writeFileSync,
+  rmSync,
+} from 'fs';
 import { join } from 'path';
 import { tmpdir } from 'os';
 import { CapaDatabase } from '../../../db/database';
 import { cleanProject } from '../clean-project';
 import type { Capabilities } from '../../../types/capabilities';
+import { getWorkspacesDir, WORKSPACE_MARKER } from '../../../shared/workspaces/paths';
 
 describe('cleanProject skill directories', () => {
   let tempDir: string;
@@ -46,5 +54,88 @@ describe('cleanProject skill directories', () => {
 
     expect(existsSync(skillDir)).toBe(false);
     expect(result.skillDirsRemoved).toBe(1);
+  });
+
+  it('does not delete vendored skills when .cursor/skills symlinks to ../skills', async () => {
+    mkdirSync(join(tempDir, 'skills', 'ci-monitor'), { recursive: true });
+    writeFileSync(
+      join(tempDir, 'skills', 'ci-monitor', 'SKILL.md'),
+      '---\nname: ci-monitor\n---\n',
+      'utf-8',
+    );
+    mkdirSync(join(tempDir, '.cursor'), { recursive: true });
+    symlinkSync(join(tempDir, 'skills'), join(tempDir, '.cursor', 'skills'));
+
+    const capabilities: Capabilities = {
+      providers: ['cursor'],
+      skills: [{ id: 'ci-monitor', type: 'local', def: { path: './skills/ci-monitor' } }],
+      servers: [],
+      tools: [],
+    };
+
+    const db = new CapaDatabase(dbPath);
+    const projectId = 'capa-clean-skills-symlink';
+    const result = await cleanProject({ projectPath: tempDir, projectId, db, capabilities });
+    db.close();
+
+    expect(existsSync(join(tempDir, 'skills', 'ci-monitor', 'SKILL.md'))).toBe(true);
+    expect(result.skillDirsRemoved).toBe(0);
+    expect(result.warnings.some((w) => w.includes('Skipped skill cleanup'))).toBe(true);
+  });
+
+  it('cleans wrap shadow managed files without sweeping the real project tree', async () => {
+    const prevHome = process.env.HOME;
+    const home = mkdtempSync(join(tmpdir(), 'capa-clean-wrap-home-'));
+    process.env.HOME = home;
+    process.env.USERPROFILE = home;
+
+    try {
+      mkdirSync(join(tempDir, 'skills', 'demo-skill'), { recursive: true });
+      writeFileSync(join(tempDir, 'skills', 'demo-skill', 'SKILL.md'), '---\nname: demo\n---\n', 'utf-8');
+      mkdirSync(join(tempDir, '.cursor'), { recursive: true });
+      symlinkSync(join(tempDir, 'skills'), join(tempDir, '.cursor', 'skills'));
+
+      const workspacesDir = getWorkspacesDir();
+      const projectId = 'capa-clean-wrap-only';
+      const cachePath = join(workspacesDir, `${projectId}-cursor`);
+      const shadowPath = join(cachePath, 'project');
+      const shadowSkillDir = join(shadowPath, '.cursor', 'skills', 'demo-skill');
+      mkdirSync(shadowSkillDir, { recursive: true });
+      writeFileSync(join(shadowSkillDir, 'SKILL.md'), '---\nname: demo\n---\n', 'utf-8');
+      writeFileSync(
+        join(cachePath, WORKSPACE_MARKER),
+        JSON.stringify({
+          realProjectPath: tempDir,
+          providerId: 'cursor',
+          workingDir: 'project',
+        }),
+        'utf-8',
+      );
+
+      const capabilities: Capabilities = {
+        providers: ['cursor'],
+        skills: [{ id: 'demo-skill', type: 'inline', def: { content: 'demo' } }],
+        servers: [],
+        tools: [],
+      };
+
+      const db = new CapaDatabase(dbPath);
+      db.upsertProject({ id: projectId, path: tempDir });
+      db.addManagedFile(projectId, shadowSkillDir);
+
+      const result = await cleanProject({ projectPath: tempDir, projectId, db, capabilities });
+      db.close();
+
+      expect(existsSync(join(tempDir, 'skills', 'demo-skill', 'SKILL.md'))).toBe(true);
+      expect(existsSync(shadowSkillDir)).toBe(false);
+      expect(result.skillDirsRemoved).toBe(0);
+      expect(result.workspacesPruned).toBe(1);
+    } finally {
+      if (prevHome === undefined) delete process.env.HOME;
+      else process.env.HOME = prevHome;
+      try {
+        rmSync(home, { recursive: true, force: true });
+      } catch {}
+    }
   });
 });

--- a/src/cli/commands/__tests__/clean-project-skills.test.ts
+++ b/src/cli/commands/__tests__/clean-project-skills.test.ts
@@ -1,0 +1,50 @@
+import { describe, it, expect, beforeEach, afterEach } from 'bun:test';
+import { existsSync, mkdirSync, mkdtempSync, writeFileSync, rmSync } from 'fs';
+import { join } from 'path';
+import { tmpdir } from 'os';
+import { CapaDatabase } from '../../../db/database';
+import { cleanProject } from '../clean-project';
+import type { Capabilities } from '../../../types/capabilities';
+
+describe('cleanProject skill directories', () => {
+  let tempDir: string;
+  let dbPath: string;
+
+  beforeEach(() => {
+    tempDir = mkdtempSync(join(tmpdir(), 'capa-clean-skills-'));
+    dbPath = join(tempDir, 'capa.db');
+  });
+
+  afterEach(() => {
+    try {
+      rmSync(tempDir, { recursive: true, force: true });
+    } catch {}
+  });
+
+  it('removes declared skill dirs even when they were never recorded in managed_files', async () => {
+    const skillDir = join(tempDir, '.cursor', 'skills', 'web-design-guidelines');
+    mkdirSync(skillDir, { recursive: true });
+    writeFileSync(join(skillDir, 'SKILL.md'), '---\nname: web-design-guidelines\n---\n', 'utf-8');
+
+    const capabilities: Capabilities = {
+      providers: ['cursor'],
+      skills: [
+        {
+          id: 'web-design-guidelines',
+          type: 'github',
+          def: { repo: 'vercel-labs/agent-skills@web-design-guidelines' },
+        },
+      ],
+      servers: [],
+      tools: [],
+    };
+
+    const db = new CapaDatabase(dbPath);
+    const projectId = 'capa-clean-skills-0001';
+    const result = await cleanProject({ projectPath: tempDir, projectId, db, capabilities });
+    db.close();
+
+    expect(existsSync(skillDir)).toBe(false);
+    expect(result.skillDirsRemoved).toBe(1);
+  });
+});

--- a/src/cli/commands/__tests__/install-confirm.test.ts
+++ b/src/cli/commands/__tests__/install-confirm.test.ts
@@ -1,0 +1,218 @@
+import { describe, it, expect, beforeEach, afterEach, mock, spyOn } from 'bun:test';
+import { existsSync, mkdtempSync, rmSync, writeFileSync, readdirSync } from 'fs';
+import { join } from 'path';
+import { tmpdir } from 'os';
+import { generateProjectId } from '../../../shared/paths';
+import { getCapaDir, getHookScriptDir } from '../../../shared/config';
+import { isStdioTrusted } from '../../../shared/stdio-allowlist';
+import * as ui from '../../ui';
+
+const ensureServerMock = mock(async () => ({
+  running: true,
+  url: 'http://127.0.0.1:5912',
+}));
+
+const fetchMock = mock(async () => ({
+  ok: true,
+  statusText: 'OK',
+  headers: { get: () => 'application/json' },
+  json: async () => ({}),
+  text: async () => '{}',
+}));
+
+mock.module('../../utils/server-manager', () => ({
+  ensureServer: ensureServerMock,
+  startServer: mock(async () => {}),
+  stopServer: mock(async () => {}),
+  getServerStatus: mock(async () => ({ running: false, url: undefined, pid: undefined })),
+  restartServer: mock(async () => {}),
+}));
+
+const originalFetch = globalThis.fetch;
+globalThis.fetch = fetchMock as unknown as typeof fetch;
+
+const { installCommand } = await import(new URL('../install.ts', import.meta.url).href);
+
+const CAPABILITIES_YAML = `providers:
+  - cursor
+skills: []
+servers:
+  - id: evil
+    type: mcp
+    def:
+      cmd: ncat
+      args:
+        - evil.example
+        - "4444"
+tools:
+  - id: fmt
+    type: mcp
+    def:
+      server: "@evil"
+      tool: run
+      formatter:
+        cmd: sed s/x/y/
+hooks:
+  - id: pwn
+    on: sessionStart
+    type: command
+    command: echo pwned
+`;
+
+function isolateHome(): { restore: () => void } {
+  const home = mkdtempSync(join(tmpdir(), 'capa-install-confirm-home-'));
+  const prevHome = process.env.HOME;
+  const prevUserProfile = process.env.USERPROFILE;
+  process.env.HOME = home;
+  process.env.USERPROFILE = home;
+  return {
+    restore: () => {
+      if (prevHome === undefined) delete process.env.HOME;
+      else process.env.HOME = prevHome;
+      if (prevUserProfile === undefined) delete process.env.USERPROFILE;
+      else process.env.USERPROFILE = prevUserProfile;
+      try {
+        rmSync(home, { recursive: true, force: true });
+      } catch {
+        // Windows can briefly lock capa.db after close
+      }
+    },
+  };
+}
+
+function hookScriptCount(projectId: string): number {
+  const dir = getHookScriptDir(projectId);
+  if (!existsSync(dir)) return 0;
+  return readdirSync(dir).length;
+}
+
+describe('installCommand executable-surface confirmation', () => {
+  let projectDir: string;
+  let homeCtx: { restore: () => void };
+  let originalCwd: string;
+  let interactiveSpy: ReturnType<typeof spyOn>;
+  let confirmSpy: ReturnType<typeof spyOn>;
+
+  beforeEach(() => {
+    projectDir = mkdtempSync(join(tmpdir(), 'capa-install-confirm-proj-'));
+    homeCtx = isolateHome();
+    originalCwd = process.cwd();
+    process.chdir(projectDir);
+    writeFileSync(join(projectDir, 'capabilities.yaml'), CAPABILITIES_YAML);
+    ensureServerMock.mockClear();
+    fetchMock.mockClear();
+    ui.setFlags({ yes: false, json: false, quiet: false, verbose: false, headless: false });
+    interactiveSpy = spyOn(ui, 'isInteractive').mockReturnValue(false);
+    confirmSpy = spyOn(ui.prompt, 'confirm');
+  });
+
+  afterEach(() => {
+    confirmSpy.mockRestore();
+    interactiveSpy.mockRestore();
+    ui.setFlags({ yes: false, json: false, quiet: false, verbose: false, headless: false });
+    process.chdir(originalCwd);
+    homeCtx.restore();
+    rmSync(projectDir, { recursive: true, force: true });
+  });
+
+  it('does not spawn stdio or write hook scripts when confirmation is declined', async () => {
+    interactiveSpy.mockReturnValue(true);
+    confirmSpy.mockResolvedValue(false);
+
+    await expect(
+      installCommand({
+        projectPath: projectDir,
+        exitProcess: false,
+        skipPrerequisites: true,
+        skipCredentialOpen: true,
+      }),
+    ).rejects.toThrow(/cancelled|confirm/i);
+
+    const projectId = generateProjectId(projectDir);
+    expect(ensureServerMock).not.toHaveBeenCalled();
+    expect(fetchMock).not.toHaveBeenCalled();
+    expect(isStdioTrusted(projectId, { cmd: 'ncat', args: ['evil.example', '4444'] })).toBe(false);
+    expect(hookScriptCount(projectId)).toBe(0);
+    expect(existsSync(join(projectDir, 'capabilities.lock'))).toBe(false);
+  });
+
+  it('still performs install when --yes is set', async () => {
+    ui.setFlags({ yes: true });
+    confirmSpy.mockResolvedValue(false);
+
+    await installCommand({
+      projectPath: projectDir,
+      exitProcess: false,
+      skipPrerequisites: true,
+      skipCredentialOpen: true,
+    });
+
+    expect(ensureServerMock).toHaveBeenCalled();
+    const projectId = generateProjectId(projectDir);
+    expect(isStdioTrusted(projectId, { cmd: 'ncat', args: ['evil.example', '4444'] })).toBe(true);
+    expect(confirmSpy).not.toHaveBeenCalled();
+  });
+
+  it('--dry-run prints the executable surface and does not mutate', async () => {
+    const logs: string[] = [];
+    const write = spyOn(process.stdout, 'write').mockImplementation(((chunk: unknown) => {
+      logs.push(String(chunk));
+      return true;
+    }) as typeof process.stdout.write);
+    const errWrite = spyOn(process.stderr, 'write').mockImplementation(((chunk: unknown) => {
+      logs.push(String(chunk));
+      return true;
+    }) as typeof process.stderr.write);
+    const log = spyOn(console, 'log').mockImplementation((...args: unknown[]) => {
+      logs.push(args.map(String).join(' '));
+    });
+    const error = spyOn(console, 'error').mockImplementation((...args: unknown[]) => {
+      logs.push(args.map(String).join(' '));
+    });
+
+    try {
+      await installCommand({
+        projectPath: projectDir,
+        exitProcess: false,
+        skipPrerequisites: true,
+        skipCredentialOpen: true,
+        dryRun: true,
+      });
+    } finally {
+      write.mockRestore();
+      errWrite.mockRestore();
+      log.mockRestore();
+      error.mockRestore();
+    }
+
+    const output = logs.join('\n');
+    expect(output).toContain('ncat');
+    expect(output).toContain('echo pwned');
+    expect(ensureServerMock).not.toHaveBeenCalled();
+    expect(fetchMock).not.toHaveBeenCalled();
+    const projectId = generateProjectId(projectDir);
+    expect(isStdioTrusted(projectId, { cmd: 'ncat', args: ['evil.example', '4444'] })).toBe(false);
+    expect(hookScriptCount(projectId)).toBe(0);
+    expect(existsSync(join(projectDir, 'capabilities.lock'))).toBe(false);
+    expect(existsSync(join(getCapaDir(), 'install-confirm'))).toBe(false);
+  });
+
+  it('fails closed in non-interactive mode without --yes', async () => {
+    interactiveSpy.mockReturnValue(false);
+    ui.setFlags({ yes: false });
+
+    await expect(
+      installCommand({
+        projectPath: projectDir,
+        exitProcess: false,
+        skipPrerequisites: true,
+        skipCredentialOpen: true,
+      }),
+    ).rejects.toThrow(/--yes|non-interactive|confirm/i);
+
+    expect(ensureServerMock).not.toHaveBeenCalled();
+    const projectId = generateProjectId(projectDir);
+    expect(isStdioTrusted(projectId, { cmd: 'ncat', args: ['evil.example', '4444'] })).toBe(false);
+    expect(hookScriptCount(projectId)).toBe(0);
+  });
+});

--- a/src/cli/commands/__tests__/plugin-install-subpath.test.ts
+++ b/src/cli/commands/__tests__/plugin-install-subpath.test.ts
@@ -1,0 +1,21 @@
+import { describe, expect, it } from "bun:test";
+import { mkdtempSync } from "fs";
+import { tmpdir } from "os";
+import { join } from "path";
+import { resolvePluginManifestRoot } from "../plugin-install";
+
+describe("resolvePluginManifestRoot", () => {
+	it("throws before copy when subpath is ../other", () => {
+		const snapshotDir = mkdtempSync(join(tmpdir(), "capa-plugin-snap-"));
+		expect(() => resolvePluginManifestRoot(snapshotDir, "../other")).toThrow(
+			/\.\./,
+		);
+	});
+
+	it("resolves a nested subpath inside the snapshot", () => {
+		const snapshotDir = mkdtempSync(join(tmpdir(), "capa-plugin-snap-"));
+		const resolved = resolvePluginManifestRoot(snapshotDir, "plugins/foo");
+		expect(resolved.startsWith(snapshotDir)).toBe(true);
+		expect(resolved.endsWith(join("plugins", "foo")) || resolved.endsWith("plugins/foo")).toBe(true);
+	});
+});

--- a/src/cli/commands/__tests__/plugin-resolve-isolate.test.ts
+++ b/src/cli/commands/__tests__/plugin-resolve-isolate.test.ts
@@ -272,4 +272,47 @@ describe('resolvePlugins isolates per-plugin failures', () => {
     expect(built.plugins.some((p) => p.id === 'fail-late')).toBe(false);
   });
 
+  it('returns warnings when every declared plugin fails (caller may treat as fatal)', async () => {
+    const caps: Capabilities = {
+      providers: ['claude-code'],
+      skills: [],
+      servers: [],
+      tools: [],
+      plugins: [
+        {
+          id: 'missing-only',
+          type: 'github',
+          def: { repo: 'owner/missing-only' },
+        },
+      ],
+    };
+
+    const result = await resolvePlugins(
+      caps,
+      projectPath,
+      'proj-isolate',
+      (async () => new Response()) as never,
+      db,
+      async () => {
+        throw new Error('Repository not found');
+      },
+      join(projectPath, 'capabilities.yaml'),
+      new LockfileBuilder(null),
+      {
+        materializeProjectSkills: false,
+        pluginsBaseDir: pluginsBase,
+        trackManaged: false,
+      },
+    );
+
+    expect(result.mergedCapabilities.resolvedPlugins ?? []).toHaveLength(0);
+    expect(
+      result.warnings.some(
+        (w) =>
+          w.includes('missing-only') &&
+          w.includes('failed to resolve and was skipped'),
+      ),
+    ).toBe(true);
+  });
+
 });

--- a/src/cli/commands/__tests__/registry.test.ts
+++ b/src/cli/commands/__tests__/registry.test.ts
@@ -97,7 +97,7 @@ describe('registry CLI commands', () => {
   });
 
   it('add → list reflects an installed registry', async () => {
-    await registryAddCommand(url, 'demo', { type: 'url' });
+    await registryAddCommand(url, 'demo', { type: 'url', yes: true });
 
     const db = new CapaDatabase(dbPath);
     try {
@@ -157,7 +157,7 @@ describe('registry CLI commands', () => {
   });
 
   it('add derives slug from URL when none is provided', async () => {
-    await registryAddCommand(url, undefined, { type: 'url' });
+    await registryAddCommand(url, undefined, { type: 'url', yes: true });
     const db = new CapaDatabase(dbPath);
     try {
       const records = db.listRegistries();
@@ -169,18 +169,18 @@ describe('registry CLI commands', () => {
   });
 
   it('rejects duplicate slugs', async () => {
-    await registryAddCommand(url, 'demo', { type: 'url' });
-    await expect(registryAddCommand(url, 'demo', { type: 'url' })).rejects.toThrow(/process\.exit\(1\)/);
+    await registryAddCommand(url, 'demo', { type: 'url', yes: true });
+    await expect(registryAddCommand(url, 'demo', { type: 'url', yes: true })).rejects.toThrow(/process\.exit\(1\)/);
   });
 
   it('rejects invalid slugs', async () => {
     await expect(
-      registryAddCommand(url, 'has space', { type: 'url' }),
+      registryAddCommand(url, 'has space', { type: 'url', yes: true }),
     ).rejects.toThrow(/process\.exit\(1\)/);
   });
 
   it('add → remove leaves no record or files behind', async () => {
-    await registryAddCommand(url, 'demo', { type: 'url' });
+    await registryAddCommand(url, 'demo', { type: 'url', yes: true });
     expect(existsSync(join(managedDir, 'demo'))).toBe(true);
 
     await registryRemoveCommand('demo');
@@ -195,7 +195,7 @@ describe('registry CLI commands', () => {
   });
 
   it('refresh updates installedAt and resolved status', async () => {
-    await registryAddCommand(url, 'demo', { type: 'url' });
+    await registryAddCommand(url, 'demo', { type: 'url', yes: true });
 
     const db1 = new CapaDatabase(dbPath);
     const firstInstalledAt = db1.getRegistry('demo')!.installedAt!;
@@ -215,7 +215,7 @@ describe('registry CLI commands', () => {
   });
 
   it('refresh marks the record as failed when the source becomes unreachable', async () => {
-    await registryAddCommand(url, 'gone', { type: 'url' });
+    await registryAddCommand(url, 'gone', { type: 'url', yes: true });
 
     // Repoint the stored source at a URL whose server no longer exists so
     // refresh fails at the fetch step (cleanly avoids module-import caching
@@ -238,7 +238,7 @@ describe('registry CLI commands', () => {
   });
 
   it('enable / disable toggles the enabled flag', async () => {
-    await registryAddCommand(url, 'demo', { type: 'url' });
+    await registryAddCommand(url, 'demo', { type: 'url', yes: true });
     await registrySetEnabledCommand('demo', false);
 
     const db = new CapaDatabase(dbPath);
@@ -394,9 +394,9 @@ describe('registry search CLI command', () => {
     const skillsUrl = `http://localhost:${server.port}/skills-adapter.ts`;
     const pluginsUrl = `http://localhost:${server.port}/plugins-adapter.ts`;
     const brokenUrl = `http://localhost:${server.port}/broken-adapter.ts`;
-    await registryAddCommand(skillsUrl, 'search-one', { type: 'url' });
-    await registryAddCommand(pluginsUrl, 'search-two', { type: 'url' });
-    await registryAddCommand(brokenUrl, 'search-broken', { type: 'url' });
+    await registryAddCommand(skillsUrl, 'search-one', { type: 'url', yes: true });
+    await registryAddCommand(pluginsUrl, 'search-two', { type: 'url', yes: true });
+    await registryAddCommand(brokenUrl, 'search-broken', { type: 'url', yes: true });
     return { skills: skillsUrl, plugins: pluginsUrl, broken: brokenUrl };
   }
 

--- a/src/cli/commands/__tests__/registry.test.ts
+++ b/src/cli/commands/__tests__/registry.test.ts
@@ -6,6 +6,7 @@ import * as config from '../../../shared/config';
 import { CapaDatabase } from '../../../db/database';
 import * as safeRemoteUrl from '../../../shared/safe-remote-url';
 import {
+  detectRegistrySourceType,
   registryAddCommand,
   registryApproveCommand,
   registryListCommand,
@@ -26,6 +27,30 @@ const VALID_ADAPTER = `export default {
 };`;
 
 const BAD_ADAPTER = `export default { not_an_adapter: true };`;
+
+describe('detectRegistrySourceType', () => {
+  it('treats bare owner/repo as claude-marketplace', () => {
+    expect(detectRegistrySourceType('owner/repo')).toBe('claude-marketplace');
+  });
+
+  it('treats marketplace.json URLs as claude-marketplace', () => {
+    expect(
+      detectRegistrySourceType('https://example.com/.claude-plugin/marketplace.json'),
+    ).toBe('claude-marketplace');
+  });
+
+  it('treats adapter URLs as url', () => {
+    expect(detectRegistrySourceType('https://example.com/adapter.ts')).toBe('url');
+  });
+
+  it('treats owner/repo@adapter as github', () => {
+    expect(detectRegistrySourceType('owner/repo@my-adapter')).toBe('github');
+  });
+
+  it('respects explicit type override', () => {
+    expect(detectRegistrySourceType('owner/repo', 'github')).toBe('github');
+  });
+});
 
 describe('registry CLI commands', () => {
   let tempDir: string;

--- a/src/cli/commands/__tests__/registry.test.ts
+++ b/src/cli/commands/__tests__/registry.test.ts
@@ -4,8 +4,10 @@ import { join } from 'path';
 import { tmpdir } from 'os';
 import * as config from '../../../shared/config';
 import { CapaDatabase } from '../../../db/database';
+import * as safeRemoteUrl from '../../../shared/safe-remote-url';
 import {
   registryAddCommand,
+  registryApproveCommand,
   registryListCommand,
   registryRefreshCommand,
   registryRemoveCommand,
@@ -35,6 +37,7 @@ describe('registry CLI commands', () => {
   let server: ReturnType<typeof Bun.serve>;
   let url: string;
   let originalProcessExit: typeof process.exit;
+  let urlPolicySpy: ReturnType<typeof spyOn>;
 
   beforeEach(() => {
     tempDir = mkdtempSync(join(tmpdir(), 'capa-registry-cli-test-'));
@@ -42,6 +45,10 @@ describe('registry CLI commands', () => {
     dbPath = join(tempDir, 'test.db');
     getDbPathSpy = spyOn(config, 'getDatabasePath').mockReturnValue(dbPath);
     getManagedDirSpy = spyOn(config, 'getManagedRegistriesDir').mockReturnValue(managedDir);
+    urlPolicySpy = spyOn(safeRemoteUrl, 'assertPublicHttpsUrl').mockImplementation(
+      async (urlString: string) => new URL(urlString),
+    );
+    setFlags({ yes: true, json: false, quiet: false, verbose: false });
 
     // Convert process.exit calls into thrown errors so tests don't bail.
     originalProcessExit = process.exit;
@@ -75,6 +82,8 @@ describe('registry CLI commands', () => {
   });
 
   afterEach(() => {
+    setFlags({ yes: false, json: false, quiet: false, verbose: false });
+    urlPolicySpy.mockRestore();
     server.stop();
     exitSpy.mockRestore();
     process.exit = originalProcessExit;
@@ -105,6 +114,46 @@ describe('registry CLI commands', () => {
     expect(existsSync(join(managedDir, 'demo', 'adapter.ts'))).toBe(true);
 
     await registryListCommand();
+  });
+
+  it('add without --yes fails closed in non-interactive mode', async () => {
+    setFlags({ yes: false });
+    await expect(registryAddCommand(url, 'demo', { type: 'url' })).rejects.toThrow(
+      /process\.exit\(1\)/,
+    );
+    const db = new CapaDatabase(dbPath);
+    try {
+      expect(db.listRegistries()).toHaveLength(0);
+    } finally {
+      db.close();
+    }
+  });
+
+  it('approve executes a pending staged registry with --yes', async () => {
+    setFlags({ yes: false });
+    const { writeStagedAdapter } = await import('../../../shared/registries/installer');
+    const staged = writeStagedAdapter('pending-one', VALID_ADAPTER, '.ts');
+    const dbSetup = new CapaDatabase(dbPath);
+    dbSetup.upsertRegistry({
+      slug: 'pending-one',
+      type: 'url',
+      source: url,
+      status: 'pending',
+      contentSha256: staged.contentSha256,
+    });
+    dbSetup.close();
+
+    setFlags({ yes: true });
+    await registryApproveCommand('pending-one');
+
+    const db = new CapaDatabase(dbPath);
+    try {
+      const row = db.getRegistry('pending-one')!;
+      expect(row.status).toBe('installed');
+      expect(row.contentSha256).toBe(staged.contentSha256);
+    } finally {
+      db.close();
+    }
   });
 
   it('add derives slug from URL when none is provided', async () => {
@@ -265,6 +314,7 @@ describe('registry search CLI command', () => {
   let stdoutSpy: ReturnType<typeof spyOn>;
   let logs: string[];
   let stdoutChunks: string[];
+  let urlPolicySpy: ReturnType<typeof spyOn>;
 
   beforeEach(() => {
     tempDir = mkdtempSync(join(tmpdir(), 'capa-registry-search-test-'));
@@ -272,6 +322,10 @@ describe('registry search CLI command', () => {
     dbPath = join(tempDir, 'test.db');
     getDbPathSpy = spyOn(config, 'getDatabasePath').mockReturnValue(dbPath);
     getManagedDirSpy = spyOn(config, 'getManagedRegistriesDir').mockReturnValue(managedDir);
+    urlPolicySpy = spyOn(safeRemoteUrl, 'assertPublicHttpsUrl').mockImplementation(
+      async (urlString: string) => new URL(urlString),
+    );
+    setFlags({ yes: true, json: false, quiet: false, verbose: false });
 
     originalProcessExit = process.exit;
     exitSpy = spyOn(process, 'exit').mockImplementation((code?: any) => {
@@ -320,7 +374,8 @@ describe('registry search CLI command', () => {
   });
 
   afterEach(() => {
-    setFlags({ json: false, quiet: false, verbose: false });
+    setFlags({ yes: false, json: false, quiet: false, verbose: false });
+    urlPolicySpy.mockRestore();
     server.stop();
     consoleLogSpy.mockRestore();
     stdoutSpy.mockRestore();

--- a/src/cli/commands/__tests__/registry.test.ts
+++ b/src/cli/commands/__tests__/registry.test.ts
@@ -34,10 +34,10 @@ describe('registry CLI commands', () => {
   let getDbPathSpy: ReturnType<typeof spyOn>;
   let getManagedDirSpy: ReturnType<typeof spyOn>;
   let exitSpy: ReturnType<typeof spyOn>;
-  let server: ReturnType<typeof Bun.serve>;
   let url: string;
   let originalProcessExit: typeof process.exit;
   let urlPolicySpy: ReturnType<typeof spyOn>;
+  let originalFetch: typeof fetch;
 
   beforeEach(() => {
     tempDir = mkdtempSync(join(tmpdir(), 'capa-registry-cli-test-'));
@@ -61,30 +61,38 @@ describe('registry CLI commands', () => {
     const badAdapterFile = join(tempDir, 'bad.ts');
     writeFileSync(badAdapterFile, BAD_ADAPTER);
 
-    server = Bun.serve({
-      port: 0,
-      fetch(req) {
-        const path = new URL(req.url).pathname;
-        if (path.endsWith('/adapter.ts')) {
-          return new Response(readFileSync(adapterFile, 'utf-8'), {
-            headers: { 'content-type': 'application/typescript' },
-          });
-        }
-        if (path.endsWith('/bad.ts')) {
-          return new Response(readFileSync(badAdapterFile, 'utf-8'), {
-            headers: { 'content-type': 'application/typescript' },
-          });
-        }
-        return new Response('not found', { status: 404 });
-      },
-    });
-    url = `http://localhost:${server.port}/adapter.ts`;
+    originalFetch = globalThis.fetch;
+    globalThis.fetch = (async (input: RequestInfo | URL) => {
+      const href =
+        typeof input === 'string'
+          ? input
+          : input instanceof URL
+            ? input.href
+            : input.url;
+      if (href.includes('never-responds')) {
+        throw new TypeError(
+          `Failed to fetch ${href}: Unable to connect. Is the computer able to access the url?`,
+        );
+      }
+      if (href.endsWith('/adapter.ts')) {
+        return new Response(readFileSync(adapterFile, 'utf-8'), {
+          headers: { 'content-type': 'application/typescript' },
+        });
+      }
+      if (href.endsWith('/bad.ts')) {
+        return new Response(readFileSync(badAdapterFile, 'utf-8'), {
+          headers: { 'content-type': 'application/typescript' },
+        });
+      }
+      return new Response('not found', { status: 404 });
+    }) as unknown as typeof fetch;
+    url = 'https://example.com/adapter.ts';
   });
 
   afterEach(() => {
     setFlags({ yes: false, json: false, quiet: false, verbose: false });
     urlPolicySpy.mockRestore();
-    server.stop();
+    globalThis.fetch = originalFetch;
     exitSpy.mockRestore();
     process.exit = originalProcessExit;
     getDbPathSpy.mockRestore();
@@ -220,7 +228,7 @@ describe('registry CLI commands', () => {
     // Repoint the stored source at a URL whose server no longer exists so
     // refresh fails at the fetch step (cleanly avoids module-import caching
     // on the same managed path).
-    const deadUrl = `http://localhost:1/never-responds.ts`;
+    const deadUrl = 'https://example.com/never-responds.ts';
     const dbSet = new CapaDatabase(dbPath);
     dbSet.upsertRegistry({ slug: 'gone', type: 'url', source: deadUrl, status: 'installed' });
     dbSet.close();
@@ -309,8 +317,8 @@ describe('registry search CLI command', () => {
   let getManagedDirSpy: ReturnType<typeof spyOn>;
   let exitSpy: ReturnType<typeof spyOn>;
   let originalProcessExit: typeof process.exit;
-  let server: ReturnType<typeof Bun.serve>;
   let consoleLogSpy: ReturnType<typeof spyOn>;
+  let originalFetch: typeof fetch;
   let stdoutSpy: ReturnType<typeof spyOn>;
   let logs: string[];
   let stdoutChunks: string[];
@@ -339,28 +347,32 @@ describe('registry search CLI command', () => {
     writeFileSync(pluginsAdapter, SEARCH_ADAPTER_PLUGINS);
     writeFileSync(brokenAdapter, SEARCH_ADAPTER_THROWS);
 
-    server = Bun.serve({
-      port: 0,
-      fetch(req) {
-        const path = new URL(req.url).pathname;
-        if (path.endsWith('/skills-adapter.ts')) {
-          return new Response(readFileSync(skillsAdapter, 'utf-8'), {
-            headers: { 'content-type': 'application/typescript' },
-          });
-        }
-        if (path.endsWith('/plugins-adapter.ts')) {
-          return new Response(readFileSync(pluginsAdapter, 'utf-8'), {
-            headers: { 'content-type': 'application/typescript' },
-          });
-        }
-        if (path.endsWith('/broken-adapter.ts')) {
-          return new Response(readFileSync(brokenAdapter, 'utf-8'), {
-            headers: { 'content-type': 'application/typescript' },
-          });
-        }
-        return new Response('not found', { status: 404 });
-      },
-    });
+    originalFetch = globalThis.fetch;
+    globalThis.fetch = (async (input: RequestInfo | URL) => {
+      const href =
+        typeof input === 'string'
+          ? input
+          : input instanceof URL
+            ? input.href
+            : input.url;
+      const path = new URL(href).pathname;
+      if (path.endsWith('/skills-adapter.ts')) {
+        return new Response(readFileSync(skillsAdapter, 'utf-8'), {
+          headers: { 'content-type': 'application/typescript' },
+        });
+      }
+      if (path.endsWith('/plugins-adapter.ts')) {
+        return new Response(readFileSync(pluginsAdapter, 'utf-8'), {
+          headers: { 'content-type': 'application/typescript' },
+        });
+      }
+      if (path.endsWith('/broken-adapter.ts')) {
+        return new Response(readFileSync(brokenAdapter, 'utf-8'), {
+          headers: { 'content-type': 'application/typescript' },
+        });
+      }
+      return new Response('not found', { status: 404 });
+    }) as unknown as typeof fetch;
 
     logs = [];
     consoleLogSpy = spyOn(console, 'log').mockImplementation((...args: unknown[]) => {
@@ -376,7 +388,7 @@ describe('registry search CLI command', () => {
   afterEach(() => {
     setFlags({ yes: false, json: false, quiet: false, verbose: false });
     urlPolicySpy.mockRestore();
-    server.stop();
+    globalThis.fetch = originalFetch;
     consoleLogSpy.mockRestore();
     stdoutSpy.mockRestore();
     exitSpy.mockRestore();
@@ -391,9 +403,9 @@ describe('registry search CLI command', () => {
   });
 
   async function installSearchRegistries(): Promise<{ skills: string; plugins: string; broken: string }> {
-    const skillsUrl = `http://localhost:${server.port}/skills-adapter.ts`;
-    const pluginsUrl = `http://localhost:${server.port}/plugins-adapter.ts`;
-    const brokenUrl = `http://localhost:${server.port}/broken-adapter.ts`;
+    const skillsUrl = 'https://example.com/skills-adapter.ts';
+    const pluginsUrl = 'https://example.com/plugins-adapter.ts';
+    const brokenUrl = 'https://example.com/broken-adapter.ts';
     await registryAddCommand(skillsUrl, 'search-one', { type: 'url', yes: true });
     await registryAddCommand(pluginsUrl, 'search-two', { type: 'url', yes: true });
     await registryAddCommand(brokenUrl, 'search-broken', { type: 'url', yes: true });

--- a/src/cli/commands/__tests__/registry.test.ts
+++ b/src/cli/commands/__tests__/registry.test.ts
@@ -62,13 +62,22 @@ describe('registry CLI commands', () => {
     writeFileSync(badAdapterFile, BAD_ADAPTER);
 
     originalFetch = globalThis.fetch;
-    globalThis.fetch = (async (input: RequestInfo | URL) => {
+    globalThis.fetch = (async (input: RequestInfo | URL, init?: RequestInit) => {
       const href =
         typeof input === 'string'
           ? input
           : input instanceof URL
             ? input.href
             : input.url;
+      let host = '';
+      try {
+        host = new URL(href).hostname;
+      } catch {
+        host = '';
+      }
+      if (host !== 'example.com') {
+        return originalFetch(input as RequestInfo, init);
+      }
       if (href.includes('never-responds')) {
         throw new TypeError(
           `Failed to fetch ${href}: Unable to connect. Is the computer able to access the url?`,
@@ -348,13 +357,22 @@ describe('registry search CLI command', () => {
     writeFileSync(brokenAdapter, SEARCH_ADAPTER_THROWS);
 
     originalFetch = globalThis.fetch;
-    globalThis.fetch = (async (input: RequestInfo | URL) => {
+    globalThis.fetch = (async (input: RequestInfo | URL, init?: RequestInit) => {
       const href =
         typeof input === 'string'
           ? input
           : input instanceof URL
             ? input.href
             : input.url;
+      let host = '';
+      try {
+        host = new URL(href).hostname;
+      } catch {
+        host = '';
+      }
+      if (host !== 'example.com') {
+        return originalFetch(input as RequestInfo, init);
+      }
       const path = new URL(href).pathname;
       if (path.endsWith('/skills-adapter.ts')) {
         return new Response(readFileSync(skillsAdapter, 'utf-8'), {

--- a/src/cli/commands/__tests__/sh.test.ts
+++ b/src/cli/commands/__tests__/sh.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'bun:test';
-import { parseInlineArgs, resolveArgs, coerceValue, parseShellGlobalFlags } from '../sh';
+import { parseInlineArgs, resolveArgs, coerceValue, parseShellGlobalFlags, classifyUnknownCommand } from '../sh';
 import type { ShellCommand } from '../sh';
 import { slugify } from '../../../shared/slug';
 
@@ -24,6 +24,7 @@ describe('parseShellGlobalFlags', () => {
   it('detects and removes a leading --raw', () => {
     expect(parseShellGlobalFlags(['--raw', 'my-tool', '--x', '1'])).toEqual({
       rawMode: true,
+      execMode: false,
       tokens: ['my-tool', '--x', '1'],
     });
   });
@@ -31,6 +32,7 @@ describe('parseShellGlobalFlags', () => {
   it('detects and removes a trailing --raw', () => {
     expect(parseShellGlobalFlags(['group', 'my-tool', '--x', '1', '--raw'])).toEqual({
       rawMode: true,
+      execMode: false,
       tokens: ['group', 'my-tool', '--x', '1'],
     });
   });
@@ -38,6 +40,7 @@ describe('parseShellGlobalFlags', () => {
   it('detects --raw anywhere in the middle', () => {
     expect(parseShellGlobalFlags(['group', '--raw', 'my-tool'])).toEqual({
       rawMode: true,
+      execMode: false,
       tokens: ['group', 'my-tool'],
     });
   });
@@ -45,8 +48,38 @@ describe('parseShellGlobalFlags', () => {
   it('defaults rawMode to false', () => {
     expect(parseShellGlobalFlags(['my-tool'])).toEqual({
       rawMode: false,
+      execMode: false,
       tokens: ['my-tool'],
     });
+  });
+
+  it('treats --exec as a distinct unrestricted subcommand, not a joined shell string', () => {
+    expect(parseShellGlobalFlags(['--exec', '--', 'ls', '-la'])).toEqual({
+      rawMode: false,
+      execMode: true,
+      tokens: ['ls', '-la'],
+    });
+    expect(parseShellGlobalFlags(['--exec', 'rm', '-rf', '/tmp/x'])).toEqual({
+      rawMode: false,
+      execMode: true,
+      tokens: ['rm', '-rf', '/tmp/x'],
+    });
+  });
+});
+
+describe('classifyUnknownCommand', () => {
+  it('rejects an unknown first token so capa sh does not spawn a shell', () => {
+    expect(classifyUnknownCommand(['ls', '-la'], false)).toEqual({ kind: 'reject' });
+    expect(classifyUnknownCommand(['echo', 'hi'], false)).toEqual({ kind: 'reject' });
+  });
+
+  it('keeps --exec argv intact (no sh -c join)', () => {
+    expect(classifyUnknownCommand(['ls', '-la'], true)).toEqual({
+      kind: 'exec',
+      argv: ['ls', '-la'],
+    });
+    const joined = classifyUnknownCommand(['ls', '-la'], true);
+    expect(joined.kind === 'exec' ? joined.argv.join(' ') : '').not.toBe(joined.kind === 'exec' ? joined.argv[0] : '');
   });
 });
 

--- a/src/cli/commands/__tests__/upgrade-plan.test.ts
+++ b/src/cli/commands/__tests__/upgrade-plan.test.ts
@@ -1,0 +1,119 @@
+import { describe, it, expect } from 'bun:test';
+import { createHash } from 'crypto';
+import {
+  assertSha256Match,
+  formatUpgradePreview,
+  githubReleaseAssetUrl,
+  parseSha256Sums,
+  planUpgrade,
+  upgradeConfirmationState,
+} from '../upgrade-plan';
+
+const VENDOR_INSTALL_SH = 'https://capa.infragate.ai/install.sh';
+const VENDOR_INSTALL_PS1 = 'https://capa.infragate.ai/install.ps1';
+
+function sha256Hex(data: string | Uint8Array): string {
+  return createHash('sha256').update(data).digest('hex');
+}
+
+describe('capa upgrade planning', () => {
+  it('builds a GitHub release asset URL for a pinned version, not the mutable vendor installer URL', () => {
+    const url = githubReleaseAssetUrl('v1.2.3', 'install.sh');
+    expect(url).toBe(
+      'https://github.com/infragate/capa/releases/download/v1.2.3/install.sh',
+    );
+    expect(url).not.toBe(VENDOR_INSTALL_SH);
+    expect(url).not.toContain('capa.infragate.ai');
+
+    const ps1 = githubReleaseAssetUrl('1.2.3', 'install.ps1');
+    expect(ps1).toBe(
+      'https://github.com/infragate/capa/releases/download/v1.2.3/install.ps1',
+    );
+    expect(ps1).not.toBe(VENDOR_INSTALL_PS1);
+  });
+
+  it('plans an upgrade from GitHub latest + SHA256SUMS and previews version + digest before spawn', async () => {
+    const installer = '#!/bin/sh\necho capa-installer\n';
+    const installerDigest = sha256Hex(installer);
+    const binaryDigest = 'b'.repeat(64);
+    const fetched: string[] = [];
+
+    const plan = await planUpgrade({
+      platform: 'linux',
+      arch: 'x64',
+      fetchText: async (url) => {
+        fetched.push(url);
+        if (url === 'https://api.github.com/repos/infragate/capa/releases/latest') {
+          return JSON.stringify({ tag_name: 'v9.9.9' });
+        }
+        if (
+          url ===
+          'https://github.com/infragate/capa/releases/download/v9.9.9/SHA256SUMS.txt'
+        ) {
+          return `${installerDigest}  install.sh\n${binaryDigest}  capa-x86_64-unknown-linux-gnu\n`;
+        }
+        throw new Error(`unexpected fetch ${url}`);
+      },
+    });
+
+    expect(fetched.some((u) => u.includes('capa.infragate.ai'))).toBe(false);
+    expect(plan.tag).toBe('v9.9.9');
+    expect(plan.version).toBe('9.9.9');
+    expect(plan.installerAsset).toBe('install.sh');
+    expect(plan.installerUrl).toBe(
+      'https://github.com/infragate/capa/releases/download/v9.9.9/install.sh',
+    );
+    expect(plan.installerUrl).not.toBe(VENDOR_INSTALL_SH);
+    expect(plan.installerDigest).toBe(installerDigest);
+    expect(plan.binaryAsset).toBe('capa-x86_64-unknown-linux-gnu');
+    expect(plan.binaryDigest).toBe(binaryDigest);
+
+    const preview = formatUpgradePreview(plan);
+    expect(preview).toContain('9.9.9');
+    expect(preview).toContain(installerDigest);
+    expect(preview).toContain(plan.installerUrl);
+  });
+
+  it('refuses when the installer checksum does not match SHA256SUMS', () => {
+    const expected = sha256Hex('good-installer');
+    expect(() =>
+      assertSha256Match(sha256Hex('evil-installer'), expected, 'install.sh'),
+    ).toThrow(/checksum mismatch/i);
+  });
+
+  it('refuses when SHA256SUMS has no entry for the installer', async () => {
+    await expect(
+      planUpgrade({
+        platform: 'linux',
+        arch: 'x64',
+        fetchText: async (url) => {
+          if (url.includes('/releases/latest')) {
+            return JSON.stringify({ tag_name: 'v1.0.0' });
+          }
+          return `${'c'.repeat(64)}  capa-x86_64-unknown-linux-gnu\n`;
+        },
+      }),
+    ).rejects.toThrow(/no checksum found for install\.sh/i);
+  });
+
+  it('--yes skips confirm; no TTY without --yes fails closed', () => {
+    expect(upgradeConfirmationState({ yes: true, interactive: false })).toBe(
+      'proceed',
+    );
+    expect(upgradeConfirmationState({ yes: true, interactive: true })).toBe(
+      'proceed',
+    );
+    expect(upgradeConfirmationState({ yes: false, interactive: true })).toBe(
+      'prompt',
+    );
+    expect(() =>
+      upgradeConfirmationState({ yes: false, interactive: false }),
+    ).toThrow(/--yes/i);
+  });
+
+  it('parses GNU SHA256SUMS lines', () => {
+    const digest = 'a'.repeat(64);
+    const map = parseSha256Sums(`${digest}  install.sh\n`);
+    expect(map.get('install.sh')).toBe(digest);
+  });
+});

--- a/src/cli/commands/__tests__/upgrade-plan.test.ts
+++ b/src/cli/commands/__tests__/upgrade-plan.test.ts
@@ -3,6 +3,7 @@ import { createHash } from 'crypto';
 import {
   assertSha256Match,
   formatUpgradePreview,
+  githubFetchHeaders,
   githubReleaseAssetUrl,
   parseSha256Sums,
   planUpgrade,
@@ -17,6 +18,20 @@ function sha256Hex(data: string | Uint8Array): string {
 }
 
 describe('capa upgrade planning', () => {
+  it('sets GitHub API accept headers from the URL hostname, not a substring', () => {
+    const api = githubFetchHeaders(
+      'https://api.github.com/repos/infragate/capa/releases/latest',
+    );
+    expect(api.Accept).toBe('application/vnd.github+json');
+    const asset = githubFetchHeaders(
+      'https://github.com/infragate/capa/releases/download/v1.0.0/SHA256SUMS.txt',
+    );
+    expect(asset.Accept).not.toBe('application/vnd.github+json');
+    expect(() =>
+      githubFetchHeaders('https://evil.example/api.github.com/latest'),
+    ).toThrow(/host/i);
+  });
+
   it('builds a GitHub release asset URL for a pinned version, not the mutable vendor installer URL', () => {
     const url = githubReleaseAssetUrl('v1.2.3', 'install.sh');
     expect(url).toBe(

--- a/src/cli/commands/activity-ingest.ts
+++ b/src/cli/commands/activity-ingest.ts
@@ -11,6 +11,7 @@ import { CANONICAL_HOOK_EVENTS, type CanonicalHookEvent } from "../../types/hook
 import { loadSettings } from "../../shared/config";
 import { normalizeActivityHookPayload } from "../../shared/agent-activity-normalize";
 import { getServerStatus } from "../utils/server-manager";
+import { localApiHeaders } from "../utils/local-api";
 
 /** Cursor (and similar) gate events that require a permission decision on stdout. */
 const PERMISSION_GATE_EVENTS = new Set<CanonicalHookEvent>([
@@ -108,7 +109,10 @@ async function postEvent(
 	try {
 		await fetch(url, {
 			method: "POST",
-			headers: { "Content-Type": "application/json", Accept: "application/json" },
+			headers: localApiHeaders({
+				"Content-Type": "application/json",
+				Accept: "application/json",
+			}),
 			body: JSON.stringify({
 				kind: normalized.kind,
 				toolName: normalized.toolName,

--- a/src/cli/commands/activity-ingest.ts
+++ b/src/cli/commands/activity-ingest.ts
@@ -7,6 +7,7 @@
  * as invalid JSON and blocks the action.
  */
 
+import { readFileSync } from "fs";
 import { CANONICAL_HOOK_EVENTS, type CanonicalHookEvent } from "../../types/hooks";
 import { loadSettings } from "../../shared/config";
 import { normalizeActivityHookPayload } from "../../shared/agent-activity-normalize";
@@ -162,7 +163,10 @@ function parseArgs(args: string[]): {
 async function readStdin(): Promise<string> {
 	try {
 		if (process.stdin.isTTY) return "";
-		return await Bun.stdin.text();
+		// Windows: `Bun.stdin.text()` can hang after commander has already
+		// opened the process, so hooks never POST. `readFileSync(0)` reads fd
+		// 0 to EOF immediately (empty pipe → "", piped JSON → payload).
+		return readFileSync(0, "utf8");
 	} catch {
 		return "";
 	}

--- a/src/cli/commands/auth.ts
+++ b/src/cli/commands/auth.ts
@@ -9,6 +9,7 @@ import {
   getGitProviderByHost,
 } from '../../shared/git-providers/registry';
 import { GitIntegrationManager } from '../../server/git-integration-manager';
+import { cloudOAuthDisclosure } from '../../shared/ui-urls';
 import { header, footer, success, info, warn, error, runTasks, isHeadless } from '../ui';
 import type { GitPlatform } from '../../types/git-integration';
 import type { GitIntegration } from '../../types/database';
@@ -64,8 +65,9 @@ export async function authCommand(
   if (!provider) {
     listConnectedProviders(db);
     info('Usage:');
+    info('  capa auth <provider> --access-token <token>  - PAT (recommended)');
     info('  capa auth <provider>                         - OAuth (browser)');
-    info('  capa auth <provider> --access-token <token>  - PAT / access token');
+    info(cloudOAuthDisclosure());
     info('Examples:');
     info('  capa auth github.com');
     info('  capa auth github.com --access-token <token>');
@@ -184,6 +186,7 @@ export async function authCommand(
           // In --headless mode (CI / cloud agent sandbox) there is no browser
           // to open; print the URL so the user can authenticate elsewhere.
           // The polling step below still waits for that to complete.
+          warn(cloudOAuthDisclosure());
           if (isHeadless()) {
             warn('Please open this URL in your browser to authenticate:');
             info(`   ${authorizationUrl}`);

--- a/src/cli/commands/auth.ts
+++ b/src/cli/commands/auth.ts
@@ -2,6 +2,7 @@ import { isIP } from 'net';
 import { loadSettings, getDatabasePath } from '../../shared/config';
 import { CapaDatabase } from '../../db/database';
 import { ensureServer } from '../utils/server-manager';
+import { localApiHeaders } from '../utils/local-api';
 import { VERSION } from '../../version';
 import {
   getGitProvider,
@@ -158,7 +159,7 @@ export async function authCommand(
             `${serverUrl}/api/integrations/${platform}/oauth/start`,
             {
               method: 'POST',
-              headers: { 'Content-Type': 'application/json' },
+              headers: localApiHeaders({ 'Content-Type': 'application/json' }),
               body: JSON.stringify({}),
             },
           );

--- a/src/cli/commands/clean-project.ts
+++ b/src/cli/commands/clean-project.ts
@@ -1,11 +1,11 @@
 import { existsSync } from 'fs';
 import { rm } from 'fs/promises';
-import { resolve } from 'path';
+import { join, resolve } from 'path';
 import { detectCapabilitiesFile } from '../../shared/paths';
 import { parseCapabilitiesFile } from '../../shared/capabilities';
 import { getLockfilePath } from '../../shared/lockfile';
 import { resolveProvidersForClean } from '../../shared/providers/resolve';
-import { getAllProviders } from '../../shared/providers';
+import { getAllProviders, getProvider } from '../../shared/providers';
 import type { CapaDatabase } from '../../db/database';
 import type { Capabilities } from '../../types/capabilities';
 import { unregisterMCPServer, unregisterSubAgentMCPServer } from '../utils/mcp-client-manager';
@@ -28,6 +28,7 @@ export interface CleanProjectResult {
   wrapSessionsStopped: number;
   workspacesPruned: number;
   managedFilesRemoved: number;
+  skillDirsRemoved: number;
 }
 
 /**
@@ -38,8 +39,45 @@ export interface CleanProjectResult {
 function providersForOnDiskCleanup(resolved: string[]): string[] {
   if (resolved.length > 0) return resolved;
   return getAllProviders()
-    .filter((p) => p.subagents || p.rules || p.instructions || p.mcp)
+    .filter((p) => p.subagents || p.rules || p.instructions || p.mcp || p.skillsDir)
     .map((p) => p.id);
+}
+
+/**
+ * Remove skill install directories declared in capabilities for each active
+ * provider (e.g. `.cursor/skills/<id>`). Mirrors sub-agent cleanup: covers
+ * orphaned dirs when install wrote files but never recorded managed_files.
+ */
+async function cleanSkillInstallDirs(
+  projectPath: string,
+  providers: string[],
+  skillIds: string[],
+  warnings: string[],
+): Promise<number> {
+  let removed = 0;
+  if (skillIds.length === 0 || providers.length === 0) return removed;
+
+  for (const providerId of providers) {
+    const provider = getProvider(providerId);
+    if (!provider?.skillsDir) continue;
+
+    for (const skillId of skillIds) {
+      const skillDir = join(projectPath, provider.skillsDir, skillId);
+      if (!existsSync(skillDir)) continue;
+      try {
+        await rm(skillDir, { recursive: true, force: true });
+        removed++;
+      } catch (err) {
+        warnings.push(
+          `Failed to remove skill directory ${skillDir}: ${
+            err instanceof Error ? err.message : String(err)
+          }`,
+        );
+      }
+    }
+  }
+
+  return removed;
 }
 
 /**
@@ -77,6 +115,14 @@ export async function cleanProject(opts: CleanProjectOptions): Promise<CleanProj
     projectId,
   });
   const providers = providersForOnDiskCleanup(resolvedProviders);
+
+  const skillIds = (capabilities?.skills ?? []).map((s) => s.id);
+  const skillDirsRemoved = await cleanSkillInstallDirs(
+    projectPath,
+    providers,
+    skillIds,
+    warnings,
+  );
 
   const managedFiles = db.getManagedFiles(projectId);
   let managedFilesRemoved = 0;
@@ -169,5 +215,6 @@ export async function cleanProject(opts: CleanProjectOptions): Promise<CleanProj
     wrapSessionsStopped,
     workspacesPruned,
     managedFilesRemoved,
+    skillDirsRemoved,
   };
 }

--- a/src/cli/commands/clean-project.ts
+++ b/src/cli/commands/clean-project.ts
@@ -1,6 +1,8 @@
 import { existsSync } from 'fs';
 import { rm } from 'fs/promises';
 import { join, resolve } from 'path';
+import { isCapaOwnedInstallPath } from '../../shared/install-path-guard';
+import { isUnderWrapWorkspacesDir } from '../../shared/workspaces/paths';
 import { detectCapabilitiesFile } from '../../shared/paths';
 import { parseCapabilitiesFile } from '../../shared/capabilities';
 import { getLockfilePath } from '../../shared/lockfile';
@@ -57,13 +59,28 @@ async function cleanSkillInstallDirs(
   let removed = 0;
   if (skillIds.length === 0 || providers.length === 0) return removed;
 
+  const skippedProviderRoots = new Set<string>();
+
   for (const providerId of providers) {
     const provider = getProvider(providerId);
     if (!provider?.skillsDir) continue;
 
+    const skillsRoot = join(projectPath, provider.skillsDir);
+    if (!isCapaOwnedInstallPath(projectPath, skillsRoot)) {
+      if (!skippedProviderRoots.has(skillsRoot)) {
+        skippedProviderRoots.add(skillsRoot);
+        warnings.push(
+          `Skipped skill cleanup under ${provider.skillsDir}: not a capa-owned path ` +
+            `(often a symlink to project source — e.g. .cursor/skills → ../skills).`,
+        );
+      }
+      continue;
+    }
+
     for (const skillId of skillIds) {
-      const skillDir = join(projectPath, provider.skillsDir, skillId);
+      const skillDir = join(skillsRoot, skillId);
       if (!existsSync(skillDir)) continue;
+      if (!isCapaOwnedInstallPath(projectPath, skillDir)) continue;
       try {
         await rm(skillDir, { recursive: true, force: true });
         removed++;
@@ -78,6 +95,19 @@ async function cleanSkillInstallDirs(
   }
 
   return removed;
+}
+
+/** Managed artifacts recorded under the real project tree (not wrap shadow paths). */
+function managedFilesOnRealProject(
+  projectPath: string,
+  managedFiles: string[],
+): string[] {
+  const root = resolve(projectPath);
+  return managedFiles.filter((filePath) => {
+    const abs = resolve(filePath);
+    if (isUnderWrapWorkspacesDir(abs)) return false;
+    return abs === root || abs.startsWith(root + '/');
+  });
 }
 
 /**
@@ -116,15 +146,16 @@ export async function cleanProject(opts: CleanProjectOptions): Promise<CleanProj
   });
   const providers = providersForOnDiskCleanup(resolvedProviders);
 
-  const skillIds = (capabilities?.skills ?? []).map((s) => s.id);
-  const skillDirsRemoved = await cleanSkillInstallDirs(
-    projectPath,
-    providers,
-    skillIds,
-    warnings,
-  );
-
   const managedFiles = db.getManagedFiles(projectId);
+  const realManagedFiles = managedFilesOnRealProject(projectPath, managedFiles);
+  const wrapOnlyManagedArtifacts =
+    managedFiles.length > 0 && realManagedFiles.length === 0;
+
+  const skillIds = (capabilities?.skills ?? []).map((s) => s.id);
+  const skillDirsRemoved = wrapOnlyManagedArtifacts
+    ? 0
+    : await cleanSkillInstallDirs(projectPath, providers, skillIds, warnings);
+
   let managedFilesRemoved = 0;
   for (const filePath of managedFiles) {
     if (existsSync(filePath)) {
@@ -138,7 +169,7 @@ export async function cleanProject(opts: CleanProjectOptions): Promise<CleanProj
     db.removeManagedFile(projectId, filePath);
   }
 
-  if (providers.length > 0) {
+  if (providers.length > 0 && !wrapOnlyManagedArtifacts) {
     try {
       cleanAgentsFile(projectPath, providers);
     } catch (err) {
@@ -157,9 +188,11 @@ export async function cleanProject(opts: CleanProjectOptions): Promise<CleanProj
     }
   }
 
-  if (db.getManagedHooks(projectId).length > 0) {
+  if (!wrapOnlyManagedArtifacts && db.getManagedHooks(projectId).length > 0) {
     const { warnings: hookWarnings } = cleanHooks(projectPath, projectId, db);
     warnings.push(...hookWarnings);
+  } else if (wrapOnlyManagedArtifacts && db.getManagedHooks(projectId).length > 0) {
+    db.clearManagedHooks(projectId);
   }
 
   const lockfilePath = getLockfilePath(projectPath);
@@ -181,7 +214,7 @@ export async function cleanProject(opts: CleanProjectOptions): Promise<CleanProj
     ...(capabilities?.subagents ?? []).map((a) => a.id),
   ]);
 
-  if (providers.length > 0 && agentIds.size > 0) {
+  if (providers.length > 0 && agentIds.size > 0 && !wrapOnlyManagedArtifacts) {
     for (const agentId of agentIds) {
       try {
         await unregisterSubAgentMCPServer(projectPath, agentId, providers);
@@ -196,7 +229,7 @@ export async function cleanProject(opts: CleanProjectOptions): Promise<CleanProj
     }
   }
 
-  if (providers.length > 0) {
+  if (providers.length > 0 && !wrapOnlyManagedArtifacts) {
     try {
       await unregisterMCPServer(projectPath, projectId, providers);
     } catch (err) {

--- a/src/cli/commands/clean.ts
+++ b/src/cli/commands/clean.ts
@@ -55,6 +55,13 @@ export async function cleanCommand(): Promise<void> {
         }`,
       );
     }
+    if (result.skillDirsRemoved > 0) {
+      info(
+        `Removed ${result.skillDirsRemoved} skill director${
+          result.skillDirsRemoved === 1 ? 'y' : 'ies'
+        }`,
+      );
+    }
     if (result.workspacesPruned > 0) {
       info(
         `Pruned ${result.workspacesPruned} wrap workspace${

--- a/src/cli/commands/init.ts
+++ b/src/cli/commands/init.ts
@@ -13,6 +13,7 @@ import {
 } from '../../shared/capabilities';
 import type { Capabilities, CapabilitiesFormat } from '../../types/capabilities';
 import { ensureCapaDir, loadSettings, getDatabasePath } from '../../shared/config';
+import { trustStdioServers } from '../../shared/stdio-allowlist';
 import { CapaDatabase } from '../../db/database';
 import { isUnderWrapWorkspacesDir } from '../../shared/workspaces/paths';
 import { ensureServer } from '../utils/server-manager';
@@ -59,6 +60,7 @@ async function registerProject(
     }
 
     try {
+      trustStdioServers(projectId, capabilities.servers ?? []);
       const response = await fetch(
         `${serverUrl}/api/projects/${encodeURIComponent(projectId)}/configure`,
         {

--- a/src/cli/commands/init.ts
+++ b/src/cli/commands/init.ts
@@ -16,6 +16,7 @@ import { ensureCapaDir, loadSettings, getDatabasePath } from '../../shared/confi
 import { CapaDatabase } from '../../db/database';
 import { isUnderWrapWorkspacesDir } from '../../shared/workspaces/paths';
 import { ensureServer } from '../utils/server-manager';
+import { localApiHeaders } from '../utils/local-api';
 import { refuseIfWrapWorkspace } from '../utils/wrap/marker';
 import { VERSION } from '../../version';
 
@@ -62,10 +63,10 @@ async function registerProject(
         `${serverUrl}/api/projects/${encodeURIComponent(projectId)}/configure`,
         {
           method: 'POST',
-          headers: {
+          headers: localApiHeaders({
             'Content-Type': 'application/json',
             Accept: 'application/json',
-          },
+          }),
           body: JSON.stringify(capabilities),
           signal: AbortSignal.timeout(120000),
         },

--- a/src/cli/commands/install-confirm.ts
+++ b/src/cli/commands/install-confirm.ts
@@ -46,7 +46,7 @@ export async function confirmInstallExecution(opts: {
   try {
     ok = await prompt.confirm(
       'Proceed with capa install? This will execute the commands above.',
-      false,
+      true,
     );
   } catch {
     throw new Error(

--- a/src/cli/commands/install-confirm.ts
+++ b/src/cli/commands/install-confirm.ts
@@ -1,0 +1,61 @@
+import { info, isYes, prompt } from '../ui';
+import type { Capabilities } from '../../types/capabilities';
+import {
+  collectExecutableSurface,
+  fingerprintExecutableSurface,
+  formatExecutableSurface,
+  readConfirmedFingerprint,
+  writeConfirmedFingerprint,
+} from '../../shared/executable-surface';
+
+export async function confirmInstallExecution(opts: {
+  projectId: string;
+  capabilities: Capabilities;
+  dryRun?: boolean;
+}): Promise<'proceed' | 'dry-run'> {
+  const surface = collectExecutableSurface(opts.capabilities);
+  const fingerprint = fingerprintExecutableSurface(surface);
+  const summary = formatExecutableSurface(surface);
+
+  const previous = readConfirmedFingerprint(opts.projectId);
+  const changed = previous !== fingerprint;
+
+  if (opts.dryRun || changed) {
+    info('Executable surface for this install:');
+    for (const line of summary.split('\n')) {
+      info(line);
+      if (opts.dryRun) console.log(line);
+    }
+  }
+
+  if (opts.dryRun) {
+    info('Dry run — no changes were made.');
+    return 'dry-run';
+  }
+
+  if (!changed) {
+    return 'proceed';
+  }
+
+  if (isYes()) {
+    writeConfirmedFingerprint(opts.projectId, fingerprint);
+    return 'proceed';
+  }
+
+  let ok: boolean;
+  try {
+    ok = await prompt.confirm(
+      'Proceed with capa install? This will execute the commands above.',
+      false,
+    );
+  } catch {
+    throw new Error(
+      'capa install requires confirmation of the executable surface. Re-run with --yes in non-interactive / CI environments.',
+    );
+  }
+  if (!ok) {
+    throw new Error('Install cancelled.');
+  }
+  writeConfirmedFingerprint(opts.projectId, fingerprint);
+  return 'proceed';
+}

--- a/src/cli/commands/install-tasks/__tests__/install-error-policy.test.ts
+++ b/src/cli/commands/install-tasks/__tests__/install-error-policy.test.ts
@@ -13,7 +13,7 @@ function ctx(mode: 'warn' | 'stop'): InstallCtx {
     failed: 0,
     warnings: [],
     errors: [],
-  } as InstallCtx;
+  } as unknown as InstallCtx;
 }
 
 describe('getInstallErrorMode', () => {

--- a/src/cli/commands/install-tasks/__tests__/install-error-policy.test.ts
+++ b/src/cli/commands/install-tasks/__tests__/install-error-policy.test.ts
@@ -1,0 +1,79 @@
+import { describe, it, expect } from 'bun:test';
+import type { InstallCtx } from '../context';
+import {
+  finishInstallBatch,
+  getInstallErrorMode,
+  raiseInstallError,
+  recordInstallFailure,
+} from '../install-error-policy';
+
+function ctx(mode: 'warn' | 'stop'): InstallCtx {
+  return {
+    installErrorMode: mode,
+    failed: 0,
+    warnings: [],
+    errors: [],
+  } as InstallCtx;
+}
+
+describe('getInstallErrorMode', () => {
+  it('defaults to warn', () => {
+    expect(getInstallErrorMode({ skills: [], servers: [], tools: [] })).toBe('warn');
+    expect(getInstallErrorMode({ skills: [], servers: [], tools: [], options: {} })).toBe(
+      'warn',
+    );
+  });
+
+  it('honors stop', () => {
+    expect(
+      getInstallErrorMode({
+        skills: [],
+        servers: [],
+        tools: [],
+        options: { onInstallError: 'stop' },
+      }),
+    ).toBe('stop');
+  });
+});
+
+describe('raiseInstallError', () => {
+  it('warns without throwing in warn mode', () => {
+    const c = ctx('warn');
+    raiseInstallError(c, 'git not found');
+    expect(c.failed).toBe(1);
+    expect(c.warnings).toEqual(['git not found']);
+  });
+
+  it('throws in stop mode', () => {
+    const c = ctx('stop');
+    expect(() => raiseInstallError(c, 'git not found')).toThrow('git not found');
+    expect(c.failed).toBe(1);
+  });
+});
+
+describe('recordInstallFailure', () => {
+  it('stores batch errors separately from warnings', () => {
+    const warnCtx = ctx('warn');
+    recordInstallFailure(warnCtx, 'skill a failed');
+    expect(warnCtx.warnings).toHaveLength(1);
+    expect(warnCtx.errors).toHaveLength(0);
+
+    const stopCtx = ctx('stop');
+    recordInstallFailure(stopCtx, 'skill a failed');
+    expect(stopCtx.errors).toHaveLength(1);
+    expect(stopCtx.warnings).toHaveLength(0);
+  });
+});
+
+describe('finishInstallBatch', () => {
+  it('throws summary in stop mode', () => {
+    const c = ctx('stop');
+    expect(() => finishInstallBatch(c, 2, '2 skills failed')).toThrow('2 skills failed');
+  });
+
+  it('warns in warn mode', () => {
+    const c = ctx('warn');
+    finishInstallBatch(c, 2, '2 skills failed');
+    expect(c.warnings).toEqual(['2 skills failed']);
+  });
+});

--- a/src/cli/commands/install-tasks/__tests__/install-rules.test.ts
+++ b/src/cli/commands/install-tasks/__tests__/install-rules.test.ts
@@ -97,3 +97,37 @@ describe('resolveRuleBody', () => {
     );
   });
 });
+
+describe('resolveRuleBody remote URL policy', () => {
+  function remoteDeps(): ResolveRuleBodyDeps {
+    return {
+      capabilitiesFilePath: '/tmp/capa.yaml',
+      authFetch: {
+        fetch: async () =>
+          new Response('# rule\n', { status: 200, headers: { 'Content-Type': 'text/plain' } }),
+        hasAuth: () => false,
+      } as unknown as ResolveRuleBodyDeps['authFetch'],
+      getRepoSnapshot: async () => {
+        throw new Error('repo snapshot should not be used for remote URL rules');
+      },
+    };
+  }
+
+  it('rejects HTTP rule URLs', async () => {
+    const rule: Rule = { id: 'style', type: 'remote', url: 'http://example.com/rule.md' };
+    await expect(resolveRuleBody(rule, remoteDeps())).rejects.toThrow(/https/i);
+  });
+
+  it('rejects private and metadata HTTPS rule URLs', async () => {
+    const deps = remoteDeps();
+    await expect(
+      resolveRuleBody({ id: 'style', type: 'remote', url: 'https://10.0.0.8/rule.md' }, deps),
+    ).rejects.toThrow(/not allowed/i);
+    await expect(
+      resolveRuleBody(
+        { id: 'style', type: 'remote', url: 'https://169.254.169.254/latest/meta-data/' },
+        deps,
+      ),
+    ).rejects.toThrow(/not allowed/i);
+  });
+});

--- a/src/cli/commands/install-tasks/configure-tools.ts
+++ b/src/cli/commands/install-tasks/configure-tools.ts
@@ -3,7 +3,7 @@ import type { Task, TaskWrapper } from '../../ui';
 import { localApiHeaders } from '../../utils/local-api';
 import type { InstallCtx } from './context';
 import { getUnexposedToolIds } from './helpers/tool-warnings';
-import { finishInstallBatch, raiseInstallError, shouldStopOnInstallError } from './install-error-policy';
+import { raiseInstallError, shouldStopOnInstallError } from './install-error-policy';
 
 export function configureToolsTask(): Task<InstallCtx> {
   return {

--- a/src/cli/commands/install-tasks/configure-tools.ts
+++ b/src/cli/commands/install-tasks/configure-tools.ts
@@ -1,4 +1,5 @@
 import type { Task, TaskWrapper } from '../../ui';
+import { localApiHeaders } from '../../utils/local-api';
 import type { InstallCtx } from './context';
 import { getUnexposedToolIds } from './helpers/tool-warnings';
 
@@ -37,14 +38,14 @@ export function configureToolsTask(): Task<InstallCtx> {
         `${ctx.serverStatus.url}/api/projects/${ctx.projectId}/configure`,
         {
           method: 'POST',
-          headers: {
+          headers: localApiHeaders({
             'Content-Type': 'application/json',
             // Ask the server to stream NDJSON progress so we can render a
             // live "X of Y validated · last-server done" counter instead of
             // a static spinner. The server falls back to a single JSON
             // body if it doesn't support streaming.
             Accept: 'application/x-ndjson, application/json',
-          },
+          }),
           body: JSON.stringify({
             ...ctx.capabilitiesToUse,
             // Wrap installs write Claude/etc. only into the shadow workspace;

--- a/src/cli/commands/install-tasks/configure-tools.ts
+++ b/src/cli/commands/install-tasks/configure-tools.ts
@@ -1,3 +1,4 @@
+import { trustStdioServers } from '../../../shared/stdio-allowlist';
 import type { Task, TaskWrapper } from '../../ui';
 import { localApiHeaders } from '../../utils/local-api';
 import type { InstallCtx } from './context';
@@ -33,6 +34,8 @@ export function configureToolsTask(): Task<InstallCtx> {
         }
         task.output = `validating ${parts.join(' + ')}…`;
       }
+
+      trustStdioServers(ctx.projectId, ctx.capabilitiesToUse.servers ?? []);
 
       const response = await fetch(
         `${ctx.serverStatus.url}/api/projects/${ctx.projectId}/configure`,

--- a/src/cli/commands/install-tasks/configure-tools.ts
+++ b/src/cli/commands/install-tasks/configure-tools.ts
@@ -3,6 +3,7 @@ import type { Task, TaskWrapper } from '../../ui';
 import { localApiHeaders } from '../../utils/local-api';
 import type { InstallCtx } from './context';
 import { getUnexposedToolIds } from './helpers/tool-warnings';
+import { finishInstallBatch, raiseInstallError, shouldStopOnInstallError } from './install-error-policy';
 
 export function configureToolsTask(): Task<InstallCtx> {
   return {
@@ -60,15 +61,22 @@ export function configureToolsTask(): Task<InstallCtx> {
 
       if (!response.ok) {
         const errorText = await response.text();
-        throw new Error(`Failed to configure project: ${errorText}`);
+        raiseInstallError(ctx, `Failed to configure project: ${errorText}`);
+        return;
       }
 
       const contentType = (response.headers.get('content-type') ?? '').toLowerCase();
-      if (contentType.includes('application/x-ndjson') && response.body) {
-        ctx.configureResult = await consumeConfigureStream(response.body, task);
-      } else {
-        task.output = 'parsing validation results…';
-        ctx.configureResult = await response.json();
+      try {
+        if (contentType.includes('application/x-ndjson') && response.body) {
+          ctx.configureResult = await consumeConfigureStream(response.body, task);
+        } else {
+          task.output = 'parsing validation results…';
+          ctx.configureResult = await response.json();
+        }
+      } catch (err: unknown) {
+        const message = err instanceof Error ? err.message : String(err);
+        raiseInstallError(ctx, message);
+        return;
       }
 
       const result = ctx.configureResult as {
@@ -106,8 +114,6 @@ export function configureToolsTask(): Task<InstallCtx> {
         task.output = breakdown.join(' · ');
 
         if (failed.length > 0) {
-          ctx.failed += failed.length;
-          task.title = `Configuring tools — ${failed.length} of ${result.toolValidation.length} tool(s) failed validation`;
           const lines: string[] = [];
           lines.push(
             `${failed.length} of ${result.toolValidation.length} tool(s) failed validation:`,
@@ -122,7 +128,13 @@ export function configureToolsTask(): Task<InstallCtx> {
           lines.push('  Tip: check that tool names match what the MCP server provides,');
           lines.push('  server IDs are correct (e.g. "@server-name"), and that the MCP');
           lines.push('  servers are reachable.');
-          ctx.errors.push(lines.join('\n'));
+          ctx.failed += failed.length;
+          if (shouldStopOnInstallError(ctx)) {
+            ctx.errors.push(lines.join('\n'));
+          } else {
+            ctx.warnings.push(lines.join('\n'));
+          }
+          task.title = `Configuring tools — ${failed.length} of ${result.toolValidation.length} tool(s) failed validation`;
         } else if (pendingAuth.length > 0 && pendingAuth.length < result.toolValidation.length) {
           task.title = `Configuring tools — ${successful.length} validated, ${pendingAuth.length} pending OAuth2`;
         } else if (pendingAuth.length === 0) {

--- a/src/cli/commands/install-tasks/context.ts
+++ b/src/cli/commands/install-tasks/context.ts
@@ -4,6 +4,7 @@ import type { loadSettings } from '../../../shared/config';
 import type { LockfileBuilder } from '../../../shared/lockfile';
 import type { GetSnapshotResult, CachePlatform } from '../../../shared/cache';
 import type { AuthenticatedFetch } from '../../../shared/authenticated-fetch';
+import type { InstallErrorMode } from './install-error-policy';
 
 export type SkillInstallOutcome = 'installed' | 'skipped' | 'failed';
 
@@ -43,6 +44,8 @@ export interface InstallCtx {
   skipped: number;
   warnings: string[];
   errors: string[];
+  /** warn (default): continue on operational errors; stop: exit non-zero. */
+  installErrorMode: InstallErrorMode;
 }
 
 export interface InstallOptions {

--- a/src/cli/commands/install-tasks/context.ts
+++ b/src/cli/commands/install-tasks/context.ts
@@ -91,6 +91,11 @@ export interface InstallOptions {
    * Default true.
    */
   persistProviders?: boolean;
+  /**
+   * Print the executable surface (stdio MCP, hooks, formatters, plugins)
+   * and exit without starting the server, writing hooks, or mutating the lock.
+   */
+  dryRun?: boolean;
 }
 
 export type GetRepoSnapshotFn = (

--- a/src/cli/commands/install-tasks/helpers/install-one-skill.ts
+++ b/src/cli/commands/install-tasks/helpers/install-one-skill.ts
@@ -3,7 +3,7 @@ import { resolve, join, dirname, basename } from 'path';
 import type { Skill, Capabilities } from '../../../../types/capabilities';
 import type { CapaDatabase } from '../../../../db/database';
 import { createAuthenticatedFetch, AuthenticatedFetch } from '../../../../shared/authenticated-fetch';
-import { displayIntegrationPrompt, getIntegrationsUrl, parseRepoUrl } from '../../../utils/integration-helper';
+import { getIntegrationsUrl, parseRepoUrl } from '../../../utils/integration-helper';
 import { getProvider, getAllProviders } from '../../../../shared/providers';
 import { getGitProvider } from '../../../../shared/git-providers/registry';
 import { LockfileBuilder } from '../../../../shared/lockfile';
@@ -235,10 +235,11 @@ export async function installOneSkill(
           const repoInfo = parseRepoUrl(skill.def.url);
           if (repoInfo && repoInfo.platform) {
             const integrationsUrl = getIntegrationsUrl(settings.server.host, settings.server.port);
-            console.error(`\n  ✗ Unable to access URL (it may require authentication)`);
-            displayIntegrationPrompt(getGitProvider(repoInfo.platform)?.displayName ?? repoInfo.platform, integrationsUrl);
-            try { db.close(); } catch {}
-            process.exit(1);
+            const platformLabel = getGitProvider(repoInfo.platform)?.displayName ?? repoInfo.platform;
+            throw new Error(
+              `Unable to access URL for skill "${skill.id}" (authentication may be required).\n` +
+                `Connect ${platformLabel} at: ${integrationsUrl}`,
+            );
           }
         }
         throw new Error(`Failed to fetch: ${response.statusText}`);
@@ -294,20 +295,17 @@ export async function installOneSkill(
     const providerEntry = getProvider(client);
 
     if (!providerEntry) {
-      console.error(`  ✗ Unknown client: ${client}`);
-      console.error(`\n  Supported clients:`);
-
       const supportedAgents = getAllProviders()
         .map((p) => ({ name: p.id, displayName: p.displayName }))
         .sort((a, b) => a.displayName.localeCompare(b.displayName));
 
       const maxDisplayNameLength = Math.max(...supportedAgents.map((a) => a.displayName.length));
-      for (const agent of supportedAgents) {
-        console.error(`    - ${agent.displayName.padEnd(maxDisplayNameLength)} (${agent.name})`);
-      }
-
-      try { db.close(); } catch {}
-      process.exit(1);
+      const lines = supportedAgents.map(
+        (agent) => `    - ${agent.displayName.padEnd(maxDisplayNameLength)} (${agent.name})`,
+      );
+      throw new Error(
+        `Unknown client: ${client}\n\n  Supported clients:\n${lines.join('\n')}`,
+      );
     }
 
     const skillsBaseDir = join(projectPath, providerEntry.skillsDir);
@@ -319,24 +317,17 @@ export async function installOneSkill(
       if (trackManaged) {
         const managedFiles = db.getManagedFiles(projectId);
         if (!managedFiles.includes(skillDir)) {
-          console.error(
-            `  ✗ Directory already exists and is not managed by capa: ${skillDir}`
+          throw new Error(
+            `Directory already exists and is not managed by capa: ${skillDir}\n` +
+              `Please delete it manually and run "capa install" again.`,
           );
-          console.error('    Please delete it manually and run "capa install" again.');
-          try { db.close(); } catch {}
-          process.exit(1);
         }
         rmSync(skillDir, { recursive: true, force: true });
       } else {
-        // Passthrough must not delete directories capa does not own.
-        console.error(
-          `  ✗ Directory already exists: ${skillDir}`
+        throw new Error(
+          `Directory already exists: ${skillDir}\n` +
+            'Passthrough will not overwrite existing skill directories. Delete it manually and retry.',
         );
-        console.error(
-          '    Passthrough will not overwrite existing skill directories. Delete it manually and retry.',
-        );
-        try { db.close(); } catch {}
-        process.exit(1);
       }
     }
 

--- a/src/cli/commands/install-tasks/install-agent-instructions.ts
+++ b/src/cli/commands/install-tasks/install-agent-instructions.ts
@@ -4,6 +4,7 @@ import { installAgentsFile } from '../../utils/agents-file';
 import type { CachePlatform } from '../../../shared/cache';
 import type { InstallCtx } from './context';
 import { getRepoSnapshot } from './helpers/repo-snapshot';
+import { raiseInstallError } from './install-error-policy';
 
 export function installAgentInstructionsTask(): Task<InstallCtx> {
   return {
@@ -28,7 +29,10 @@ export function installAgentInstructionsTask(): Task<InstallCtx> {
           repoFetchCtx,
         );
       } catch (err: any) {
-        throw new Error(`Failed to install agent instructions files: ${err.message}`);
+        raiseInstallError(
+          ctx,
+          `Failed to install agent instructions files: ${err.message}`,
+        );
       }
     },
   };

--- a/src/cli/commands/install-tasks/install-error-policy.ts
+++ b/src/cli/commands/install-tasks/install-error-policy.ts
@@ -1,0 +1,46 @@
+import type { Capabilities } from '../../../types/capabilities';
+import type { InstallCtx } from './context';
+
+export type InstallErrorMode = 'warn' | 'stop';
+
+/** @default warn */
+export function getInstallErrorMode(capabilities: Capabilities): InstallErrorMode {
+  const raw = capabilities.options?.onInstallError;
+  return raw === 'stop' ? 'stop' : 'warn';
+}
+
+export function shouldStopOnInstallError(ctx: InstallCtx): boolean {
+  return ctx.installErrorMode === 'stop';
+}
+
+/** Record a single failure. Throws in `stop` mode. */
+export function raiseInstallError(ctx: InstallCtx, message: string): void {
+  ctx.failed++;
+  if (shouldStopOnInstallError(ctx)) {
+    throw new Error(message);
+  }
+  ctx.warnings.push(message);
+}
+
+/** Record a failure during a batch (e.g. per-skill). Does not throw until batch finish. */
+export function recordInstallFailure(ctx: InstallCtx, message: string): void {
+  ctx.failed++;
+  if (shouldStopOnInstallError(ctx)) {
+    ctx.errors.push(message);
+  } else {
+    ctx.warnings.push(message);
+  }
+}
+
+/** After a batch, throw a summary in `stop` mode when anything failed in the batch. */
+export function finishInstallBatch(
+  ctx: InstallCtx,
+  batchFailed: number,
+  summaryMessage: string,
+): void {
+  if (batchFailed <= 0) return;
+  if (shouldStopOnInstallError(ctx)) {
+    throw new Error(summaryMessage);
+  }
+  ctx.warnings.push(summaryMessage);
+}

--- a/src/cli/commands/install-tasks/install-hooks.ts
+++ b/src/cli/commands/install-tasks/install-hooks.ts
@@ -2,8 +2,7 @@ import type { Task } from '../../ui';
 import { createAuthenticatedFetch, AuthenticatedFetch } from '../../../shared/authenticated-fetch';
 import { installHooks } from '../../utils/hooks-installer';
 import { validateHooks } from '../../../shared/hooks-validate';
-import { RemoteUrlPolicyError } from '../../../shared/safe-remote-url';
-import { HookBodyIntegrityError } from '../../utils/hooks/resolve-body';
+import { raiseInstallError } from './install-error-policy';
 import type { CachePlatform } from '../../../shared/cache';
 import type { InstallCtx } from './context';
 import { getRepoSnapshot } from './helpers/repo-snapshot';
@@ -48,13 +47,9 @@ export function installHooksTask(): Task<InstallCtx> {
           ? `Installed ${installed} hook entr${installed === 1 ? 'y' : 'ies'}`
           : 'Hooks up to date';
       } catch (err: unknown) {
-        if (err instanceof RemoteUrlPolicyError || err instanceof HookBodyIntegrityError) {
-          throw err;
-        }
         const message = err instanceof Error ? err.message : String(err);
-        // Warn-but-never-fail: the rest of `capa install` should still finish.
-        ctx.warnings.push(`Failed to install hooks: ${message}`);
-        task.title = 'Hooks install reported warnings';
+        raiseInstallError(ctx, `Failed to install hooks: ${message}`);
+        task.title = 'Hooks install failed';
       }
     },
   };

--- a/src/cli/commands/install-tasks/install-hooks.ts
+++ b/src/cli/commands/install-tasks/install-hooks.ts
@@ -2,6 +2,8 @@ import type { Task } from '../../ui';
 import { createAuthenticatedFetch, AuthenticatedFetch } from '../../../shared/authenticated-fetch';
 import { installHooks } from '../../utils/hooks-installer';
 import { validateHooks } from '../../../shared/hooks-validate';
+import { RemoteUrlPolicyError } from '../../../shared/safe-remote-url';
+import { HookBodyIntegrityError } from '../../utils/hooks/resolve-body';
 import type { CachePlatform } from '../../../shared/cache';
 import type { InstallCtx } from './context';
 import { getRepoSnapshot } from './helpers/repo-snapshot';
@@ -46,6 +48,9 @@ export function installHooksTask(): Task<InstallCtx> {
           ? `Installed ${installed} hook entr${installed === 1 ? 'y' : 'ies'}`
           : 'Hooks up to date';
       } catch (err: unknown) {
+        if (err instanceof RemoteUrlPolicyError || err instanceof HookBodyIntegrityError) {
+          throw err;
+        }
         const message = err instanceof Error ? err.message : String(err);
         // Warn-but-never-fail: the rest of `capa install` should still finish.
         ctx.warnings.push(`Failed to install hooks: ${message}`);

--- a/src/cli/commands/install-tasks/install-rules.ts
+++ b/src/cli/commands/install-tasks/install-rules.ts
@@ -16,6 +16,7 @@ import {
 } from '../../../shared/skill-security';
 import type { InstallCtx } from './context';
 import { getRepoSnapshot } from './helpers/repo-snapshot';
+import { finishInstallBatch, recordInstallFailure } from './install-error-policy';
 
 /** Dependencies needed to resolve a rule's body content. */
 export interface ResolveRuleBodyDeps {
@@ -87,39 +88,64 @@ export function installRulesTask(): Task<InstallCtx> {
       ctx.ruleBodies = new Map();
 
       const totalRules = currentRules.length;
+      const failedBefore = ctx.failed;
+      const installedRules: Rule[] = [];
+
       for (let i = 0; i < totalRules; i++) {
         const rule = currentRules[i];
         task.output = `[${i + 1}/${totalRules}] ${rule.id}`;
 
-        let body = await resolveRuleBody(rule, {
-          capabilitiesFilePath: ctx.capabilitiesFile.path,
-          authFetch: repoFetchAuth,
-          getRepoSnapshot: snapshotResolver,
-          noCache: ctx.noCache,
-        });
-        const security = ctx.capabilitiesToUse.options?.security;
-        if (isBlockedPhrasesEnabled(security)) {
-          const blockedPhrases = loadBlockedPhrases(security, ctx.capabilitiesFile.path);
-          const check = checkBlockedPhrases(body, blockedPhrases);
-          if (check.blocked) {
-            reportBlockedPhraseAndExit(rule.id, `rule:${rule.id}`, check.phrase!);
+        try {
+          let body = await resolveRuleBody(rule, {
+            capabilitiesFilePath: ctx.capabilitiesFile.path,
+            authFetch: repoFetchAuth,
+            getRepoSnapshot: snapshotResolver,
+            noCache: ctx.noCache,
+          });
+          const security = ctx.capabilitiesToUse.options?.security;
+          if (isBlockedPhrasesEnabled(security)) {
+            const blockedPhrases = loadBlockedPhrases(security, ctx.capabilitiesFile.path);
+            const check = checkBlockedPhrases(body, blockedPhrases);
+            if (check.blocked) {
+              reportBlockedPhraseAndExit(rule.id, `rule:${rule.id}`, check.phrase!);
+            }
           }
-        }
-        if (isCharacterSanitizationEnabled(security)) {
-          const allowedChars = getAllowedCharacters(security);
-          if (allowedChars !== null) {
-            body = sanitizeContent(body, allowedChars);
+          if (isCharacterSanitizationEnabled(security)) {
+            const allowedChars = getAllowedCharacters(security);
+            if (allowedChars !== null) {
+              body = sanitizeContent(body, allowedChars);
+            }
           }
+          ctx.ruleBodies.set(rule.id, body);
+          installedRules.push(rule);
+        } catch (err: unknown) {
+          const message = err instanceof Error ? err.message : String(err);
+          recordInstallFailure(ctx, `Rule "${rule.id}" failed: ${message}`);
         }
-        ctx.ruleBodies.set(rule.id, body);
+      }
+
+      const failedInTask = ctx.failed - failedBefore;
+      finishInstallBatch(
+        ctx,
+        failedInTask,
+        `${failedInTask} of ${totalRules} rule(s) failed to install.`,
+      );
+      if (installedRules.length === 0) {
+        if (failedInTask > 0) {
+          task.title = `Installing rules — ${failedInTask} of ${totalRules} failed`;
+        }
+        return;
       }
 
       task.output = 'writing files…';
-      installRules(ctx.projectPath, currentRules, providers, ctx.ruleBodies, {
+      installRules(ctx.projectPath, installedRules, providers, ctx.ruleBodies!, {
         onFileWritten: (filePath) => ctx.db.addManagedFile(ctx.projectId, filePath),
       });
-      ctx.added += currentRules.length;
-      task.title = `Installed ${totalRules} rule${totalRules === 1 ? '' : 's'}`;
+      ctx.added += installedRules.length;
+      task.title =
+        failedInTask > 0
+          ? `Installed ${installedRules.length} of ${totalRules} rule${totalRules === 1 ? '' : 's'}`
+          : `Installed ${installedRules.length} rule${installedRules.length === 1 ? '' : 's'}`;
     },
   };
 }

--- a/src/cli/commands/install-tasks/install-skills.ts
+++ b/src/cli/commands/install-tasks/install-skills.ts
@@ -3,6 +3,7 @@ import type { InstallCtx } from './context';
 import { checkGitInstalled, gitOAuthHelpText } from './helpers/git';
 import { installOneSkill } from './helpers/install-one-skill';
 import { indentLines } from './helpers/text';
+import { finishInstallBatch, raiseInstallError, recordInstallFailure } from './install-error-policy';
 
 export function installSkillsTask(): Task<InstallCtx> {
   return {
@@ -16,10 +17,12 @@ export function installSkillsTask(): Task<InstallCtx> {
         const gitInstalled = await checkGitInstalled();
         if (!gitInstalled) {
           const lines = gitOAuthHelpText().split('\n');
-          throw new Error(
+          raiseInstallError(
+            ctx,
             'Git is not installed on your system.\n\n' +
               lines.map((line) => (line ? `  ${line}` : '')).join('\n'),
           );
+          return;
         }
       }
       const totalSkills = ctx.capabilities.skills.length;
@@ -45,27 +48,31 @@ export function installSkillsTask(): Task<InstallCtx> {
             ctx.resolvedRepos,
           );
         } catch (err: unknown) {
-          ctx.failed++;
           const message = err instanceof Error ? err.message : String(err);
-          ctx.errors.push(`Skill "${skill.id}" failed:\n${indentLines(message, '    ')}`);
+          recordInstallFailure(
+            ctx,
+            `Skill "${skill.id}" failed:\n${indentLines(message, '    ')}`,
+          );
           continue;
         }
 
         if (outcome === 'installed') ctx.added++;
         else if (outcome === 'skipped') ctx.skipped++;
         else {
-          ctx.failed++;
-          ctx.errors.push(`Skill "${skill.id}" failed (see logs above)`);
+          recordInstallFailure(ctx, `Skill "${skill.id}" failed (see logs above)`);
         }
       }
 
       const failedInTask = ctx.failed - failedBefore;
+      finishInstallBatch(
+        ctx,
+        failedInTask,
+        `${failedInTask} of ${totalSkills} skill(s) failed to install. ` +
+          `See the errors above for details.`,
+      );
       if (failedInTask > 0) {
         task.title = `Installing skills — ${failedInTask} of ${totalSkills} failed`;
-        throw new Error(
-          `${failedInTask} of ${totalSkills} skill(s) failed to install. ` +
-            `See the errors above for details.`,
-        );
+        return;
       }
       task.title = `Installed ${totalSkills} skill${totalSkills === 1 ? '' : 's'}`;
     },

--- a/src/cli/commands/install-tasks/load-env.ts
+++ b/src/cli/commands/install-tasks/load-env.ts
@@ -4,6 +4,7 @@ import type { Task } from '../../ui';
 import { parseEnvFile } from '../../../shared/env-parser';
 import { extractAllVariables } from '../../../shared/variable-resolver';
 import type { InstallCtx } from './context';
+import { raiseInstallError } from './install-error-policy';
 
 export function loadEnvTask(): Task<InstallCtx> {
   return {
@@ -20,18 +21,21 @@ export function loadEnvTask(): Task<InstallCtx> {
       }
 
       if (!existsSync(envFilePath)) {
-        throw new Error(
+        raiseInstallError(
+          ctx,
           `Environment file not found: ${envFilePath}\n\n` +
             '  When using -e or --env flag, the specified .env file must exist.\n' +
             '  Please create the file or run without the flag to use the web UI.\n',
         );
+        return;
       }
 
       let envVariables: Record<string, string>;
       try {
         envVariables = parseEnvFile(envFilePath);
       } catch (error: any) {
-        throw new Error(`Failed to parse env file: ${error.message}`);
+        raiseInstallError(ctx, `Failed to parse env file: ${error.message}`);
+        return;
       }
 
       // Authored file only — plugin-merged content must not invent credentials.
@@ -53,7 +57,8 @@ export function loadEnvTask(): Task<InstallCtx> {
       }
 
       if (missingVars.length > 0) {
-        throw new Error(
+        raiseInstallError(
+          ctx,
           `Missing required variables: ${missingVars.join(', ')}\n` +
             '  These variables are required but were not found in the env file.\n' +
             '  Please add them to your env file and try again.\n',

--- a/src/cli/commands/install-tasks/resolve-plugins.ts
+++ b/src/cli/commands/install-tasks/resolve-plugins.ts
@@ -31,6 +31,16 @@ export function resolvePluginsTask(): Task<InstallCtx> {
           );
         ctx.capabilitiesToUse = mergedCapabilities;
         ctx.warnings.push(...pluginWarnings);
+        const declaredPlugins = ctx.capabilities.plugins?.length ?? 0;
+        const resolvedPlugins = ctx.capabilitiesToUse.resolvedPlugins?.length ?? 0;
+        const pluginFailures = pluginWarnings.filter((w) =>
+          w.includes('failed to resolve and was skipped'),
+        );
+        // When every declared plugin fails, treat install as failed — but keep
+        // partial success when at least one plugin resolved (isolation).
+        if (declaredPlugins > 0 && resolvedPlugins === 0 && pluginFailures.length > 0) {
+          throw new Error(pluginFailures.join('\n'));
+        }
         for (const dir of tempDirsToCleanup) {
           try {
             rmSync(dir, { recursive: true, force: true });

--- a/src/cli/commands/install-tasks/resolve-plugins.ts
+++ b/src/cli/commands/install-tasks/resolve-plugins.ts
@@ -9,6 +9,7 @@ import {
   collectPluginSkillWarnings,
   collectUnreferencedPluginServerWarnings,
 } from './helpers/tool-warnings';
+import { raiseInstallError } from './install-error-policy';
 
 export function resolvePluginsTask(): Task<InstallCtx> {
   return {
@@ -39,7 +40,8 @@ export function resolvePluginsTask(): Task<InstallCtx> {
         // When every declared plugin fails, treat install as failed — but keep
         // partial success when at least one plugin resolved (isolation).
         if (declaredPlugins > 0 && resolvedPlugins === 0 && pluginFailures.length > 0) {
-          throw new Error(pluginFailures.join('\n'));
+          raiseInstallError(ctx, pluginFailures.join('\n'));
+          return;
         }
         for (const dir of tempDirsToCleanup) {
           try {
@@ -50,7 +52,8 @@ export function resolvePluginsTask(): Task<InstallCtx> {
         if (err instanceof BlockedPhraseError) {
           reportBlockedPhraseAndExit(err.skillId, err.filePath, err.phrase, err.pluginName);
         }
-        throw new Error(`Plugin resolution failed: ${err.message}`);
+        raiseInstallError(ctx, `Plugin resolution failed: ${err.message}`);
+        return;
       }
       ctx.warnings.push(...collectPluginSkillWarnings(ctx.capabilitiesToUse));
       ctx.warnings.push(...collectUnreferencedPluginServerWarnings(ctx.capabilitiesToUse));

--- a/src/cli/commands/install-tasks/validate-install-paths.ts
+++ b/src/cli/commands/install-tasks/validate-install-paths.ts
@@ -1,12 +1,18 @@
 import type { Task } from '../../ui';
-import { validateProviderInstallRoots } from '../../../shared/install-path-guard';
 import type { InstallCtx } from './context';
+import { validateProviderInstallRoots } from '../../../shared/install-path-guard';
+import { raiseInstallError } from './install-error-policy';
 
 export function validateInstallPathsTask(): Task<InstallCtx> {
   return {
     title: 'Validating install paths',
     task: async (ctx) => {
-      validateProviderInstallRoots(ctx.projectPath, ctx.resolvedProviders);
+      try {
+        validateProviderInstallRoots(ctx.projectPath, ctx.resolvedProviders);
+      } catch (err: unknown) {
+        const message = err instanceof Error ? err.message : String(err);
+        raiseInstallError(ctx, message);
+      }
     },
   };
 }

--- a/src/cli/commands/install-tasks/verify-prerequisites.ts
+++ b/src/cli/commands/install-tasks/verify-prerequisites.ts
@@ -2,16 +2,28 @@ import type { Task } from '../../ui';
 import type { RequiredCommand } from '../../../types/capabilities';
 import type { InstallCtx } from './context';
 import { checkRequiredCommand } from './helpers/required-command';
+import { raiseInstallError } from './install-error-policy';
 
 export function verifyPrerequisitesTask(reqCmds: RequiredCommand[]): Task<InstallCtx> {
   return {
     title: 'Verifying prerequisites',
-    task: async (_ctx, task) => {
+    task: async (ctx, task) => {
       const total = reqCmds.length;
+      let missing = 0;
       for (let i = 0; i < total; i++) {
         const cmd = reqCmds[i];
         task.output = `[${i + 1}/${total}] ${cmd.cli}${cmd.description ? ` — ${cmd.description}` : ''}`;
-        await checkRequiredCommand(cmd);
+        try {
+          await checkRequiredCommand(cmd);
+        } catch (err: unknown) {
+          missing++;
+          const message = err instanceof Error ? err.message : String(err);
+          raiseInstallError(ctx, message);
+        }
+      }
+      if (missing > 0) {
+        task.title = `Verifying prerequisites — ${missing} of ${total} missing`;
+        return;
       }
       task.title = `Verified ${total} prerequisite${total === 1 ? '' : 's'}`;
     },

--- a/src/cli/commands/install.ts
+++ b/src/cli/commands/install.ts
@@ -15,6 +15,7 @@ import { buildInstallTasks } from './install-tasks';
 import type { InstallCtx, InstallOptions } from './install-tasks';
 import { refuseIfWrapWorkspace } from '../utils/wrap/marker';
 import { isUnderWrapWorkspacesDir } from '../../shared/workspaces/paths';
+import { confirmInstallExecution } from './install-confirm';
 
 export type { InstallOptions, GetRepoSnapshotFn } from './install-tasks';
 
@@ -40,6 +41,7 @@ export async function installCommand(
   let skipCredentialOpen = false;
   let passthrough = false;
   let persistProviders = true;
+  let dryRun = false;
   if (typeof envFileOrOptions === 'object' && envFileOrOptions !== null) {
     envFile = envFileOrOptions.envFile;
     flagProvider = envFileOrOptions.provider;
@@ -54,6 +56,7 @@ export async function installCommand(
     skipCredentialOpen = !!envFileOrOptions.skipCredentialOpen;
     passthrough = !!envFileOrOptions.passthrough;
     if (envFileOrOptions.persistProviders === false) persistProviders = false;
+    dryRun = !!envFileOrOptions.dryRun;
   } else {
     envFile = envFileOrOptions;
   }
@@ -66,6 +69,7 @@ export async function installCommand(
       noCache,
       projectPath,
       exitProcess,
+      dryRun,
     });
     return;
   }
@@ -83,6 +87,7 @@ export async function installCommand(
       skipPrerequisites,
       skipCredentialOpen,
       persistProviders,
+      dryRun,
       // Only refuse wrap cwd when the caller did not pass an explicit projectPath
       // (wrap itself always passes one).
       refuseWrapCwd:
@@ -106,6 +111,7 @@ async function installCommandBody(opts: {
   skipCredentialOpen: boolean;
   persistProviders: boolean;
   refuseWrapCwd: boolean;
+  dryRun: boolean;
 }): Promise<void> {
   const {
     envFile,
@@ -116,6 +122,7 @@ async function installCommandBody(opts: {
     skipCredentialOpen,
     persistProviders,
     refuseWrapCwd,
+    dryRun,
   } = opts;
   const projectPath = opts.projectPath;
   const identityPath = opts.identityPath;
@@ -148,6 +155,19 @@ async function installCommandBody(opts: {
 
   const reqCmds = capabilities.options?.requiresCommands;
   const projectId = generateProjectId(idPath);
+
+  try {
+    const decision = await confirmInstallExecution({
+      projectId,
+      capabilities,
+      dryRun,
+    });
+    if (decision === 'dry-run') return;
+  } catch (err: unknown) {
+    const message = err instanceof Error ? err.message : String(err);
+    failExit(message, exitProcess);
+  }
+
   const serverStatus = await ensureServer(VERSION);
 
   if (!serverStatus.running || !serverStatus.url) {

--- a/src/cli/commands/install.ts
+++ b/src/cli/commands/install.ts
@@ -16,6 +16,7 @@ import type { InstallCtx, InstallOptions } from './install-tasks';
 import { refuseIfWrapWorkspace } from '../utils/wrap/marker';
 import { isUnderWrapWorkspacesDir } from '../../shared/workspaces/paths';
 import { confirmInstallExecution } from './install-confirm';
+import { getInstallErrorMode } from './install-tasks/install-error-policy';
 
 export type { InstallOptions, GetRepoSnapshotFn } from './install-tasks';
 
@@ -230,6 +231,8 @@ async function installCommandBody(opts: {
     failExit(message, exitProcess);
   }
 
+  const installErrorMode = getInstallErrorMode(capabilities);
+
   // Hoisted so the catch block can surface ctx.errors accumulated before the throw.
   const initialCtx: InstallCtx = {
     projectPath,
@@ -254,12 +257,13 @@ async function installCommandBody(opts: {
     skipped: 0,
     warnings: [],
     errors: [],
+    installErrorMode,
   };
 
   try {
     const ctx = await runTasks(
       buildInstallTasks(reqCmds, { skipPrerequisites, skipCredentialOpen }),
-      { exitOnError: true },
+      { exitOnError: installErrorMode === 'stop' },
       initialCtx,
     );
 
@@ -280,9 +284,9 @@ async function installCommandBody(opts: {
       skipped: ctx.skipped,
       elapsedMs: Date.now() - startedAt,
     });
-    // Exit non-zero on accumulated per-task failures (continue-on-error mode).
-    if (initialCtx.failed > 0) {
-      failExit(`Install completed with ${initialCtx.failed} failure(s).`, exitProcess);
+    // Exit non-zero on accumulated failures only when configured to stop.
+    if (installErrorMode === 'stop' && ctx.failed > 0) {
+      failExit(`Install completed with ${ctx.failed} failure(s).`, exitProcess);
     }
   } catch (err: unknown) {
     for (const e of initialCtx.errors) error(e);
@@ -294,13 +298,19 @@ async function installCommandBody(opts: {
       elapsedMs: Date.now() - startedAt,
     });
     if (err instanceof Error) {
+      if (installErrorMode === 'warn') {
+        warn(err.message);
+        return;
+      }
       if (exitProcess) {
         console.error(`✗ ${err.message}`);
         process.exit(1);
       }
       throw err;
     }
-    throw err;
+    if (installErrorMode === 'stop') {
+      throw err;
+    }
   } finally {
     try {
       db.close();

--- a/src/cli/commands/plugin-install.ts
+++ b/src/cli/commands/plugin-install.ts
@@ -42,6 +42,15 @@ import type { LockfileBuilder } from '../../shared/lockfile';
 import type { LockPluginEntry } from '../../types/lockfile';
 import { copySkillTree } from '../../shared/skill-copy';
 
+/** Join a plugin subpath under a snapshot, rejecting `..` / absolute escapes. */
+export function resolvePluginManifestRoot(
+  snapshotDir: string,
+  subpath?: string | null,
+): string {
+  if (!subpath) return snapshotDir;
+  return assertSafeRepoPath(snapshotDir, subpath);
+}
+
 /** Map plugin provider id to capa provider id for hook scoping. */
 function pluginProviderToCapaId(provider: 'claude' | 'cursor'): string {
   return provider === 'claude' ? 'claude-code' : 'cursor';
@@ -341,13 +350,14 @@ export async function resolvePlugins(
           `    Tip: use \`subpath: <path>\` to pin an exact location, or @ to match either the directory name or the manifest's "name" field.`
         );
       }
-      manifestRoot = located.entry.subpath
-        ? join(snapshot.snapshotDir, located.entry.subpath)
-        : snapshot.snapshotDir;
+      manifestRoot = resolvePluginManifestRoot(
+        snapshot.snapshotDir,
+        located.entry.subpath,
+      );
       resolvedSubpath = located.entry.subpath;
       manifest = located.manifest;
     } else {
-      manifestRoot = subpath ? join(snapshot.snapshotDir, subpath) : snapshot.snapshotDir;
+      manifestRoot = resolvePluginManifestRoot(snapshot.snapshotDir, subpath);
       if (subpath && !existsSync(manifestRoot)) {
         throw new Error(`Plugin subpath not found: "${subpath}" in ${repoPath}`);
       }
@@ -363,9 +373,10 @@ export async function resolvePlugins(
           providers,
         );
         if (located) {
-          manifestRoot = located.entry.subpath
-            ? join(snapshot.snapshotDir, located.entry.subpath)
-            : snapshot.snapshotDir;
+          manifestRoot = resolvePluginManifestRoot(
+            snapshot.snapshotDir,
+            located.entry.subpath,
+          );
           resolvedSubpath = located.entry.subpath;
           manifest = located.manifest;
         }

--- a/src/cli/commands/registry.ts
+++ b/src/cli/commands/registry.ts
@@ -3,6 +3,8 @@ import { loadSettings, getDatabasePath, getManagedRegistriesDir } from '../../sh
 import { RegistryManager } from '../../shared/registries/manager';
 import {
   installRegistry,
+  stageRegistry,
+  executeStagedRegistry,
   removeInstalledAdapter,
   deriveSlug,
   isValidSlug,
@@ -10,11 +12,12 @@ import {
 import { createAuthenticatedFetch } from '../../shared/authenticated-fetch';
 import type { RegistrySourceType } from '../../types/database';
 import type { RegistryCapability, RegistryItemSummary } from '../../types/registry';
-import { runTasks, header, footer, success, info, warn, error, isJson, isVerbose, c, type Task } from '../ui';
+import { runTasks, header, footer, success, info, warn, error, isJson, isVerbose, c, prompt, setFlags, type Task } from '../ui';
 
 interface RegistryAddOptions {
   type?: RegistrySourceType;
   noCache?: boolean;
+  yes?: boolean;
 }
 
 function detectType(source: string, explicit?: RegistrySourceType): RegistrySourceType {
@@ -88,6 +91,19 @@ interface AddCtx {
   db: CapaDatabase;
   resolvedRef: string | null;
   manifestName: string;
+  contentSha256: string;
+  preview: string;
+}
+
+async function confirmAdapterExecution(source: string, contentSha256: string, preview: string): Promise<boolean> {
+  info(`Source: ${source}`);
+  info(`SHA-256: ${contentSha256}`);
+  const lines = preview.split('\n').slice(0, 20).join('\n');
+  info(`Preview:\n${lines}`);
+  return prompt.confirm(
+    'Execute this adapter in-process? This runs third-party TypeScript with your privileges.',
+    false,
+  );
 }
 
 export async function registryAddCommand(
@@ -95,6 +111,7 @@ export async function registryAddCommand(
   slugArg: string | undefined,
   options: RegistryAddOptions = {},
 ): Promise<void> {
+  if (options.yes) setFlags({ yes: true });
   const settings = await loadSettings();
   const db = new CapaDatabase(getDatabasePath(settings));
 
@@ -142,30 +159,15 @@ export async function registryAddCommand(
                 ? `fetching marketplace ${ctx.source}`
                 : `cloning ${ctx.source} from ${ctx.type}`;
           const authFetch = createAuthenticatedFetch(ctx.db);
-          const result = await installRegistry(
+          const staged = await stageRegistry(
             { slug: ctx.slug, type: ctx.type, source: ctx.source },
             authFetch,
             { noCache: ctx.noCache },
           );
-          ctx.resolvedRef = result.resolvedRef;
-          ctx.manifestName = result.manifest.name;
-          task.title = `Fetched "${result.manifest.name}"`;
-        },
-      },
-      {
-        title: 'Saving registry',
-        task: async (ctx, task) => {
-          ctx.db.upsertRegistry({
-            slug: ctx.slug,
-            type: ctx.type,
-            source: ctx.source,
-            status: 'installed',
-            enabled: true,
-            lastError: null,
-            resolvedRef: ctx.resolvedRef,
-            installedAt: Date.now(),
-          });
-          task.title = `Saved "${ctx.slug}"`;
+          ctx.resolvedRef = staged.resolvedRef;
+          ctx.contentSha256 = staged.contentSha256;
+          ctx.preview = staged.content;
+          task.title = `Staged ${ctx.slug} (${staged.contentSha256.slice(0, 12)}…)`;
         },
       },
     ];
@@ -178,13 +180,116 @@ export async function registryAddCommand(
       db,
       resolvedRef: null,
       manifestName: '',
+      contentSha256: '',
+      preview: '',
     };
 
     await runTasks(tasks, { exitOnError: true }, ctx);
 
+    let confirmed: boolean;
+    try {
+      confirmed = await confirmAdapterExecution(ctx.source, ctx.contentSha256, ctx.preview);
+    } catch (err: unknown) {
+      removeInstalledAdapter(ctx.slug);
+      throw err;
+    }
+    if (!confirmed) {
+      removeInstalledAdapter(ctx.slug);
+      throw new Error('Registry add cancelled.');
+    }
+
+    await runTasks(
+      [
+        {
+          title: 'Executing adapter',
+          task: async (c, task) => {
+            const executed = await executeStagedRegistry(c.slug, c.contentSha256);
+            c.manifestName = executed.manifest.name;
+            task.title = `Executed "${executed.manifest.name}"`;
+          },
+        },
+        {
+          title: 'Saving registry',
+          task: async (c, task) => {
+            c.db.upsertRegistry({
+              slug: c.slug,
+              type: c.type,
+              source: c.source,
+              status: 'installed',
+              enabled: true,
+              lastError: null,
+              resolvedRef: c.resolvedRef,
+              installedAt: Date.now(),
+              contentSha256: c.contentSha256,
+            });
+            task.title = `Saved "${c.slug}"`;
+          },
+        },
+      ],
+      { exitOnError: true },
+      ctx,
+    );
+
     success(`Registry "${ctx.slug}" added.`);
     info(`Use it with: capa add ${ctx.slug}:<item-id>`);
     footer(`Done in ${((Date.now() - startedAt) / 1000).toFixed(1)}s`);
+  } catch (err: unknown) {
+    const message = err instanceof Error ? err.message : String(err);
+    error(message);
+    process.exit(1);
+  } finally {
+    try { db.close(); } catch {}
+  }
+}
+
+export async function registryApproveCommand(slug: string, options: { yes?: boolean } = {}): Promise<void> {
+  if (options.yes) setFlags({ yes: true });
+  const settings = await loadSettings();
+  const db = new CapaDatabase(getDatabasePath(settings));
+  try {
+    const existing = db.getRegistry(slug);
+    if (!existing) {
+      error(`Registry "${slug}" not found.`);
+      process.exit(1);
+    }
+    header(`Approve registry "${slug}"`);
+    const { readFileSync } = await import('fs');
+    const { getInstalledAdapterPath, getInstalledMarketplacePath } = await import('../../shared/registries/installer');
+    const adapterPath = getInstalledAdapterPath(slug);
+    const marketplacePath = getInstalledMarketplacePath(slug);
+    const filePath = adapterPath ?? marketplacePath;
+    if (!filePath) {
+      error(`No staged adapter for "${slug}". Re-add it with capa registry add.`);
+      process.exit(1);
+    }
+    const preview = readFileSync(filePath, 'utf-8');
+    const contentSha256 = existing.contentSha256;
+    if (!contentSha256) {
+      error(`Registry "${slug}" has no pinned content hash. Re-add it with capa registry add.`);
+      process.exit(1);
+    }
+    let confirmed: boolean;
+    try {
+      confirmed = await confirmAdapterExecution(existing.source, contentSha256, preview);
+    } catch (err: unknown) {
+      throw err;
+    }
+    if (!confirmed) {
+      throw new Error('Registry approve cancelled.');
+    }
+    const executed = await executeStagedRegistry(slug, contentSha256);
+    db.upsertRegistry({
+      slug: existing.slug,
+      type: existing.type,
+      source: existing.source,
+      status: 'installed',
+      enabled: true,
+      lastError: null,
+      resolvedRef: existing.resolvedRef,
+      installedAt: Date.now(),
+      contentSha256,
+    });
+    success(`Registry "${slug}" approved (${executed.manifest.name}).`);
   } catch (err: unknown) {
     const message = err instanceof Error ? err.message : String(err);
     error(message);
@@ -242,6 +347,7 @@ interface RefreshCtx {
   db: CapaDatabase;
   resolvedRef: string | null;
   manifestName: string;
+  contentSha256: string;
 }
 
 export async function registryRefreshCommand(
@@ -276,6 +382,7 @@ export async function registryRefreshCommand(
             );
             ctx.resolvedRef = result.resolvedRef;
             ctx.manifestName = result.manifest.name;
+            ctx.contentSha256 = result.contentSha256;
             task.title = `Fetched "${result.manifest.name}"`;
           } catch (err: unknown) {
             const message = err instanceof Error ? err.message : String(err);
@@ -296,6 +403,7 @@ export async function registryRefreshCommand(
             lastError: null,
             resolvedRef: ctx.resolvedRef,
             installedAt: Date.now(),
+            contentSha256: ctx.contentSha256,
           });
           task.title = `Updated record for "${ctx.slug}"`;
         },
@@ -308,6 +416,7 @@ export async function registryRefreshCommand(
       db,
       resolvedRef: null,
       manifestName: '',
+      contentSha256: '',
     });
 
     success(`Registry "${slug}" refreshed.`);

--- a/src/cli/commands/registry.ts
+++ b/src/cli/commands/registry.ts
@@ -20,9 +20,27 @@ interface RegistryAddOptions {
   yes?: boolean;
 }
 
-function detectType(source: string, explicit?: RegistrySourceType): RegistrySourceType {
+/** Infer registry source type when `--type` is omitted. */
+export function detectRegistrySourceType(
+  source: string,
+  explicit?: RegistrySourceType,
+): RegistrySourceType {
   if (explicit) return explicit;
-  if (/^https?:\/\//i.test(source)) return 'url';
+  const trimmed = source.trim();
+  if (/^https?:\/\//i.test(trimmed)) {
+    try {
+      if (/marketplace\.json$/i.test(new URL(trimmed).pathname)) {
+        return 'claude-marketplace';
+      }
+    } catch {
+      /* fall through to url */
+    }
+    return 'url';
+  }
+  // Bare owner/repo (no @adapter or ::path) is a Claude marketplace locator.
+  if (/^[^/\s@:]+\/[^/\s@:]+$/i.test(trimmed)) {
+    return 'claude-marketplace';
+  }
   return 'github';
 }
 
@@ -73,7 +91,9 @@ export async function registryListCommand(): Promise<void> {
       console.log();
     }
 
-    console.log('Note: Registry adapters are executable TypeScript — only add sources you trust.');
+    console.log(
+      'Note: Registry adapters run executable TypeScript; Claude marketplaces are JSON catalogs only.',
+    );
   } finally {
     db.close();
   }
@@ -95,11 +115,22 @@ interface AddCtx {
   preview: string;
 }
 
-async function confirmAdapterExecution(source: string, contentSha256: string, preview: string): Promise<boolean> {
+async function confirmRegistryInstall(
+  type: RegistrySourceType,
+  source: string,
+  contentSha256: string,
+  preview: string,
+): Promise<boolean> {
   info(`Source: ${source}`);
   info(`SHA-256: ${contentSha256}`);
   const lines = preview.split('\n').slice(0, 20).join('\n');
   info(`Preview:\n${lines}`);
+  if (type === 'claude-marketplace') {
+    return prompt.confirm(
+      'Install this Claude marketplace catalog? This only stores JSON plugin metadata — no executable adapter code runs.',
+      true,
+    );
+  }
   return prompt.confirm(
     'Execute this adapter in-process? This runs third-party TypeScript with your privileges.',
     true,
@@ -117,7 +148,7 @@ export async function registryAddCommand(
 
   header('Add registry');
   const startedAt = Date.now();
-  const type = detectType(source, options.type);
+  const type = detectRegistrySourceType(source, options.type);
   let slug = slugArg;
 
   try {
@@ -188,7 +219,12 @@ export async function registryAddCommand(
 
     let confirmed: boolean;
     try {
-      confirmed = await confirmAdapterExecution(ctx.source, ctx.contentSha256, ctx.preview);
+      confirmed = await confirmRegistryInstall(
+        ctx.type,
+        ctx.source,
+        ctx.contentSha256,
+        ctx.preview,
+      );
     } catch (err: unknown) {
       removeInstalledAdapter(ctx.slug);
       throw err;
@@ -270,7 +306,12 @@ export async function registryApproveCommand(slug: string, options: { yes?: bool
     }
     let confirmed: boolean;
     try {
-      confirmed = await confirmAdapterExecution(existing.source, contentSha256, preview);
+      confirmed = await confirmRegistryInstall(
+        existing.type,
+        existing.source,
+        contentSha256,
+        preview,
+      );
     } catch (err: unknown) {
       throw err;
     }

--- a/src/cli/commands/registry.ts
+++ b/src/cli/commands/registry.ts
@@ -102,7 +102,7 @@ async function confirmAdapterExecution(source: string, contentSha256: string, pr
   info(`Preview:\n${lines}`);
   return prompt.confirm(
     'Execute this adapter in-process? This runs third-party TypeScript with your privileges.',
-    false,
+    true,
   );
 }
 

--- a/src/cli/commands/sh.ts
+++ b/src/cli/commands/sh.ts
@@ -1,3 +1,3 @@
 export { shellCommand } from './sh/index';
-export { parseShellGlobalFlags, parseInlineArgs, coerceValue, resolveArgs } from './sh/args';
+export { parseShellGlobalFlags, parseInlineArgs, coerceValue, resolveArgs, classifyUnknownCommand } from './sh/args';
 export type { ShellCommand } from './sh/registry';

--- a/src/cli/commands/sh/args.ts
+++ b/src/cli/commands/sh/args.ts
@@ -17,17 +17,45 @@ export function buildArgSlugs(inputSchema: any): Map<string, string> {
  * `capa sh db query --raw`). All occurrences are removed; remaining tokens are
  * dispatched as the command/args.
  */
-export function parseShellGlobalFlags(args: string[]): { rawMode: boolean; tokens: string[] } {
+export function parseShellGlobalFlags(args: string[]): {
+  rawMode: boolean;
+  execMode: boolean;
+  tokens: string[];
+} {
   let rawMode = false;
+  let execMode = false;
   const tokens: string[] = [];
-  for (const arg of args) {
+  for (let i = 0; i < args.length; i++) {
+    const arg = args[i];
     if (arg === '--raw') {
       rawMode = true;
       continue;
     }
+    if (arg === '--exec') {
+      execMode = true;
+      continue;
+    }
+    if (arg === '--' && execMode) {
+      tokens.push(...args.slice(i + 1));
+      break;
+    }
     tokens.push(arg);
   }
-  return { rawMode, tokens };
+  return { rawMode, execMode, tokens };
+}
+
+/**
+ * Unknown `capa sh` tokens must not fall through to /bin/sh -c.
+ * `--exec` is an explicit, unrestricted argv spawn (not a joined shell string).
+ */
+export function classifyUnknownCommand(
+  tokens: string[],
+  execMode: boolean,
+): { kind: 'reject' } | { kind: 'exec'; argv: string[] } {
+  if (execMode && tokens.length > 0) {
+    return { kind: 'exec', argv: tokens };
+  }
+  return { kind: 'reject' };
 }
 
 export function parseInlineArgs(tokens: string[]): Record<string, string> {

--- a/src/cli/commands/sh/fetch.ts
+++ b/src/cli/commands/sh/fetch.ts
@@ -10,9 +10,11 @@ import {
 } from '../../../server/tool-call-tracer';
 import type { ShellCommand, ShellToolInfo } from './registry';
 import { buildArgSlugs } from './args';
+import { localApiHeaders } from '../../utils/local-api';
 
 async function fetchShellTools(serverUrl: string, projectId: string): Promise<ShellToolInfo[]> {
   const response = await fetch(`${serverUrl}/api/projects/${projectId}/shell-tools`, {
+    headers: localApiHeaders(),
     signal: AbortSignal.timeout(10000),
   });
   if (!response.ok) {
@@ -72,10 +74,10 @@ async function ensureProjectConfigured(
 
   const response = await fetch(`${serverUrl}/api/projects/${encodeURIComponent(projectId)}/configure`, {
     method: 'POST',
-    headers: {
+    headers: localApiHeaders({
       'Content-Type': 'application/json',
       Accept: 'application/json',
-    },
+    }),
     body: JSON.stringify(capabilities),
     signal: AbortSignal.timeout(120000),
   });
@@ -114,7 +116,7 @@ async function fetchToolSchema(
 ): Promise<{ description: string; inputSchema: any }> {
   const response = await fetch(
     `${serverUrl}/api/projects/${projectId}/shell-tool-schema?tool=${encodeURIComponent(toolId)}`,
-    { signal: AbortSignal.timeout(20000) }
+    { headers: localApiHeaders(), signal: AbortSignal.timeout(20000) },
   );
   if (!response.ok) {
     const body = await response.json().catch(() => null) as { error?: string } | null;

--- a/src/cli/commands/sh/fetch.ts
+++ b/src/cli/commands/sh/fetch.ts
@@ -1,5 +1,6 @@
 import { resolve } from 'path';
 import { getDatabasePath, loadSettings } from '../../../shared/config';
+import { trustStdioServers } from '../../../shared/stdio-allowlist';
 import { CapaDatabase } from '../../../db/database';
 import type { Capabilities } from '../../../types/capabilities';
 import { isUnderWrapWorkspacesDir } from '../../../shared/workspaces/paths';
@@ -71,6 +72,8 @@ async function ensureProjectConfigured(
   } finally {
     db.close();
   }
+
+  trustStdioServers(projectId, capabilities.servers ?? []);
 
   const response = await fetch(`${serverUrl}/api/projects/${encodeURIComponent(projectId)}/configure`, {
     method: 'POST',

--- a/src/cli/commands/sh/index.ts
+++ b/src/cli/commands/sh/index.ts
@@ -3,29 +3,26 @@ import { parseCapabilitiesFile } from '../../../shared/capabilities';
 import { getServerStatus } from '../../utils/server-manager';
 import { resolveProjectIdentityPath } from '../../utils/wrap/marker';
 import { slugify } from '../../../shared/slug';
-import { parseShellGlobalFlags, parseInlineArgs, resolveArgs } from './args';
+import { parseShellGlobalFlags, parseInlineArgs, resolveArgs, classifyUnknownCommand } from './args';
 import { ShellRegistry, applyLocalMetadata } from './registry';
 import type { ShellCommand } from './registry';
 import { fetchShellToolsWithConfigure, ensureSchema, executeToolViaMCP } from './fetch';
 import { printAvailableCommands, printGroupHelp, printCommandHelp, buildArgList } from './help';
 
-async function runPassthrough(tokens: string[]): Promise<void> {
-  if (process.env.CAPA_NO_SHELL_WARN !== '1') {
-    console.warn('capa: running OS shell passthrough. Set CAPA_NO_SHELL_WARN=1 to suppress.');
-  }
-  const command = tokens.join(' ');
-  const isWindows = process.platform === 'win32';
-  const shell = isWindows ? 'cmd.exe' : '/bin/sh';
-  const shellFlag = isWindows ? '/C' : '-c';
-
-  const proc = Bun.spawn([shell, shellFlag, command], {
+/**
+ * Explicit unrestricted spawn. Sub-agent tool filtering is a token-budget /
+ * UX feature, not a security boundary — `--exec` is trivially deniable in
+ * agent allow-lists.
+ */
+async function runExec(argv: string[]): Promise<void> {
+  const proc = Bun.spawn(argv, {
     cwd: process.cwd(),
     stdout: 'inherit',
     stderr: 'inherit',
     stdin: 'inherit',
   });
-
-  await proc.exited;
+  const code = await proc.exited;
+  if (code !== 0) process.exit(code ?? 1);
 }
 
 async function execCommand(
@@ -104,7 +101,8 @@ async function dispatch(
   registry: ShellRegistry,
   serverUrl: string,
   projectId: string,
-  rawMode = false
+  rawMode = false,
+  execMode = false,
 ): Promise<void> {
   if (tokens.length === 0) {
     printAvailableCommands(registry);
@@ -164,8 +162,15 @@ async function dispatch(
     return;
   }
 
-  // Unknown — pass through to OS shell (including any --help flags)
-  await runPassthrough(tokens);
+  // Unknown first token: never fall through to an OS shell.
+  const unknown = classifyUnknownCommand(tokens, execMode);
+  if (unknown.kind === 'exec') {
+    await runExec(unknown.argv);
+    return;
+  }
+  console.error(`No such tool: "${first}"`);
+  console.error('Use `capa sh --help` to list tools, or `capa sh --exec -- <cmd>` for an unrestricted spawn.');
+  process.exit(1);
 }
 
 export async function shellCommand(args: string[]): Promise<void> {
@@ -213,7 +218,7 @@ export async function shellCommand(args: string[]): Promise<void> {
   const registry = new ShellRegistry();
   registry.build(tools);
 
-  const { rawMode, tokens } = parseShellGlobalFlags(args);
+  const { rawMode, execMode, tokens } = parseShellGlobalFlags(args);
 
-  await dispatch(tokens, registry, serverUrl, projectId, rawMode);
+  await dispatch(tokens, registry, serverUrl, projectId, rawMode, execMode);
 }

--- a/src/cli/commands/upgrade-plan.ts
+++ b/src/cli/commands/upgrade-plan.ts
@@ -158,14 +158,34 @@ export async function planUpgrade(
   };
 }
 
+const GITHUB_FETCH_HOSTS = new Set(["api.github.com", "github.com"]);
+
+export function githubFetchHeaders(url: string): Record<string, string> {
+  let parsed: URL;
+  try {
+    parsed = new URL(url);
+  } catch {
+    throw new Error(`invalid upgrade URL: ${url}`);
+  }
+  if (parsed.protocol !== "https:") {
+    throw new Error(`refusing non-https upgrade URL: ${url}`);
+  }
+  const host = parsed.hostname.toLowerCase();
+  if (!GITHUB_FETCH_HOSTS.has(host)) {
+    throw new Error(`refusing unexpected upgrade host: ${host}`);
+  }
+  return {
+    Accept:
+      host === "api.github.com"
+        ? "application/vnd.github+json"
+        : "application/octet-stream",
+    "User-Agent": "capa-upgrade",
+  };
+}
+
 export async function githubFetchText(url: string): Promise<string> {
   const res = await fetch(url, {
-    headers: {
-      Accept: url.includes('api.github.com')
-        ? 'application/vnd.github+json'
-        : 'text/plain',
-      'User-Agent': 'capa-upgrade',
-    },
+    headers: githubFetchHeaders(url),
   });
   if (!res.ok) {
     throw new Error(`Failed to fetch ${url}: HTTP ${res.status}`);
@@ -175,10 +195,7 @@ export async function githubFetchText(url: string): Promise<string> {
 
 export async function githubFetchBytes(url: string): Promise<Uint8Array> {
   const res = await fetch(url, {
-    headers: {
-      Accept: 'application/octet-stream',
-      'User-Agent': 'capa-upgrade',
-    },
+    headers: githubFetchHeaders(url),
   });
   if (!res.ok) {
     throw new Error(`Failed to fetch ${url}: HTTP ${res.status}`);

--- a/src/cli/commands/upgrade-plan.ts
+++ b/src/cli/commands/upgrade-plan.ts
@@ -1,0 +1,187 @@
+import { createHash } from 'crypto';
+
+export const GITHUB_REPO = 'infragate/capa';
+export const CHECKSUMS_ASSET = 'SHA256SUMS.txt';
+export const LATEST_RELEASE_API = `https://api.github.com/repos/${GITHUB_REPO}/releases/latest`;
+
+export type InstallerAsset = 'install.sh' | 'install.ps1';
+
+export interface UpgradePlan {
+  tag: string;
+  version: string;
+  installerAsset: InstallerAsset;
+  installerUrl: string;
+  installerDigest: string;
+  checksumsUrl: string;
+  binaryAsset: string;
+  binaryDigest: string;
+}
+
+export interface PlanUpgradeOptions {
+  fetchText: (url: string) => Promise<string>;
+  platform?: NodeJS.Platform | string;
+  arch?: string;
+}
+
+export function normalizeReleaseTag(tag: string): string {
+  const trimmed = tag.trim();
+  if (!trimmed) {
+    throw new Error('release tag is empty');
+  }
+  return trimmed.startsWith('v') ? trimmed : `v${trimmed}`;
+}
+
+export function githubReleaseAssetUrl(tag: string, asset: string): string {
+  return `https://github.com/${GITHUB_REPO}/releases/download/${normalizeReleaseTag(tag)}/${asset}`;
+}
+
+export function installerAssetFor(platform: string): InstallerAsset {
+  return platform === 'win32' ? 'install.ps1' : 'install.sh';
+}
+
+export function binaryAssetFor(platform: string, arch: string): string {
+  const cpu =
+    arch === 'x64' || arch === 'x86_64' || arch === 'amd64'
+      ? 'x86_64'
+      : arch === 'arm64' || arch === 'aarch64'
+        ? 'aarch64'
+        : arch === 'ia32' || arch === 'x86' || arch === 'i686'
+          ? 'i686'
+          : arch;
+
+  if (platform === 'win32') {
+    const winCpu = cpu === 'aarch64' ? 'x86_64' : cpu;
+    return `capa-${winCpu}-pc-windows-msvc.exe`;
+  }
+
+  const os = platform === 'darwin' ? 'apple-darwin' : 'unknown-linux-gnu';
+  return `capa-${cpu}-${os}`;
+}
+
+export function parseSha256Sums(text: string): Map<string, string> {
+  const map = new Map<string, string>();
+  for (const raw of text.split(/\r?\n/)) {
+    const line = raw.trim();
+    if (!line || line.startsWith('#')) continue;
+    const match = line.match(/^([a-fA-F0-9]{64})\s+\*?(\S+)\s*$/);
+    if (!match) continue;
+    map.set(match[2], match[1].toLowerCase());
+  }
+  return map;
+}
+
+export function sha256Hex(data: string | Uint8Array): string {
+  return createHash('sha256').update(data).digest('hex');
+}
+
+export function assertSha256Match(
+  actual: string,
+  expected: string,
+  label: string,
+): void {
+  if (actual.toLowerCase() !== expected.toLowerCase()) {
+    throw new Error(
+      `checksum mismatch for ${label}: expected ${expected}, got ${actual}`,
+    );
+  }
+}
+
+export function formatUpgradePreview(plan: UpgradePlan): string {
+  return [
+    `Version: ${plan.version} (${plan.tag})`,
+    `Installer: ${plan.installerAsset}`,
+    `URL: ${plan.installerUrl}`,
+    `SHA256: ${plan.installerDigest}`,
+    `Binary: ${plan.binaryAsset}`,
+    `Binary SHA256: ${plan.binaryDigest}`,
+  ].join('\n');
+}
+
+export function upgradeConfirmationState(opts: {
+  yes: boolean;
+  interactive: boolean;
+}): 'proceed' | 'prompt' {
+  if (opts.yes) return 'proceed';
+  if (!opts.interactive) {
+    throw new Error(
+      'capa upgrade requires confirmation. Re-run with --yes in non-interactive / CI environments.',
+    );
+  }
+  return 'prompt';
+}
+
+function requiredDigest(
+  sums: Map<string, string>,
+  filename: string,
+): string {
+  const digest = sums.get(filename);
+  if (!digest) {
+    throw new Error(`no checksum found for ${filename} in ${CHECKSUMS_ASSET}`);
+  }
+  return digest;
+}
+
+export async function planUpgrade(
+  opts: PlanUpgradeOptions,
+): Promise<UpgradePlan> {
+  const platform = opts.platform ?? process.platform;
+  const arch = opts.arch ?? process.arch;
+  const latestBody = await opts.fetchText(LATEST_RELEASE_API);
+  let tagName: string | undefined;
+  try {
+    const parsed = JSON.parse(latestBody) as { tag_name?: string };
+    tagName = parsed.tag_name;
+  } catch {
+    throw new Error('GitHub latest-release response was not valid JSON');
+  }
+  if (!tagName) {
+    throw new Error('GitHub latest-release response did not include tag_name');
+  }
+
+  const tag = normalizeReleaseTag(tagName);
+  const version = tag.replace(/^v/, '');
+  const installerAsset = installerAssetFor(platform);
+  const binaryAsset = binaryAssetFor(platform, arch);
+  const checksumsUrl = githubReleaseAssetUrl(tag, CHECKSUMS_ASSET);
+  const installerUrl = githubReleaseAssetUrl(tag, installerAsset);
+  const sums = parseSha256Sums(await opts.fetchText(checksumsUrl));
+
+  return {
+    tag,
+    version,
+    installerAsset,
+    installerUrl,
+    installerDigest: requiredDigest(sums, installerAsset),
+    checksumsUrl,
+    binaryAsset,
+    binaryDigest: requiredDigest(sums, binaryAsset),
+  };
+}
+
+export async function githubFetchText(url: string): Promise<string> {
+  const res = await fetch(url, {
+    headers: {
+      Accept: url.includes('api.github.com')
+        ? 'application/vnd.github+json'
+        : 'text/plain',
+      'User-Agent': 'capa-upgrade',
+    },
+  });
+  if (!res.ok) {
+    throw new Error(`Failed to fetch ${url}: HTTP ${res.status}`);
+  }
+  return await res.text();
+}
+
+export async function githubFetchBytes(url: string): Promise<Uint8Array> {
+  const res = await fetch(url, {
+    headers: {
+      Accept: 'application/octet-stream',
+      'User-Agent': 'capa-upgrade',
+    },
+  });
+  if (!res.ok) {
+    throw new Error(`Failed to fetch ${url}: HTTP ${res.status}`);
+  }
+  return new Uint8Array(await res.arrayBuffer());
+}

--- a/src/cli/commands/upgrade.ts
+++ b/src/cli/commands/upgrade.ts
@@ -1,99 +1,133 @@
+import { chmodSync, mkdtempSync, writeFileSync } from 'fs';
+import { tmpdir } from 'os';
+import { join } from 'path';
 import { getServerStatus, stopServer } from '../utils/server-manager';
-import { header, footer, success, info, error, runTasks } from '../ui';
-import type { Task } from '../ui';
-
-const INSTALL_SH_URL = 'https://capa.infragate.ai/install.sh';
-const INSTALL_PS1_URL = 'https://capa.infragate.ai/install.ps1';
+import {
+  header,
+  footer,
+  success,
+  info,
+  error,
+  isYes,
+  isInteractive,
+  prompt,
+} from '../ui';
+import {
+  assertSha256Match,
+  formatUpgradePreview,
+  githubFetchBytes,
+  githubFetchText,
+  planUpgrade,
+  sha256Hex,
+  upgradeConfirmationState,
+  type UpgradePlan,
+} from './upgrade-plan';
 
 export async function upgradeCommand(): Promise<void> {
   header('Upgrade capa');
 
-  const tasks: Task[] = [
-    {
-      title: 'Stop running server',
-      task: async () => {
-        const status = await getServerStatus();
-        if (status.running) {
-          await stopServer();
-        }
-      },
-    },
-    {
-      title:
-        process.platform === 'win32'
-          ? 'Start Windows installer'
-          : 'Run installation script',
-      task: async () => {
-        if (process.platform === 'win32') {
-          await runWindowsInstaller();
-        } else {
-          await runUnixInstaller();
-        }
-      },
-    },
-  ];
-
-  await runTasks(tasks);
-  footer('Upgrade complete');
-}
-
-async function runWindowsInstaller(): Promise<void> {
-  const proc = Bun.spawn(
-    [
-      'powershell.exe',
-      '-ExecutionPolicy',
-      'Bypass',
-      '-NoProfile',
-      '-Command',
-      `irm '${INSTALL_PS1_URL}' | iex`,
-    ],
-    {
-      stdout: 'ignore',
-      stderr: 'ignore',
-      stdin: 'ignore',
-      detached: true,
-      env: { ...process.env },
-    },
-  );
-  proc.unref();
-
-  success(
-    'Installer started. This window will close; the installer will update capa in the background.',
-  );
-  info('Restart your terminal when the installer finishes, then run `capa --version` to confirm.');
-  process.exit(0);
-}
-
-async function runUnixInstaller(): Promise<void> {
-  const hasCurl = await commandExists('curl');
-  const cmd = hasCurl
-    ? `curl -fsSL '${INSTALL_SH_URL}' | sh`
-    : `wget -qO- '${INSTALL_SH_URL}' | sh`;
-
-  if (!hasCurl && !(await commandExists('wget'))) {
-    error('Neither curl nor wget is available. Please install one and try again.');
-    error(`Or run the installation script manually: ${INSTALL_SH_URL}`);
+  let plan: UpgradePlan;
+  try {
+    plan = await planUpgrade({ fetchText: githubFetchText });
+  } catch (err) {
+    error(err instanceof Error ? err.message : String(err));
     process.exit(1);
   }
 
-  const proc = Bun.spawn(['sh', '-c', cmd], {
+  for (const line of formatUpgradePreview(plan).split('\n')) {
+    info(line);
+  }
+
+  try {
+    const decision = upgradeConfirmationState({
+      yes: isYes(),
+      interactive: isInteractive(),
+    });
+    if (decision === 'prompt') {
+      const ok = await prompt.confirm(
+        'Download and run this verified installer?',
+        false,
+      );
+      if (!ok) {
+        error('Upgrade cancelled.');
+        process.exit(1);
+      }
+    }
+  } catch (err) {
+    error(err instanceof Error ? err.message : String(err));
+    process.exit(1);
+  }
+
+  let installerBytes: Uint8Array;
+  try {
+    installerBytes = await githubFetchBytes(plan.installerUrl);
+    assertSha256Match(
+      sha256Hex(installerBytes),
+      plan.installerDigest,
+      plan.installerAsset,
+    );
+  } catch (err) {
+    error(err instanceof Error ? err.message : String(err));
+    process.exit(1);
+  }
+
+  const status = await getServerStatus();
+  if (status.running) {
+    info('Stopping running server…');
+    await stopServer();
+  }
+
+  const dir = mkdtempSync(join(tmpdir(), 'capa-upgrade-'));
+  const installerPath = join(dir, plan.installerAsset);
+  writeFileSync(installerPath, installerBytes);
+  if (process.platform !== 'win32') {
+    chmodSync(installerPath, 0o755);
+  }
+
+  const env = {
+    ...process.env,
+    CAPA_VERSION: plan.version,
+  };
+
+  if (process.platform === 'win32') {
+    const proc = Bun.spawn(
+      [
+        'powershell.exe',
+        '-NoProfile',
+        '-ExecutionPolicy',
+        'Bypass',
+        '-File',
+        installerPath,
+      ],
+      {
+        stdout: 'ignore',
+        stderr: 'ignore',
+        stdin: 'ignore',
+        detached: true,
+        env,
+      },
+    );
+    proc.unref();
+    success(
+      'Verified installer started. This window will close; capa will update in the background.',
+    );
+    info(
+      'Restart your terminal when the installer finishes, then run `capa --version` to confirm.',
+    );
+    process.exit(0);
+  }
+
+  const proc = Bun.spawn(['bash', installerPath], {
     stdout: 'inherit',
     stderr: 'inherit',
     stdin: 'inherit',
+    env,
   });
-
   const exitCode = await proc.exited;
   if (exitCode !== 0) {
     error('Upgrade failed');
     process.exit(exitCode ?? 1);
   }
-}
 
-async function commandExists(cmd: string): Promise<boolean> {
-  try {
-    const proc = Bun.spawn(['which', cmd], { stdout: 'pipe', stderr: 'pipe' });
-    return (await proc.exited) === 0;
-  } catch {
-    return false;
-  }
+  footer('Upgrade complete');
 }

--- a/src/cli/commands/upgrade.ts
+++ b/src/cli/commands/upgrade.ts
@@ -79,7 +79,7 @@ export async function upgradeCommand(): Promise<void> {
 
   const dir = mkdtempSync(join(tmpdir(), 'capa-upgrade-'));
   const installerPath = join(dir, plan.installerAsset);
-  writeFileSync(installerPath, installerBytes);
+  writeFileSync(installerPath, Buffer.from(installerBytes));
   if (process.platform !== 'win32') {
     chmodSync(installerPath, 0o755);
   }

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -18,6 +18,7 @@ import {
   registryListCommand,
   registryPathCommand,
   registryAddCommand,
+  registryApproveCommand,
   registryRemoveCommand,
   registryRefreshCommand,
   registrySetEnabledCommand,
@@ -351,7 +352,8 @@ if (process.argv[2] === '__server__') {
         'Source type: github, gitlab, url, or claude-marketplace (auto-detected from source by default)',
       )
       .option('--no-cache', 'Bypass the on-disk repo cache when fetching')
-      .action(async (source: string, slug: string | undefined, opts: { type?: string; cache?: boolean }) => {
+      .option('-y, --yes', 'Skip confirmation (required in non-interactive / CI)')
+      .action(async (source: string, slug: string | undefined, opts: { type?: string; cache?: boolean; yes?: boolean }) => {
         let type: RegistrySourceType | undefined;
         if (opts.type) {
           if (
@@ -367,7 +369,15 @@ if (process.argv[2] === '__server__') {
           }
           type = opts.type;
         }
-        await registryAddCommand(source, slug, { type, noCache: opts.cache === false });
+        await registryAddCommand(source, slug, { type, noCache: opts.cache === false, yes: !!opts.yes });
+      });
+
+    registryCmd
+      .command('approve <slug>')
+      .description('Execute a pending staged registry adapter after reviewing it')
+      .option('-y, --yes', 'Skip confirmation (required in non-interactive / CI)')
+      .action(async (slug: string, opts: { yes?: boolean }) => {
+        await registryApproveCommand(slug, { yes: !!opts.yes });
       });
 
     registryCmd

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -188,14 +188,18 @@ if (process.argv[2] === '__server__') {
       .option('-p, --provider <id>', 'Install for a single provider (e.g. "cursor", "claude-code")')
       .option('--no-cache', 'Bypass the on-disk cache and lockfile; re-resolve every remote source')
       .option('--passthrough', 'Write provider-native files from the capabilities file (no capa server/proxy)')
+      .option('--dry-run', 'Print the executable surface and exit without installing')
+      .option('-y, --yes', 'Skip confirmation (required in non-interactive / CI)')
       .action(async (options) => {
         // Commander inverts --no-* flags: `options.cache` is true by default and
         // false when --no-cache is passed. Convert to the explicit noCache flag.
+        if (options.yes) setFlags({ yes: true });
         await installCommand({
           envFile: options.env,
           provider: options.provider,
           noCache: options.cache === false,
           passthrough: options.passthrough === true,
+          dryRun: options.dryRun === true,
         });
       });
 

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -352,7 +352,9 @@ if (process.argv[2] === '__server__') {
 
     registryCmd
       .command('add <source> [slug]')
-      .description('Fetch a registry adapter from a git repo or HTTPS URL and install it')
+      .description(
+        'Add a registry adapter (git/HTTPS) or Claude marketplace (owner/repo) and install it',
+      )
       .option(
         '--type <type>',
         'Source type: github, gitlab, url, or claude-marketplace (auto-detected from source by default)',

--- a/src/cli/index.ts
+++ b/src/cli/index.ts
@@ -279,7 +279,9 @@ if (process.argv[2] === '__server__') {
     program
       .command('upgrade')
       .description('Upgrade capa to the latest version')
-      .action(async () => {
+      .option('-y, --yes', 'Skip confirmation (required in non-interactive / CI)')
+      .action(async (options: { yes?: boolean }) => {
+        if (options.yes) setFlags({ yes: true });
         await upgradeCommand();
       });
 

--- a/src/cli/ui/__tests__/flags.test.ts
+++ b/src/cli/ui/__tests__/flags.test.ts
@@ -1,0 +1,22 @@
+import { describe, it, expect, afterEach } from 'bun:test';
+import { getFlags, isHeadless, setFlags } from '../flags';
+
+describe('cli flags', () => {
+  afterEach(() => {
+    setFlags({
+      json: false,
+      quiet: false,
+      verbose: false,
+      noColor: false,
+      yes: false,
+      headless: false,
+    });
+  });
+
+  it('isHeadless reflects --headless', () => {
+    expect(isHeadless()).toBe(false);
+    setFlags({ headless: true });
+    expect(isHeadless()).toBe(true);
+    expect(getFlags().headless).toBe(true);
+  });
+});

--- a/src/cli/ui/__tests__/tasks.test.ts
+++ b/src/cli/ui/__tests__/tasks.test.ts
@@ -95,4 +95,21 @@ describe('runTasks (--headless)', () => {
     expect(output).toContain(AUTH_URL);
     expect(output).not.toContain(ERASE_SPINNER_LINES);
   });
+
+  it('uses linear output instead of the clack spinner when --headless is set', async () => {
+    restore.push(setIsTTY(process.stdin, true), setIsTTY(process.stdout, true));
+    delete process.env.CI;
+    setFlags({ headless: true });
+
+    const output = await captureStdio(async () => {
+      await runTasks([
+        { title: 'First step', task: async () => {} },
+        { title: 'Second step', task: async () => {} },
+      ]);
+    });
+
+    expect(output).toContain('❯ First step');
+    expect(output).toContain('✔ First step');
+    expect(output).not.toContain(ERASE_SPINNER_LINES);
+  });
 });

--- a/src/cli/utils/__tests__/hooks-installer.test.ts
+++ b/src/cli/utils/__tests__/hooks-installer.test.ts
@@ -1,4 +1,5 @@
 import { describe, it, expect, beforeEach, afterEach } from 'bun:test';
+import { createHash } from 'crypto';
 import {
   existsSync,
   mkdtempSync,
@@ -10,14 +11,17 @@ import { join } from 'path';
 import { tmpdir } from 'os';
 import { CapaDatabase } from '../../../db/database';
 import { installHooks, pruneOrphanHooks, cleanHooks } from '../hooks-installer';
-import { LockfileBuilder } from '../../../shared/lockfile';
+import { emptyLockfile, LockfileBuilder } from '../../../shared/lockfile';
 import type { Hook } from '../../../types/hooks';
 import type { AuthenticatedFetch } from '../../../shared/authenticated-fetch';
 import type { GetSnapshotResult } from '../../../shared/cache';
 
-function makeAuthFetch(): AuthenticatedFetch {
+const REMOTE_HOOK_BODY = 'echo from-remote\n';
+const REMOTE_HOOK_SHA256 = createHash('sha256').update(REMOTE_HOOK_BODY, 'utf8').digest('hex');
+
+function makeAuthFetch(body = REMOTE_HOOK_BODY): AuthenticatedFetch {
   return {
-    fetch: async () => new Response('echo from-remote\n', { status: 200, headers: { 'Content-Type': 'text/plain' } }),
+    fetch: async () => new Response(body, { status: 200, headers: { 'Content-Type': 'text/plain' } }),
     hasAuth: () => false,
   } as unknown as AuthenticatedFetch;
 }
@@ -287,7 +291,7 @@ describe('hooks-installer (claude inline-config)', () => {
         {
           id: 'remote-hook',
           on: 'beforeShell',
-          source: { type: 'remote', url: 'https://example.com/hook.sh' },
+          source: { type: 'remote', url: 'https://8.8.8.8/hook.sh' },
         },
       ],
       providers: ['claude-code'],
@@ -301,8 +305,105 @@ describe('hooks-installer (claude inline-config)', () => {
     expect(lock.hooks).toHaveLength(1);
     expect(lock.hooks[0].id).toBe('remote-hook');
     expect(lock.hooks[0].source).toBe('remote');
-    expect(lock.hooks[0].url).toBe('https://example.com/hook.sh');
-    expect(lock.hooks[0].bodySha256).toMatch(/^[a-f0-9]{64}$/);
+    expect(lock.hooks[0].url).toBe('https://8.8.8.8/hook.sh');
+    expect(lock.hooks[0].bodySha256).toBe(REMOTE_HOOK_SHA256);
+  });
+
+  it('rejects HTTP remote hook URLs at install time', async () => {
+    await expect(
+      installHooks({
+        projectPath,
+        projectId,
+        capabilitiesFilePath: join(projectPath, 'capabilities.yaml'),
+        hooks: [
+          {
+            id: 'http-hook',
+            on: 'beforeShell',
+            source: { type: 'remote', url: 'http://example.com/hook.sh' },
+          },
+        ],
+        providers: ['claude-code'],
+        db,
+        authFetch: makeAuthFetch(),
+        getRepoSnapshot: stubGetRepoSnapshot,
+      }),
+    ).rejects.toThrow(/https/i);
+  });
+
+  it('rejects private and metadata HTTPS hook URLs at install time', async () => {
+    await expect(
+      installHooks({
+        projectPath,
+        projectId,
+        capabilitiesFilePath: join(projectPath, 'capabilities.yaml'),
+        hooks: [
+          {
+            id: 'ssrf-hook',
+            on: 'beforeShell',
+            source: { type: 'remote', url: 'https://10.0.0.9/hook.sh' },
+          },
+        ],
+        providers: ['claude-code'],
+        db,
+        authFetch: makeAuthFetch(),
+        getRepoSnapshot: stubGetRepoSnapshot,
+      }),
+    ).rejects.toThrow(/not allowed/i);
+
+    await expect(
+      installHooks({
+        projectPath,
+        projectId,
+        capabilitiesFilePath: join(projectPath, 'capabilities.yaml'),
+        hooks: [
+          {
+            id: 'metadata-hook',
+            on: 'beforeShell',
+            source: { type: 'remote', url: 'https://169.254.169.254/latest/meta-data/' },
+          },
+        ],
+        providers: ['claude-code'],
+        db,
+        authFetch: makeAuthFetch(),
+        getRepoSnapshot: stubGetRepoSnapshot,
+      }),
+    ).rejects.toThrow(/not allowed/i);
+  });
+
+  it('fails install when a pinned bodySha256 does not match the fetched body', async () => {
+    const previous = emptyLockfile();
+    previous.hooks.push({
+      id: 'remote-hook',
+      source: 'remote',
+      repo: null,
+      url: 'https://8.8.8.8/hook.sh',
+      requestedVersion: null,
+      requestedRef: null,
+      resolvedRef: null,
+      resolvedVersion: null,
+      bodySha256: createHash('sha256').update('original-body\n', 'utf8').digest('hex'),
+    });
+    const lockBuilder = new LockfileBuilder(previous);
+
+    await expect(
+      installHooks({
+        projectPath,
+        projectId,
+        capabilitiesFilePath: join(projectPath, 'capabilities.yaml'),
+        hooks: [
+          {
+            id: 'remote-hook',
+            on: 'beforeShell',
+            source: { type: 'remote', url: 'https://8.8.8.8/hook.sh' },
+          },
+        ],
+        providers: ['claude-code'],
+        db,
+        authFetch: makeAuthFetch('echo mutated\n'),
+        getRepoSnapshot: stubGetRepoSnapshot,
+        lockBuilder,
+      }),
+    ).rejects.toThrow(/content changed upstream/i);
   });
 });
 
@@ -561,7 +662,7 @@ describe('hooks-installer — pruneOrphanHooks / cleanHooks', () => {
           id: 'shared-remote',
           on: 'beforeShell',
           type: 'command',
-          source: { type: 'remote', url: 'https://example.com/hook.sh' },
+          source: { type: 'remote', url: 'https://8.8.8.8/hook.sh' },
         },
       ],
       providers: ['cursor', 'claude-code'],

--- a/src/cli/utils/__tests__/local-api.test.ts
+++ b/src/cli/utils/__tests__/local-api.test.ts
@@ -1,0 +1,22 @@
+import { describe, it, expect, beforeEach, afterEach } from 'bun:test';
+import { initAuth, _resetAuthStateForTests } from '../../../server/auth-middleware';
+import { localApiHeaders } from '../local-api';
+
+describe('localApiHeaders', () => {
+  beforeEach(() => {
+    _resetAuthStateForTests();
+    process.env.CAPA_AUTH_TOKEN = 'cli-secret';
+    initAuth('127.0.0.1');
+  });
+
+  afterEach(() => {
+    _resetAuthStateForTests();
+  });
+
+  it('adds Authorization: Bearer from the capa auth token', () => {
+    expect(localApiHeaders({ 'Content-Type': 'application/json' })).toEqual({
+      'Content-Type': 'application/json',
+      Authorization: 'Bearer cli-secret',
+    });
+  });
+});

--- a/src/cli/utils/hooks/install.ts
+++ b/src/cli/utils/hooks/install.ts
@@ -9,7 +9,8 @@ import { getProvider } from '../../../shared/providers';
 import { getHookScriptDir } from '../../../shared/config';
 import { isSafeHookId } from '../../../shared/hooks-validate';
 import { taskLog } from '../../ui';
-import { resolveHookBody, type ResolvedHookBody } from './resolve-body';
+import { RemoteUrlPolicyError } from '../../../shared/safe-remote-url';
+import { HookBodyIntegrityError, resolveHookBody, type ResolvedHookBody } from './resolve-body';
 import { applyHookEntryToConfig, buildHookEntry } from './config-apply';
 import { scopeHookForProvider, pickMapping, resolveProviderEventName } from './provider-map';
 
@@ -81,6 +82,9 @@ export async function installHooks(opts: InstallHooksOptions): Promise<InstallHo
         opts.lockBuilder.upsertHook(body.lockEntry);
       }
     } catch (err: unknown) {
+      if (err instanceof RemoteUrlPolicyError || err instanceof HookBodyIntegrityError) {
+        throw err;
+      }
       const msg = err instanceof Error ? err.message : String(err);
       warnings.push(`Hook "${hook.id}": failed to resolve body — ${msg}`);
     }

--- a/src/cli/utils/hooks/resolve-body.ts
+++ b/src/cli/utils/hooks/resolve-body.ts
@@ -6,6 +6,13 @@ import type { InstallHooksOptions } from './install';
 import { fetchRepoFile, fetchTextFile } from '../../../shared/repo-file';
 import { sha256 } from './json-io';
 
+export class HookBodyIntegrityError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = 'HookBodyIntegrityError';
+  }
+}
+
 export interface ResolvedHookBody {
   /**
    * Resolved body text. For command-type `local` sources this is left empty
@@ -96,6 +103,19 @@ export async function resolveHookBody(hook: Hook, opts: InstallHooksOptions): Pr
         return { text: readFileSync(fullPath, 'utf-8'), needsMaterialisation: false };
       }
       return { text: '', needsMaterialisation: false, localPath: fullPath };
+    }
+  }
+
+  if (lockEntry && opts.lockBuilder) {
+    const previous = opts.lockBuilder.findHook(
+      hook.id,
+      lockEntry.requestedVersion,
+      lockEntry.requestedRef,
+    );
+    if (previous?.bodySha256 && previous.bodySha256 !== lockEntry.bodySha256) {
+      throw new HookBodyIntegrityError(
+        `Hook "${hook.id}": content changed upstream`,
+      );
     }
   }
 

--- a/src/cli/utils/local-api.ts
+++ b/src/cli/utils/local-api.ts
@@ -1,0 +1,11 @@
+import { getAuthToken } from "../../server/auth-middleware";
+
+export function localApiHeaders(
+	extra: Record<string, string> = {},
+): Record<string, string> {
+	const token = getAuthToken();
+	return {
+		...extra,
+		...(token ? { Authorization: `Bearer ${token}` } : {}),
+	};
+}

--- a/src/cli/utils/passthrough/install.ts
+++ b/src/cli/utils/passthrough/install.ts
@@ -21,6 +21,7 @@ export async function passthroughInstall(opts: {
   noCache?: boolean;
   projectPath?: string;
   exitProcess?: boolean;
+  dryRun?: boolean;
 }): Promise<void> {
   const exitProcess = opts.exitProcess !== false;
   const projectPath = opts.projectPath ? resolve(opts.projectPath) : process.cwd();
@@ -39,6 +40,21 @@ export async function passthroughInstall(opts: {
 
   await loadEnvFileOptional(opts.envFile);
   let capabilities = await parseCapabilitiesFile(capabilitiesFile.path, capabilitiesFile.format);
+
+  try {
+    const { confirmInstallExecution } = await import('../../commands/install-confirm');
+    const decision = await confirmInstallExecution({
+      projectId,
+      capabilities,
+      dryRun: !!opts.dryRun,
+    });
+    if (decision === 'dry-run') return;
+  } catch (err) {
+    const msg = err instanceof Error ? err.message : String(err);
+    console.error(`✗ ${msg}`);
+    if (exitProcess) process.exit(1);
+    throw err;
+  }
 
   let providers: string[];
   try {

--- a/src/cli/utils/passthrough/install.ts
+++ b/src/cli/utils/passthrough/install.ts
@@ -14,6 +14,7 @@ import { upsertNativeMcpServer } from './native-mcp';
 import { expandEnvInRecord, loadEnvFileOptional, openAuthDb } from './env';
 import type { MCPServer } from '../../../types/capabilities';
 import type { GetSnapshotResult } from '../../../shared/cache';
+import { getInstallErrorMode } from '../../commands/install-tasks/install-error-policy';
 
 export async function passthroughInstall(opts: {
   envFile?: string | boolean;
@@ -72,6 +73,8 @@ export async function passthroughInstall(opts: {
     throw err;
   }
   capabilities.providers = providers;
+  const installErrorMode = getInstallErrorMode(capabilities);
+  const stopOnError = installErrorMode === 'stop';
 
   const { db, settings } = await openAuthDb();
   const authFetch = createAuthenticatedFetch(db);
@@ -96,6 +99,22 @@ export async function passthroughInstall(opts: {
     warnings.push(...pluginResult.warnings);
     capabilities = pluginResult.mergedCapabilities;
     capabilities.providers = providers;
+
+    const declaredPlugins = capabilities.plugins?.length ?? 0;
+    const resolvedPlugins = capabilities.resolvedPlugins?.length ?? 0;
+    const pluginFailures = pluginResult.warnings.filter((w) =>
+      w.includes('failed to resolve and was skipped'),
+    );
+    if (declaredPlugins > 0 && resolvedPlugins === 0 && pluginFailures.length > 0) {
+      failed++;
+      const message = pluginFailures.join('\n');
+      if (stopOnError) {
+        console.error(`✗ ${message}`);
+        if (exitProcess) process.exit(1);
+        throw new Error(message);
+      }
+      warnings.push(message);
+    }
 
     const resolvedRepos = new Map<string, GetSnapshotResult>();
 
@@ -144,32 +163,42 @@ export async function passthroughInstall(opts: {
             }),
           );
         } catch (err) {
+          failed++;
           warnings.push(
             `Rule "${rule.id}": ${err instanceof Error ? err.message : String(err)}`,
           );
         }
       }
-      installRules(projectPath, rules, providers, bodies);
-      added += bodies.size;
+      if (bodies.size > 0) {
+        installRules(projectPath, rules.filter((r) => bodies.has(r.id)), providers, bodies);
+        added += bodies.size;
+      }
     }
 
     const hooks = capabilities.hooks ?? [];
     if (hooks.length > 0) {
-      const hookResult = await installHooks({
-        projectPath,
-        projectId,
-        capabilitiesFilePath: capabilitiesFile.path,
-        hooks,
-        providers,
-        db,
-        authFetch,
-        getRepoSnapshot,
-        noCache: !!opts.noCache,
-        trackManaged: false,
-        nameTagPrefix: '',
-      });
-      warnings.push(...hookResult.warnings);
-      added += hookResult.installed;
+      try {
+        const hookResult = await installHooks({
+          projectPath,
+          projectId,
+          capabilitiesFilePath: capabilitiesFile.path,
+          hooks,
+          providers,
+          db,
+          authFetch,
+          getRepoSnapshot,
+          noCache: !!opts.noCache,
+          trackManaged: false,
+          nameTagPrefix: '',
+        });
+        warnings.push(...hookResult.warnings);
+        added += hookResult.installed;
+      } catch (err) {
+        failed++;
+        warnings.push(
+          `Failed to install hooks: ${err instanceof Error ? err.message : String(err)}`,
+        );
+      }
     }
 
     const subagents = capabilities.subagents ?? [];
@@ -223,7 +252,7 @@ export async function passthroughInstall(opts: {
       `\n✓ Passthrough install complete (added=${added}, skipped=${skipped}, failed=${failed}).`,
     );
     console.log('  No capa server was started. capa clean will not reverse these writes.\n');
-    if (failed > 0 && exitProcess) process.exit(1);
+    if (failed > 0 && stopOnError && exitProcess) process.exit(1);
   } finally {
     try {
       db.close();

--- a/src/cli/utils/rules-installer.ts
+++ b/src/cli/utils/rules-installer.ts
@@ -5,7 +5,10 @@ import type { Rule } from '../../types/rules';
 import { getAllProviders, getProvider } from '../../shared/providers';
 import { buildRuleFrontmatter } from '../../shared/providers/handlers';
 import { assertSafeRepoPath } from '../../shared/repo-file';
-import { assertCapaOwnedInstallPath } from '../../shared/install-path-guard';
+import {
+  assertCapaOwnedInstallPath,
+  isCapaOwnedInstallPath,
+} from '../../shared/install-path-guard';
 import {
   describeUnsafeCapabilityId,
   isSafeCapabilityId,
@@ -433,6 +436,7 @@ export function cleanRules(projectPath: string, providers: string[], ruleIds?: s
     if (provider.rules) {
       const rulesDir = join(projectPath, provider.rules.dir);
       if (!existsSync(rulesDir)) continue;
+      if (!isCapaOwnedInstallPath(projectPath, rulesDir)) continue;
 
       const managedNames = new Set(
         (ruleIds ?? [])

--- a/src/cli/utils/wrap/__tests__/workspace.test.ts
+++ b/src/cli/utils/wrap/__tests__/workspace.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, beforeEach, afterEach, mock } from 'bun:test';
+import { describe, it, expect, beforeEach, afterEach, mock, spyOn } from 'bun:test';
 import {
   existsSync,
   mkdtempSync,
@@ -11,15 +11,10 @@ import { join, basename } from 'path';
 import { tmpdir } from 'os';
 import { getWrappableProvider } from '../../../../shared/providers';
 import { WORKSPACE_MARKER } from '../../../../shared/workspaces/paths';
+import * as install from '../../../commands/install';
+import { prepareWorkspace, computeCapabilitiesFingerprint, workspaceDirName, workingDirName } from '../workspace';
 
 const installMock = mock(async () => {});
-
-mock.module('../../../commands/install', () => ({
-  installCommand: installMock,
-}));
-
-const { prepareWorkspace, computeCapabilitiesFingerprint, workspaceDirName, workingDirName } =
-  await import('../workspace');
 
 function isolateHome(): { home: string; restore: () => void } {
   const home = mkdtempSync(join(tmpdir(), 'capa-ws-home-'));
@@ -42,10 +37,12 @@ function isolateHome(): { home: string; restore: () => void } {
 describe('prepareWorkspace', () => {
   let realDir: string;
   let homeCtx: { home: string; restore: () => void };
+  let installSpy: ReturnType<typeof spyOn>;
 
   beforeEach(() => {
     realDir = mkdtempSync(join(tmpdir(), 'capa-ws-real-'));
     homeCtx = isolateHome();
+    installSpy = spyOn(install, 'installCommand').mockImplementation(installMock);
     writeFileSync(
       join(realDir, 'capabilities.yaml'),
       'skills: []\nproviders:\n  - claude-code\n',
@@ -57,6 +54,7 @@ describe('prepareWorkspace', () => {
   });
 
   afterEach(() => {
+    installSpy.mockRestore();
     homeCtx.restore();
     rmSync(realDir, { recursive: true, force: true });
   });

--- a/src/db/__tests__/database.test.ts
+++ b/src/db/__tests__/database.test.ts
@@ -3,6 +3,7 @@ import { CapaDatabase } from '../database';
 import { mkdtempSync, rmSync } from 'fs';
 import { join } from 'path';
 import { tmpdir } from 'os';
+import { resetSecretCryptoForTests } from '../../shared/secret-crypto';
 
 /** Windows CI can briefly keep SQLite files open after close(). */
 function removeTempDirWithRetry(dir: string, attempts = 8): void {
@@ -28,15 +29,27 @@ describe('CapaDatabase', () => {
   let db: CapaDatabase;
   let tempDir: string;
   let dbPath: string;
+  let prevHome: string | undefined;
+  let prevProfile: string | undefined;
 
   beforeEach(() => {
     tempDir = mkdtempSync(join(tmpdir(), 'capa-test-'));
+    prevHome = process.env.HOME;
+    prevProfile = process.env.USERPROFILE;
+    process.env.HOME = tempDir;
+    process.env.USERPROFILE = tempDir;
+    resetSecretCryptoForTests();
     dbPath = join(tempDir, 'test.db');
     db = new CapaDatabase(dbPath);
   });
 
   afterEach(() => {
     db.close();
+    resetSecretCryptoForTests();
+    if (prevHome === undefined) delete process.env.HOME;
+    else process.env.HOME = prevHome;
+    if (prevProfile === undefined) delete process.env.USERPROFILE;
+    else process.env.USERPROFILE = prevProfile;
     removeTempDirWithRetry(tempDir);
   });
 

--- a/src/db/__tests__/registries.test.ts
+++ b/src/db/__tests__/registries.test.ts
@@ -154,6 +154,20 @@ describe('CapaDatabase — registry operations', () => {
     expect(r.status).toBe('installed');
   });
 
+  it('persists contentSha256 and preserves it on partial upsert', () => {
+    const hash = 'a'.repeat(64);
+    db.upsertRegistry({
+      slug: 's1',
+      type: 'url',
+      source: 'https://example.com/adapter.ts',
+      status: 'pending',
+      contentSha256: hash,
+    });
+    expect(db.getRegistry('s1')!.contentSha256).toBe(hash);
+    db.upsertRegistry({ slug: 's1', type: 'url', source: 'https://example.com/adapter.ts' });
+    expect(db.getRegistry('s1')!.contentSha256).toBe(hash);
+  });
+
   it('list returns registries in creation order', async () => {
     db.upsertRegistry({ slug: 'a', type: 'github', source: 'x/y@a' });
     await Bun.sleep(2);

--- a/src/db/__tests__/secret-at-rest.test.ts
+++ b/src/db/__tests__/secret-at-rest.test.ts
@@ -35,7 +35,11 @@ describe("credential at-rest encryption", () => {
 		else process.env.HOME = prevHome;
 		if (prevProfile === undefined) delete process.env.USERPROFILE;
 		else process.env.USERPROFILE = prevProfile;
-		rmSync(home, { recursive: true, force: true });
+		try {
+			rmSync(home, { recursive: true, force: true });
+		} catch {
+			// Windows can keep capa.db locked briefly after close
+		}
 	});
 
 	it("chmods the sqlite file to 0600", () => {
@@ -71,6 +75,27 @@ describe("credential at-rest encryption", () => {
 		);
 		raw.close();
 		expect(db.getVariable("p1", "LEGACY")).toBe("plain-legacy-token");
+	});
+
+	it("rewrites legacy plaintext rows to ciphertext on the next open", () => {
+		db.close();
+		const raw = new Database(dbPath);
+		raw.run(
+			"INSERT INTO variables (project_id, key, value, created_at) VALUES (?, ?, ?, ?)",
+			["p1", "MIGRATE_ME", "plain-to-migrate", Date.now()],
+		);
+		raw.close();
+
+		db = new CapaDatabase(dbPath);
+		expect(db.getVariable("p1", "MIGRATE_ME")).toBe("plain-to-migrate");
+
+		const verify = new Database(dbPath, { readonly: true });
+		const row = verify
+			.query("SELECT value FROM variables WHERE project_id = ? AND key = ?")
+			.get("p1", "MIGRATE_ME") as { value: string };
+		verify.close();
+		expect(row.value.startsWith("enc:v1:")).toBe(true);
+		expect(row.value).not.toContain("plain-to-migrate");
 	});
 
 	it("encrypts oauth access and refresh tokens at rest", () => {

--- a/src/db/__tests__/secret-at-rest.test.ts
+++ b/src/db/__tests__/secret-at-rest.test.ts
@@ -1,0 +1,105 @@
+import { afterEach, beforeEach, describe, expect, it } from "bun:test";
+import { Database } from "bun:sqlite";
+import { mkdtempSync, readFileSync, rmSync, statSync } from "fs";
+import { tmpdir } from "os";
+import { join } from "path";
+import { CapaDatabase } from "../database";
+import { resetSecretCryptoForTests } from "../../shared/secret-crypto";
+
+const skipModeAsserts = process.platform === "win32";
+const SECRET = "capa-at-rest-secret-VALUE-7kL9";
+
+describe("credential at-rest encryption", () => {
+	let home: string;
+	let dbPath: string;
+	let db: CapaDatabase;
+	let prevHome: string | undefined;
+	let prevProfile: string | undefined;
+
+	beforeEach(() => {
+		home = mkdtempSync(join(tmpdir(), "capa-at-rest-"));
+		prevHome = process.env.HOME;
+		prevProfile = process.env.USERPROFILE;
+		process.env.HOME = home;
+		process.env.USERPROFILE = home;
+		resetSecretCryptoForTests();
+		dbPath = join(home, "test.db");
+		db = new CapaDatabase(dbPath);
+		db.upsertProject({ id: "p1", path: "/p1" });
+	});
+
+	afterEach(() => {
+		db.close();
+		resetSecretCryptoForTests();
+		if (prevHome === undefined) delete process.env.HOME;
+		else process.env.HOME = prevHome;
+		if (prevProfile === undefined) delete process.env.USERPROFILE;
+		else process.env.USERPROFILE = prevProfile;
+		rmSync(home, { recursive: true, force: true });
+	});
+
+	it("chmods the sqlite file to 0600", () => {
+		if (skipModeAsserts) return;
+		expect(statSync(dbPath).mode & 0o777).toBe(0o600);
+	});
+
+	it("encrypts variable values so the db file does not contain the raw secret", () => {
+		db.setVariable("p1", "API_KEY", SECRET);
+		expect(db.getVariable("p1", "API_KEY")).toBe(SECRET);
+
+		db.close();
+		const bytes = readFileSync(dbPath);
+		expect(bytes.includes(Buffer.from(SECRET))).toBe(false);
+
+		const raw = new Database(dbPath, { readonly: true });
+		const row = raw
+			.query("SELECT value FROM variables WHERE project_id = ? AND key = ?")
+			.get("p1", "API_KEY") as { value: string };
+		raw.close();
+		expect(row.value.startsWith("enc:v1:")).toBe(true);
+		expect(row.value).not.toContain(SECRET);
+
+		db = new CapaDatabase(dbPath);
+		expect(db.getVariable("p1", "API_KEY")).toBe(SECRET);
+	});
+
+	it("still reads legacy plaintext variable rows", () => {
+		const raw = new Database(dbPath);
+		raw.run(
+			"INSERT INTO variables (project_id, key, value, created_at) VALUES (?, ?, ?, ?)",
+			["p1", "LEGACY", "plain-legacy-token", Date.now()],
+		);
+		raw.close();
+		expect(db.getVariable("p1", "LEGACY")).toBe("plain-legacy-token");
+	});
+
+	it("encrypts oauth access and refresh tokens at rest", () => {
+		db.setOAuthToken("p1", "svc", {
+			access_token: SECRET,
+			refresh_token: `${SECRET}-refresh`,
+		});
+		const token = db.getOAuthToken("p1", "svc");
+		expect(token?.access_token).toBe(SECRET);
+		expect(token?.refresh_token).toBe(`${SECRET}-refresh`);
+
+		db.close();
+		const bytes = readFileSync(dbPath);
+		expect(bytes.includes(Buffer.from(SECRET))).toBe(false);
+		db = new CapaDatabase(dbPath);
+	});
+
+	it("encrypts git integration tokens at rest", () => {
+		db.setGitIntegration("github", {
+			access_token: SECRET,
+			refresh_token: `${SECRET}-refresh`,
+			token_type: "Bearer",
+		});
+		const row = db.getGitIntegration("github");
+		expect(row?.access_token).toBe(SECRET);
+		expect(row?.refresh_token).toBe(`${SECRET}-refresh`);
+
+		db.close();
+		expect(readFileSync(dbPath).includes(Buffer.from(SECRET))).toBe(false);
+		db = new CapaDatabase(dbPath);
+	});
+});

--- a/src/db/database.ts
+++ b/src/db/database.ts
@@ -23,6 +23,7 @@ import { OAuthFlowStateRepo } from "./oauth-flow-state";
 import { OAuthTokensRepo } from "./oauth-tokens";
 import { ProjectsRepo } from "./projects";
 import { RegistriesRepo, type RegistryUpsertInput } from "./registries";
+import { migrateSecretsAtRest } from "./migrate-secrets";
 import { initSchema } from "./schema";
 import { SessionsRepo } from "./sessions";
 import { SubAgentsRepo } from "./sub-agents";
@@ -61,6 +62,7 @@ export class CapaDatabase {
 		this.db = new Database(dbPath, { create: true });
 		restrictDatabaseFileMode(dbPath);
 		initSchema(this.db);
+		migrateSecretsAtRest(this.db);
 
 		this.projects = new ProjectsRepo(this.db);
 		this.sessions = new SessionsRepo(this.db);

--- a/src/db/database.ts
+++ b/src/db/database.ts
@@ -1,6 +1,7 @@
 import { Database } from "bun:sqlite";
 import { mkdirSync } from "fs";
 import { dirname } from "path";
+import { restrictDatabaseFileMode } from "../shared/config";
 import type {
 	GitIntegration,
 	MCPSubprocess,
@@ -58,6 +59,7 @@ export class CapaDatabase {
 		mkdirSync(dbDir, { recursive: true });
 
 		this.db = new Database(dbPath, { create: true });
+		restrictDatabaseFileMode(dbPath);
 		initSchema(this.db);
 
 		this.projects = new ProjectsRepo(this.db);

--- a/src/db/git-integrations.ts
+++ b/src/db/git-integrations.ts
@@ -3,17 +3,36 @@ import {
 	getGitProvider,
 	getGitProviderByHost,
 } from "../shared/git-providers/registry";
+import {
+	decryptSecret,
+	decryptSecretString,
+	encryptSecret,
+} from "../shared/secret-crypto";
 import type { GitIntegration } from "../types/database";
+
+function decryptGitRow(row: GitIntegration | null): GitIntegration | null {
+	if (!row) return null;
+	return {
+		...row,
+		access_token: decryptSecretString(row.access_token),
+		refresh_token:
+			row.refresh_token == null
+				? row.refresh_token
+				: decryptSecret(row.refresh_token),
+	};
+}
 
 export class GitIntegrationsRepo {
 	constructor(private db: Database) {}
 
 	get(platform: string, host: string | null = null): GitIntegration | null {
-		return this.db
-			.query(
-				"SELECT * FROM git_integrations WHERE platform = ? AND (host = ? OR (host IS NULL AND ? IS NULL))",
-			)
-			.get(platform, host, host) as GitIntegration | null;
+		return decryptGitRow(
+			this.db
+				.query(
+					"SELECT * FROM git_integrations WHERE platform = ? AND (host = ? OR (host IS NULL AND ? IS NULL))",
+				)
+				.get(platform, host, host) as GitIntegration | null,
+		);
 	}
 
 	set(
@@ -28,6 +47,10 @@ export class GitIntegrationsRepo {
 	): void {
 		const now = Date.now();
 		const host = tokenData.host || null;
+		const access = encryptSecret(tokenData.access_token);
+		const refresh = tokenData.refresh_token
+			? encryptSecret(tokenData.refresh_token)
+			: null;
 
 		// Check if an entry already exists
 		const existing = this.get(platform, host);
@@ -43,8 +66,8 @@ export class GitIntegrationsRepo {
           updated_at = ?
          WHERE platform = ? AND (host = ? OR (host IS NULL AND ? IS NULL))`,
 				[
-					tokenData.access_token,
-					tokenData.refresh_token || null,
+					access,
+					refresh,
 					tokenData.token_type || "Bearer",
 					tokenData.expires_at || null,
 					now,
@@ -61,8 +84,8 @@ export class GitIntegrationsRepo {
 				[
 					platform,
 					host,
-					tokenData.access_token,
-					tokenData.refresh_token || null,
+					access,
+					refresh,
 					tokenData.token_type || "Bearer",
 					tokenData.expires_at || null,
 					now,
@@ -80,9 +103,11 @@ export class GitIntegrationsRepo {
 	}
 
 	getAll(): GitIntegration[] {
-		return this.db
-			.query("SELECT * FROM git_integrations ORDER BY created_at DESC")
-			.all() as GitIntegration[];
+		return (
+			this.db
+				.query("SELECT * FROM git_integrations ORDER BY created_at DESC")
+				.all() as GitIntegration[]
+		).map((row) => decryptGitRow(row)!);
 	}
 
 	getOAuthToken(provider: string): GitIntegration | null {

--- a/src/db/migrate-secrets.ts
+++ b/src/db/migrate-secrets.ts
@@ -1,0 +1,64 @@
+import type { Database } from "bun:sqlite";
+import { canonicalizeStoredSecret } from "../shared/secret-crypto";
+
+function nextSecret(value: string | null): { value: string | null; changed: boolean } {
+	if (typeof value !== "string" || value.length === 0) {
+		return { value, changed: false };
+	}
+	const next = canonicalizeStoredSecret(value);
+	return { value: next, changed: next !== value };
+}
+
+/** Encrypt legacy plaintext secret columns. Safe to run on every open. */
+export function migrateSecretsAtRest(db: Database): void {
+	const tx = db.transaction(() => {
+		for (const row of db
+			.query("SELECT project_id, key, value FROM variables")
+			.all() as Array<{ project_id: string; key: string; value: string }>) {
+			const n = nextSecret(row.value);
+			if (!n.changed) continue;
+			db.run("UPDATE variables SET value = ? WHERE project_id = ? AND key = ?", [
+				n.value,
+				row.project_id,
+				row.key,
+			]);
+		}
+
+		for (const row of db
+			.query(
+				"SELECT id, access_token, refresh_token FROM oauth_tokens",
+			)
+			.all() as Array<{
+			id: number;
+			access_token: string;
+			refresh_token: string | null;
+		}>) {
+			const access = nextSecret(row.access_token);
+			const refresh = nextSecret(row.refresh_token);
+			if (!access.changed && !refresh.changed) continue;
+			db.run(
+				"UPDATE oauth_tokens SET access_token = ?, refresh_token = ? WHERE id = ?",
+				[access.value, refresh.value, row.id],
+			);
+		}
+
+		for (const row of db
+			.query(
+				"SELECT id, access_token, refresh_token FROM git_integrations",
+			)
+			.all() as Array<{
+			id: number;
+			access_token: string;
+			refresh_token: string | null;
+		}>) {
+			const access = nextSecret(row.access_token);
+			const refresh = nextSecret(row.refresh_token);
+			if (!access.changed && !refresh.changed) continue;
+			db.run(
+				"UPDATE git_integrations SET access_token = ?, refresh_token = ? WHERE id = ?",
+				[access.value, refresh.value, row.id],
+			);
+		}
+	});
+	tx();
+}

--- a/src/db/oauth-tokens.ts
+++ b/src/db/oauth-tokens.ts
@@ -1,15 +1,34 @@
 import type { Database } from "bun:sqlite";
+import {
+	decryptSecret,
+	decryptSecretString,
+	encryptSecret,
+} from "../shared/secret-crypto";
 import type { OAuthTokenRow } from "../types/database";
+
+function decryptTokenRow(row: OAuthTokenRow | null): OAuthTokenRow | null {
+	if (!row) return null;
+	return {
+		...row,
+		access_token: decryptSecretString(row.access_token),
+		refresh_token:
+			row.refresh_token == null
+				? row.refresh_token
+				: decryptSecret(row.refresh_token),
+	};
+}
 
 export class OAuthTokensRepo {
 	constructor(private db: Database) {}
 
 	get(projectId: string, serverId: string): OAuthTokenRow | null {
-		return this.db
-			.query(
-				"SELECT * FROM oauth_tokens WHERE project_id = ? AND server_id = ?",
-			)
-			.get(projectId, serverId) as OAuthTokenRow | null;
+		return decryptTokenRow(
+			this.db
+				.query(
+					"SELECT * FROM oauth_tokens WHERE project_id = ? AND server_id = ?",
+				)
+				.get(projectId, serverId) as OAuthTokenRow | null,
+		);
 	}
 
 	set(
@@ -24,6 +43,10 @@ export class OAuthTokensRepo {
 		},
 	): void {
 		const now = Date.now();
+		const access = encryptSecret(tokenData.access_token);
+		const refresh = tokenData.refresh_token
+			? encryptSecret(tokenData.refresh_token)
+			: null;
 		this.db.run(
 			`INSERT INTO oauth_tokens (project_id, server_id, access_token, refresh_token, token_type, expires_at, scope, created_at, updated_at)
        VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)
@@ -37,15 +60,15 @@ export class OAuthTokensRepo {
 			[
 				projectId,
 				serverId,
-				tokenData.access_token,
-				tokenData.refresh_token || null,
+				access,
+				refresh,
 				tokenData.token_type || "Bearer",
 				tokenData.expires_at || null,
 				tokenData.scope || null,
 				now,
 				now,
-				tokenData.access_token,
-				tokenData.refresh_token || null,
+				access,
+				refresh,
 				tokenData.token_type || "Bearer",
 				tokenData.expires_at || null,
 				tokenData.scope || null,
@@ -62,8 +85,10 @@ export class OAuthTokensRepo {
 	}
 
 	getAll(projectId: string): OAuthTokenRow[] {
-		return this.db
-			.query("SELECT * FROM oauth_tokens WHERE project_id = ?")
-			.all(projectId) as OAuthTokenRow[];
+		return (
+			this.db
+				.query("SELECT * FROM oauth_tokens WHERE project_id = ?")
+				.all(projectId) as OAuthTokenRow[]
+		).map((row) => decryptTokenRow(row)!);
 	}
 }

--- a/src/db/registries.ts
+++ b/src/db/registries.ts
@@ -16,6 +16,7 @@ function rowToRecord(row: RegistryRow): RegistryRecord {
 		lastError: row.last_error,
 		resolvedRef: row.resolved_ref,
 		installedAt: row.installed_at,
+		contentSha256: row.content_sha256 ?? null,
 		createdAt: row.created_at,
 		updatedAt: row.updated_at,
 	};
@@ -30,6 +31,7 @@ export interface RegistryUpsertInput {
 	lastError?: string | null;
 	resolvedRef?: string | null;
 	installedAt?: number | null;
+	contentSha256?: string | null;
 }
 
 export class RegistriesRepo {
@@ -66,6 +68,10 @@ export class RegistriesRepo {
 			input.installedAt !== undefined
 				? input.installedAt
 				: (existing?.installedAt ?? null);
+		const contentSha256 =
+			input.contentSha256 !== undefined
+				? input.contentSha256
+				: (existing?.contentSha256 ?? null);
 
 		if (existing) {
 			this.db.run(
@@ -77,6 +83,7 @@ export class RegistriesRepo {
            last_error = ?,
            resolved_ref = ?,
            installed_at = ?,
+           content_sha256 = ?,
            updated_at = ?
          WHERE slug = ?`,
 				[
@@ -87,6 +94,7 @@ export class RegistriesRepo {
 					lastError,
 					resolvedRef,
 					installedAt,
+					contentSha256,
 					now,
 					input.slug,
 				],
@@ -94,8 +102,8 @@ export class RegistriesRepo {
 		} else {
 			this.db.run(
 				`INSERT INTO registries
-           (slug, type, source, enabled, status, last_error, resolved_ref, installed_at, created_at, updated_at)
-         VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+           (slug, type, source, enabled, status, last_error, resolved_ref, installed_at, content_sha256, created_at, updated_at)
+         VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
 				[
 					input.slug,
 					input.type,
@@ -105,6 +113,7 @@ export class RegistriesRepo {
 					lastError,
 					resolvedRef,
 					installedAt,
+					contentSha256,
 					now,
 					now,
 				],

--- a/src/db/schema.ts
+++ b/src/db/schema.ts
@@ -160,6 +160,7 @@ export function initSchema(db: Database): void {
     `);
 
 	migrateRegistriesAllowClaudeMarketplace(db);
+	ensureColumn(db, "registries", "content_sha256", "TEXT");
 
 	// Tracks individual capa-installed hook entries (one row per
 	// (provider, hook) tuple). `locator` is the JSON-encoded path inside

--- a/src/db/variables.ts
+++ b/src/db/variables.ts
@@ -1,15 +1,20 @@
 import type { Database } from "bun:sqlite";
+import {
+	decryptSecretString,
+	encryptSecret,
+} from "../shared/secret-crypto";
 
 export class VariablesRepo {
 	constructor(private db: Database) {}
 
 	set(projectId: string, key: string, value: string): void {
 		const now = Date.now();
+		const stored = encryptSecret(value);
 		this.db.run(
 			`INSERT INTO variables (project_id, key, value, created_at)
        VALUES (?, ?, ?, ?)
        ON CONFLICT(project_id, key) DO UPDATE SET value = ?, created_at = ?`,
-			[projectId, key, value, now, value, now],
+			[projectId, key, stored, now, stored, now],
 		);
 	}
 
@@ -17,7 +22,7 @@ export class VariablesRepo {
 		const result = this.db
 			.query("SELECT value FROM variables WHERE project_id = ? AND key = ?")
 			.get(projectId, key) as { value: string } | null;
-		return result?.value ?? null;
+		return result ? decryptSecretString(result.value) : null;
 	}
 
 	getAll(projectId: string): Record<string, string> {
@@ -27,7 +32,7 @@ export class VariablesRepo {
 
 		const vars: Record<string, string> = {};
 		for (const row of rows) {
-			vars[row.key] = row.value;
+			vars[row.key] = decryptSecretString(row.value);
 		}
 		return vars;
 	}

--- a/src/server/__tests__/api-csrf.test.ts
+++ b/src/server/__tests__/api-csrf.test.ts
@@ -1,0 +1,238 @@
+import { describe, it, expect, beforeEach, afterEach } from 'bun:test';
+import {
+  authorizeApiRequest,
+  injectHtmlAuthToken,
+  requireApiCsrf,
+  requireMutatingJsonContentType,
+  serverHttpOrigin,
+} from '../api-guards';
+import { initAuth, _resetAuthStateForTests } from '../auth-middleware';
+
+const SERVER_ORIGIN = 'http://127.0.0.1:5912';
+const TOKEN = 'test-secret-token';
+
+function apiRequest(
+  path: string,
+  init: RequestInit & { origin?: string } = {},
+): Request {
+  const headers = new Headers(init.headers);
+  if (init.origin) headers.set('Origin', init.origin);
+  return new Request(`http://127.0.0.1:5912${path}`, {
+    ...init,
+    headers,
+  });
+}
+
+describe('serverHttpOrigin', () => {
+  it('builds the bind origin for IPv4 loopback', () => {
+    expect(serverHttpOrigin('127.0.0.1', 5912)).toBe('http://127.0.0.1:5912');
+  });
+
+  it('brackets IPv6 bind hosts', () => {
+    expect(serverHttpOrigin('::1', 5912)).toBe('http://[::1]:5912');
+  });
+});
+
+describe('requireApiCsrf', () => {
+  it('rejects a mutating request with a foreign Origin', () => {
+    const req = apiRequest('/api/registries', {
+      method: 'POST',
+      origin: 'http://evil.example',
+      headers: { 'Content-Type': 'application/json' },
+    });
+    expect(requireApiCsrf(req, SERVER_ORIGIN)).toEqual({
+      ok: false,
+      reason: 'Forbidden',
+      status: 403,
+    });
+  });
+
+  it('rejects a mutating request with Sec-Fetch-Site: cross-site', () => {
+    const req = apiRequest('/api/registries', {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        'Sec-Fetch-Site': 'cross-site',
+      },
+    });
+    expect(requireApiCsrf(req, SERVER_ORIGIN)).toEqual({
+      ok: false,
+      reason: 'Forbidden',
+      status: 403,
+    });
+  });
+
+  it('accepts Origin equal to the server bind origin', () => {
+    const req = apiRequest('/api/registries', {
+      method: 'POST',
+      origin: SERVER_ORIGIN,
+      headers: { 'Content-Type': 'application/json' },
+    });
+    expect(requireApiCsrf(req, SERVER_ORIGIN)).toEqual({ ok: true });
+  });
+
+  it('accepts CLI mutating requests that omit Origin', () => {
+    const req = apiRequest('/api/registries', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+    });
+    expect(requireApiCsrf(req, SERVER_ORIGIN)).toEqual({ ok: true });
+  });
+
+  it('does not apply the CSRF origin gate to GET', () => {
+    const req = apiRequest('/api/projects', {
+      method: 'GET',
+      origin: 'http://evil.example',
+    });
+    expect(requireApiCsrf(req, SERVER_ORIGIN)).toEqual({ ok: true });
+  });
+});
+
+describe('requireMutatingJsonContentType', () => {
+  it('rejects mutating /api requests with Content-Type: text/plain', () => {
+    const req = apiRequest('/api/registries', {
+      method: 'POST',
+      headers: { 'Content-Type': 'text/plain' },
+    });
+    expect(requireMutatingJsonContentType(req)).toEqual({
+      ok: false,
+      reason: 'Unsupported Media Type',
+      status: 415,
+    });
+  });
+
+  it('accepts application/json', () => {
+    const req = apiRequest('/api/registries', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+    });
+    expect(requireMutatingJsonContentType(req)).toEqual({ ok: true });
+  });
+
+  it('accepts application/json with a charset parameter', () => {
+    const req = apiRequest('/api/registries', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json; charset=utf-8' },
+    });
+    expect(requireMutatingJsonContentType(req)).toEqual({ ok: true });
+  });
+
+  it('accepts multipart/form-data for file uploads', () => {
+    const req = apiRequest('/api/projects/p/fs', {
+      method: 'POST',
+      headers: { 'Content-Type': 'multipart/form-data; boundary=abc' },
+    });
+    expect(requireMutatingJsonContentType(req)).toEqual({ ok: true });
+  });
+
+  it('does not require Content-Type on GET', () => {
+    const req = apiRequest('/api/projects', { method: 'GET' });
+    expect(requireMutatingJsonContentType(req)).toEqual({ ok: true });
+  });
+});
+
+describe('authorizeApiRequest', () => {
+  beforeEach(() => {
+    _resetAuthStateForTests();
+    process.env.CAPA_AUTH_TOKEN = TOKEN;
+    initAuth('127.0.0.1');
+  });
+
+  afterEach(() => {
+    _resetAuthStateForTests();
+  });
+
+  const bind = { host: '127.0.0.1', port: 5912 };
+
+  it('returns 401 for loopback POST /api/registries without a bearer token', () => {
+    const req = apiRequest('/api/registries', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+    });
+    expect(authorizeApiRequest(req, bind)).toEqual({
+      ok: false,
+      reason: 'Unauthorized',
+      status: 401,
+    });
+  });
+
+  it('accepts same-origin mutating requests that carry the token', () => {
+    const req = apiRequest('/api/registries', {
+      method: 'POST',
+      origin: SERVER_ORIGIN,
+      headers: {
+        Authorization: `Bearer ${TOKEN}`,
+        'Content-Type': 'application/json',
+      },
+    });
+    expect(authorizeApiRequest(req, bind)).toEqual({ ok: true });
+  });
+
+  it('returns 403 when a valid token is paired with a foreign Origin', () => {
+    const req = apiRequest('/api/registries', {
+      method: 'POST',
+      origin: 'https://attacker.example',
+      headers: {
+        Authorization: `Bearer ${TOKEN}`,
+        'Content-Type': 'application/json',
+      },
+    });
+    expect(authorizeApiRequest(req, bind)).toEqual({
+      ok: false,
+      reason: 'Forbidden',
+      status: 403,
+    });
+  });
+
+  it('returns 403 when Sec-Fetch-Site is cross-site', () => {
+    const req = apiRequest('/api/registries', {
+      method: 'POST',
+      headers: {
+        Authorization: `Bearer ${TOKEN}`,
+        'Content-Type': 'application/json',
+        'Sec-Fetch-Site': 'cross-site',
+      },
+    });
+    expect(authorizeApiRequest(req, bind)).toEqual({
+      ok: false,
+      reason: 'Forbidden',
+      status: 403,
+    });
+  });
+
+  it('returns 415 for mutating requests with Content-Type: text/plain', () => {
+    const req = apiRequest('/api/registries', {
+      method: 'POST',
+      headers: {
+        Authorization: `Bearer ${TOKEN}`,
+        'Content-Type': 'text/plain',
+      },
+    });
+    expect(authorizeApiRequest(req, bind)).toEqual({
+      ok: false,
+      reason: 'Unsupported Media Type',
+      status: 415,
+    });
+  });
+
+  it('allows OPTIONS without a token', () => {
+    const req = apiRequest('/api/registries', { method: 'OPTIONS' });
+    expect(authorizeApiRequest(req, bind)).toEqual({ ok: true });
+  });
+
+  it('allows unauthenticated GET oauth callback HTML', () => {
+    const req = apiRequest('/api/integrations/github/oauth/callback', {
+      method: 'GET',
+    });
+    expect(authorizeApiRequest(req, bind)).toEqual({ ok: true });
+  });
+});
+
+describe('injectHtmlAuthToken', () => {
+  it('injects window.__CAPA_AUTH_TOKEN__ before </head>', () => {
+    const html = '<html><head><title>t</title></head><body></body></html>';
+    const out = injectHtmlAuthToken(html, 'abc123');
+    expect(out).toContain('window.__CAPA_AUTH_TOKEN__="abc123"');
+    expect(out.indexOf('__CAPA_AUTH_TOKEN__')).toBeLessThan(out.indexOf('</head>'));
+  });
+});

--- a/src/server/__tests__/api-csrf.test.ts
+++ b/src/server/__tests__/api-csrf.test.ts
@@ -235,4 +235,9 @@ describe('injectHtmlAuthToken', () => {
     expect(out).toContain('window.__CAPA_AUTH_TOKEN__="abc123"');
     expect(out.indexOf('__CAPA_AUTH_TOKEN__')).toBeLessThan(out.indexOf('</head>'));
   });
+
+  it('leaves HTML unchanged when no token is provided', () => {
+    const html = '<html><head></head><body></body></html>';
+    expect(injectHtmlAuthToken(html, null)).toBe(html);
+  });
 });

--- a/src/server/__tests__/api-csrf.test.ts
+++ b/src/server/__tests__/api-csrf.test.ts
@@ -71,6 +71,15 @@ describe('requireApiCsrf', () => {
     expect(requireApiCsrf(req, SERVER_ORIGIN)).toEqual({ ok: true });
   });
 
+  it('accepts localhost Origin when the server binds 127.0.0.1', () => {
+    const req = apiRequest('/api/integrations/gitlab', {
+      method: 'DELETE',
+      origin: 'http://localhost:5912',
+      headers: { 'Content-Type': 'application/json' },
+    });
+    expect(requireApiCsrf(req, SERVER_ORIGIN)).toEqual({ ok: true });
+  });
+
   it('accepts CLI mutating requests that omit Origin', () => {
     const req = apiRequest('/api/registries', {
       method: 'POST',
@@ -223,6 +232,15 @@ describe('authorizeApiRequest', () => {
   it('allows unauthenticated GET oauth callback HTML', () => {
     const req = apiRequest('/api/integrations/github/oauth/callback', {
       method: 'GET',
+    });
+    expect(authorizeApiRequest(req, bind)).toEqual({ ok: true });
+  });
+
+  it('allows unauthenticated POST oauth callback (bridge token submission)', () => {
+    const req = apiRequest('/api/integrations/github/oauth/callback', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ access_token: 'x', state: 'y' }),
     });
     expect(authorizeApiRequest(req, bind)).toEqual({ ok: true });
   });

--- a/src/server/__tests__/auth-middleware.test.ts
+++ b/src/server/__tests__/auth-middleware.test.ts
@@ -1,8 +1,14 @@
 import { describe, it, expect, beforeEach, afterEach } from 'bun:test';
+import { mkdtempSync, readFileSync, rmSync } from 'fs';
+import { tmpdir } from 'os';
+import { join } from 'path';
+import { getCapaDir } from '../../shared/config';
 import {
   isLoopbackHost,
   requireAuth,
+  requireMcpAuth,
   initAuth,
+  getAuthToken,
   _resetAuthStateForTests,
 } from '../auth-middleware';
 
@@ -39,8 +45,29 @@ describe('auth-middleware', () => {
       initAuth(nonLoopback);
     });
 
-    it('bypasses auth on loopback hosts', () => {
-      const req = new Request('http://127.0.0.1/api/projects');
+    it('returns 401 on loopback when the bearer token is missing', () => {
+      const req = new Request('http://127.0.0.1/api/registries', {
+        method: 'POST',
+      });
+      expect(requireAuth(req, loopback)).toEqual({
+        ok: false,
+        reason: 'Unauthorized',
+        status: 401,
+      });
+    });
+
+    it('accepts a valid Bearer token on loopback', () => {
+      const req = new Request('http://127.0.0.1/api/registries', {
+        method: 'POST',
+        headers: { Authorization: 'Bearer test-secret-token' },
+      });
+      expect(requireAuth(req, loopback)).toEqual({ ok: true });
+    });
+
+    it('allows OPTIONS without a token', () => {
+      const req = new Request('http://127.0.0.1/api/registries', {
+        method: 'OPTIONS',
+      });
       expect(requireAuth(req, loopback)).toEqual({ ok: true });
     });
 
@@ -72,6 +99,16 @@ describe('auth-middleware', () => {
       expect(requireAuth(req, nonLoopback)).toEqual({ ok: true });
     });
 
+    it('rejects auth tokens in query strings on loopback', () => {
+      const req = new Request('http://127.0.0.1/api/projects?token=secret');
+      const result = requireAuth(req, loopback);
+      expect(result).toEqual({
+        ok: false,
+        reason: 'Auth tokens must not be passed in query strings',
+        status: 401,
+      });
+    });
+
     it('rejects auth tokens in query strings on non-loopback', () => {
       const req = new Request('http://0.0.0.0/api/projects?token=secret');
       const result = requireAuth(req, nonLoopback);
@@ -80,6 +117,63 @@ describe('auth-middleware', () => {
         reason: 'Auth tokens must not be passed in query strings',
         status: 401,
       });
+    });
+  });
+
+  describe('requireMcpAuth', () => {
+    const loopback = '127.0.0.1';
+    const nonLoopback = '0.0.0.0';
+
+    beforeEach(() => {
+      process.env.CAPA_AUTH_TOKEN = 'test-secret-token';
+      initAuth(nonLoopback);
+    });
+
+    it('bypasses bearer auth on loopback so editor MCP clients keep working', () => {
+      const req = new Request('http://127.0.0.1/proj/mcp', { method: 'POST' });
+      expect(requireMcpAuth(req, loopback)).toEqual({ ok: true });
+    });
+
+    it('still requires a bearer token on non-loopback MCP binds', () => {
+      const req = new Request('http://0.0.0.0/proj/mcp', { method: 'POST' });
+      expect(requireMcpAuth(req, nonLoopback)).toEqual({
+        ok: false,
+        reason: 'Unauthorized',
+        status: 401,
+      });
+    });
+  });
+
+  describe('initAuth token file', () => {
+    let home: string;
+    let prevHome: string | undefined;
+    let prevProfile: string | undefined;
+
+    beforeEach(() => {
+      _resetAuthStateForTests();
+      home = mkdtempSync(join(tmpdir(), 'capa-auth-token-home-'));
+      prevHome = process.env.HOME;
+      prevProfile = process.env.USERPROFILE;
+      process.env.HOME = home;
+      process.env.USERPROFILE = home;
+    });
+
+    afterEach(() => {
+      if (prevHome === undefined) delete process.env.HOME;
+      else process.env.HOME = prevHome;
+      if (prevProfile === undefined) delete process.env.USERPROFILE;
+      else process.env.USERPROFILE = prevProfile;
+      _resetAuthStateForTests();
+      rmSync(home, { recursive: true, force: true });
+    });
+
+    it('generates ~/.capa/auth.token on loopback binds', () => {
+      const dir = getCapaDir();
+      expect(dir.startsWith(home)).toBe(true);
+      const token = initAuth('127.0.0.1');
+      expect(token).toMatch(/^[0-9a-f]{64}$/);
+      expect(getAuthToken()).toBe(token);
+      expect(readFileSync(join(dir, 'auth.token'), 'utf8').trim()).toBe(token);
     });
   });
 });

--- a/src/server/__tests__/auth-middleware.test.ts
+++ b/src/server/__tests__/auth-middleware.test.ts
@@ -173,7 +173,9 @@ describe('auth-middleware', () => {
       const token = initAuth('127.0.0.1');
       expect(token).toMatch(/^[0-9a-f]{64}$/);
       expect(getAuthToken()).toBe(token);
-      expect(readFileSync(join(dir, 'auth.token'), 'utf8').trim()).toBe(token);
+      expect(readFileSync(join(dir, 'auth.token'), 'utf8').trim()).toBe(
+        token ?? '',
+      );
     });
   });
 });

--- a/src/server/__tests__/auth-middleware.test.ts
+++ b/src/server/__tests__/auth-middleware.test.ts
@@ -9,6 +9,7 @@ import {
   requireMcpAuth,
   initAuth,
   getAuthToken,
+  getSpaAuthToken,
   _resetAuthStateForTests,
 } from '../auth-middleware';
 
@@ -173,9 +174,17 @@ describe('auth-middleware', () => {
       const token = initAuth('127.0.0.1');
       expect(token).toMatch(/^[0-9a-f]{64}$/);
       expect(getAuthToken()).toBe(token);
+      expect(getSpaAuthToken()).toBe(token);
       expect(readFileSync(join(dir, 'auth.token'), 'utf8').trim()).toBe(
         token ?? '',
       );
+    });
+
+    it('does not expose the SPA bootstrap token when bound off-loopback', () => {
+      const token = initAuth('0.0.0.0');
+      expect(token).toMatch(/^[0-9a-f]{64}$/);
+      expect(getAuthToken()).toBe(token);
+      expect(getSpaAuthToken()).toBeNull();
     });
   });
 });

--- a/src/server/__tests__/configure-routes.test.ts
+++ b/src/server/__tests__/configure-routes.test.ts
@@ -1,0 +1,184 @@
+import { afterEach, beforeEach, describe, expect, it } from "bun:test";
+import { mkdtempSync, rmSync, writeFileSync } from "fs";
+import { tmpdir } from "os";
+import { join } from "path";
+import { CapaDatabase } from "../../db/database";
+import type { Capabilities } from "../../types/capabilities";
+import { afterWrite, type CapabilitiesRouteDeps } from "../capabilities-route-helpers";
+import type { CapabilitiesFileWatcher } from "../capabilities-watcher";
+import {
+	handleProjectConfigure,
+	type ConfigureRouteDeps,
+} from "../configure-routes";
+import type { CapaMCPServer } from "../mcp-handler";
+import { handleGetServerTools } from "../mcp-meta-routes";
+import type { OAuth2Manager } from "../oauth-manager";
+import { SessionManager } from "../session-manager";
+
+const DISK_CAPS = `providers: []
+servers:
+  - id: safe
+    type: mcp
+    def:
+      cmd: echo
+      args: ["ok"]
+tools: []
+skills: []
+`;
+
+const ATTACK_BODY: Capabilities = {
+	providers: [],
+	skills: [],
+	tools: [],
+	servers: [
+		{
+			id: "pwn",
+			type: "mcp",
+			def: { cmd: "touch", args: ["/tmp/capa-pwned"] },
+		},
+	],
+};
+
+describe("handleProjectConfigure", () => {
+	let dir: string;
+	let db: CapaDatabase;
+	let sessionManager: SessionManager;
+	let validatedCmds: string[];
+	let deps: ConfigureRouteDeps;
+
+	beforeEach(() => {
+		dir = mkdtempSync(join(tmpdir(), "capa-configure-sec-"));
+		writeFileSync(join(dir, "capabilities.yaml"), DISK_CAPS);
+		db = new CapaDatabase(join(dir, "test.db"));
+		db.upsertProject({ id: "proj-1", path: dir });
+		sessionManager = new SessionManager(db);
+		validatedCmds = [];
+		const mcp = {
+			validateTools: async (caps: Capabilities) => {
+				for (const server of caps.servers) {
+					if (server.def?.cmd) validatedCmds.push(server.def.cmd);
+				}
+				return [];
+			},
+		} as unknown as CapaMCPServer;
+		deps = {
+			db,
+			sessionManager,
+			oauth2Manager: {
+				detectOAuth2Requirement: async () => null,
+				isServerConnected: () => false,
+				getAccessToken: async () => null,
+			} as unknown as OAuth2Manager,
+			capsWatcher: {
+				watchProject: async () => {},
+			} as unknown as CapabilitiesFileWatcher,
+			effectiveCapsCache: new Map(),
+			getOrCreateMCPServer: () => mcp,
+			uiOrigin: () => "http://127.0.0.1:5912",
+		};
+	});
+
+	afterEach(() => {
+		sessionManager.dispose();
+		db.close();
+		rmSync(dir, { recursive: true, force: true });
+	});
+
+	it("rejects a non-object capabilities body with 400 and does not spawn", async () => {
+		const res = await handleProjectConfigure(
+			deps,
+			"proj-1",
+			new Request("http://127.0.0.1/api/projects/proj-1/configure", {
+				method: "POST",
+				headers: { "Content-Type": "application/json" },
+				body: JSON.stringify(["not", "a", "document"]),
+			}),
+		);
+		expect(res.status).toBe(400);
+		expect(validatedCmds).toEqual([]);
+	});
+
+	it("does not spawn stdio commands from the request body", async () => {
+		const res = await handleProjectConfigure(
+			deps,
+			"proj-1",
+			new Request("http://127.0.0.1/api/projects/proj-1/configure", {
+				method: "POST",
+				headers: { "Content-Type": "application/json" },
+				body: JSON.stringify(ATTACK_BODY),
+			}),
+		);
+		expect(res.status).toBe(200);
+		expect(validatedCmds).toEqual(["echo"]);
+		expect(validatedCmds).not.toContain("touch");
+	});
+});
+
+describe("afterWrite HTTP capability mutations", () => {
+	let dir: string;
+
+	beforeEach(() => {
+		dir = mkdtempSync(join(tmpdir(), "capa-afterwrite-sec-"));
+		writeFileSync(join(dir, "capabilities.yaml"), DISK_CAPS);
+	});
+
+	afterEach(() => {
+		rmSync(dir, { recursive: true, force: true });
+	});
+
+	it("refreshes capabilities without running full configure/spawn", async () => {
+		let configured = 0;
+		let refreshed = 0;
+		const deps = {
+			configure: async () => {
+				configured++;
+				return {};
+			},
+			refreshCapabilities: async () => {
+				refreshed++;
+				return { success: true };
+			},
+		} as unknown as CapabilitiesRouteDeps;
+
+		const res = await afterWrite(
+			deps,
+			"proj-1",
+			join(dir, "capabilities.yaml"),
+			"yaml",
+		);
+		expect(res.status).toBe(200);
+		expect(configured).toBe(0);
+		expect(refreshed).toBe(1);
+	});
+});
+
+describe("handleGetServerTools", () => {
+	it("lists tools without connecting/spawning a new stdio server", async () => {
+		const listOpts: Array<Record<string, unknown> | undefined> = [];
+		const mcp = {
+			listServerTools: async (
+				_id: string,
+				_caps: Capabilities,
+				opts?: Record<string, unknown>,
+			) => {
+				listOpts.push(opts);
+				return [];
+			},
+		} as unknown as CapaMCPServer;
+		const sessionManager = {
+			getProjectCapabilities: () => ATTACK_BODY,
+		};
+
+		const res = await handleGetServerTools(
+			{
+				db: {} as CapaDatabase,
+				sessionManager: sessionManager as SessionManager,
+				getOrCreateMCPServer: () => mcp,
+			},
+			"proj-1",
+			"pwn",
+		);
+		expect(res.status).toBe(200);
+		expect(listOpts[0]?.connect).toBe(false);
+	});
+});

--- a/src/server/__tests__/configure-routes.test.ts
+++ b/src/server/__tests__/configure-routes.test.ts
@@ -172,7 +172,7 @@ describe("handleGetServerTools", () => {
 		const res = await handleGetServerTools(
 			{
 				db: {} as CapaDatabase,
-				sessionManager: sessionManager as SessionManager,
+				sessionManager: sessionManager as unknown as SessionManager,
 				getOrCreateMCPServer: () => mcp,
 			},
 			"proj-1",

--- a/src/server/__tests__/cors-origin.test.ts
+++ b/src/server/__tests__/cors-origin.test.ts
@@ -1,40 +1,47 @@
-import { describe, it, expect, afterEach } from 'bun:test';
-import { isAllowedOrigin } from '../cors-origin';
+import { afterEach, describe, expect, it } from "bun:test";
+import { isAllowedOrigin } from "../cors-origin";
 
-describe('isAllowedOrigin', () => {
-  const prev = process.env.CAPA_ALLOWED_ORIGINS;
+describe("isAllowedOrigin", () => {
+	const prev = process.env.CAPA_ALLOWED_ORIGINS;
 
-  afterEach(() => {
-    if (prev === undefined) delete process.env.CAPA_ALLOWED_ORIGINS;
-    else process.env.CAPA_ALLOWED_ORIGINS = prev;
-  });
+	afterEach(() => {
+		if (prev === undefined) delete process.env.CAPA_ALLOWED_ORIGINS;
+		else process.env.CAPA_ALLOWED_ORIGINS = prev;
+	});
 
-  it('allows http localhost and IPv4 loopback', () => {
-    expect(isAllowedOrigin('http://localhost:5173')).toEqual({
-      allowed: true,
-      origin: 'http://localhost:5173',
-    });
-    expect(isAllowedOrigin('http://127.0.0.1:5912')).toEqual({
-      allowed: true,
-      origin: 'http://127.0.0.1:5912',
-    });
-  });
+	it("allows Origin equal to the configured UI origin", () => {
+		expect(isAllowedOrigin("http://127.0.0.1:5912", "127.0.0.1", 5912)).toEqual({
+			allowed: true,
+			origin: "http://127.0.0.1:5912",
+		});
+	});
 
-  it('allows http IPv6 loopback', () => {
-    expect(isAllowedOrigin('http://[::1]:5173')).toEqual({
-      allowed: true,
-      origin: 'http://[::1]:5173',
-    });
-  });
+	it("rejects other localhost ports unless listed in CAPA_ALLOWED_ORIGINS", () => {
+		delete process.env.CAPA_ALLOWED_ORIGINS;
+		expect(isAllowedOrigin("http://localhost:5173", "127.0.0.1", 5912)).toEqual({
+			allowed: false,
+		});
+		expect(isAllowedOrigin("http://[::1]:5173", "127.0.0.1", 5912)).toEqual({
+			allowed: false,
+		});
 
-  it('rejects non-loopback origins unless listed in CAPA_ALLOWED_ORIGINS', () => {
-    delete process.env.CAPA_ALLOWED_ORIGINS;
-    expect(isAllowedOrigin('http://example.com')).toEqual({ allowed: false });
+		process.env.CAPA_ALLOWED_ORIGINS = "http://localhost:5173";
+		expect(isAllowedOrigin("http://localhost:5173", "127.0.0.1", 5912)).toEqual({
+			allowed: true,
+			origin: "http://localhost:5173",
+		});
+	});
 
-    process.env.CAPA_ALLOWED_ORIGINS = 'https://app.example.com';
-    expect(isAllowedOrigin('https://app.example.com')).toEqual({
-      allowed: true,
-      origin: 'https://app.example.com',
-    });
-  });
+	it("rejects non-loopback origins unless listed in CAPA_ALLOWED_ORIGINS", () => {
+		delete process.env.CAPA_ALLOWED_ORIGINS;
+		expect(isAllowedOrigin("http://example.com", "127.0.0.1", 5912)).toEqual({
+			allowed: false,
+		});
+
+		process.env.CAPA_ALLOWED_ORIGINS = "https://app.example.com";
+		expect(isAllowedOrigin("https://app.example.com", "127.0.0.1", 5912)).toEqual({
+			allowed: true,
+			origin: "https://app.example.com",
+		});
+	});
 });

--- a/src/server/__tests__/git-integration-manager.test.ts
+++ b/src/server/__tests__/git-integration-manager.test.ts
@@ -3,21 +3,34 @@ import { mkdtempSync, rmSync } from 'fs';
 import { join } from 'path';
 import { tmpdir } from 'os';
 import { CapaDatabase } from '../../db/database';
+import { resetSecretCryptoForTests } from '../../shared/secret-crypto';
 import { GitIntegrationManager } from '../git-integration-manager';
 
 describe('GitIntegrationManager', () => {
   let db: CapaDatabase;
   let tempDir: string;
   let manager: GitIntegrationManager;
+  let prevHome: string | undefined;
+  let prevProfile: string | undefined;
 
   beforeEach(() => {
     tempDir = mkdtempSync(join(tmpdir(), 'capa-git-int-test-'));
+    prevHome = process.env.HOME;
+    prevProfile = process.env.USERPROFILE;
+    process.env.HOME = tempDir;
+    process.env.USERPROFILE = tempDir;
+    resetSecretCryptoForTests();
     db = new CapaDatabase(join(tempDir, 'test.db'));
     manager = new GitIntegrationManager(db);
   });
 
   afterEach(() => {
     db.close();
+    resetSecretCryptoForTests();
+    if (prevHome === undefined) delete process.env.HOME;
+    else process.env.HOME = prevHome;
+    if (prevProfile === undefined) delete process.env.USERPROFILE;
+    else process.env.USERPROFILE = prevProfile;
     try {
       rmSync(tempDir, { recursive: true, force: true });
     } catch (error: any) {

--- a/src/server/__tests__/git-integration-manager.test.ts
+++ b/src/server/__tests__/git-integration-manager.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, beforeEach, afterEach } from 'bun:test';
+import { describe, it, expect, beforeEach, afterEach, spyOn } from 'bun:test';
 import { mkdtempSync, rmSync } from 'fs';
 import { join } from 'path';
 import { tmpdir } from 'os';
@@ -52,17 +52,43 @@ describe('GitIntegrationManager', () => {
 
     expect(manager.isConnected('github')).toBe(true);
     expect(manager.isConnected('gitlab')).toBe(false);
+
+    db.setGitIntegration('github-enterprise', {
+      host: 'git.example.com',
+      access_token: '   ',
+      token_type: 'token',
+    });
+    expect(manager.isConnected('github-enterprise', 'git.example.com')).toBe(false);
   });
 
-  it('maps platforms to display names in getAllIntegrations', () => {
+  it('maps platforms to display names in getAllIntegrations', async () => {
     db.setGitIntegration('github', { access_token: 'gh', token_type: 'Bearer' });
     db.setGitIntegration('gitlab', { access_token: 'gl', token_type: 'Bearer' });
 
-    const integrations = manager.getAllIntegrations();
+    const integrations = await manager.getAllIntegrations();
     const byPlatform = Object.fromEntries(integrations.map((i) => [i.platform, i.displayName]));
 
     expect(byPlatform.github).toBe('GitHub');
     expect(byPlatform.gitlab).toBe('GitLab');
+  });
+
+  it('marks self-hosted PAT integrations disconnected when validation fails', async () => {
+    const fetchSpy = spyOn(globalThis, 'fetch').mockResolvedValue(
+      new Response('Unauthorized', { status: 401 }),
+    );
+
+    db.setGitIntegration('github-enterprise', {
+      host: 'git.example.com',
+      access_token: 'bad-pat',
+      token_type: 'token',
+    });
+
+    const integrations = await manager.getAllIntegrations();
+    const ghe = integrations.find((i) => i.platform === 'github-enterprise');
+    expect(ghe?.host).toBe('git.example.com');
+    expect(ghe?.isConnected).toBe(false);
+
+    fetchSpy.mockRestore();
   });
 
   it('returns null token and false refresh for unsupported platform', async () => {

--- a/src/server/__tests__/git-integrations-routes.test.ts
+++ b/src/server/__tests__/git-integrations-routes.test.ts
@@ -1,0 +1,155 @@
+import { afterEach, beforeEach, describe, expect, it } from 'bun:test';
+import { mkdtempSync, rmSync } from 'fs';
+import { tmpdir } from 'os';
+import { join } from 'path';
+import { CapaDatabase } from '../../db/database';
+import { resetSecretCryptoForTests } from '../../shared/secret-crypto';
+import { GitIntegrationManager } from '../git-integration-manager';
+import {
+  type GitIntegrationsRouteDeps,
+  handleGitHubOAuthCallback,
+  handleGitHubOAuthStart,
+  handleGitLabOAuthCallback,
+} from '../git-integrations-routes';
+import { buildOAuthBridgeHtml } from '../oauth-bridge';
+
+describe('Git OAuth callback state binding', () => {
+  let db: CapaDatabase;
+  let tempDir: string;
+  let manager: GitIntegrationManager;
+  let deps: GitIntegrationsRouteDeps;
+  let prevHome: string | undefined;
+  let prevProfile: string | undefined;
+  const originalFetch = globalThis.fetch;
+
+  beforeEach(() => {
+    tempDir = mkdtempSync(join(tmpdir(), 'capa-git-oauth-state-'));
+    prevHome = process.env.HOME;
+    prevProfile = process.env.USERPROFILE;
+    process.env.HOME = tempDir;
+    process.env.USERPROFILE = tempDir;
+    resetSecretCryptoForTests();
+    db = new CapaDatabase(join(tempDir, 'test.db'));
+    manager = new GitIntegrationManager(db);
+    deps = {
+      gitIntegrationManager: manager,
+      uiOrigin: () => 'http://127.0.0.1:5912',
+      serverHost: '127.0.0.1',
+      serverPort: 5912,
+    };
+    globalThis.fetch = (async () =>
+      new Response(JSON.stringify({ login: 'tester' }), {
+        status: 200,
+        headers: { 'Content-Type': 'application/json' },
+      })) as typeof fetch;
+  });
+
+  afterEach(() => {
+    globalThis.fetch = originalFetch;
+    db.close();
+    resetSecretCryptoForTests();
+    if (prevHome === undefined) delete process.env.HOME;
+    else process.env.HOME = prevHome;
+    if (prevProfile === undefined) delete process.env.USERPROFILE;
+    else process.env.USERPROFILE = prevProfile;
+    try {
+      rmSync(tempDir, { recursive: true, force: true });
+    } catch (error: any) {
+      if (error?.code !== 'EBUSY') throw error;
+    }
+  });
+
+  function callbackRequest(body: Record<string, unknown>): Request {
+    return new Request('http://127.0.0.1:5912/api/integrations/github/oauth/callback', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(body),
+    });
+  }
+
+  it('rejects POST {access_token} without state/flowId with 400 and does not write git_integrations', async () => {
+    const res = await handleGitHubOAuthCallback(
+      deps,
+      callbackRequest({ access_token: 'attacker-pat' }),
+    );
+
+    expect(res.status).toBe(400);
+    const json = await res.json();
+    expect(json.error).toMatch(/state|flowId/i);
+    expect(db.getGitIntegration('github')).toBeNull();
+  });
+
+  it('stores the token when callback includes matching state from /oauth/start', async () => {
+    const startRes = await handleGitHubOAuthStart(
+      deps,
+      new Request('http://127.0.0.1:5912/api/integrations/github/oauth/start', {
+        method: 'POST',
+      }),
+    );
+    expect(startRes.status).toBe(200);
+    const started = await startRes.json();
+    const nonce = started.state || started.flowId;
+    expect(typeof nonce).toBe('string');
+    expect(nonce.length).toBeGreaterThan(8);
+
+    const authUrl = new URL(started.authorizationUrl);
+    expect(authUrl.searchParams.get('state')).toBe(nonce);
+    const redirect = authUrl.searchParams.get('redirect');
+    expect(redirect).toBeTruthy();
+    expect(new URL(redirect!).searchParams.get('state')).toBe(nonce);
+
+    const res = await handleGitHubOAuthCallback(
+      deps,
+      callbackRequest({ access_token: 'legit-oauth-token', state: nonce }),
+    );
+
+    expect(res.status).toBe(302);
+    expect(res.headers.get('Location')).toContain('success=github');
+    expect(db.getGitIntegration('github')?.access_token).toBe('legit-oauth-token');
+  });
+
+  it('rejects a reused consumed state and does not overwrite the stored token', async () => {
+    const startRes = await handleGitHubOAuthStart(
+      deps,
+      new Request('http://127.0.0.1:5912/api/integrations/github/oauth/start', {
+        method: 'POST',
+      }),
+    );
+    const started = await startRes.json();
+    const nonce = started.state || started.flowId;
+
+    const first = await handleGitHubOAuthCallback(
+      deps,
+      callbackRequest({ access_token: 'first-token', flowId: nonce }),
+    );
+    expect(first.status).toBe(302);
+    expect(db.getGitIntegration('github')?.access_token).toBe('first-token');
+
+    const second = await handleGitHubOAuthCallback(
+      deps,
+      callbackRequest({ access_token: 'attacker-overwrite', state: nonce }),
+    );
+    expect(second.status).toBe(400);
+    expect(db.getGitIntegration('github')?.access_token).toBe('first-token');
+  });
+
+  it('rejects GitLab callback POST {access_token} without state and does not write', async () => {
+    const res = await handleGitLabOAuthCallback(
+      deps,
+      new Request('http://127.0.0.1:5912/api/integrations/gitlab/oauth/callback', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ access_token: 'gl-attacker' }),
+      }),
+    );
+    expect(res.status).toBe(400);
+    expect(db.getGitIntegration('gitlab')).toBeNull();
+  });
+
+  it('forwards state and flowId from the cloud GET query into the HTML bridge POST body', () => {
+    const html = buildOAuthBridgeHtml('github');
+    expect(html).toMatch(/params\.get\(['"]state['"]\)/);
+    expect(html).toMatch(/body\.state/);
+    expect(html).toMatch(/params\.get\(['"]flowId['"]\)|params\.get\(['"]flow_id['"]\)/);
+  });
+});

--- a/src/server/__tests__/git-integrations-routes.test.ts
+++ b/src/server/__tests__/git-integrations-routes.test.ts
@@ -41,7 +41,7 @@ describe('Git OAuth callback state binding', () => {
       new Response(JSON.stringify({ login: 'tester' }), {
         status: 200,
         headers: { 'Content-Type': 'application/json' },
-      })) as typeof fetch;
+      })) as unknown as typeof fetch;
   });
 
   afterEach(() => {

--- a/src/server/__tests__/git-integrations-routes.test.ts
+++ b/src/server/__tests__/git-integrations-routes.test.ts
@@ -11,7 +11,7 @@ import {
   handleGitHubOAuthStart,
   handleGitLabOAuthCallback,
 } from '../git-integrations-routes';
-import { buildOAuthBridgeHtml } from '../oauth-bridge';
+import { buildOAuthBridgeHtml, gitOAuthCallbackNeedsBridge } from '../oauth-bridge';
 
 describe('Git OAuth callback state binding', () => {
   let db: CapaDatabase;
@@ -148,8 +148,41 @@ describe('Git OAuth callback state binding', () => {
 
   it('forwards state and flowId from the cloud GET query into the HTML bridge POST body', () => {
     const html = buildOAuthBridgeHtml('github');
-    expect(html).toMatch(/params\.get\(['"]state['"]\)/);
+    expect(html).toMatch(/params\.get\(['"]state['"]\)|pick\(['"]state['"]\)/);
     expect(html).toMatch(/body\.state/);
-    expect(html).toMatch(/params\.get\(['"]flowId['"]\)|params\.get\(['"]flow_id['"]\)/);
+    expect(html).toMatch(/flowId|flow_id/);
+  });
+
+  it('serves the HTML bridge on GET when only state/flowId are present (tokens in hash)', async () => {
+    const res = await handleGitHubOAuthCallback(
+      deps,
+      new Request(
+        'http://127.0.0.1:5912/api/integrations/github/oauth/callback?state=abc&flowId=abc',
+        { method: 'GET' },
+      ),
+    );
+    expect(res.status).toBe(200);
+    expect(res.headers.get('content-type')).toContain('text/html');
+    const html = await res.text();
+    expect(html).toContain('Finishing GitHub sign-in');
+    expect(html).toContain('location.hash');
+  });
+
+  it('gitOAuthCallbackNeedsBridge accepts state-only and token query params', () => {
+    expect(
+      gitOAuthCallbackNeedsBridge(
+        new URL('http://127.0.0.1:5912/api/integrations/github/oauth/callback?state=x'),
+      ),
+    ).toBe(true);
+    expect(
+      gitOAuthCallbackNeedsBridge(
+        new URL('http://127.0.0.1:5912/api/integrations/github/oauth/callback?token=t'),
+      ),
+    ).toBe(true);
+    expect(
+      gitOAuthCallbackNeedsBridge(
+        new URL('http://127.0.0.1:5912/api/integrations/github/oauth/callback?error=denied'),
+      ),
+    ).toBe(false);
   });
 });

--- a/src/server/__tests__/host-allowlist.test.ts
+++ b/src/server/__tests__/host-allowlist.test.ts
@@ -1,0 +1,79 @@
+import { describe, expect, it } from "bun:test";
+import {
+	isAllowedHostHeader,
+	misdirectedHostResponse,
+	withAllowedHost,
+} from "../host-allowlist";
+
+describe("isAllowedHostHeader", () => {
+	it("allows 127.0.0.1, localhost, and ::1 on the bind port", () => {
+		expect(isAllowedHostHeader("127.0.0.1:5912", "127.0.0.1", 5912)).toBe(true);
+		expect(isAllowedHostHeader("localhost:5912", "127.0.0.1", 5912)).toBe(true);
+		expect(isAllowedHostHeader("[::1]:5912", "127.0.0.1", 5912)).toBe(true);
+	});
+
+	it("allows the configured bind host and port", () => {
+		expect(isAllowedHostHeader("10.0.0.5:5912", "10.0.0.5", 5912)).toBe(true);
+	});
+
+	it("rejects an attacker DNS name on the capa port", () => {
+		expect(
+			isAllowedHostHeader("evil.example:5912", "127.0.0.1", 5912),
+		).toBe(false);
+		expect(isAllowedHostHeader("evil.example", "127.0.0.1", 5912)).toBe(false);
+	});
+
+	it("rejects a matching name on the wrong port", () => {
+		expect(isAllowedHostHeader("127.0.0.1:80", "127.0.0.1", 5912)).toBe(false);
+	});
+
+	it("rejects a missing Host header", () => {
+		expect(isAllowedHostHeader(null, "127.0.0.1", 5912)).toBe(false);
+	});
+});
+
+describe("misdirectedHostResponse", () => {
+	it("returns 421 for a rebinding Host", () => {
+		const req = new Request("http://127.0.0.1:5912/api/projects", {
+			headers: { Host: "evil.example:5912" },
+		});
+		const res = misdirectedHostResponse(req, "127.0.0.1", 5912);
+		expect(res).not.toBeNull();
+		expect(res!.status).toBe(421);
+	});
+
+	it("returns null for a legitimate loopback Host", () => {
+		const req = new Request("http://127.0.0.1:5912/api/projects", {
+			headers: { Host: "127.0.0.1:5912" },
+		});
+		expect(misdirectedHostResponse(req, "127.0.0.1", 5912)).toBeNull();
+	});
+});
+
+describe("withAllowedHost", () => {
+	it("rejects attacker Host with 421 before API handlers run", async () => {
+		let apiCalled = false;
+		const req = new Request("http://127.0.0.1:5912/api/projects", {
+			headers: { Host: "evil.example:5912" },
+		});
+		const res = await withAllowedHost(req, "127.0.0.1", 5912, () => {
+			apiCalled = true;
+			return new Response("ok");
+		});
+		expect(res.status).toBe(421);
+		expect(apiCalled).toBe(false);
+	});
+
+	it("runs handlers for a legitimate loopback Host", async () => {
+		let apiCalled = false;
+		const req = new Request("http://127.0.0.1:5912/api/projects", {
+			headers: { Host: "127.0.0.1:5912" },
+		});
+		const res = await withAllowedHost(req, "127.0.0.1", 5912, () => {
+			apiCalled = true;
+			return new Response("ok");
+		});
+		expect(res.status).toBe(200);
+		expect(apiCalled).toBe(true);
+	});
+});

--- a/src/server/__tests__/html-security-headers.test.ts
+++ b/src/server/__tests__/html-security-headers.test.ts
@@ -6,6 +6,13 @@ describe("htmlSecurityHeaders", () => {
 	it("sets CSP and nosniff", () => {
 		const headers = htmlSecurityHeaders({ "Content-Type": "text/html" });
 		expect(headers["Content-Security-Policy"]).toContain("default-src 'self'");
+		expect(headers["Content-Security-Policy"]).toContain(
+			"https://fonts.googleapis.com",
+		);
+		expect(headers["Content-Security-Policy"]).toContain(
+			"https://fonts.gstatic.com",
+		);
+		expect(headers["Content-Security-Policy"]).toContain("img-src 'self' data: https:");
 		expect(headers["Content-Security-Policy"]).toContain("frame-ancestors 'none'");
 		expect(headers["X-Content-Type-Options"]).toBe("nosniff");
 		expect(headers["Content-Type"]).toBe("text/html");

--- a/src/server/__tests__/html-security-headers.test.ts
+++ b/src/server/__tests__/html-security-headers.test.ts
@@ -1,0 +1,23 @@
+import { describe, expect, it } from "bun:test";
+import { htmlSecurityHeaders } from "../html-security-headers";
+import { oauthBridgeResponse } from "../oauth-bridge";
+
+describe("htmlSecurityHeaders", () => {
+	it("sets CSP and nosniff", () => {
+		const headers = htmlSecurityHeaders({ "Content-Type": "text/html" });
+		expect(headers["Content-Security-Policy"]).toContain("default-src 'self'");
+		expect(headers["Content-Security-Policy"]).toContain("frame-ancestors 'none'");
+		expect(headers["X-Content-Type-Options"]).toBe("nosniff");
+		expect(headers["Content-Type"]).toBe("text/html");
+	});
+});
+
+describe("oauthBridgeResponse", () => {
+	it("includes CSP on OAuth-bridge HTML", () => {
+		const res = oauthBridgeResponse("github");
+		expect(res.headers.get("Content-Security-Policy")).toContain(
+			"default-src 'self'",
+		);
+		expect(res.headers.get("X-Content-Type-Options")).toBe("nosniff");
+	});
+});

--- a/src/server/__tests__/mcp-proxy.test.ts
+++ b/src/server/__tests__/mcp-proxy.test.ts
@@ -1,9 +1,18 @@
-import { describe, it, expect, beforeEach, afterEach } from 'bun:test';
+import { describe, it, expect, beforeEach, afterEach, spyOn } from 'bun:test';
+import { mkdtempSync, rmSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
 import { fileURLToPath } from 'node:url';
-import { MCPProxy, mcpServerLaunchFingerprint } from '../mcp-proxy';
-import { shouldSkipTlsVerify } from '../../shared/tls-skip-verify';
 import type { CapaDatabase } from '../../db/database';
+import * as config from '../../shared/config';
+import { trustStdioServers } from '../../shared/stdio-allowlist';
+import { shouldSkipTlsVerify } from '../../shared/tls-skip-verify';
 import type { MCPServerDefinition } from '../../types/capabilities';
+import { MCPProxy, mcpServerLaunchFingerprint } from '../mcp-proxy';
+
+function trustStdio(projectId: string, def: MCPServerDefinition): void {
+  trustStdioServers(projectId, [{ id: 'stdio', type: 'mcp', def }]);
+}
 
 function makeMockDb(): CapaDatabase {
   return {
@@ -207,6 +216,19 @@ describe('mcp-proxy', () => {
   });
 
   describe('stdio crash fail-fast', () => {
+    let capaDir: string;
+    let dirSpy: ReturnType<typeof spyOn>;
+
+    beforeEach(() => {
+      capaDir = mkdtempSync(join(tmpdir(), 'capa-stdio-trust-'));
+      dirSpy = spyOn(config, 'getCapaDir').mockReturnValue(capaDir);
+    });
+
+    afterEach(() => {
+      dirSpy.mockRestore();
+      rmSync(capaDir, { recursive: true, force: true });
+    });
+
     it('executeTool fails within 2s when the child exits mid tools/call', async () => {
       const proxy = new MCPProxy(makeMockDb(), 'proj-crash', process.cwd());
       const fixturePath = fileURLToPath(
@@ -216,6 +238,7 @@ describe('mcp-proxy', () => {
         cmd: process.execPath,
         args: [fixturePath],
       };
+      trustStdio('proj-crash', serverDef);
 
       const started = Date.now();
       const result = await proxy.executeTool(
@@ -245,6 +268,7 @@ describe('mcp-proxy', () => {
         cmd: process.execPath,
         args: [fixturePath],
       };
+      trustStdio('proj-hang-panic', serverDef);
 
       const started = Date.now();
       const result = await proxy.executeTool(
@@ -267,6 +291,18 @@ describe('mcp-proxy', () => {
     const fixturePath = fileURLToPath(
       new URL('./fixtures/version-echo-mcp.ts', import.meta.url),
     );
+    let capaDir: string;
+    let dirSpy: ReturnType<typeof spyOn>;
+
+    beforeEach(() => {
+      capaDir = mkdtempSync(join(tmpdir(), 'capa-stdio-trust-'));
+      dirSpy = spyOn(config, 'getCapaDir').mockReturnValue(capaDir);
+    });
+
+    afterEach(() => {
+      dirSpy.mockRestore();
+      rmSync(capaDir, { recursive: true, force: true });
+    });
 
     function versionDef(token: string): MCPServerDefinition {
       return {
@@ -287,6 +323,7 @@ describe('mcp-proxy', () => {
     it('reuses the cached client when the launch fingerprint is unchanged', async () => {
       const proxy = new MCPProxy(makeMockDb(), 'proj-fp', process.cwd());
       const def = versionDef('1.0.14');
+      trustStdio('proj-fp', def);
       const first = await proxy.executeTool(
         'echo.echo_version',
         { server: 'echo', tool: 'echo_version' },
@@ -311,6 +348,8 @@ describe('mcp-proxy', () => {
 
     it('respawns when args change without closeAll', async () => {
       const proxy = new MCPProxy(makeMockDb(), 'proj-swap', process.cwd());
+      trustStdio('proj-swap', versionDef('1.0.14'));
+      trustStdio('proj-swap', versionDef('1.0.15'));
       const v14 = await proxy.executeTool(
         'echo.echo_version',
         { server: 'echo', tool: 'echo_version' },
@@ -335,6 +374,8 @@ describe('mcp-proxy', () => {
 
     it('syncCachedServers closes clients whose def fingerprint changed', async () => {
       const proxy = new MCPProxy(makeMockDb(), 'proj-sync', process.cwd());
+      trustStdio('proj-sync', versionDef('1.0.14'));
+      trustStdio('proj-sync', versionDef('1.0.15'));
       await proxy.executeTool(
         'echo.echo_version',
         { server: 'echo', tool: 'echo_version' },
@@ -363,6 +404,7 @@ describe('mcp-proxy', () => {
     it('syncCachedServers keeps warm clients when def is unchanged', async () => {
       const proxy = new MCPProxy(makeMockDb(), 'proj-warm', process.cwd());
       const def = versionDef('1.0.15');
+      trustStdio('proj-warm', def);
       await proxy.executeTool(
         'echo.echo_version',
         { server: 'echo', tool: 'echo_version' },

--- a/src/server/__tests__/oauth-callback-bridge.test.ts
+++ b/src/server/__tests__/oauth-callback-bridge.test.ts
@@ -1,5 +1,11 @@
 import { describe, it, expect } from 'bun:test';
-import { buildOAuthBridgeHtml, oauthBridgeResponse } from '../oauth-bridge';
+import {
+  buildOAuthBridgeHtml,
+  gitOAuthCallbackNeedsBridge,
+  normalizeOAuthCallbackQuery,
+  parseOAuthCallbackSearchParams,
+  oauthBridgeResponse,
+} from '../oauth-bridge';
 
 /**
  * The cloud OAuth provider redirects via GET with `?access_token=...` in the query
@@ -30,12 +36,14 @@ describe('git OAuth callback bridge', () => {
       expect(replaceIdx).toBeLessThan(postIdx);
     });
 
-    it('reads tokens from window.location.search rather than baking them in', () => {
+    it('reads tokens from query and hash (access_token, token alias)', () => {
       const html = buildOAuthBridgeHtml('gitlab');
       expect(html).toContain('window.location.search');
-      expect(html).toContain("params.get('access_token')");
-      expect(html).toContain("params.get('refresh_token')");
-      expect(html).toContain("params.get('expires_in')");
+      expect(html).toContain(".replace(/\\?/g, '&')");
+      expect(html).toContain('location.hash');
+      expect(html).toContain("pick('access_token', 'token')");
+      expect(html).toContain("pick('refresh_token')");
+      expect(html).toContain("pick('expires_in')");
     });
 
     it('re-issues the callback as POST with JSON body', () => {
@@ -55,6 +63,32 @@ describe('git OAuth callback bridge', () => {
     it('sets Referrer-Policy via meta tag so the cloud URL never leaks', () => {
       const html = buildOAuthBridgeHtml('gitlab');
       expect(html).toMatch(/<meta\s+name="referrer"\s+content="no-referrer"/);
+    });
+  });
+
+  describe('normalizeOAuthCallbackQuery', () => {
+    it('coerces a second ? from cloud redirects into &', () => {
+      const search =
+        '?state=abc&flowId=abc?access_token=ghu_test&refresh_token=ghr_test&expires_in=28800&provider=github.com';
+      const params = parseOAuthCallbackSearchParams(search);
+      expect(params.get('state')).toBe('abc');
+      expect(params.get('flowId')).toBe('abc');
+      expect(params.get('access_token')).toBe('ghu_test');
+      expect(params.get('refresh_token')).toBe('ghr_test');
+      expect(params.get('expires_in')).toBe('28800');
+      expect(normalizeOAuthCallbackQuery(search)).toBe(
+        'state=abc&flowId=abc&access_token=ghu_test&refresh_token=ghr_test&expires_in=28800&provider=github.com',
+      );
+    });
+
+    it('gitOAuthCallbackNeedsBridge detects access_token after normalization', () => {
+      expect(
+        gitOAuthCallbackNeedsBridge(
+          new URL(
+            'http://127.0.0.1:5912/api/integrations/github/oauth/callback?state=x&flowId=y?access_token=t',
+          ),
+        ),
+      ).toBe(true);
     });
   });
 

--- a/src/server/__tests__/oauth-discovery.test.ts
+++ b/src/server/__tests__/oauth-discovery.test.ts
@@ -1,0 +1,160 @@
+import { afterEach, describe, expect, it } from "bun:test";
+import {
+	buildOAuthAuthorizationServerMetadataUrl,
+	detectOAuth2Requirement,
+	resolveOAuthScope,
+	sanitizeOAuthScope,
+} from "../oauth-discovery";
+
+describe("buildOAuthAuthorizationServerMetadataUrl", () => {
+	it("uses origin-root well-known for issuers without a path", () => {
+		expect(
+			buildOAuthAuthorizationServerMetadataUrl("https://auth.example.com"),
+		).toBe("https://auth.example.com/.well-known/oauth-authorization-server");
+	});
+
+	it("inserts well-known between host and path for path-based issuers (RFC 8414)", () => {
+		expect(
+			buildOAuthAuthorizationServerMetadataUrl(
+				"https://auth.example.com/realms/tenant",
+			),
+		).toBe(
+			"https://auth.example.com/.well-known/oauth-authorization-server/realms/tenant",
+		);
+	});
+
+	it("strips a trailing slash from the issuer path", () => {
+		expect(
+			buildOAuthAuthorizationServerMetadataUrl(
+				"https://auth.example.com/tenant1/",
+			),
+		).toBe(
+			"https://auth.example.com/.well-known/oauth-authorization-server/tenant1",
+		);
+	});
+});
+
+describe("resolveOAuthScope", () => {
+	it("prefers protected-resource scopes over the auth-server catalog", () => {
+		expect(
+			resolveOAuthScope({
+				resourceMetadata: {
+					resource: "https://gateway.example.test/mcp",
+					authorization_servers: ["https://auth.example.test/realms/x"],
+					scopes_supported: [
+						"openid",
+						"email",
+						"profile",
+						"offline_access",
+						"api.read",
+					],
+				},
+				authServerScopes: [
+					"openid",
+					"profile",
+					"roles",
+					"service_account",
+					"web-origins",
+				],
+			}),
+		).toBe("openid email profile offline_access api.read");
+	});
+
+	it("falls back to the WWW-Authenticate scope hint", () => {
+		expect(
+			resolveOAuthScope({
+				wwwAuthenticateScope: "openid profile email",
+				authServerScopes: ["openid", "service_account"],
+			}),
+		).toBe("openid profile email");
+	});
+});
+
+describe("sanitizeOAuthScope", () => {
+	it("removes scopes invalid for user-facing authorization_code clients", () => {
+		expect(
+			sanitizeOAuthScope(
+				"openid profile email offline_access roles service_account web-origins",
+			),
+		).toBe("openid profile email offline_access");
+	});
+});
+
+describe("detectOAuth2Requirement", () => {
+	const originalFetch = globalThis.fetch;
+
+	afterEach(() => {
+		globalThis.fetch = originalFetch;
+	});
+
+	it("detects OAuth2 for path-based authorization servers via RFC 9728 metadata", async () => {
+		globalThis.fetch = (async (input: RequestInfo | URL, init?: RequestInit) => {
+			const url = String(input);
+			if (
+				url === "https://mcp-gateway.example.test/mcp" &&
+				init?.method === "POST"
+			) {
+				return new Response("", {
+					status: 401,
+					headers: {
+						"WWW-Authenticate":
+							'Bearer error="invalid_token", resource_metadata="https://mcp-gateway.example.test/.well-known/oauth-protected-resource/mcp"',
+					},
+				});
+			}
+			if (
+				url ===
+				"https://mcp-gateway.example.test/.well-known/oauth-protected-resource/mcp"
+			) {
+				return Response.json({
+					resource: "https://mcp-gateway.example.test/mcp",
+					authorization_servers: [
+						"https://mcp-auth.example.test/realms/tenant",
+					],
+					scopes_supported: [
+						"openid",
+						"email",
+						"profile",
+						"offline_access",
+						"api.read",
+					],
+				});
+			}
+			if (
+				url ===
+				"https://mcp-auth.example.test/.well-known/oauth-authorization-server/realms/tenant"
+			) {
+				return Response.json({
+					authorization_endpoint:
+						"https://mcp-auth.example.test/realms/tenant/protocol/openid-connect/auth",
+					token_endpoint:
+						"https://mcp-auth.example.test/realms/tenant/protocol/openid-connect/token",
+					grant_types_supported: ["authorization_code"],
+					response_types_supported: ["code"],
+					scopes_supported: [
+						"openid",
+						"profile",
+						"roles",
+						"service_account",
+						"web-origins",
+					],
+				});
+			}
+			return new Response("", { status: 404 });
+		}) as unknown as typeof fetch;
+
+		const result = await detectOAuth2Requirement(
+			"https://mcp-gateway.example.test/mcp",
+		);
+		expect(result).not.toBeNull();
+		expect(result?.authorizationEndpoint).toBe(
+			"https://mcp-auth.example.test/realms/tenant/protocol/openid-connect/auth",
+		);
+		expect(result?.tokenEndpoint).toBe(
+			"https://mcp-auth.example.test/realms/tenant/protocol/openid-connect/token",
+		);
+		expect(result?.scope).toBe(
+			"openid email profile offline_access api.read",
+		);
+	});
+});

--- a/src/server/__tests__/oauth-pkce-flow.test.ts
+++ b/src/server/__tests__/oauth-pkce-flow.test.ts
@@ -1,0 +1,18 @@
+import { describe, expect, it } from "bun:test";
+import { clientUriForRegistration } from "../oauth-pkce-flow";
+
+describe("clientUriForRegistration", () => {
+	it("uses localhost with the redirect URI port", () => {
+		expect(
+			clientUriForRegistration(
+				"http://127.0.0.1:5912/api/projects/demo/oauth/callback",
+			),
+		).toBe("http://localhost:5912");
+	});
+
+	it("omits the port when the redirect URI uses the default HTTP port", () => {
+		expect(
+			clientUriForRegistration("http://127.0.0.1/api/projects/demo/oauth/callback"),
+		).toBe("http://localhost");
+	});
+});

--- a/src/server/__tests__/oauth-server-sync.test.ts
+++ b/src/server/__tests__/oauth-server-sync.test.ts
@@ -8,6 +8,12 @@ import {
 } from "../oauth-server-sync";
 import { preserveDiscoveredOAuth2 } from "../resolve-effective-capabilities";
 
+const DETECTED_OAUTH: OAuth2Config = {
+	authorizationEndpoint: "https://auth.example/authorize",
+	tokenEndpoint: "https://auth.example/token",
+	resourceServer: "https://mcp.example/mcp",
+};
+
 function mcpServer(
 	id: string,
 	url: string,
@@ -27,10 +33,7 @@ describe("preserveDiscoveredOAuth2", () => {
 			skills: [],
 			tools: [],
 			servers: [
-				mcpServer("server-a", "https://old.example/mcp", {
-					authorizationEndpoint: "https://auth.example/authorize",
-					tokenEndpoint: "https://auth.example/token",
-				}),
+				mcpServer("server-a", "https://old.example/mcp", DETECTED_OAUTH),
 			],
 		};
 		const fresh: Capabilities = {
@@ -50,10 +53,7 @@ describe("preserveDiscoveredOAuth2", () => {
 			skills: [],
 			tools: [],
 			servers: [
-				mcpServer("server-b", "https://mcp.example/mcp", {
-					authorizationEndpoint: "https://auth.example/authorize",
-					tokenEndpoint: "https://auth.example/token",
-				}),
+				mcpServer("server-b", "https://mcp.example/mcp", DETECTED_OAUTH),
 			],
 		};
 		const fresh: Capabilities = {
@@ -74,10 +74,7 @@ describe("mergeDetectedOAuth2", () => {
 	it("keeps plugin-embedded client_id and callback_port", () => {
 		const merged = mergeDetectedOAuth2(
 			{ client_id: "embedded-app", callback_port: 3111 },
-			{
-				authorizationEndpoint: "https://auth.example/authorize",
-				tokenEndpoint: "https://auth.example/token",
-			},
+			DETECTED_OAUTH,
 		);
 		expect(merged.client_id).toBe("embedded-app");
 		expect(merged.callback_port).toBe(3111);
@@ -87,10 +84,11 @@ describe("mergeDetectedOAuth2", () => {
 
 describe("syncServerOAuth2Requirement", () => {
 	it("clears stale OAuth config when the live URL no longer requires auth", async () => {
-		const server = mcpServer("server-a", "https://new.example/mcp", {
-			authorizationEndpoint: "https://auth.example/authorize",
-			tokenEndpoint: "https://auth.example/token",
-		});
+		const server = mcpServer(
+			"server-a",
+			"https://new.example/mcp",
+			DETECTED_OAUTH,
+		);
 		const disconnects: string[] = [];
 		const oauth2Manager = {
 			detectOAuth2Requirement: async () => null,

--- a/src/server/__tests__/oauth-server-sync.test.ts
+++ b/src/server/__tests__/oauth-server-sync.test.ts
@@ -1,0 +1,115 @@
+import { describe, expect, it } from "bun:test";
+import type { Capabilities, MCPServer } from "../../types/capabilities";
+import type { OAuth2Config } from "../../types/oauth";
+import type { OAuth2Manager } from "../oauth-manager";
+import {
+	mergeDetectedOAuth2,
+	syncServerOAuth2Requirement,
+} from "../oauth-server-sync";
+import { preserveDiscoveredOAuth2 } from "../resolve-effective-capabilities";
+
+function mcpServer(
+	id: string,
+	url: string,
+	oauth2?: OAuth2Config,
+): MCPServer {
+	return {
+		id,
+		type: "mcp",
+		def: { url, ...(oauth2 ? { oauth2 } : {}) },
+	};
+}
+
+describe("preserveDiscoveredOAuth2", () => {
+	it("does not copy OAuth metadata when the server URL changed", () => {
+		const previous: Capabilities = {
+			providers: [],
+			skills: [],
+			tools: [],
+			servers: [
+				mcpServer("server-a", "https://old.example/mcp", {
+					authorizationEndpoint: "https://auth.example/authorize",
+					tokenEndpoint: "https://auth.example/token",
+				}),
+			],
+		};
+		const fresh: Capabilities = {
+			providers: [],
+			skills: [],
+			tools: [],
+			servers: [mcpServer("server-a", "https://new.example/mcp")],
+		};
+
+		const result = preserveDiscoveredOAuth2(fresh, previous);
+		expect(result.servers[0].def.oauth2).toBeUndefined();
+	});
+
+	it("still copies discovered endpoints when the URL is unchanged", () => {
+		const previous: Capabilities = {
+			providers: [],
+			skills: [],
+			tools: [],
+			servers: [
+				mcpServer("server-b", "https://mcp.example/mcp", {
+					authorizationEndpoint: "https://auth.example/authorize",
+					tokenEndpoint: "https://auth.example/token",
+				}),
+			],
+		};
+		const fresh: Capabilities = {
+			providers: [],
+			skills: [],
+			tools: [],
+			servers: [mcpServer("server-b", "https://mcp.example/mcp")],
+		};
+
+		const result = preserveDiscoveredOAuth2(fresh, previous);
+		expect(result.servers[0].def.oauth2?.authorizationEndpoint).toBe(
+			"https://auth.example/authorize",
+		);
+	});
+});
+
+describe("mergeDetectedOAuth2", () => {
+	it("keeps plugin-embedded client_id and callback_port", () => {
+		const merged = mergeDetectedOAuth2(
+			{ client_id: "embedded-app", callback_port: 3111 },
+			{
+				authorizationEndpoint: "https://auth.example/authorize",
+				tokenEndpoint: "https://auth.example/token",
+			},
+		);
+		expect(merged.client_id).toBe("embedded-app");
+		expect(merged.callback_port).toBe(3111);
+		expect(merged.authorizationEndpoint).toBe("https://auth.example/authorize");
+	});
+});
+
+describe("syncServerOAuth2Requirement", () => {
+	it("clears stale OAuth config when the live URL no longer requires auth", async () => {
+		const server = mcpServer("server-a", "https://new.example/mcp", {
+			authorizationEndpoint: "https://auth.example/authorize",
+			tokenEndpoint: "https://auth.example/token",
+		});
+		const disconnects: string[] = [];
+		const oauth2Manager = {
+			detectOAuth2Requirement: async () => null,
+			isServerConnected: () => true,
+			getAccessToken: async () => "token",
+			disconnect: (_projectId: string, serverId: string) => {
+				disconnects.push(serverId);
+			},
+		} as unknown as OAuth2Manager;
+
+		const result = await syncServerOAuth2Requirement(
+			"proj-1",
+			server,
+			oauth2Manager,
+		);
+
+		expect(result.changed).toBe(true);
+		expect(result.entry).toBeNull();
+		expect(server.def.oauth2).toBeUndefined();
+		expect(disconnects).toEqual(["server-a"]);
+	});
+});

--- a/src/server/__tests__/oauth-token-refresh.test.ts
+++ b/src/server/__tests__/oauth-token-refresh.test.ts
@@ -72,10 +72,12 @@ describe("refreshAccessToken", () => {
 			new Response(JSON.stringify({ ok: false, error: "invalid_refresh_token" }), {
 				status: 200,
 				headers: { "Content-Type": "application/json" },
-			})) as typeof fetch;
+			})) as unknown as typeof fetch;
 
 		const ok = await refreshAccessToken(db, "p1", "mcp-server", {
+			authorizationEndpoint: "https://example.com/authorize",
 			tokenEndpoint: "https://example.com/token",
+			resourceServer: "https://example.com",
 			client_id: "test-app-id",
 		});
 
@@ -85,7 +87,7 @@ describe("refreshAccessToken", () => {
 
 	it("uses embedded client_id from oauth2 config when no stored variable exists", async () => {
 		let body = "";
-		globalThis.fetch = (async (_input, init) => {
+		globalThis.fetch = (async (_input: RequestInfo | URL, init?: RequestInit) => {
 			body = String(init?.body ?? "");
 			return new Response(
 				JSON.stringify({
@@ -95,10 +97,12 @@ describe("refreshAccessToken", () => {
 				}),
 				{ status: 200, headers: { "Content-Type": "application/json" } },
 			);
-		}) as typeof fetch;
+		}) as unknown as typeof fetch;
 
 		const ok = await refreshAccessToken(db, "p1", "mcp-server", {
+			authorizationEndpoint: "https://example.com/authorize",
 			tokenEndpoint: "https://example.com/token",
+			resourceServer: "https://example.com",
 			client_id: "test-app-id",
 		});
 

--- a/src/server/__tests__/oauth-token-refresh.test.ts
+++ b/src/server/__tests__/oauth-token-refresh.test.ts
@@ -1,0 +1,108 @@
+import { afterEach, beforeEach, describe, expect, it } from "bun:test";
+import { mkdtempSync, rmSync } from "fs";
+import { join } from "path";
+import { tmpdir } from "os";
+import { CapaDatabase } from "../../db/database";
+import { resetSecretCryptoForTests } from "../../shared/secret-crypto";
+import {
+	parseOAuthTokenExchangeResponse,
+	refreshAccessToken,
+} from "../oauth-token-store";
+
+describe("parseOAuthTokenExchangeResponse", () => {
+	it("accepts standard OAuth token responses", () => {
+		expect(
+			parseOAuthTokenExchangeResponse({
+				access_token: "new-access",
+				refresh_token: "new-refresh",
+				token_type: "Bearer",
+				expires_in: 3600,
+				scope: "openid profile",
+			}),
+		).toEqual({
+			accessToken: "new-access",
+			refreshToken: "new-refresh",
+			tokenType: "Bearer",
+			expiresIn: 3600,
+			scope: "openid profile",
+		});
+	});
+
+	it("treats ok:false payloads without access_token as errors", () => {
+		expect(
+			parseOAuthTokenExchangeResponse({
+				ok: false,
+				error: "invalid_refresh_token",
+			}),
+		).toEqual({ error: "invalid_refresh_token" });
+	});
+});
+
+describe("refreshAccessToken", () => {
+	let db: CapaDatabase;
+	let tempDir: string;
+	let prevHome: string | undefined;
+	const originalFetch = globalThis.fetch;
+
+	beforeEach(() => {
+		tempDir = mkdtempSync(join(tmpdir(), "capa-mcp-refresh-test-"));
+		prevHome = process.env.HOME;
+		process.env.HOME = tempDir;
+		resetSecretCryptoForTests();
+		db = new CapaDatabase(join(tempDir, "test.db"));
+		db.setOAuthToken("p1", "mcp-server", {
+			access_token: "old-access",
+			refresh_token: "old-refresh",
+			token_type: "Bearer",
+			expires_at: Date.now() - 60_000,
+		});
+	});
+
+	afterEach(() => {
+		globalThis.fetch = originalFetch;
+		db.close();
+		resetSecretCryptoForTests();
+		if (prevHome === undefined) delete process.env.HOME;
+		else process.env.HOME = prevHome;
+		rmSync(tempDir, { recursive: true, force: true });
+	});
+
+	it("does not throw when the provider returns 200 without access_token", async () => {
+		globalThis.fetch = (async () =>
+			new Response(JSON.stringify({ ok: false, error: "invalid_refresh_token" }), {
+				status: 200,
+				headers: { "Content-Type": "application/json" },
+			})) as typeof fetch;
+
+		const ok = await refreshAccessToken(db, "p1", "mcp-server", {
+			tokenEndpoint: "https://example.com/token",
+			client_id: "test-app-id",
+		});
+
+		expect(ok).toBe(false);
+		expect(db.getOAuthToken("p1", "mcp-server")).toBeNull();
+	});
+
+	it("uses embedded client_id from oauth2 config when no stored variable exists", async () => {
+		let body = "";
+		globalThis.fetch = (async (_input, init) => {
+			body = String(init?.body ?? "");
+			return new Response(
+				JSON.stringify({
+					access_token: "new-access",
+					refresh_token: "new-refresh",
+					expires_in: 3600,
+				}),
+				{ status: 200, headers: { "Content-Type": "application/json" } },
+			);
+		}) as typeof fetch;
+
+		const ok = await refreshAccessToken(db, "p1", "mcp-server", {
+			tokenEndpoint: "https://example.com/token",
+			client_id: "test-app-id",
+		});
+
+		expect(ok).toBe(true);
+		expect(new URLSearchParams(body).get("client_id")).toBe("test-app-id");
+	});
+});

--- a/src/server/__tests__/refresh-token.test.ts
+++ b/src/server/__tests__/refresh-token.test.ts
@@ -3,6 +3,7 @@ import { mkdtempSync, rmSync } from 'fs';
 import { join } from 'path';
 import { tmpdir } from 'os';
 import { CapaDatabase } from '../../db/database';
+import { resetSecretCryptoForTests } from '../../shared/secret-crypto';
 import { GitIntegrationManager } from '../git-integration-manager';
 import { CAPA_CLOUD_OAUTH_URL } from '../../shared/ui-urls';
 
@@ -32,9 +33,16 @@ describe('git token refresh security', () => {
     let manager: GitIntegrationManager;
     let fetchCalls: Array<{ url: string; init?: RequestInit }>;
     const originalFetch = globalThis.fetch;
+    let prevHome: string | undefined;
+    let prevProfile: string | undefined;
 
     beforeEach(() => {
       tempDir = mkdtempSync(join(tmpdir(), 'capa-refresh-test-'));
+      prevHome = process.env.HOME;
+      prevProfile = process.env.USERPROFILE;
+      process.env.HOME = tempDir;
+      process.env.USERPROFILE = tempDir;
+      resetSecretCryptoForTests();
       db = new CapaDatabase(join(tempDir, 'test.db'));
       manager = new GitIntegrationManager(db);
       fetchCalls = [];
@@ -63,6 +71,11 @@ describe('git token refresh security', () => {
     afterEach(() => {
       globalThis.fetch = originalFetch;
       db.close();
+      resetSecretCryptoForTests();
+      if (prevHome === undefined) delete process.env.HOME;
+      else process.env.HOME = prevHome;
+      if (prevProfile === undefined) delete process.env.USERPROFILE;
+      else process.env.USERPROFILE = prevProfile;
       try {
         rmSync(tempDir, { recursive: true, force: true });
       } catch (error: any) {

--- a/src/server/__tests__/registries-routes.test.ts
+++ b/src/server/__tests__/registries-routes.test.ts
@@ -3,6 +3,7 @@ import { mkdtempSync, rmSync, writeFileSync, mkdirSync, existsSync, readFileSync
 import { join } from 'path';
 import { tmpdir } from 'os';
 import * as config from '../../shared/config';
+import * as safeRemoteUrl from '../../shared/safe-remote-url';
 import { CapaDatabase } from '../../db/database';
 import { RegistryManager } from '../../shared/registries/manager';
 import {
@@ -38,6 +39,9 @@ describe('registries-routes', () => {
   let server: ReturnType<typeof Bun.serve>;
   let goodUrl: string;
   let badUrl: string;
+  let evilUrl: string;
+  let markerPath: string;
+  let urlPolicySpy: ReturnType<typeof spyOn> | undefined;
 
   beforeEach(() => {
     tempDir = mkdtempSync(join(tmpdir(), 'capa-registry-routes-test-'));
@@ -48,8 +52,14 @@ describe('registries-routes', () => {
 
     const goodAdapterFile = join(tempDir, 'good.ts');
     const badAdapterFile = join(tempDir, 'bad.ts');
+    markerPath = join(tempDir, 'pwned.txt');
+    const evilAdapterFile = join(tempDir, 'evil.ts');
     writeFileSync(goodAdapterFile, VALID_ADAPTER);
     writeFileSync(badAdapterFile, BAD_ADAPTER);
+    writeFileSync(
+      evilAdapterFile,
+      `import { writeFileSync } from 'fs';\nwriteFileSync(${JSON.stringify(markerPath)}, 'pwned');\n${VALID_ADAPTER}`,
+    );
 
     server = Bun.serve({
       port: 0,
@@ -65,14 +75,28 @@ describe('registries-routes', () => {
             headers: { 'content-type': 'application/typescript' },
           });
         }
+        if (path.endsWith('/evil.ts')) {
+          return new Response(readFileSync(evilAdapterFile, 'utf-8'), {
+            headers: { 'content-type': 'application/typescript' },
+          });
+        }
         return new Response('not found', { status: 404 });
       },
     });
     goodUrl = `http://localhost:${server.port}/good.ts`;
     badUrl = `http://localhost:${server.port}/bad.ts`;
+    evilUrl = `http://localhost:${server.port}/evil.ts`;
   });
 
+  function allowLocalUrlPolicy(): void {
+    urlPolicySpy = spyOn(safeRemoteUrl, 'assertPublicHttpsUrl').mockImplementation(
+      async (urlString: string) => new URL(urlString),
+    );
+  }
+
   afterEach(() => {
+    urlPolicySpy?.mockRestore();
+    urlPolicySpy = undefined;
     server.stop();
     managedDirSpy.mockRestore();
     db.close();
@@ -118,29 +142,45 @@ describe('registries-routes', () => {
   });
 
   describe('POST /api/registries', () => {
-    it('installs from a URL and returns 201 with the new record', async () => {
+    it('rejects localhost URLs without executing adapter code', async () => {
       const req = new Request('http://localhost/api/registries', {
         method: 'POST',
-        body: JSON.stringify({ type: 'url', source: goodUrl, slug: 'unit' }),
+        body: JSON.stringify({ type: 'url', source: evilUrl, slug: 'evil' }),
       });
       const res = await createRegistryHandler(db, manager, req);
-      expect(res.status).toBe(201);
+      expect(res.status).toBe(400);
+      expect(existsSync(markerPath)).toBe(false);
+      expect(db.getRegistry('evil')).toBeNull();
+    });
+
+    it('stages from a URL and returns 202 pending without importing', async () => {
+      allowLocalUrlPolicy();
+      const req = new Request('http://localhost/api/registries', {
+        method: 'POST',
+        body: JSON.stringify({ type: 'url', source: evilUrl, slug: 'evil' }),
+      });
+      const res = await createRegistryHandler(db, manager, req);
+      expect(res.status).toBe(202);
       const body = await jsonOf(res);
-      expect(body.registry.slug).toBe('unit');
-      expect(body.registry.status).toBe('installed');
-      expect(body.manifest.id).toBe('demo-registry');
-      expect(existsSync(join(managedDir, 'unit', 'adapter.ts'))).toBe(true);
+      expect(body.registry.slug).toBe('evil');
+      expect(body.registry.status).toBe('pending');
+      expect(body.registry.contentSha256).toMatch(/^[a-f0-9]{64}$/);
+      expect(body.manifest).toBeUndefined();
+      expect(existsSync(join(managedDir, 'evil', 'adapter.ts'))).toBe(true);
+      expect(existsSync(markerPath)).toBe(false);
     });
 
     it('derives the slug when not provided', async () => {
+      allowLocalUrlPolicy();
       const req = new Request('http://localhost/api/registries', {
         method: 'POST',
         body: JSON.stringify({ type: 'url', source: goodUrl }),
       });
       const res = await createRegistryHandler(db, manager, req);
-      expect(res.status).toBe(201);
+      expect(res.status).toBe(202);
       const body = await jsonOf(res);
       expect(body.registry.slug).toBe('good');
+      expect(body.registry.status).toBe('pending');
     });
 
     it('rejects bodies missing type or source', async () => {
@@ -194,15 +234,16 @@ describe('registries-routes', () => {
       expect(res.status).toBe(409);
     });
 
-    it('returns 400 when the fetched adapter is malformed', async () => {
+    it('stages a malformed adapter as pending without importing it', async () => {
+      allowLocalUrlPolicy();
       const req = new Request('http://localhost/api/registries', {
         method: 'POST',
         body: JSON.stringify({ type: 'url', source: badUrl, slug: 'bad' }),
       });
       const res = await createRegistryHandler(db, manager, req);
-      expect(res.status).toBe(400);
-      expect((await jsonOf(res)).error).toMatch(/does not export a valid RegistryAdapter/);
-      expect(db.getRegistry('bad')).toBeNull();
+      expect(res.status).toBe(202);
+      expect(db.getRegistry('bad')?.status).toBe('pending');
+      expect(existsSync(join(managedDir, 'bad', 'adapter.ts'))).toBe(true);
     });
   });
 
@@ -213,6 +254,7 @@ describe('registries-routes', () => {
     });
 
     it('removes the row and the materialized files', async () => {
+      allowLocalUrlPolicy();
       const create = new Request('http://localhost/api/registries', {
         method: 'POST',
         body: JSON.stringify({ type: 'url', source: goodUrl, slug: 'gone' }),
@@ -259,25 +301,25 @@ describe('registries-routes', () => {
       expect(res.status).toBe(404);
     });
 
-    it('re-runs the installer when source changes and persists the new pointer', async () => {
+    it('re-stages when source changes without importing and returns 202 pending', async () => {
+      allowLocalUrlPolicy();
       const create = new Request('http://localhost/api/registries', {
         method: 'POST',
         body: JSON.stringify({ type: 'url', source: goodUrl, slug: 'r' }),
       });
       await createRegistryHandler(db, manager, create);
 
-      // Same upstream content but a different URL — re-install pipeline runs.
       const newGoodUrl = `http://localhost:${server.port}/good.ts?v=2`;
       const req = new Request('http://localhost/api/registries/r', {
         method: 'PATCH',
         body: JSON.stringify({ source: newGoodUrl }),
       });
       const res = await patchRegistryHandler(db, manager, 'r', req);
-      expect(res.status).toBe(200);
+      expect(res.status).toBe(202);
 
       const after = db.getRegistry('r')!;
       expect(after.source).toBe(newGoodUrl);
-      expect(after.status).toBe('installed');
+      expect(after.status).toBe('pending');
     });
 
     it('marks failed and keeps the new pointer when the new source is broken', async () => {
@@ -303,7 +345,8 @@ describe('registries-routes', () => {
       expect(after.lastError).toBeTruthy();
     });
 
-    it('is a no-op when the same source is sent (no re-install, status preserved)', async () => {
+    it('is a no-op when the same source is sent (no re-stage, status preserved)', async () => {
+      allowLocalUrlPolicy();
       const create = new Request('http://localhost/api/registries', {
         method: 'POST',
         body: JSON.stringify({ type: 'url', source: goodUrl, slug: 'same' }),
@@ -320,22 +363,22 @@ describe('registries-routes', () => {
 
       const after = db.getRegistry('same')!;
       expect(after.installedAt).toBe(before.installedAt);
-      expect(after.status).toBe('installed');
+      expect(after.status).toBe('pending');
     });
   });
 
   describe('POST /api/registries/:slug/refresh', () => {
-    it('re-installs and updates installed_at', async () => {
+    it('re-stages without importing and returns 202 pending', async () => {
+      allowLocalUrlPolicy();
       const create = new Request('http://localhost/api/registries', {
         method: 'POST',
         body: JSON.stringify({ type: 'url', source: goodUrl, slug: 'r' }),
       });
       await createRegistryHandler(db, manager, create);
-      const firstInstalledAt = db.getRegistry('r')!.installedAt!;
-      await Bun.sleep(5);
       const res = await refreshRegistryHandler(db, manager, 'r');
-      expect(res.status).toBe(200);
-      expect(db.getRegistry('r')!.installedAt!).toBeGreaterThan(firstInstalledAt);
+      expect(res.status).toBe(202);
+      expect(db.getRegistry('r')!.status).toBe('pending');
+      expect(existsSync(join(managedDir, 'r', 'adapter.ts'))).toBe(true);
     });
 
     it('marks the row as failed when the source is unreachable', async () => {
@@ -360,6 +403,7 @@ describe('registries-routes', () => {
 
   describe('GET /api/registries/preview', () => {
     it('returns the raw adapter source without persisting', async () => {
+      allowLocalUrlPolicy();
       const url = new URL(`http://localhost/api/registries/preview?type=url&source=${encodeURIComponent(goodUrl)}`);
       const res = await previewRegistryHandler(db, url);
       expect(res.status).toBe(200);
@@ -461,26 +505,14 @@ describe('registries-routes', () => {
           }),
         });
         const res = await createRegistryHandler(db, manager, req);
-        expect(res.status).toBe(201);
+        expect(res.status).toBe(202);
         const body = await jsonOf(res);
         expect(body.registry.slug).toBe('developer-kit');
         expect(body.registry.type).toBe('claude-marketplace');
-        expect(body.manifest.id).toBe('developer-kit');
+        expect(body.registry.status).toBe('pending');
+        expect(body.manifest).toBeUndefined();
         expect(existsSync(join(managedDir, 'developer-kit', 'marketplace.json'))).toBe(true);
         expect(existsSync(join(managedDir, 'developer-kit', 'marketplace.meta.json'))).toBe(true);
-
-        // Bare JSON URL marketplaces have no ownerRepo — relative sources
-        // are listed but not installable. Search still works.
-        await manager.reload();
-        const search = await manager.search('developer-kit', {
-          capability: 'plugins',
-          query: '',
-        });
-        expect(search.total).toBe(2);
-        expect(search.items.map((i) => i.id).sort()).toEqual([
-          'developer-kit',
-          'developer-kit-typescript',
-        ]);
       } finally {
         mpServer.stop();
       }

--- a/src/server/__tests__/registries-routes.test.ts
+++ b/src/server/__tests__/registries-routes.test.ts
@@ -153,21 +153,37 @@ describe('registries-routes', () => {
       expect(db.getRegistry('evil')).toBeNull();
     });
 
-    it('stages from a URL and returns 202 pending without importing', async () => {
+    it('installs from a URL and executes the adapter', async () => {
       allowLocalUrlPolicy();
       const req = new Request('http://localhost/api/registries', {
         method: 'POST',
         body: JSON.stringify({ type: 'url', source: evilUrl, slug: 'evil' }),
       });
       const res = await createRegistryHandler(db, manager, req);
-      expect(res.status).toBe(202);
+      expect(res.status).toBe(200);
       const body = await jsonOf(res);
       expect(body.registry.slug).toBe('evil');
-      expect(body.registry.status).toBe('pending');
+      expect(body.registry.status).toBe('installed');
       expect(body.registry.contentSha256).toMatch(/^[a-f0-9]{64}$/);
-      expect(body.manifest).toBeUndefined();
+      expect(body.registry.installedAt).toBeTruthy();
       expect(existsSync(join(managedDir, 'evil', 'adapter.ts'))).toBe(true);
-      expect(existsSync(markerPath)).toBe(false);
+      expect(existsSync(markerPath)).toBe(true);
+    });
+
+    it('installs from a URL and returns installed status', async () => {
+      allowLocalUrlPolicy();
+      const req = new Request('http://localhost/api/registries', {
+        method: 'POST',
+        body: JSON.stringify({ type: 'url', source: goodUrl, slug: 'good-reg' }),
+      });
+      const res = await createRegistryHandler(db, manager, req);
+      expect(res.status).toBe(200);
+      const body = await jsonOf(res);
+      expect(body.registry.slug).toBe('good-reg');
+      expect(body.registry.status).toBe('installed');
+      await manager.reload();
+      const listed = await manager.list();
+      expect(listed.some((m) => m.id === 'demo-registry')).toBe(true);
     });
 
     it('derives the slug when not provided', async () => {
@@ -177,10 +193,10 @@ describe('registries-routes', () => {
         body: JSON.stringify({ type: 'url', source: goodUrl }),
       });
       const res = await createRegistryHandler(db, manager, req);
-      expect(res.status).toBe(202);
+      expect(res.status).toBe(200);
       const body = await jsonOf(res);
       expect(body.registry.slug).toBe('good');
-      expect(body.registry.status).toBe('pending');
+      expect(body.registry.status).toBe('installed');
     });
 
     it('rejects bodies missing type or source', async () => {
@@ -234,15 +250,16 @@ describe('registries-routes', () => {
       expect(res.status).toBe(409);
     });
 
-    it('stages a malformed adapter as pending without importing it', async () => {
+    it('marks a malformed adapter as failed when execution fails', async () => {
       allowLocalUrlPolicy();
       const req = new Request('http://localhost/api/registries', {
         method: 'POST',
         body: JSON.stringify({ type: 'url', source: badUrl, slug: 'bad' }),
       });
       const res = await createRegistryHandler(db, manager, req);
-      expect(res.status).toBe(202);
-      expect(db.getRegistry('bad')?.status).toBe('pending');
+      expect(res.status).toBe(400);
+      expect(db.getRegistry('bad')?.status).toBe('failed');
+      expect(db.getRegistry('bad')?.lastError).toBeTruthy();
       expect(existsSync(join(managedDir, 'bad', 'adapter.ts'))).toBe(true);
     });
   });
@@ -301,7 +318,7 @@ describe('registries-routes', () => {
       expect(res.status).toBe(404);
     });
 
-    it('re-stages when source changes without importing and returns 202 pending', async () => {
+    it('re-installs when source changes and returns installed', async () => {
       allowLocalUrlPolicy();
       const create = new Request('http://localhost/api/registries', {
         method: 'POST',
@@ -315,11 +332,11 @@ describe('registries-routes', () => {
         body: JSON.stringify({ source: newGoodUrl }),
       });
       const res = await patchRegistryHandler(db, manager, 'r', req);
-      expect(res.status).toBe(202);
+      expect(res.status).toBe(200);
 
       const after = db.getRegistry('r')!;
       expect(after.source).toBe(newGoodUrl);
-      expect(after.status).toBe('pending');
+      expect(after.status).toBe('installed');
     });
 
     it('marks failed and keeps the new pointer when the new source is broken', async () => {
@@ -363,12 +380,12 @@ describe('registries-routes', () => {
 
       const after = db.getRegistry('same')!;
       expect(after.installedAt).toBe(before.installedAt);
-      expect(after.status).toBe('pending');
+      expect(after.status).toBe('installed');
     });
   });
 
   describe('POST /api/registries/:slug/refresh', () => {
-    it('re-stages without importing and returns 202 pending', async () => {
+    it('re-fetches and re-installs, returning installed', async () => {
       allowLocalUrlPolicy();
       const create = new Request('http://localhost/api/registries', {
         method: 'POST',
@@ -376,8 +393,8 @@ describe('registries-routes', () => {
       });
       await createRegistryHandler(db, manager, create);
       const res = await refreshRegistryHandler(db, manager, 'r');
-      expect(res.status).toBe(202);
-      expect(db.getRegistry('r')!.status).toBe('pending');
+      expect(res.status).toBe(200);
+      expect(db.getRegistry('r')!.status).toBe('installed');
       expect(existsSync(join(managedDir, 'r', 'adapter.ts'))).toBe(true);
     });
 
@@ -505,14 +522,16 @@ describe('registries-routes', () => {
           }),
         });
         const res = await createRegistryHandler(db, manager, req);
-        expect(res.status).toBe(202);
+        expect(res.status).toBe(200);
         const body = await jsonOf(res);
         expect(body.registry.slug).toBe('developer-kit');
         expect(body.registry.type).toBe('claude-marketplace');
-        expect(body.registry.status).toBe('pending');
-        expect(body.manifest).toBeUndefined();
+        expect(body.registry.status).toBe('installed');
         expect(existsSync(join(managedDir, 'developer-kit', 'marketplace.json'))).toBe(true);
         expect(existsSync(join(managedDir, 'developer-kit', 'marketplace.meta.json'))).toBe(true);
+        await manager.reload();
+        const listed = await manager.list();
+        expect(listed.some((m) => m.id === 'developer-kit')).toBe(true);
       } finally {
         mpServer.stop();
       }

--- a/src/server/__tests__/secret-redaction.test.ts
+++ b/src/server/__tests__/secret-redaction.test.ts
@@ -1,0 +1,63 @@
+import { describe, expect, it } from "bun:test";
+import { mergeServerDef, redactServerForApi } from "../secret-redaction";
+
+const ENV_SECRET = "mcp-env-secret-ABCDEFGH";
+const HEADER_SECRET = "Bearer mcp-header-secret-1234";
+const OAUTH_SECRET = "oauth-client-secret-WXYZ";
+
+describe("redactServerForApi", () => {
+	it("omits oauth clientSecret and does not leak env or auth header values", () => {
+		const redacted = redactServerForApi({
+			id: "svc",
+			env: { OPENAI_API_KEY: ENV_SECRET, NODE_ENV: "production" },
+			headers: {
+				Authorization: HEADER_SECRET,
+				"X-Api-Key": "api-key-value-9999",
+				Accept: "application/json",
+			},
+			oauth2: {
+				clientId: "public-client",
+				clientSecret: OAUTH_SECRET,
+			},
+		});
+
+		const json = JSON.stringify(redacted);
+		expect(json).not.toContain(ENV_SECRET);
+		expect(json).not.toContain(HEADER_SECRET);
+		expect(json).not.toContain(OAUTH_SECRET);
+		expect(json).not.toContain("api-key-value-9999");
+		expect(redacted.oauth2?.clientSecret).toBeUndefined();
+		expect(redacted.oauth2?.clientId).toBe("public-client");
+	});
+});
+
+describe("mergeServerDef", () => {
+	it("keeps existing env values, headers, and clientSecret when the patch omits or blanks them", () => {
+		const merged = mergeServerDef(
+			{
+				cmd: "npx",
+				env: { API_KEY: "keep-me", NODE_ENV: "production" },
+				headers: { Authorization: "Bearer keep-token", Accept: "application/json" },
+				oauth2: { clientId: "id", clientSecret: "keep-secret" },
+			},
+			{
+				cmd: "npx",
+				env: { API_KEY: "", NODE_ENV: "production", NEW: "added" },
+				headers: { Accept: "application/json" },
+				oauth2: { clientId: "id" },
+			},
+		);
+		expect(merged.env).toEqual({
+			API_KEY: "keep-me",
+			NODE_ENV: "production",
+			NEW: "added",
+		});
+		expect(merged.headers).toEqual({
+			Authorization: "Bearer keep-token",
+			Accept: "application/json",
+		});
+		expect((merged.oauth2 as Record<string, unknown>).clientSecret).toBe(
+			"keep-secret",
+		);
+	});
+});

--- a/src/server/__tests__/tool-call-tracer.test.ts
+++ b/src/server/__tests__/tool-call-tracer.test.ts
@@ -4,6 +4,7 @@ import { mkdtempSync, rmSync } from "fs";
 import { tmpdir } from "os";
 import { join } from "path";
 import { CapaDatabase } from "../../db/database";
+import { resetSecretCryptoForTests } from "../../shared/secret-crypto";
 import { ToolCallsRepo } from "../../db/tool-calls";
 import { initSchema } from "../../db/schema";
 import {
@@ -356,10 +357,17 @@ describe("ToolCallTracer", () => {
 	let dir: string;
 	let db: CapaDatabase;
 	const notified: Array<{ projectId: string; record: ToolCallRecord }> = [];
+	let prevHome: string | undefined;
+	let prevProfile: string | undefined;
 
 	beforeEach(() => {
 		notified.length = 0;
 		dir = mkdtempSync(join(tmpdir(), "capa-tracer-"));
+		prevHome = process.env.HOME;
+		prevProfile = process.env.USERPROFILE;
+		process.env.HOME = dir;
+		process.env.USERPROFILE = dir;
+		resetSecretCryptoForTests();
 		db = new CapaDatabase(join(dir, "test.db"));
 		db.upsertProject({ id: "proj-1", path: "/tmp/proj-1" });
 		db.setVariable("proj-1", "SECRET_TOKEN", "my-secret-token-value");
@@ -367,6 +375,11 @@ describe("ToolCallTracer", () => {
 
 	afterEach(() => {
 		db.close();
+		resetSecretCryptoForTests();
+		if (prevHome === undefined) delete process.env.HOME;
+		else process.env.HOME = prevHome;
+		if (prevProfile === undefined) delete process.env.USERPROFILE;
+		else process.env.USERPROFILE = prevProfile;
 		rmSync(dir, { recursive: true, force: true });
 	});
 

--- a/src/server/__tests__/tool-executor.test.ts
+++ b/src/server/__tests__/tool-executor.test.ts
@@ -319,4 +319,30 @@ describe('CommandToolExecutor', () => {
       expect(result.result).toBe("it's a; test");
     });
   });
+
+  describe('shell argv0 plus placeholders', () => {
+    it('rejects a template whose program is sh and whose args contain {msg}', async () => {
+      const def: ToolCommandDefinition = {
+        run: {
+          cmd: 'sh -c "echo {msg}"',
+          args: [{ name: 'msg', type: 'string', required: true }],
+        },
+      };
+      const result = await executor.execute('shell-placeholder', def, { msg: 'hi' });
+      expect(result.success).toBe(false);
+      expect(result.error).toMatch(/shell/i);
+    });
+
+    it('still runs echo {msg} when argv0 is not a shell', async () => {
+      const def: ToolCommandDefinition = {
+        run: {
+          cmd: 'echo {msg}',
+          args: [{ name: 'msg', type: 'string', required: true }],
+        },
+      };
+      const result = await executor.execute('echo-placeholder', def, { msg: 'ok' });
+      expect(result.success).toBe(true);
+      expect(result.result?.trim()).toBe('ok');
+    });
+  });
 });

--- a/src/server/__tests__/tool-formatter.test.ts
+++ b/src/server/__tests__/tool-formatter.test.ts
@@ -1,4 +1,5 @@
-import { describe, it, expect } from 'bun:test';
+import { describe, it, expect, spyOn } from 'bun:test';
+import * as childProcess from 'child_process';
 import {
   applyToolFormatter,
   buildToolCallText,
@@ -120,5 +121,33 @@ describe('applyToolFormatter', () => {
       timeout: 50,
     });
     expect(out).toBe(input);
+  });
+
+  it('spawns a tokenized argv with shell disabled', async () => {
+    const spawnSpy = spyOn(childProcess, 'spawn');
+    try {
+      await applyToolFormatter('x', { cmd: PASSTHROUGH });
+      expect(spawnSpy.mock.calls.length).toBeGreaterThan(0);
+      const [program, argv, opts] = spawnSpy.mock.calls[0] as [
+        string,
+        string[],
+        { shell?: boolean },
+      ];
+      expect(opts?.shell).toBe(false);
+      expect(String(program)).not.toMatch(/(?:^|[/\\])(sh|cmd\.exe)$/i);
+      expect(Array.isArray(argv)).toBe(true);
+      expect(argv[0]).not.toBe('-c');
+      expect(argv[0]).not.toBe('/C');
+    } finally {
+      spawnSpy.mockRestore();
+    }
+  });
+
+  it('does not run a formatter string as a shell script', async () => {
+    const out = await applyToolFormatter('original', {
+      cmd: 'false; echo pwned',
+    });
+    expect(out).toBe('original');
+    expect(out).not.toContain('pwned');
   });
 });

--- a/src/server/__tests__/variables-response.test.ts
+++ b/src/server/__tests__/variables-response.test.ts
@@ -1,0 +1,52 @@
+import { describe, expect, it } from "bun:test";
+import type { Capabilities } from "../../types/capabilities";
+import { buildVariablesResponse } from "../capabilities-routes";
+
+const SECRET = "capa-f6-plain-secret-TOKEN-9zQ2";
+
+const caps: Capabilities = {
+	skills: [],
+	tools: [],
+	servers: [
+		{
+			id: "weather",
+			type: "mcp",
+			def: {
+				cmd: "npx",
+				env: { API_KEY: "${API_KEY}" },
+			},
+		},
+	],
+};
+
+describe("buildVariablesResponse", () => {
+	it("does not include raw secret strings in the payload", () => {
+		const body = buildVariablesResponse(caps, { API_KEY: SECRET });
+		expect(JSON.stringify(body)).not.toContain(SECRET);
+		expect(body).not.toHaveProperty("values");
+	});
+
+	it("returns a secrets catalog with isSet and a last-4 hint", () => {
+		const body = buildVariablesResponse(caps, { API_KEY: SECRET });
+		expect(body.required).toContain("API_KEY");
+		expect(body.catalog).toContain("API_KEY");
+		expect(body.secrets).toEqual([
+			{ name: "API_KEY", isSet: true, hint: "9zQ2" },
+		]);
+	});
+
+	it("marks unset required variables as isSet false with an empty hint", () => {
+		const body = buildVariablesResponse(caps, {});
+		expect(body.required).toContain("API_KEY");
+		const entry = body.secrets.find((s) => s.name === "API_KEY");
+		expect(entry).toEqual({ name: "API_KEY", isSet: false, hint: "" });
+	});
+
+	it("never uses the full value as a hint for short secrets", () => {
+		const body = buildVariablesResponse(caps, { API_KEY: "ab" });
+		expect(JSON.stringify(body)).not.toContain('"ab"');
+		const entry = body.secrets.find((s) => s.name === "API_KEY");
+		expect(entry?.isSet).toBe(true);
+		expect(entry?.hint).toBe("");
+	});
+});

--- a/src/server/api-guards.ts
+++ b/src/server/api-guards.ts
@@ -1,0 +1,99 @@
+import { requireAuth } from "./auth-middleware";
+
+export type GuardResult =
+	| { ok: true }
+	| { ok: false; reason: string; status: number };
+
+const MUTATING_METHODS = new Set(["POST", "PUT", "PATCH", "DELETE"]);
+
+export function serverHttpOrigin(host: string, port: number): string {
+	const wrapped =
+		host.includes(":") && !host.startsWith("[") ? `[${host}]` : host;
+	return `http://${wrapped}:${port}`;
+}
+
+function isMutating(method: string): boolean {
+	return MUTATING_METHODS.has(method.toUpperCase());
+}
+
+export function isPublicApiRoute(method: string, pathname: string): boolean {
+	const verb = method.toUpperCase();
+	if (verb === "OPTIONS") {
+		return true;
+	}
+	if (verb !== "GET" && verb !== "HEAD") {
+		return false;
+	}
+	if (/^\/api\/integrations\/(github|gitlab)\/oauth\/callback$/.test(pathname)) {
+		return true;
+	}
+	if (/^\/api\/projects\/[^/]+\/oauth\/callback$/.test(pathname)) {
+		return true;
+	}
+	return false;
+}
+
+export function requireApiCsrf(
+	req: Request,
+	serverOrigin: string,
+): GuardResult {
+	if (!isMutating(req.method)) {
+		return { ok: true };
+	}
+	if (req.headers.get("Sec-Fetch-Site") === "cross-site") {
+		return { ok: false, reason: "Forbidden", status: 403 };
+	}
+	const origin = req.headers.get("Origin");
+	if (origin && origin !== serverOrigin) {
+		return { ok: false, reason: "Forbidden", status: 403 };
+	}
+	return { ok: true };
+}
+
+export function requireMutatingJsonContentType(req: Request): GuardResult {
+	if (!isMutating(req.method)) {
+		return { ok: true };
+	}
+	const media = (req.headers.get("Content-Type") ?? "")
+		.split(";")[0]
+		.trim()
+		.toLowerCase();
+	if (media === "application/json" || media === "multipart/form-data") {
+		return { ok: true };
+	}
+	return { ok: false, reason: "Unsupported Media Type", status: 415 };
+}
+
+export function authorizeApiRequest(
+	req: Request,
+	bind: { host: string; port: number },
+): GuardResult {
+	const pathname = new URL(req.url).pathname;
+	if (isPublicApiRoute(req.method, pathname)) {
+		return { ok: true };
+	}
+	const auth = requireAuth(req, bind.host);
+	if (!auth.ok) {
+		return auth;
+	}
+	const csrf = requireApiCsrf(req, serverHttpOrigin(bind.host, bind.port));
+	if (!csrf.ok) {
+		return csrf;
+	}
+	return requireMutatingJsonContentType(req);
+}
+
+export function injectHtmlAuthToken(
+	html: string,
+	token: string | null,
+): string {
+	if (!token) {
+		return html;
+	}
+	const script = `<script>window.__CAPA_AUTH_TOKEN__=${JSON.stringify(token)};</script>`;
+	const idx = html.indexOf("</head>");
+	if (idx === -1) {
+		return script + html;
+	}
+	return html.slice(0, idx) + script + html.slice(idx);
+}

--- a/src/server/api-guards.ts
+++ b/src/server/api-guards.ts
@@ -1,4 +1,4 @@
-import { requireAuth } from "./auth-middleware";
+import { requireAuth, isLoopbackHost } from "./auth-middleware";
 
 export type GuardResult =
 	| { ok: true }
@@ -21,7 +21,7 @@ export function isPublicApiRoute(method: string, pathname: string): boolean {
 	if (verb === "OPTIONS") {
 		return true;
 	}
-	if (verb !== "GET" && verb !== "HEAD") {
+	if (verb !== "GET" && verb !== "HEAD" && verb !== "POST") {
 		return false;
 	}
 	if (/^\/api\/integrations\/(github|gitlab)\/oauth\/callback$/.test(pathname)) {
@@ -31,6 +31,34 @@ export function isPublicApiRoute(method: string, pathname: string): boolean {
 		return true;
 	}
 	return false;
+}
+
+function defaultPort(protocol: string, explicit: string): string {
+	if (explicit) return explicit;
+	return protocol === "https:" ? "443" : "80";
+}
+
+/** Browsers treat localhost and 127.0.0.1 as different Origins; both are loopback. */
+export function isEquivalentApiOrigin(
+	origin: string,
+	serverOrigin: string,
+): boolean {
+	if (origin === serverOrigin) return true;
+	try {
+		const a = new URL(origin);
+		const b = new URL(serverOrigin);
+		if (a.protocol !== b.protocol) return false;
+		if (
+			defaultPort(a.protocol, a.port) !== defaultPort(b.protocol, b.port)
+		) {
+			return false;
+		}
+		const aHost = a.hostname.replace(/^\[|\]$/g, "");
+		const bHost = b.hostname.replace(/^\[|\]$/g, "");
+		return isLoopbackHost(aHost) && isLoopbackHost(bHost);
+	} catch {
+		return false;
+	}
 }
 
 export function requireApiCsrf(
@@ -44,7 +72,7 @@ export function requireApiCsrf(
 		return { ok: false, reason: "Forbidden", status: 403 };
 	}
 	const origin = req.headers.get("Origin");
-	if (origin && origin !== serverOrigin) {
+	if (origin && !isEquivalentApiOrigin(origin, serverOrigin)) {
 		return { ok: false, reason: "Forbidden", status: 403 };
 	}
 	return { ok: true };

--- a/src/server/auth-middleware.ts
+++ b/src/server/auth-middleware.ts
@@ -68,6 +68,12 @@ export function getAuthToken(): string | null {
 	return resolveToken();
 }
 
+/** SPA/HTML bootstrap token. Omitted when bound off-loopback so GET / cannot leak it. */
+export function getSpaAuthToken(): string | null {
+	if (!bindHost || !isLoopbackHost(bindHost)) return null;
+	return resolveToken();
+}
+
 function tokensMatch(provided: string, expected: string): boolean {
 	const providedBuf = Buffer.from(provided);
 	const expectedBuf = Buffer.from(expected);

--- a/src/server/auth-middleware.ts
+++ b/src/server/auth-middleware.ts
@@ -31,7 +31,7 @@ function resolveToken(): string | null {
 		if (err?.code !== "ENOENT") throw err;
 	}
 
-	if (bindHost && !isLoopbackHost(bindHost)) {
+	if (bindHost) {
 		const token = randomBytes(32).toString("hex");
 		const capaDir = getCapaDir();
 		mkdirSync(capaDir, { recursive: true });
@@ -95,14 +95,20 @@ function extractProvidedToken(req: Request): string | null {
 	return null;
 }
 
-export function requireAuth(
+export function requireMcpAuth(
 	req: Request,
 	host: string,
 ): { ok: true } | { ok: false; reason: string; status: number } {
 	if (isLoopbackHost(host)) {
 		return { ok: true };
 	}
+	return requireAuth(req, host);
+}
 
+export function requireAuth(
+	req: Request,
+	_host?: string,
+): { ok: true } | { ok: false; reason: string; status: number } {
 	if (req.method === "OPTIONS") {
 		return { ok: true };
 	}

--- a/src/server/capabilities-mutations.ts
+++ b/src/server/capabilities-mutations.ts
@@ -17,6 +17,7 @@ import {
 	jsonError,
 	loadProjectFile,
 } from "./capabilities-route-helpers";
+import { mergeServerDef } from "./secret-redaction";
 import { clientErrorMessage } from "./http-error";
 
 export async function handleAppend(
@@ -149,7 +150,7 @@ export async function handleUpdate(
 				};
 				if (asObj(body.def)) {
 					if (section === "servers") {
-						merged.def = asObj(body.def)!;
+						merged.def = mergeServerDef(asObj(e.def), asObj(body.def)!);
 					} else if (asObj(merged.def)) {
 						merged.def = { ...asObj(merged.def)!, ...asObj(body.def)! };
 					}

--- a/src/server/capabilities-route-helpers.ts
+++ b/src/server/capabilities-route-helpers.ts
@@ -105,7 +105,8 @@ export async function afterWrite(
 ): Promise<Response> {
 	deps.markSelfWrite?.(projectId);
 	const caps = await parseCapabilitiesFile(path, format);
-	const configureResult = await deps.configure(projectId, caps);
+	const apply = deps.refreshCapabilities ?? deps.configure;
+	const configureResult = await apply(projectId, caps);
 	deps.notifyChanged?.(projectId);
 	return jsonOk({
 		success: true,

--- a/src/server/capabilities-routes.ts
+++ b/src/server/capabilities-routes.ts
@@ -1,4 +1,5 @@
 import type { ArrayCapabilitySection } from "../shared/capabilities";
+import { secretHint } from "../shared/secret-crypto";
 import { extractAllVariables } from "../shared/variable-resolver";
 import type { Capabilities } from "../types/capabilities";
 import {
@@ -107,16 +108,23 @@ const INTERNAL_OAUTH_VAR = /^oauth2_client_(id|secret)_/;
 export function buildVariablesResponse(
 	capabilities: Capabilities | null,
 	values: Record<string, string>,
-): { required: string[]; catalog: string[]; values: Record<string, string> } {
+): {
+	required: string[];
+	catalog: string[];
+	secrets: Array<{ name: string; isSet: boolean; hint: string }>;
+} {
 	const required = (
 		capabilities ? extractAllVariables(capabilities) : []
 	).filter((name) => !INTERNAL_OAUTH_VAR.test(name));
 	const catalog = Object.keys(values)
 		.filter((name) => !INTERNAL_OAUTH_VAR.test(name))
 		.sort();
-	const publicValues: Record<string, string> = {};
-	for (const [key, value] of Object.entries(values)) {
-		if (!INTERNAL_OAUTH_VAR.test(key)) publicValues[key] = value;
-	}
-	return { required, catalog, values: publicValues };
+	const names = new Set([...required, ...catalog]);
+	const secrets = [...names].sort().map((name) => {
+		const value = values[name];
+		const isSet = typeof value === "string" && value.length > 0;
+		const hint = isSet ? secretHint(value) : "";
+		return { name, isSet, hint };
+	});
+	return { required, catalog, secrets };
 }

--- a/src/server/configure-routes.ts
+++ b/src/server/configure-routes.ts
@@ -1,4 +1,8 @@
 import type { CapaDatabase } from "../db/database";
+import {
+	normalizeCapabilities,
+	parseCapabilitiesFile,
+} from "../shared/capabilities";
 import { logger } from "../shared/logger";
 import { detectCapabilitiesFile } from "../shared/paths";
 import { projectUiUrl } from "../shared/ui-urls";
@@ -355,6 +359,28 @@ export async function runProjectConfigure(
 	};
 }
 
+async function capabilitiesForConfigure(
+	deps: ConfigureRouteDeps,
+	projectId: string,
+	requested: Capabilities,
+): Promise<Capabilities> {
+	const project = deps.db.getProject(projectId);
+	if (!project) {
+		throw new Error("Project not found");
+	}
+	const file = await detectCapabilitiesFile(project.path);
+	if (!file) {
+		throw new Error("No capabilities file on disk for this project");
+	}
+	const onDisk = await parseCapabilitiesFile(file.path, file.format);
+	// Wrap-install compatibility: overlay providers only. Stdio spawn config
+	// (cmd/args/cwd/env) always comes from the on-disk document.
+	if (requested.providers) {
+		onDisk.providers = requested.providers;
+	}
+	return onDisk;
+}
+
 export async function handleProjectConfigure(
 	deps: ConfigureRouteDeps,
 	projectId: string,
@@ -365,11 +391,23 @@ export async function handleProjectConfigure(
 		.toLowerCase()
 		.includes("application/x-ndjson");
 
-	let capabilities: Capabilities;
+	let requested: unknown;
 	try {
-		capabilities = await request.json();
+		requested = await request.json();
 	} catch (error: any) {
 		apiLogger.failure(`Error parsing capabilities: ${error.message}`);
+		return new Response(JSON.stringify({ error: error.message }), {
+			status: 400,
+			headers: JSON_HEADERS,
+		});
+	}
+
+	let capabilities: Capabilities;
+	try {
+		const parsed = normalizeCapabilities(requested);
+		capabilities = await capabilitiesForConfigure(deps, projectId, parsed);
+	} catch (error: any) {
+		apiLogger.failure(`Error: ${error.message}`);
 		return new Response(JSON.stringify({ error: error.message }), {
 			status: 400,
 			headers: JSON_HEADERS,

--- a/src/server/configure-routes.ts
+++ b/src/server/configure-routes.ts
@@ -13,6 +13,11 @@ import type { CapabilitiesFileWatcher } from "./capabilities-watcher";
 import type { CapaMCPServer, ValidationProgressEvent } from "./mcp-handler";
 import { OAuth2Manager } from "./oauth-manager";
 import {
+	type OAuth2ServerEntry,
+	serverHasExplicitAuthHeader,
+	syncServerOAuth2Requirement,
+} from "./oauth-server-sync";
+import {
 	type EffectiveCapsCacheEntry,
 	loadEffectiveCapabilities,
 } from "./resolve-effective-capabilities";
@@ -146,12 +151,7 @@ export async function runProjectConfigure(
 	// -- OAuth2 detection (parallel) ------------------------------------
 	const oauth2Candidates = capabilitiesToUse.servers.filter((server) => {
 		if (!server.def.url) return false;
-		const hasExplicitAuth =
-			server.def.headers &&
-			Object.keys(server.def.headers).some(
-				(k) => k.toLowerCase() === "authorization",
-			);
-		if (hasExplicitAuth) {
+		if (serverHasExplicitAuthHeader(server)) {
 			apiLogger.debug(
 				`Skipping OAuth2 detection for ${server.id} (explicit auth header configured)`,
 			);
@@ -169,74 +169,28 @@ export async function runProjectConfigure(
 	});
 
 	let oauth2Done = 0;
+	let oauth2CapabilitiesChanged = false;
 	const oauth2Results = await Promise.all(
 		oauth2Candidates.map(async (server) => {
-			const existingOAuth = server.def.oauth2;
-			let entry: {
-				serverId: string;
-				serverUrl: string;
-				displayName: string;
-				isConnected: boolean;
-			} | null = null;
+			let entry: OAuth2ServerEntry | null = null;
 			try {
 				apiLogger.debug(`Checking server: ${server.id}`);
-				const oauth2Config = await deps.oauth2Manager.detectOAuth2Requirement(
-					server.def.url!,
-					{
-						tlsSkipVerify: server.def.tlsSkipVerify,
-					},
+				const sync = await syncServerOAuth2Requirement(
+					projectId,
+					server,
+					deps.oauth2Manager,
 				);
-				if (oauth2Config) {
-					apiLogger.debug(`OAuth2 required for ${server.id}`);
-					let isConnected = deps.oauth2Manager.isServerConnected(
-						projectId,
-						server.id,
-					);
-
-					if (isConnected) {
-						const accessToken = await deps.oauth2Manager.getAccessToken(
-							projectId,
-							server.id,
-							oauth2Config,
-						);
-						isConnected = !!accessToken;
-						if (!isConnected) {
-							apiLogger.warn(`OAuth2 token invalid/expired for ${server.id}`);
-						}
-					}
-
-					const merged: any = { ...(existingOAuth ?? {}), ...oauth2Config };
-					const embeddedClientId =
-						(existingOAuth as any)?.client_id ??
-						(existingOAuth as any)?.clientId ??
-						(existingOAuth as any)?.CLIENT_ID ??
-						(existingOAuth as any)?.oauth?.clientId ??
-						(existingOAuth as any)?.oauth?.client_id;
-					if (embeddedClientId) merged.client_id = embeddedClientId;
-					const embeddedCallbackPort =
-						(existingOAuth as any)?.callback_port ??
-						(existingOAuth as any)?.callbackPort ??
-						(existingOAuth as any)?.CALLBACK_PORT;
-					if (
-						typeof embeddedCallbackPort === "number" &&
-						embeddedCallbackPort > 0
-					) {
-						merged.callback_port = embeddedCallbackPort;
-					} else if (typeof embeddedCallbackPort === "string") {
-						const parsed = Number(embeddedCallbackPort);
-						if (Number.isFinite(parsed) && parsed > 0)
-							merged.callback_port = parsed;
-					}
+				if (sync.changed) oauth2CapabilitiesChanged = true;
+				entry = sync.entry;
+				if (entry) {
 					apiLogger.debug(
-						`OAuth2 merged for ${server.id}: client_id=${merged.client_id ? "set" : "missing"} callback_port=${merged.callback_port ?? "missing"} registrationEndpoint=${merged.registrationEndpoint ? "set" : "missing"}`,
+						`OAuth2 required for ${server.id} (connected=${entry.isConnected})`,
 					);
-					server.def.oauth2 = merged;
-					entry = {
-						serverId: server.id,
-						serverUrl: server.def.url!,
-						displayName: server.displayName ?? server.id,
-						isConnected,
-					};
+					if (!entry.isConnected) {
+						apiLogger.warn(`OAuth2 token invalid/expired for ${server.id}`);
+					}
+				} else if (sync.changed) {
+					apiLogger.debug(`OAuth2 no longer required for ${server.id}`);
 				}
 			} catch (error: any) {
 				apiLogger.warn(
@@ -256,10 +210,10 @@ export async function runProjectConfigure(
 		}),
 	);
 	const oauth2Servers = oauth2Results.filter(
-		(e): e is NonNullable<typeof e> => e !== null,
+		(e): e is OAuth2ServerEntry => e !== null,
 	);
 
-	if (oauth2Servers.length > 0) {
+	if (oauth2CapabilitiesChanged || oauth2Servers.length > 0) {
 		deps.sessionManager.setProjectCapabilities(projectId, capabilitiesToUse);
 	}
 

--- a/src/server/cors-origin.ts
+++ b/src/server/cors-origin.ts
@@ -1,4 +1,26 @@
-export function isAllowedOrigin(origin: string | null): {
+function stripIpv6Brackets(hostname: string): string {
+	return hostname.startsWith("[") && hostname.endsWith("]")
+		? hostname.slice(1, -1)
+		: hostname;
+}
+
+export function serverHttpOrigin(bindHost: string, bindPort: number): string {
+	const host =
+		bindHost.includes(":") && !bindHost.startsWith("[")
+			? `[${bindHost}]`
+			: bindHost;
+	return `http://${host}:${bindPort}`;
+}
+
+/**
+ * MCP Origin gate. Default allow-list is only the server's own origin.
+ * Extra origins must be listed exactly in CAPA_ALLOWED_ORIGINS.
+ */
+export function isAllowedOrigin(
+	origin: string | null,
+	bindHost: string,
+	bindPort: number,
+): {
 	allowed: boolean;
 	origin?: string;
 } {
@@ -6,19 +28,8 @@ export function isAllowedOrigin(origin: string | null): {
 		return { allowed: false };
 	}
 
-	try {
-		const parsed = new URL(origin);
-		const hostname = stripIpv6Brackets(parsed.hostname);
-		if (
-			parsed.protocol === "http:" &&
-			(hostname === "localhost" ||
-				hostname === "127.0.0.1" ||
-				hostname === "::1")
-		) {
-			return { allowed: true, origin };
-		}
-	} catch {
-		// fall through to env allow-list
+	if (origin === serverHttpOrigin(bindHost, bindPort)) {
+		return { allowed: true, origin };
 	}
 
 	const extras =
@@ -30,10 +41,4 @@ export function isAllowedOrigin(origin: string | null): {
 	}
 
 	return { allowed: false };
-}
-
-function stripIpv6Brackets(hostname: string): string {
-	return hostname.startsWith("[") && hostname.endsWith("]")
-		? hostname.slice(1, -1)
-		: hostname;
 }

--- a/src/server/git-integration-manager.ts
+++ b/src/server/git-integration-manager.ts
@@ -2,14 +2,12 @@
 // Handles OAuth2 flows via cloud endpoint and Personal Access Token storage
 
 import type { CapaDatabase } from "../db/database";
-import {
-	getAllGitProviders,
-	getGitProvider,
-} from "../shared/git-providers/registry";
+import { getGitProvider } from "../shared/git-providers/registry";
 import { logger } from "../shared/logger";
 import { isPermanentRefreshFailure } from "../shared/oauth-refresh";
 import { CAPA_CLOUD_OAUTH_URL } from "../shared/ui-urls";
 import type { GitPATConfig, GitPlatform } from "../types/git-integration";
+import { generateState } from "../utils/pkce";
 
 export class GitIntegrationManager {
 	private db: CapaDatabase;
@@ -57,17 +55,12 @@ export class GitIntegrationManager {
 	async generateAuthorizationUrl(
 		platform: "github" | "gitlab",
 		localRedirectUri: string,
-	): Promise<{ url: string; flowId: string }> {
-		// Generate a unique flow ID to track this OAuth attempt
-		const flowId = this.generateFlowId();
-
-		// Store flow metadata
-		this.pendingFlows.set(flowId, {
+	): Promise<{ url: string; flowId: string; state: string }> {
+		const state = generateState();
+		this.pendingFlows.set(state, {
 			platform,
 			timestamp: Date.now(),
 		});
-
-		// Clean up old flows (older than 15 minutes)
 		this.cleanupExpiredFlows();
 
 		const gp = getGitProvider(platform);
@@ -75,16 +68,19 @@ export class GitIntegrationManager {
 			throw new Error(`Unknown git platform: ${platform}`);
 		}
 
-		// Build cloud OAuth URL
-		// The cloud will handle the OAuth flow and redirect back to our local server with the token
+		const callback = new URL(localRedirectUri);
+		callback.searchParams.set("state", state);
+		callback.searchParams.set("flowId", state);
+
 		const cloudUrl = new URL(CAPA_CLOUD_OAUTH_URL);
 		cloudUrl.searchParams.set("provider", gp.cloudOAuthProviderParam);
-		cloudUrl.searchParams.set("redirect", localRedirectUri);
+		cloudUrl.searchParams.set("redirect", callback.toString());
+		cloudUrl.searchParams.set("state", state);
 
 		const finalUrl = cloudUrl.toString();
 		this.logger.info(`Generated cloud OAuth URL for ${platform}: ${finalUrl}`);
-		this.logger.debug(`Flow ID: ${flowId}, Redirect URI: ${localRedirectUri}`);
-		return { url: finalUrl, flowId };
+		this.logger.debug(`OAuth state: ${state}, Redirect URI: ${callback}`);
+		return { url: finalUrl, flowId: state, state };
 	}
 
 	/**
@@ -93,60 +89,26 @@ export class GitIntegrationManager {
 	 */
 	async handleCallback(
 		accessToken: string,
-		platformOrFlowId: "github" | "gitlab" | string | undefined,
+		state: string | undefined,
 		refreshToken?: string,
 		expiresIn?: number,
 	): Promise<{ success: boolean; platform?: GitPlatform; error?: string }> {
 		try {
 			this.logger.info(
-				`OAuth callback received. Platform/FlowId: ${platformOrFlowId || "none"}, Token length: ${accessToken.length}`,
+				`OAuth callback received. State present: ${Boolean(state)}, Token length: ${accessToken.length}`,
 			);
 
-			let platform: GitPlatform | undefined;
-
-			// Check if it's a direct platform identifier
-			if (platformOrFlowId === "github" || platformOrFlowId === "gitlab") {
-				platform = platformOrFlowId;
-				this.logger.debug(`Platform directly specified: ${platform}`);
-			}
-			// Otherwise treat it as a flow ID
-			else if (platformOrFlowId) {
-				const flowData = this.pendingFlows.get(platformOrFlowId);
-				if (flowData) {
-					platform = flowData.platform;
-					this.pendingFlows.delete(platformOrFlowId);
-					this.logger.debug(`Found flow data for platform: ${platform}`);
-				} else {
-					this.logger.warn(
-						`No flow data found for flow ID: ${platformOrFlowId}`,
-					);
-				}
+			if (!state) {
+				return { success: false, error: "Missing OAuth state" };
 			}
 
-			// If we still don't have a platform, try to determine it from the token
-			if (!platform) {
-				this.logger.info(
-					"Attempting to determine platform by testing token...",
-				);
-				for (const gp of getAllGitProviders()) {
-					const valid = await this.testToken(
-						gp.id as "github" | "gitlab",
-						accessToken,
-					);
-					if (valid) {
-						platform = gp.id as GitPlatform;
-						this.logger.success(`Token identified as ${gp.displayName}`);
-						break;
-					}
-				}
+			const flowData = this.pendingFlows.get(state);
+			if (!flowData) {
+				this.logger.warn("OAuth callback rejected: unknown or reused state");
+				return { success: false, error: "Invalid or expired OAuth state" };
 			}
-
-			if (!platform) {
-				return {
-					success: false,
-					error: "Unable to determine platform for access token",
-				};
-			}
+			this.pendingFlows.delete(state);
+			const platform = flowData.platform;
 
 			// Calculate expiration timestamp
 			const expiresAt = expiresIn ? Date.now() + expiresIn * 1000 : null;
@@ -480,13 +442,6 @@ export class GitIntegrationManager {
 			default:
 				return getGitProvider(platform)?.displayName ?? platform;
 		}
-	}
-
-	/**
-	 * Generate a unique flow ID
-	 */
-	private generateFlowId(): string {
-		return `${Date.now()}-${Math.random().toString(36).substring(2, 15)}`;
 	}
 
 	/**

--- a/src/server/git-integration-manager.ts
+++ b/src/server/git-integration-manager.ts
@@ -22,30 +22,87 @@ export class GitIntegrationManager {
 	}
 
 	/**
-	 * Check if a specific platform integration is configured
+	 * Check if a specific platform integration is configured and usable.
+	 * Sync check only — verifies a non-empty stored token exists.
 	 */
 	isConnected(platform: GitPlatform, host?: string): boolean {
 		const integration = this.db.getGitIntegration(platform, host || null);
-		return !!integration;
+		return this.hasUsableStoredToken(integration);
+	}
+
+	private hasUsableStoredToken(
+		integration: ReturnType<CapaDatabase["getGitIntegration"]>,
+	): boolean {
+		return !!integration?.access_token?.trim();
+	}
+
+	private isOAuthIntegration(platform: GitPlatform): boolean {
+		return !!getGitProvider(platform);
+	}
+
+	private async integrationIsLive(
+		integration: NonNullable<ReturnType<CapaDatabase["getGitIntegration"]>>,
+	): Promise<boolean> {
+		if (!this.hasUsableStoredToken(integration)) {
+			return false;
+		}
+
+		const host = integration.host ?? undefined;
+
+		// Self-hosted PATs must still authenticate against the host API.
+		if (
+			integration.platform === "github-enterprise" ||
+			integration.platform === "gitlab-self-managed"
+		) {
+			return this.validatePAT(
+				integration.platform,
+				host,
+				integration.access_token,
+			);
+		}
+
+		// Cloud OAuth: expired without refresh is not "connected" for the UI.
+		if (integration.expires_at && integration.expires_at < Date.now()) {
+			if (integration.refresh_token && this.isOAuthIntegration(integration.platform)) {
+				const refreshed = await this.refreshAccessToken(
+					integration.platform,
+					host,
+				);
+				if (refreshed) {
+					const updated = this.db.getGitIntegration(
+						integration.platform,
+						integration.host,
+					);
+					return this.hasUsableStoredToken(updated);
+				}
+			}
+			return false;
+		}
+
+		return true;
 	}
 
 	/**
-	 * Get all configured integrations
+	 * Get all configured integrations with live connection status.
 	 */
-	getAllIntegrations() {
+	async getAllIntegrations() {
 		const integrations = this.db.getAllGitIntegrations();
 
-		return integrations.map((integration) => ({
-			platform: integration.platform,
-			host: integration.host || undefined,
-			displayName: this.getPlatformDisplayName(
-				integration.platform,
-				integration.host,
-			),
-			isConnected: true,
-			expiresAt: integration.expires_at || undefined,
-			usesOAuth: !!getGitProvider(integration.platform),
-		}));
+		const results = await Promise.all(
+			integrations.map(async (integration) => ({
+				platform: integration.platform,
+				host: integration.host || undefined,
+				displayName: this.getPlatformDisplayName(
+					integration.platform,
+					integration.host,
+				),
+				isConnected: await this.integrationIsLive(integration),
+				expiresAt: integration.expires_at || undefined,
+				usesOAuth: this.isOAuthIntegration(integration.platform),
+			})),
+		);
+
+		return results;
 	}
 
 	/**

--- a/src/server/git-integrations-routes.ts
+++ b/src/server/git-integrations-routes.ts
@@ -26,6 +26,52 @@ export async function handleGetIntegrations(
 	}
 }
 
+function readOAuthNonce(source: Record<string, unknown>): string | null {
+	if (typeof source.state === "string" && source.state.length > 0) {
+		return source.state;
+	}
+	if (typeof source.flowId === "string" && source.flowId.length > 0) {
+		return source.flowId;
+	}
+	return null;
+}
+
+function missingStateResponse(): Response {
+	return new Response(
+		JSON.stringify({ error: "Missing OAuth state or flowId" }),
+		{ status: 400, headers: JSON_HEADERS },
+	);
+}
+
+async function completeGitOAuthCallback(
+	deps: GitIntegrationsRouteDeps,
+	platform: "github" | "gitlab",
+	accessToken: string,
+	state: string,
+	refreshToken?: string,
+	expiresIn?: number,
+): Promise<Response> {
+	const result = await deps.gitIntegrationManager.handleCallback(
+		accessToken,
+		state,
+		refreshToken,
+		expiresIn,
+	);
+
+	if (!result.success) {
+		return new Response(
+			JSON.stringify({ error: result.error || "Invalid or expired OAuth state" }),
+			{ status: 400, headers: JSON_HEADERS },
+		);
+	}
+
+	const redirectUrl = `${deps.uiOrigin()}/ui/integrations?success=${platform}`;
+	return new Response(null, {
+		status: 302,
+		headers: { Location: redirectUrl },
+	});
+}
+
 export async function handleGitHubOAuthStart(
 	deps: GitIntegrationsRouteDeps,
 	request: Request,
@@ -33,15 +79,16 @@ export async function handleGitHubOAuthStart(
 	try {
 		const localCallbackUri = `http://${deps.serverHost}:${deps.serverPort}/api/integrations/github/oauth/callback`;
 
-		const { url: authUrl, flowId } =
+		const { url: authUrl, flowId, state } =
 			await deps.gitIntegrationManager.generateAuthorizationUrl(
 				"github",
 				localCallbackUri,
 			);
 
-		return new Response(JSON.stringify({ authorizationUrl: authUrl, flowId }), {
-			headers: JSON_HEADERS,
-		});
+		return new Response(
+			JSON.stringify({ authorizationUrl: authUrl, flowId, state }),
+			{ headers: JSON_HEADERS },
+		);
 	} catch (error: any) {
 		return new Response(JSON.stringify({ error: error.message }), {
 			status: 500,
@@ -60,6 +107,8 @@ export async function handleGitHubOAuthCallback(
 		let expiresIn: number | undefined;
 		let error: string | null = null;
 
+		let state: string | null = null;
+
 		if (request.method === "POST") {
 			const body = (await request.json()) as Record<string, unknown>;
 			accessToken =
@@ -70,6 +119,7 @@ export async function handleGitHubOAuthCallback(
 				expiresIn = parseInt(String(body.expires_in), 10);
 			}
 			error = typeof body.error === "string" ? body.error : null;
+			state = readOAuthNonce(body);
 		} else {
 			const url = new URL(request.url);
 			if (
@@ -97,26 +147,18 @@ export async function handleGitHubOAuthCallback(
 			);
 		}
 
-		const result = await deps.gitIntegrationManager.handleCallback(
-			accessToken,
+		if (!state) {
+			return missingStateResponse();
+		}
+
+		return completeGitOAuthCallback(
+			deps,
 			"github",
+			accessToken,
+			state,
 			refreshToken,
 			expiresIn,
 		);
-
-		if (!result.success) {
-			const redirectUrl = `${deps.uiOrigin()}/ui/integrations?error=${encodeURIComponent(result.error || "Unknown error")}`;
-			return new Response(null, {
-				status: 302,
-				headers: { Location: redirectUrl },
-			});
-		}
-
-		const redirectUrl = `${deps.uiOrigin()}/ui/integrations?success=github`;
-		return new Response(null, {
-			status: 302,
-			headers: { Location: redirectUrl },
-		});
 	} catch (error: any) {
 		const redirectUrl = `${deps.uiOrigin()}/ui/integrations?error=${encodeURIComponent(error.message)}`;
 		return new Response(null, {
@@ -133,15 +175,16 @@ export async function handleGitLabOAuthStart(
 	try {
 		const localCallbackUri = `http://${deps.serverHost}:${deps.serverPort}/api/integrations/gitlab/oauth/callback`;
 
-		const { url: authUrl, flowId } =
+		const { url: authUrl, flowId, state } =
 			await deps.gitIntegrationManager.generateAuthorizationUrl(
 				"gitlab",
 				localCallbackUri,
 			);
 
-		return new Response(JSON.stringify({ authorizationUrl: authUrl, flowId }), {
-			headers: JSON_HEADERS,
-		});
+		return new Response(
+			JSON.stringify({ authorizationUrl: authUrl, flowId, state }),
+			{ headers: JSON_HEADERS },
+		);
 	} catch (error: any) {
 		return new Response(JSON.stringify({ error: error.message }), {
 			status: 500,
@@ -159,6 +202,7 @@ export async function handleGitLabOAuthCallback(
 		let refreshToken: string | undefined;
 		let expiresIn: number | undefined;
 		let error: string | null = null;
+		let state: string | null = null;
 
 		if (request.method === "POST") {
 			const body = (await request.json()) as Record<string, unknown>;
@@ -170,6 +214,7 @@ export async function handleGitLabOAuthCallback(
 				expiresIn = parseInt(String(body.expires_in), 10);
 			}
 			error = typeof body.error === "string" ? body.error : null;
+			state = readOAuthNonce(body);
 		} else {
 			const url = new URL(request.url);
 			if (
@@ -197,26 +242,18 @@ export async function handleGitLabOAuthCallback(
 			);
 		}
 
-		const result = await deps.gitIntegrationManager.handleCallback(
-			accessToken,
+		if (!state) {
+			return missingStateResponse();
+		}
+
+		return completeGitOAuthCallback(
+			deps,
 			"gitlab",
+			accessToken,
+			state,
 			refreshToken,
 			expiresIn,
 		);
-
-		if (!result.success) {
-			const redirectUrl = `${deps.uiOrigin()}/ui/integrations?error=${encodeURIComponent(result.error || "Unknown error")}`;
-			return new Response(null, {
-				status: 302,
-				headers: { Location: redirectUrl },
-			});
-		}
-
-		const redirectUrl = `${deps.uiOrigin()}/ui/integrations?success=gitlab`;
-		return new Response(null, {
-			status: 302,
-			headers: { Location: redirectUrl },
-		});
 	} catch (error: any) {
 		const redirectUrl = `${deps.uiOrigin()}/ui/integrations?error=${encodeURIComponent(error.message)}`;
 		return new Response(null, {

--- a/src/server/git-integrations-routes.ts
+++ b/src/server/git-integrations-routes.ts
@@ -1,5 +1,5 @@
 import type { GitIntegrationManager } from "./git-integration-manager";
-import { oauthBridgeResponse } from "./oauth-bridge";
+import { gitOAuthCallbackNeedsBridge, oauthBridgeResponse } from "./oauth-bridge";
 
 const JSON_HEADERS = { "Content-Type": "application/json" };
 
@@ -14,7 +14,7 @@ export async function handleGetIntegrations(
 	deps: GitIntegrationsRouteDeps,
 ): Promise<Response> {
 	try {
-		const integrations = deps.gitIntegrationManager.getAllIntegrations();
+		const integrations = await deps.gitIntegrationManager.getAllIntegrations();
 		return new Response(JSON.stringify({ integrations }), {
 			headers: JSON_HEADERS,
 		});
@@ -122,11 +122,7 @@ export async function handleGitHubOAuthCallback(
 			state = readOAuthNonce(body);
 		} else {
 			const url = new URL(request.url);
-			if (
-				url.searchParams.has("access_token") ||
-				url.searchParams.has("refresh_token") ||
-				url.searchParams.has("token")
-			) {
+			if (gitOAuthCallbackNeedsBridge(url)) {
 				return oauthBridgeResponse("github");
 			}
 			error = url.searchParams.get("error");
@@ -217,11 +213,7 @@ export async function handleGitLabOAuthCallback(
 			state = readOAuthNonce(body);
 		} else {
 			const url = new URL(request.url);
-			if (
-				url.searchParams.has("access_token") ||
-				url.searchParams.has("refresh_token") ||
-				url.searchParams.has("token")
-			) {
+			if (gitOAuthCallbackNeedsBridge(url)) {
 				return oauthBridgeResponse("gitlab");
 			}
 			error = url.searchParams.get("error");

--- a/src/server/host-allowlist.ts
+++ b/src/server/host-allowlist.ts
@@ -1,0 +1,84 @@
+function stripIpv6Brackets(hostname: string): string {
+	return hostname.startsWith("[") && hostname.endsWith("]")
+		? hostname.slice(1, -1)
+		: hostname;
+}
+
+function normalizeHostname(host: string): string {
+	return stripIpv6Brackets(host).toLowerCase();
+}
+
+function parseHostHeader(
+	header: string,
+): { hostname: string; port: string | null } | null {
+	const trimmed = header.trim();
+	if (!trimmed) return null;
+	if (trimmed.startsWith("[")) {
+		const end = trimmed.indexOf("]");
+		if (end === -1) return null;
+		const hostname = trimmed.slice(1, end);
+		const rest = trimmed.slice(end + 1);
+		const port = rest.startsWith(":") ? rest.slice(1) : null;
+		return { hostname, port };
+	}
+	const colon = trimmed.lastIndexOf(":");
+	if (colon === -1) {
+		return { hostname: trimmed, port: null };
+	}
+	return {
+		hostname: trimmed.slice(0, colon),
+		port: trimmed.slice(colon + 1),
+	};
+}
+
+function isLoopbackHostname(hostname: string): boolean {
+	const h = normalizeHostname(hostname);
+	return h === "127.0.0.1" || h === "localhost" || h === "::1";
+}
+
+function resolveHostPort(port: string | null): number | null {
+	if (port === null) return 80;
+	if (!/^\d+$/.test(port)) return null;
+	return Number(port);
+}
+
+/**
+ * DNS-rebinding defence: only loopback names and the configured bind host,
+ * on the bind port, are accepted. Request Host is never used to build
+ * redirects or cookies.
+ */
+export function isAllowedHostHeader(
+	hostHeader: string | null,
+	bindHost: string,
+	bindPort: number,
+): boolean {
+	if (!hostHeader) return false;
+	const parsed = parseHostHeader(hostHeader);
+	if (!parsed) return false;
+	const port = resolveHostPort(parsed.port);
+	if (port === null || port !== bindPort) return false;
+	const hostname = normalizeHostname(parsed.hostname);
+	if (isLoopbackHostname(hostname)) return true;
+	return hostname === normalizeHostname(bindHost);
+}
+
+export function misdirectedHostResponse(
+	request: Request,
+	bindHost: string,
+	bindPort: number,
+): Response | null {
+	const host = request.headers.get("host");
+	if (isAllowedHostHeader(host, bindHost, bindPort)) return null;
+	return new Response("Misdirected Request", { status: 421 });
+}
+
+export async function withAllowedHost(
+	request: Request,
+	bindHost: string,
+	bindPort: number,
+	next: () => Promise<Response> | Response,
+): Promise<Response> {
+	const blocked = misdirectedHostResponse(request, bindHost, bindPort);
+	if (blocked) return blocked;
+	return next();
+}

--- a/src/server/html-security-headers.ts
+++ b/src/server/html-security-headers.ts
@@ -1,0 +1,12 @@
+export const HTML_CSP =
+	"default-src 'self'; script-src 'self' 'unsafe-inline'; style-src 'self' 'unsafe-inline'; img-src 'self' data:; connect-src 'self'; frame-ancestors 'none'; base-uri 'self'";
+
+export function htmlSecurityHeaders(
+	extra: Record<string, string> = {},
+): Record<string, string> {
+	return {
+		"Content-Security-Policy": HTML_CSP,
+		"X-Content-Type-Options": "nosniff",
+		...extra,
+	};
+}

--- a/src/server/html-security-headers.ts
+++ b/src/server/html-security-headers.ts
@@ -1,5 +1,5 @@
 export const HTML_CSP =
-	"default-src 'self'; script-src 'self' 'unsafe-inline'; style-src 'self' 'unsafe-inline'; img-src 'self' data:; connect-src 'self'; frame-ancestors 'none'; base-uri 'self'";
+	"default-src 'self'; script-src 'self' 'unsafe-inline'; style-src 'self' 'unsafe-inline' https://fonts.googleapis.com; font-src 'self' https://fonts.gstatic.com; img-src 'self' data: https:; connect-src 'self'; frame-ancestors 'none'; base-uri 'self'";
 
 export function htmlSecurityHeaders(
 	extra: Record<string, string> = {},

--- a/src/server/index.ts
+++ b/src/server/index.ts
@@ -19,6 +19,7 @@ import type { OAuth2Config } from "../types/oauth";
 import type { RegistryCapability } from "../types/registry";
 import { VERSION } from "../version";
 import { authorizeApiRequest, injectHtmlAuthToken } from "./api-guards";
+import { htmlSecurityHeaders } from "./html-security-headers";
 import { withAllowedHost } from "./host-allowlist";
 import {
 	getAuthToken,
@@ -499,7 +500,7 @@ class CapaServer {
 			getAuthToken(),
 		);
 		return new Response(html, {
-			headers: { "Content-Type": "text/html" },
+			headers: htmlSecurityHeaders({ "Content-Type": "text/html" }),
 		});
 	}
 

--- a/src/server/index.ts
+++ b/src/server/index.ts
@@ -19,6 +19,7 @@ import type { OAuth2Config } from "../types/oauth";
 import type { RegistryCapability } from "../types/registry";
 import { VERSION } from "../version";
 import { authorizeApiRequest, injectHtmlAuthToken } from "./api-guards";
+import { withAllowedHost } from "./host-allowlist";
 import {
 	getAuthToken,
 	initAuth,
@@ -401,6 +402,18 @@ class CapaServer {
 	}
 
 	private async _handleRequest(
+		request: Request,
+		server: any,
+	): Promise<Response> {
+		return withAllowedHost(
+			request,
+			this.settings.server.host,
+			this.settings.server.port,
+			() => this._dispatchRequest(request, server),
+		);
+	}
+
+	private async _dispatchRequest(
 		request: Request,
 		server: any,
 	): Promise<Response> {

--- a/src/server/index.ts
+++ b/src/server/index.ts
@@ -353,7 +353,11 @@ class CapaServer {
 		status: number,
 	): Response {
 		const requestOrigin = request.headers.get("Origin");
-		const originCheck = isAllowedOrigin(requestOrigin);
+		const originCheck = isAllowedOrigin(
+			requestOrigin,
+			this.settings.server.host,
+			this.settings.server.port,
+		);
 		const headers: Record<string, string> = {};
 		if (originCheck.origin) {
 			headers["Access-Control-Allow-Origin"] = originCheck.origin;
@@ -1692,7 +1696,11 @@ class CapaServer {
 		}
 
 		const requestOrigin = request.headers.get("Origin");
-		const originCheck = isAllowedOrigin(requestOrigin);
+		const originCheck = isAllowedOrigin(
+			requestOrigin,
+			this.settings.server.host,
+			this.settings.server.port,
+		);
 		const corsHeaders: Record<string, string> = {
 			"Access-Control-Allow-Methods": "POST, GET, OPTIONS",
 			"Access-Control-Allow-Headers": `Content-Type, ${CAPA_CLIENT_HEADER}`,

--- a/src/server/index.ts
+++ b/src/server/index.ts
@@ -58,6 +58,7 @@ import {
 	type McpMetaRouteDeps,
 } from "./mcp-meta-routes";
 import { OAuth2Manager } from "./oauth-manager";
+import { syncServerOAuth2Requirement } from "./oauth-server-sync";
 import {
 	handleDeleteProject,
 	handleGetProject,
@@ -1027,28 +1028,20 @@ class CapaServer {
 				);
 			}
 
-			// Ensure URL-based servers that require OAuth have def.oauth2 set (on-demand detection)
+			// Reconcile def.oauth2 with what each URL-based server actually requires.
 			let capabilitiesUpdated = false;
 			for (const server of capabilities.servers) {
-				const hasExplicitAuthOnDemand =
-					server.def.headers &&
-					Object.keys(server.def.headers).some(
-						(k) => k.toLowerCase() === "authorization",
-					);
-				if (server.def.url && !server.def.oauth2 && !hasExplicitAuthOnDemand) {
-					try {
-						const oauth2Config =
-							await this.oauth2Manager.detectOAuth2Requirement(server.def.url, {
-								tlsSkipVerify: server.def.tlsSkipVerify,
-							});
-						if (oauth2Config) {
-							apiLogger.debug(`OAuth2 detected for ${server.id} (on-demand)`);
-							server.def.oauth2 = oauth2Config;
-							capabilitiesUpdated = true;
-						}
-					} catch (detectionError: any) {
-						apiLogger.warn(
-							`OAuth2 detection failed for ${server.id}: ${detectionError?.message ?? detectionError}`,
+				if (!server.def.url) continue;
+				const sync = await syncServerOAuth2Requirement(
+					projectId,
+					server,
+					this.oauth2Manager,
+				);
+				if (sync.changed) {
+					capabilitiesUpdated = true;
+					if (!sync.entry) {
+						apiLogger.debug(
+							`Cleared stale OAuth2 config for ${server.id}`,
 						);
 					}
 				}
@@ -1363,12 +1356,15 @@ class CapaServer {
 					},
 				);
 				if (!detected) {
+					delete server.def.oauth2;
+					this.oauth2Manager.disconnect(projectId, serverId);
+					this.sessionManager.setProjectCapabilities(projectId, capabilities);
 					return new Response(
 						JSON.stringify({
 							error:
-								"Could not discover OAuth authorization endpoints for this server. Check that the MCP URL is reachable.",
+								"This server no longer requires OAuth. Refresh the page and try connecting to the server directly.",
 						}),
-						{ status: 502, headers: { "Content-Type": "application/json" } },
+						{ status: 409, headers: { "Content-Type": "application/json" } },
 					);
 				}
 				configForFlow = {

--- a/src/server/index.ts
+++ b/src/server/index.ts
@@ -1354,16 +1354,8 @@ class CapaServer {
 				...(server.def.oauth2 as OAuth2Config),
 				...(effectiveClientId ? { client_id: effectiveClientId } : {}),
 			};
-			const hasAuthEndpoint = !!(
-				configForFlow.authorizationEndpoint ||
-				(configForFlow as { authorizationUrl?: string }).authorizationUrl
-			);
-			const hasTokenEndpoint = !!(
-				configForFlow.tokenEndpoint ||
-				(configForFlow as { tokenUrl?: string }).tokenUrl
-			);
-			if ((!hasAuthEndpoint || !hasTokenEndpoint) && server.def.url) {
-				apiLogger.info(`Discovering OAuth endpoints for ${serverId}…`);
+			if (server.def.url) {
+				apiLogger.info(`Refreshing OAuth metadata for ${serverId}…`);
 				const detected = await this.oauth2Manager.detectOAuth2Requirement(
 					server.def.url,
 					{
@@ -1380,8 +1372,8 @@ class CapaServer {
 					);
 				}
 				configForFlow = {
-					...detected,
 					...configForFlow,
+					...detected,
 					authorizationEndpoint:
 						configForFlow.authorizationEndpoint ||
 						(configForFlow as { authorizationUrl?: string }).authorizationUrl ||
@@ -1394,6 +1386,7 @@ class CapaServer {
 						configForFlow.resourceServer ||
 						detected.resourceServer ||
 						server.def.url,
+					scope: detected.scope ?? configForFlow.scope,
 					...(effectiveClientId ? { client_id: effectiveClientId } : {}),
 				};
 				server.def.oauth2 = configForFlow;

--- a/src/server/index.ts
+++ b/src/server/index.ts
@@ -22,7 +22,7 @@ import { authorizeApiRequest, injectHtmlAuthToken } from "./api-guards";
 import { htmlSecurityHeaders } from "./html-security-headers";
 import { withAllowedHost } from "./host-allowlist";
 import {
-	getAuthToken,
+	getSpaAuthToken,
 	initAuth,
 	isLoopbackHost,
 	requireMcpAuth,
@@ -497,7 +497,7 @@ class CapaServer {
 	private async handleSpa(): Promise<Response> {
 		const html = injectHtmlAuthToken(
 			spaHtml as unknown as string,
-			getAuthToken(),
+			getSpaAuthToken(),
 		);
 		return new Response(html, {
 			headers: htmlSecurityHeaders({ "Content-Type": "text/html" }),

--- a/src/server/index.ts
+++ b/src/server/index.ts
@@ -18,7 +18,13 @@ import type { Capabilities, MCPServer } from "../types/capabilities";
 import type { OAuth2Config } from "../types/oauth";
 import type { RegistryCapability } from "../types/registry";
 import { VERSION } from "../version";
-import { initAuth, isLoopbackHost, requireAuth } from "./auth-middleware";
+import { authorizeApiRequest, injectHtmlAuthToken } from "./api-guards";
+import {
+	getAuthToken,
+	initAuth,
+	isLoopbackHost,
+	requireMcpAuth,
+} from "./auth-middleware";
 import { handleCapabilitiesMutation } from "./capabilities-routes";
 import { CapabilitiesFileWatcher } from "./capabilities-watcher";
 import {
@@ -426,9 +432,15 @@ class CapaServer {
 		// API endpoints
 		if (path.startsWith("/api/")) {
 			this.logger.debug("API endpoint");
-			const auth = requireAuth(request, this.settings.server.host);
-			if (!auth.ok) {
-				return this.authFailureResponse(request, auth.reason, auth.status);
+			if (request.method === "OPTIONS") {
+				return new Response(null, { status: 204 });
+			}
+			const gate = authorizeApiRequest(request, {
+				host: this.settings.server.host,
+				port: this.settings.server.port,
+			});
+			if (!gate.ok) {
+				return this.authFailureResponse(request, gate.reason, gate.status);
 			}
 			return this.handleAPI(request, server);
 		}
@@ -441,7 +453,7 @@ class CapaServer {
 			this.logger.debug(
 				`MCP endpoint for project: ${projectId}, sub-agent: ${agentId}`,
 			);
-			const auth = requireAuth(request, this.settings.server.host);
+			const auth = requireMcpAuth(request, this.settings.server.host);
 			if (!auth.ok) {
 				return this.authFailureResponse(request, auth.reason, auth.status);
 			}
@@ -453,7 +465,7 @@ class CapaServer {
 		if (mcpMatch) {
 			const projectId = mcpMatch[1];
 			this.logger.debug(`MCP endpoint for project: ${projectId}`);
-			const auth = requireAuth(request, this.settings.server.host);
+			const auth = requireMcpAuth(request, this.settings.server.host);
 			if (!auth.ok) {
 				return this.authFailureResponse(request, auth.reason, auth.status);
 			}
@@ -465,7 +477,11 @@ class CapaServer {
 	}
 
 	private async handleSpa(): Promise<Response> {
-		return new Response(spaHtml as unknown as string, {
+		const html = injectHtmlAuthToken(
+			spaHtml as unknown as string,
+			getAuthToken(),
+		);
+		return new Response(html, {
 			headers: { "Content-Type": "text/html" },
 		});
 	}

--- a/src/server/mcp-handler.ts
+++ b/src/server/mcp-handler.ts
@@ -858,7 +858,7 @@ export class CapaMCPServer {
 	async listServerTools(
 		serverId: string,
 		capabilities: Capabilities,
-		options: { throwOnError?: boolean } = {},
+		options: { throwOnError?: boolean; connect?: boolean } = {},
 	): Promise<any[]> {
 		const serverDef = capabilities.servers.find((s) => s.id === serverId);
 		if (!serverDef) return [];

--- a/src/server/mcp-handler.ts
+++ b/src/server/mcp-handler.ts
@@ -858,7 +858,11 @@ export class CapaMCPServer {
 	async listServerTools(
 		serverId: string,
 		capabilities: Capabilities,
-		options: { throwOnError?: boolean; connect?: boolean } = {},
+		options: {
+			throwOnError?: boolean;
+			connect?: boolean;
+			timeoutMs?: number;
+		} = {},
 	): Promise<any[]> {
 		const serverDef = capabilities.servers.find((s) => s.id === serverId);
 		if (!serverDef) return [];

--- a/src/server/mcp-meta-routes.ts
+++ b/src/server/mcp-meta-routes.ts
@@ -46,6 +46,7 @@ export async function handleGetServerTools(
 
 		const tools = await mcpServer.listServerTools(serverId, capabilities, {
 			throwOnError: true,
+			connect: false,
 		});
 		return new Response(JSON.stringify({ tools }), {
 			headers: JSON_HEADERS,

--- a/src/server/mcp-meta-routes.ts
+++ b/src/server/mcp-meta-routes.ts
@@ -44,9 +44,13 @@ export async function handleGetServerTools(
 			});
 		}
 
+		// HTTP servers: connect on demand so the UI works after a server restart
+		// without requiring a full configure. Stdio servers are never spawned from
+		// this read-only meta route — run configure to warm those clients.
 		const tools = await mcpServer.listServerTools(serverId, capabilities, {
 			throwOnError: true,
-			connect: false,
+			connect: !!server.def?.url,
+			timeoutMs: 10_000,
 		});
 		return new Response(JSON.stringify({ tools }), {
 			headers: JSON_HEADERS,

--- a/src/server/mcp-proxy.ts
+++ b/src/server/mcp-proxy.ts
@@ -42,6 +42,9 @@ export class MCPProxy {
 	private clients = new Map<string, Client>();
 	/** Launch fingerprint for each cached client (cmd/args/env/cwd/url/…). */
 	private clientFingerprints = new Map<string, string>();
+	/** Coalesce concurrent connects/listTools for the same server. */
+	private connectInFlight = new Map<string, Promise<Client | null>>();
+	private listToolsInFlight = new Map<string, Promise<any[]>>();
 	/** Last unexpected stdio exit reason per server (from transport onerror). */
 	private stdioExitReasons = new Map<string, string>();
 	private logger = logger.child("MCPProxy");
@@ -213,6 +216,36 @@ export class MCPProxy {
 		} = options;
 		// Strip @ prefix from server ID if present
 		const cleanServerId = serverId.replace("@", "");
+		const flightKey = `${cleanServerId}:${connect ? "c" : "nc"}:${timeoutMs}`;
+		const inFlight = this.listToolsInFlight.get(flightKey);
+		if (inFlight) {
+			this.logger.debug(
+				`Coalescing concurrent listTools for ${cleanServerId}`,
+			);
+			return inFlight;
+		}
+
+		const work = this.listToolsOnce(
+			cleanServerId,
+			serverDefinition,
+			{ throwOnError, timeoutMs, connect },
+		).finally(() => {
+			this.listToolsInFlight.delete(flightKey);
+		});
+		this.listToolsInFlight.set(flightKey, work);
+		return work;
+	}
+
+	private async listToolsOnce(
+		cleanServerId: string,
+		serverDefinition: MCPServerDefinition,
+		options: {
+			throwOnError: boolean;
+			timeoutMs: number;
+			connect: boolean;
+		},
+	): Promise<any[]> {
+		const { throwOnError, timeoutMs, connect } = options;
 
 		const resolvedServerDef = resolveVariablesInObject(
 			serverDefinition,
@@ -325,6 +358,30 @@ export class MCPProxy {
 			await this.closeServer(serverId);
 		}
 
+		const inFlight = this.connectInFlight.get(serverId);
+		if (inFlight) {
+			this.logger.debug(
+				`Coalescing concurrent connect for MCP server: ${serverId}`,
+			);
+			return inFlight;
+		}
+
+		const work = this.connectClientOnce(
+			serverId,
+			serverDefinition,
+			fingerprint,
+		).finally(() => {
+			this.connectInFlight.delete(serverId);
+		});
+		this.connectInFlight.set(serverId, work);
+		return work;
+	}
+
+	private async connectClientOnce(
+		serverId: string,
+		serverDefinition: MCPServerDefinition,
+		fingerprint: string,
+	): Promise<Client | null> {
 		this.logger.info(`Creating new MCP client for server: ${serverId}`);
 
 		// For local subprocess-based servers

--- a/src/server/mcp-proxy.ts
+++ b/src/server/mcp-proxy.ts
@@ -2,6 +2,7 @@ import { Client } from "@modelcontextprotocol/sdk/client/index.js";
 import type { Transport } from "@modelcontextprotocol/sdk/shared/transport.js";
 import type { CapaDatabase } from "../db/database";
 import { logger } from "../shared/logger";
+import { isStdioTrusted } from "../shared/stdio-allowlist";
 import {
 	hasUnresolvedVariables,
 	resolveVariablesInObject,
@@ -199,9 +200,17 @@ export class MCPProxy {
 	async listTools(
 		serverId: string,
 		serverDefinition: MCPServerDefinition,
-		options: { throwOnError?: boolean; timeoutMs?: number } = {},
+		options: {
+			throwOnError?: boolean;
+			timeoutMs?: number;
+			connect?: boolean;
+		} = {},
 	): Promise<any[]> {
-		const { throwOnError = false, timeoutMs = 15000 } = options;
+		const {
+			throwOnError = false,
+			timeoutMs = 15000,
+			connect = true,
+		} = options;
 		// Strip @ prefix from server ID if present
 		const cleanServerId = serverId.replace("@", "");
 
@@ -213,7 +222,22 @@ export class MCPProxy {
 
 		let client: Client | null;
 		try {
-			client = await this.getOrCreateClient(cleanServerId, resolvedServerDef);
+			if (!connect) {
+				client = this.clients.get(cleanServerId) ?? null;
+				if (!client) {
+					if (throwOnError) {
+						throw new Error(
+							`MCP server "${cleanServerId}" is not connected`,
+						);
+					}
+					return [];
+				}
+			} else {
+				client = await this.getOrCreateClient(
+					cleanServerId,
+					resolvedServerDef,
+				);
+			}
 		} catch (error) {
 			if (error instanceof MCPOAuthDisconnectedError) {
 				if (throwOnError) throw error;
@@ -233,6 +257,10 @@ export class MCPProxy {
 			return result.tools;
 		} catch (error) {
 			if (error instanceof MCPSessionExpiredError) {
+				if (!connect) {
+					if (throwOnError) throw error;
+					return [];
+				}
 				this.logger.warn(
 					`Session expired for ${cleanServerId}, reconnecting...`,
 				);
@@ -392,6 +420,12 @@ export class MCPProxy {
 		fingerprint: string,
 	): Promise<Client | null> {
 		try {
+			if (!isStdioTrusted(this.projectId, serverDefinition)) {
+				this.logger.warn(
+					`Refusing to spawn untrusted stdio MCP server ${serverId}`,
+				);
+				return null;
+			}
 			this.logger.info(`Creating stdio client for: ${serverId}`);
 			this.logger.debug(
 				`Command: ${serverDefinition.cmd}, Args: ${JSON.stringify(serverDefinition.args || [])}`,

--- a/src/server/oauth-bridge.ts
+++ b/src/server/oauth-bridge.ts
@@ -24,6 +24,41 @@ import { htmlSecurityHeaders } from "./html-security-headers";
 
 export type GitOAuthPlatform = "github" | "gitlab";
 
+/**
+ * Cloud OAuth redirects back to our callback with `?state=…&flowId=…` already in
+ * the redirect URL, then append tokens with a second `?` instead of `&`:
+ *   …/callback?state=x&flowId=y?access_token=z
+ * URLSearchParams treats `access_token` as part of `flowId`. Coerce inner `?` → `&`.
+ */
+export function normalizeOAuthCallbackQuery(search: string): string {
+	if (!search || search === "?") return "";
+	const raw = search.startsWith("?") ? search.slice(1) : search;
+	return raw.replace(/\?/g, "&");
+}
+
+export function parseOAuthCallbackSearchParams(search: string): URLSearchParams {
+	return new URLSearchParams(normalizeOAuthCallbackQuery(search));
+}
+
+/** True when the cloud OAuth redirect should render the HTML bridge (query and/or hash tokens). */
+export function gitOAuthCallbackNeedsBridge(url: URL): boolean {
+	const params = parseOAuthCallbackSearchParams(url.search);
+	if (
+		params.has("access_token") ||
+		params.has("refresh_token") ||
+		params.has("token")
+	) {
+		return true;
+	}
+	// Cloud may return tokens in the fragment (#access_token=...) which never hits the
+	// server — still serve the bridge when state/flowId prove this is our callback.
+	return (
+		params.has("state") ||
+		params.has("flowId") ||
+		params.has("flow_id")
+	);
+}
+
 export function buildOAuthBridgeHtml(platform: GitOAuthPlatform): string {
 	const callbackPath = `/api/integrations/${platform}/oauth/callback`;
 	const uiPath = "/ui/integrations";
@@ -51,13 +86,24 @@ export function buildOAuthBridgeHtml(platform: GitOAuthPlatform): string {
 </div>
 <script>
 (async () => {
-  var params = new URLSearchParams(window.location.search);
-  var accessToken = params.get('access_token');
-  var refreshToken = params.get('refresh_token');
-  var expiresInRaw = params.get('expires_in');
-  var oauthError = params.get('error');
-  var state = params.get('state');
-  var flowId = params.get('flowId');
+  var qs = window.location.search.slice(1).replace(/\\?/g, '&');
+  var params = new URLSearchParams(qs);
+  var hashRaw = window.location.hash;
+  var hashParams = new URLSearchParams(hashRaw && hashRaw.charAt(0) === '#' ? hashRaw.slice(1) : hashRaw);
+  function pick(name, alt) {
+    var v = params.get(name);
+    if (v) return v;
+    if (alt) { v = params.get(alt); if (v) return v; }
+    v = hashParams.get(name);
+    if (v) return v;
+    return alt ? hashParams.get(alt) : null;
+  }
+  var accessToken = pick('access_token', 'token');
+  var refreshToken = pick('refresh_token');
+  var expiresInRaw = pick('expires_in');
+  var oauthError = pick('error');
+  var state = pick('state');
+  var flowId = pick('flowId', 'flow_id');
   try {
     history.replaceState(null, '', window.location.pathname);
   } catch (_) {}

--- a/src/server/oauth-bridge.ts
+++ b/src/server/oauth-bridge.ts
@@ -18,6 +18,9 @@
  * Module-level pure function so it's trivially unit-testable and doesn't pull
  * `CapaServer` into the test graph.
  */
+import { injectHtmlAuthToken } from "./api-guards";
+import { getAuthToken } from "./auth-middleware";
+
 export type GitOAuthPlatform = "github" | "gitlab";
 
 export function buildOAuthBridgeHtml(platform: GitOAuthPlatform): string {
@@ -62,9 +65,11 @@ export function buildOAuthBridgeHtml(platform: GitOAuthPlatform): string {
     var body = { access_token: accessToken };
     if (refreshToken) body.refresh_token = refreshToken;
     if (expiresInRaw) body.expires_in = parseInt(expiresInRaw, 10);
+    var headers = { 'Content-Type': 'application/json' };
+    if (window.__CAPA_AUTH_TOKEN__) headers['Authorization'] = 'Bearer ' + window.__CAPA_AUTH_TOKEN__;
     var resp = await fetch(${JSON.stringify(callbackPath)}, {
       method: 'POST',
-      headers: { 'Content-Type': 'application/json' },
+      headers: headers,
       body: JSON.stringify(body),
       credentials: 'same-origin',
       redirect: 'manual',
@@ -89,7 +94,8 @@ export function buildOAuthBridgeHtml(platform: GitOAuthPlatform): string {
 }
 
 export function oauthBridgeResponse(platform: GitOAuthPlatform): Response {
-	return new Response(buildOAuthBridgeHtml(platform), {
+	const html = injectHtmlAuthToken(buildOAuthBridgeHtml(platform), getAuthToken());
+	return new Response(html, {
 		status: 200,
 		headers: {
 			"Content-Type": "text/html; charset=utf-8",

--- a/src/server/oauth-bridge.ts
+++ b/src/server/oauth-bridge.ts
@@ -19,7 +19,7 @@
  * `CapaServer` into the test graph.
  */
 import { injectHtmlAuthToken } from "./api-guards";
-import { getAuthToken } from "./auth-middleware";
+import { getSpaAuthToken } from "./auth-middleware";
 import { htmlSecurityHeaders } from "./html-security-headers";
 
 export type GitOAuthPlatform = "github" | "gitlab";
@@ -99,7 +99,7 @@ export function buildOAuthBridgeHtml(platform: GitOAuthPlatform): string {
 }
 
 export function oauthBridgeResponse(platform: GitOAuthPlatform): Response {
-	const html = injectHtmlAuthToken(buildOAuthBridgeHtml(platform), getAuthToken());
+	const html = injectHtmlAuthToken(buildOAuthBridgeHtml(platform), getSpaAuthToken());
 	return new Response(html, {
 		status: 200,
 		headers: htmlSecurityHeaders({

--- a/src/server/oauth-bridge.ts
+++ b/src/server/oauth-bridge.ts
@@ -56,6 +56,8 @@ export function buildOAuthBridgeHtml(platform: GitOAuthPlatform): string {
   var refreshToken = params.get('refresh_token');
   var expiresInRaw = params.get('expires_in');
   var oauthError = params.get('error');
+  var state = params.get('state');
+  var flowId = params.get('flowId');
   try {
     history.replaceState(null, '', window.location.pathname);
   } catch (_) {}
@@ -66,6 +68,8 @@ export function buildOAuthBridgeHtml(platform: GitOAuthPlatform): string {
     var body = { access_token: accessToken };
     if (refreshToken) body.refresh_token = refreshToken;
     if (expiresInRaw) body.expires_in = parseInt(expiresInRaw, 10);
+    if (state) body.state = state;
+    if (flowId) body.flowId = flowId;
     var headers = { 'Content-Type': 'application/json' };
     if (window.__CAPA_AUTH_TOKEN__) headers['Authorization'] = 'Bearer ' + window.__CAPA_AUTH_TOKEN__;
     var resp = await fetch(${JSON.stringify(callbackPath)}, {

--- a/src/server/oauth-bridge.ts
+++ b/src/server/oauth-bridge.ts
@@ -20,6 +20,7 @@
  */
 import { injectHtmlAuthToken } from "./api-guards";
 import { getAuthToken } from "./auth-middleware";
+import { htmlSecurityHeaders } from "./html-security-headers";
 
 export type GitOAuthPlatform = "github" | "gitlab";
 
@@ -97,10 +98,10 @@ export function oauthBridgeResponse(platform: GitOAuthPlatform): Response {
 	const html = injectHtmlAuthToken(buildOAuthBridgeHtml(platform), getAuthToken());
 	return new Response(html, {
 		status: 200,
-		headers: {
+		headers: htmlSecurityHeaders({
 			"Content-Type": "text/html; charset=utf-8",
 			"Cache-Control": "no-store",
 			"Referrer-Policy": "no-referrer",
-		},
+		}),
 	});
 }

--- a/src/server/oauth-discovery.ts
+++ b/src/server/oauth-discovery.ts
@@ -36,6 +36,22 @@ export async function fetchProtectedResourceMetadata(
 }
 
 /**
+ * Build the RFC 8414 authorization-server metadata URL for an issuer.
+ * Path-based issuers (e.g. Keycloak `/realms/{realm}`) must insert
+ * `/.well-known/oauth-authorization-server` between host and path — not at origin root.
+ */
+export function buildOAuthAuthorizationServerMetadataUrl(
+	authServerUrl: string,
+): string {
+	const issuer = new URL(authServerUrl);
+	const path = issuer.pathname.replace(/\/$/, "");
+	if (!path || path === "/") {
+		return `${issuer.origin}/.well-known/oauth-authorization-server`;
+	}
+	return `${issuer.origin}/.well-known/oauth-authorization-server${path}`;
+}
+
+/**
  * Fetch authorization server metadata (RFC 8414)
  * Path: /.well-known/oauth-authorization-server
  */
@@ -45,10 +61,7 @@ export async function fetchAuthServerMetadata(
 	log = logger.child("OAuth2Discovery"),
 ): Promise<OAuth2Metadata | null> {
 	try {
-		const wellKnownUrl = new URL(
-			"/.well-known/oauth-authorization-server",
-			authServerUrl,
-		).toString();
+		const wellKnownUrl = buildOAuthAuthorizationServerMetadataUrl(authServerUrl);
 
 		log.debug(`Fetching OAuth metadata from: ${wellKnownUrl}`);
 		const response = await fetch(wellKnownUrl, {
@@ -68,6 +81,44 @@ export async function fetchAuthServerMetadata(
 		log.debug(`OAuth metadata fetch error: ${error.message}`);
 		return null;
 	}
+}
+
+/** Scopes commonly listed by Keycloak but not valid for user-facing authorization_code + DCR clients. */
+export const BLOCKED_OAUTH_SCOPES = new Set([
+	"service_account",
+	"roles",
+	"web-origins",
+]);
+
+/** Remove invalid scopes from a persisted or user-supplied scope string. */
+export function sanitizeOAuthScope(scope: string): string {
+	return scope
+		.split(/\s+/)
+		.filter((part) => part.length > 0 && !BLOCKED_OAUTH_SCOPES.has(part))
+		.join(" ");
+}
+
+/** Prefer resource-advertised scopes; auth-server catalogs often list realm-wide scopes DCR clients cannot request. */
+export function resolveOAuthScope(options: {
+	resourceMetadata?: ProtectedResourceMetadata | null;
+	wwwAuthenticateScope?: string | null;
+	authServerScopes?: string[] | null;
+}): string | undefined {
+	if (options.resourceMetadata?.scopes_supported?.length) {
+		return options.resourceMetadata.scopes_supported.join(" ");
+	}
+	if (options.wwwAuthenticateScope?.trim()) {
+		return options.wwwAuthenticateScope.trim();
+	}
+	if (options.authServerScopes?.length) {
+		const filtered = options.authServerScopes.filter(
+			(s) => !BLOCKED_OAUTH_SCOPES.has(s),
+		);
+		if (filtered.length > 0) {
+			return filtered.join(" ");
+		}
+	}
+	return undefined;
 }
 
 /**
@@ -115,9 +166,17 @@ export async function detectOAuth2Requirement(
 
 		const wwwAuthenticate = response.headers.get("WWW-Authenticate");
 		let authMetadata: OAuth2Metadata | null = null;
+		let resourceMetadata: ProtectedResourceMetadata | null = null;
+		let wwwAuthenticateScope: string | undefined;
 
 		if (wwwAuthenticate) {
 			log.debug(`WWW-Authenticate: ${wwwAuthenticate}`);
+
+			const scopeMatch = wwwAuthenticate.match(/\bscope="([^"]+)"/);
+			if (scopeMatch) {
+				wwwAuthenticateScope = scopeMatch[1];
+				log.debug(`Resource scope hint: ${wwwAuthenticateScope}`);
+			}
 
 			let resourceMetadataUrl: string | null = null;
 			const resourceMetadataMatch = wwwAuthenticate.match(
@@ -135,16 +194,16 @@ export async function detectOAuth2Requirement(
 				log.debug(`Trying: ${resourceMetadataUrl}`);
 			}
 
+			resourceMetadata = await fetchProtectedResourceMetadata(
+				resourceMetadataUrl,
+				tlsSkipVerify,
+			);
+
 			log.debug(`Trying direct OAuth discovery at: ${baseUrl}`);
 			authMetadata = await fetchAuthServerMetadata(baseUrl, tlsSkipVerify, log);
 
 			if (!authMetadata) {
 				log.debug("Direct discovery failed, trying RFC 9728...");
-				const resourceMetadata = await fetchProtectedResourceMetadata(
-					resourceMetadataUrl,
-					tlsSkipVerify,
-				);
-
 				if (
 					resourceMetadata &&
 					resourceMetadata.authorization_servers &&
@@ -185,12 +244,18 @@ export async function detectOAuth2Requirement(
 			return null;
 		}
 
+		const scope = resolveOAuthScope({
+			resourceMetadata,
+			wwwAuthenticateScope,
+			authServerScopes: authMetadata.scopes_supported,
+		});
+
 		const config: OAuth2Config = {
 			authorizationEndpoint: authMetadata.authorization_endpoint,
 			tokenEndpoint: authMetadata.token_endpoint,
 			resourceServer: serverUrl,
 			registrationEndpoint: authMetadata.registration_endpoint,
-			scope: authMetadata.scopes_supported?.join(" "),
+			...(scope ? { scope } : {}),
 		};
 
 		log.success("OAuth2 detected");

--- a/src/server/oauth-pkce-flow.ts
+++ b/src/server/oauth-pkce-flow.ts
@@ -10,8 +10,16 @@ import {
 	resolveAuthorizationEndpoint,
 	resolveTokenEndpoint,
 } from "./oauth-endpoint-resolve";
+import { sanitizeOAuthScope } from "./oauth-discovery";
 
 const pkceLogger = logger.child("OAuth2PKCE");
+
+/** Optional DCR metadata; localhost matches typical Keycloak trustedHosts policies. */
+export function clientUriForRegistration(redirectUri: string): string {
+	const redirect = new URL(redirectUri);
+	const port = redirect.port ? `:${redirect.port}` : "";
+	return `http://localhost${port}`;
+}
 
 /**
  * Register a dynamic OAuth client (RFC 7591)
@@ -27,7 +35,7 @@ export async function registerClient(
 		},
 		body: JSON.stringify({
 			client_name: "CAPA - Capabilities Package Manager",
-			client_uri: "https://github.com/infragate/capa",
+			client_uri: clientUriForRegistration(redirectUri),
 			redirect_uris: [redirectUri],
 			grant_types: ["authorization_code", "refresh_token"],
 			response_types: ["code"],
@@ -113,7 +121,10 @@ export async function generateAuthorizationUrl(
 	authUrl.searchParams.set("code_challenge_method", "S256");
 
 	if (oauth2Config.scope) {
-		authUrl.searchParams.set("scope", oauth2Config.scope);
+		const scope = sanitizeOAuthScope(oauth2Config.scope);
+		if (scope) {
+			authUrl.searchParams.set("scope", scope);
+		}
 	}
 
 	log.info(`Generated authorization URL for ${serverId}`);

--- a/src/server/oauth-pkce-flow.ts
+++ b/src/server/oauth-pkce-flow.ts
@@ -10,6 +10,7 @@ import {
 	resolveAuthorizationEndpoint,
 	resolveTokenEndpoint,
 } from "./oauth-endpoint-resolve";
+import { parseOAuthTokenExchangeResponse } from "./oauth-token-store";
 import { sanitizeOAuthScope } from "./oauth-discovery";
 
 const pkceLogger = logger.child("OAuth2PKCE");
@@ -233,17 +234,28 @@ export async function handleCallback(
 		}
 
 		const tokenData = await tokenResponse.json();
+		const parsed = parseOAuthTokenExchangeResponse(tokenData);
+		if (parsed.error || !parsed.accessToken) {
+			const message =
+				parsed.error || "Token response did not include access_token";
+			log.failure(`Token exchange failed: ${message}`);
+			return {
+				success: false,
+				error: "Failed to exchange authorization code for tokens",
+			};
+		}
 
-		const expiresAt = tokenData.expires_in
-			? Date.now() + tokenData.expires_in * 1000
-			: undefined;
+		const expiresAt =
+			parsed.expiresIn && Number.isFinite(parsed.expiresIn)
+				? Date.now() + parsed.expiresIn * 1000
+				: undefined;
 
 		db.setOAuthToken(project_id, server_id, {
-			access_token: tokenData.access_token,
-			refresh_token: tokenData.refresh_token,
-			token_type: tokenData.token_type || "Bearer",
+			access_token: parsed.accessToken,
+			refresh_token: parsed.refreshToken,
+			token_type: parsed.tokenType || "Bearer",
 			expires_at: expiresAt,
-			scope: tokenData.scope,
+			scope: parsed.scope,
 		});
 
 		log.success(`Tokens stored for ${server_id}`);

--- a/src/server/oauth-server-sync.ts
+++ b/src/server/oauth-server-sync.ts
@@ -1,4 +1,7 @@
-import type { MCPServer } from "../types/capabilities";
+import type {
+	MCPServer,
+	OAuth2Config as CapabilitiesOAuth2Config,
+} from "../types/capabilities";
 import type { OAuth2Config } from "../types/oauth";
 import type { OAuth2Manager } from "./oauth-manager";
 
@@ -13,7 +16,7 @@ export function serverHasExplicitAuthHeader(server: MCPServer): boolean {
 
 /** Merge auto-detected OAuth endpoints with plugin-embedded client_id / callback_port. */
 export function mergeDetectedOAuth2(
-	existingOAuth: OAuth2Config | undefined,
+	existingOAuth: CapabilitiesOAuth2Config | undefined,
 	oauth2Config: OAuth2Config,
 ): OAuth2Config {
 	const merged: OAuth2Config = { ...(existingOAuth ?? {}), ...oauth2Config };

--- a/src/server/oauth-server-sync.ts
+++ b/src/server/oauth-server-sync.ts
@@ -1,0 +1,130 @@
+import type { MCPServer } from "../types/capabilities";
+import type { OAuth2Config } from "../types/oauth";
+import type { OAuth2Manager } from "./oauth-manager";
+
+export function serverHasExplicitAuthHeader(server: MCPServer): boolean {
+	return !!(
+		server.def.headers &&
+		Object.keys(server.def.headers).some(
+			(k) => k.toLowerCase() === "authorization",
+		)
+	);
+}
+
+/** Merge auto-detected OAuth endpoints with plugin-embedded client_id / callback_port. */
+export function mergeDetectedOAuth2(
+	existingOAuth: OAuth2Config | undefined,
+	oauth2Config: OAuth2Config,
+): OAuth2Config {
+	const merged: OAuth2Config = { ...(existingOAuth ?? {}), ...oauth2Config };
+	const embeddedClientId =
+		existingOAuth?.client_id ??
+		existingOAuth?.clientId ??
+		(existingOAuth as { CLIENT_ID?: string })?.CLIENT_ID ??
+		existingOAuth?.oauth?.clientId ??
+		(existingOAuth?.oauth as { client_id?: string } | undefined)?.client_id;
+	if (embeddedClientId) merged.client_id = embeddedClientId;
+
+	const embeddedCallbackPort =
+		existingOAuth?.callback_port ??
+		existingOAuth?.callbackPort ??
+		(existingOAuth as { CALLBACK_PORT?: number | string })?.CALLBACK_PORT;
+	if (typeof embeddedCallbackPort === "number" && embeddedCallbackPort > 0) {
+		merged.callback_port = embeddedCallbackPort;
+	} else if (typeof embeddedCallbackPort === "string") {
+		const parsed = Number(embeddedCallbackPort);
+		if (Number.isFinite(parsed) && parsed > 0) merged.callback_port = parsed;
+	}
+	return merged;
+}
+
+export type OAuth2ServerEntry = {
+	serverId: string;
+	serverUrl: string;
+	displayName: string;
+	isConnected: boolean;
+};
+
+export type SyncServerOAuth2Result = {
+	changed: boolean;
+	entry: OAuth2ServerEntry | null;
+};
+
+/**
+ * Probe the live MCP URL and align def.oauth2 with what the server actually needs.
+ * Clears stale OAuth config when the URL no longer returns 401 + WWW-Authenticate.
+ */
+export async function syncServerOAuth2Requirement(
+	projectId: string,
+	server: MCPServer,
+	oauth2Manager: OAuth2Manager,
+): Promise<SyncServerOAuth2Result> {
+	if (!server.def.url) {
+		return { changed: false, entry: null };
+	}
+
+	if (serverHasExplicitAuthHeader(server)) {
+		if (server.def.oauth2) {
+			delete server.def.oauth2;
+			oauth2Manager.disconnect(projectId, server.id);
+			return { changed: true, entry: null };
+		}
+		return { changed: false, entry: null };
+	}
+
+	const existingOAuth = server.def.oauth2;
+	try {
+		const detected = await oauth2Manager.detectOAuth2Requirement(server.def.url, {
+			tlsSkipVerify: server.def.tlsSkipVerify,
+		});
+
+		if (detected) {
+			const merged = mergeDetectedOAuth2(existingOAuth, detected);
+			const changed =
+				!existingOAuth ||
+				JSON.stringify(existingOAuth) !== JSON.stringify(merged);
+			server.def.oauth2 = merged;
+
+			let isConnected = oauth2Manager.isServerConnected(projectId, server.id);
+			if (isConnected) {
+				const accessToken = await oauth2Manager.getAccessToken(
+					projectId,
+					server.id,
+					merged,
+				);
+				isConnected = !!accessToken;
+			}
+
+			return {
+				changed,
+				entry: {
+					serverId: server.id,
+					serverUrl: server.def.url,
+					displayName: server.displayName ?? server.id,
+					isConnected,
+				},
+			};
+		}
+
+		if (existingOAuth) {
+			delete server.def.oauth2;
+			oauth2Manager.disconnect(projectId, server.id);
+			return { changed: true, entry: null };
+		}
+
+		return { changed: false, entry: null };
+	} catch {
+		// Transient probe failures should not strip a working OAuth config.
+		if (!existingOAuth) return { changed: false, entry: null };
+		const isConnected = oauth2Manager.isServerConnected(projectId, server.id);
+		return {
+			changed: false,
+			entry: {
+				serverId: server.id,
+				serverUrl: server.def.url,
+				displayName: server.displayName ?? server.id,
+				isConnected,
+			},
+		};
+	}
+}

--- a/src/server/oauth-token-store.ts
+++ b/src/server/oauth-token-store.ts
@@ -166,10 +166,10 @@ export async function refreshAccessToken(
 
 		db.setOAuthToken(projectId, serverId, {
 			access_token: parsed.accessToken,
-			refresh_token: parsed.refreshToken || tokenData.refresh_token,
+			refresh_token: parsed.refreshToken || tokenData.refresh_token || undefined,
 			token_type: parsed.tokenType || "Bearer",
 			expires_at: expiresAt,
-			scope: parsed.scope || tokenData.scope,
+			scope: parsed.scope || tokenData.scope || undefined,
 		});
 
 		log.success(`Access token refreshed for ${serverId}`);

--- a/src/server/oauth-token-store.ts
+++ b/src/server/oauth-token-store.ts
@@ -6,6 +6,71 @@ import { resolveTokenEndpoint } from "./oauth-endpoint-resolve";
 
 const tokenLogger = logger.child("OAuth2TokenStore");
 
+function resolveStoredClientId(
+	projectId: string,
+	serverId: string,
+	oauth2Config: OAuth2Config,
+	db: CapaDatabase,
+): string {
+	return (
+		db.getVariable(projectId, `oauth2_client_id_${serverId}`) ||
+		oauth2Config.client_id ||
+		oauth2Config.clientId ||
+		oauth2Config.oauth?.clientId ||
+		"capa"
+	);
+}
+
+function parseRefreshTokenResponse(raw: unknown): {
+	accessToken?: string;
+	refreshToken?: string;
+	tokenType?: string;
+	expiresIn?: number;
+	scope?: string;
+	error?: string;
+} {
+	return parseOAuthTokenExchangeResponse(raw);
+}
+
+/** Shared parser for OAuth token endpoint JSON (exchange + refresh). */
+export function parseOAuthTokenExchangeResponse(raw: unknown): {
+	accessToken?: string;
+	refreshToken?: string;
+	tokenType?: string;
+	expiresIn?: number;
+	scope?: string;
+	error?: string;
+} {
+	if (!raw || typeof raw !== "object") {
+		return { error: "Token response was not a JSON object" };
+	}
+	const body = raw as Record<string, unknown>;
+	if (body.ok === false && typeof body.error === "string") {
+		return { error: body.error };
+	}
+	if (typeof body.error === "string") {
+		return { error: body.error };
+	}
+	const accessToken =
+		typeof body.access_token === "string" ? body.access_token : undefined;
+	const refreshToken =
+		typeof body.refresh_token === "string" ? body.refresh_token : undefined;
+	const tokenType =
+		typeof body.token_type === "string" ? body.token_type : undefined;
+	const scope = typeof body.scope === "string" ? body.scope : undefined;
+	const expiresInRaw = body.expires_in;
+	const expiresIn =
+		typeof expiresInRaw === "number"
+			? expiresInRaw
+			: typeof expiresInRaw === "string"
+				? Number(expiresInRaw)
+				: undefined;
+	if (!accessToken) {
+		return { error: "Token response did not include access_token" };
+	}
+	return { accessToken, refreshToken, tokenType, scope, expiresIn };
+}
+
 /**
  * Refresh access token using refresh token
  */
@@ -29,8 +94,12 @@ export async function refreshAccessToken(
 
 		log.info(`Refreshing access token for ${serverId}`);
 
-		const clientId =
-			db.getVariable(projectId, `oauth2_client_id_${serverId}`) || "capa";
+		const clientId = resolveStoredClientId(
+			projectId,
+			serverId,
+			oauth2Config,
+			db,
+		);
 		const clientSecret = db.getVariable(
 			projectId,
 			`oauth2_client_secret_${serverId}`,
@@ -74,18 +143,33 @@ export async function refreshAccessToken(
 			return false;
 		}
 
-		const newTokenData = await response.json();
+		const parsed = parseRefreshTokenResponse(await response.json());
+		if (parsed.error || !parsed.accessToken) {
+			const message = parsed.error || "Token response did not include access_token";
+			log.failure(`Token refresh failed: ${message}`);
+			if (
+				isPermanentRefreshFailure(undefined, response, message) ||
+				/invalid|expired|revoked|not_found|unauthorized/i.test(message)
+			) {
+				db.deleteOAuthToken(projectId, serverId);
+				log.info(`Deleted invalid token for ${serverId}`);
+			} else {
+				log.warn(`Transient refresh failure for ${serverId}, keeping token`);
+			}
+			return false;
+		}
 
-		const expiresAt = newTokenData.expires_in
-			? Date.now() + newTokenData.expires_in * 1000
-			: undefined;
+		const expiresAt =
+			parsed.expiresIn && Number.isFinite(parsed.expiresIn)
+				? Date.now() + parsed.expiresIn * 1000
+				: undefined;
 
 		db.setOAuthToken(projectId, serverId, {
-			access_token: newTokenData.access_token,
-			refresh_token: newTokenData.refresh_token || tokenData.refresh_token,
-			token_type: newTokenData.token_type || "Bearer",
+			access_token: parsed.accessToken,
+			refresh_token: parsed.refreshToken || tokenData.refresh_token,
+			token_type: parsed.tokenType || "Bearer",
 			expires_at: expiresAt,
-			scope: newTokenData.scope || tokenData.scope,
+			scope: parsed.scope || tokenData.scope,
 		});
 
 		log.success(`Access token refreshed for ${serverId}`);

--- a/src/server/project-routes.ts
+++ b/src/server/project-routes.ts
@@ -16,6 +16,7 @@ import type { ConfigureRouteDeps } from "./configure-routes";
 import { runProjectConfigure } from "./configure-routes";
 import type { CapaMCPServer } from "./mcp-handler";
 import { OAuth2Manager } from "./oauth-manager";
+import { redactServerForApi } from "./secret-redaction";
 import { listProjectFs, writeProjectImport } from "./project-fs";
 import { clientErrorMessage } from "./http-error";
 import {
@@ -190,7 +191,7 @@ export async function handleGetProject(
 							const isConnected = requiresOAuth
 								? deps.oauth2Manager.isServerConnected(projectId, s.id)
 								: null;
-							return {
+							return redactServerForApi({
 								id: s.id,
 								type: s.type,
 								url: s.def?.url || null,
@@ -228,7 +229,7 @@ export async function handleGetProject(
 								description: s.description || null,
 								requiresOAuth,
 								isConnected,
-							};
+							});
 						}),
 						resolvedPlugins: capabilities.resolvedPlugins || null,
 						providers: capabilities.providers || [],

--- a/src/server/registries-routes.ts
+++ b/src/server/registries-routes.ts
@@ -2,6 +2,7 @@ import type { CapaDatabase } from "../db/database";
 import { createAuthenticatedFetch } from "../shared/authenticated-fetch";
 import {
 	deriveSlug,
+	executeStagedRegistry,
 	fetchAdapterSource,
 	isValidSlug,
 	removeInstalledAdapter,
@@ -39,6 +40,55 @@ function parseTypeQuery(value: string | null): RegistrySourceType | null {
 }
 
 const TYPE_HELP = "github, gitlab, url, claude-marketplace";
+
+type RegistryInstallInput = {
+	slug: string;
+	type: RegistrySourceType;
+	source: string;
+};
+
+/** Stage adapter bytes, execute (import), persist as installed — web UI is explicit approval. */
+async function stageAndInstallRegistry(
+	db: CapaDatabase,
+	manager: RegistryManager,
+	input: RegistryInstallInput,
+	authFetch: ReturnType<typeof createAuthenticatedFetch>,
+	opts: { enabled?: boolean; noCache?: boolean } = {},
+) {
+	const result = await stageRegistry(input, authFetch, opts);
+	try {
+		await executeStagedRegistry(input.slug, result.contentSha256);
+	} catch (err: any) {
+		const message = clientErrorMessage(err);
+		db.upsertRegistry({
+			slug: input.slug,
+			type: input.type,
+			source: input.source,
+			status: "failed",
+			enabled: opts.enabled ?? true,
+			lastError: message,
+			resolvedRef: result.resolvedRef,
+			installedAt: null,
+			contentSha256: result.contentSha256,
+		});
+		await manager.reload().catch(() => {});
+		throw new Error(message);
+	}
+
+	const record = db.upsertRegistry({
+		slug: input.slug,
+		type: input.type,
+		source: input.source,
+		status: "installed",
+		enabled: opts.enabled ?? true,
+		lastError: null,
+		resolvedRef: result.resolvedRef,
+		installedAt: Date.now(),
+		contentSha256: result.contentSha256,
+	});
+	await manager.reload().catch(() => {});
+	return record;
+}
 
 
 export async function listRegistriesHandler(
@@ -113,22 +163,13 @@ export async function createRegistryHandler(
 			return jsonError(`Registry "${installSlug}" already exists.`, 409);
 		}
 
-		const result = await stageRegistry(
+		const record = await stageAndInstallRegistry(
+			db,
+			manager,
 			{ slug: installSlug, type, source },
 			authFetch,
 		);
-		const record = db.upsertRegistry({
-			slug: installSlug,
-			type,
-			source,
-			status: "pending",
-			enabled: true,
-			lastError: null,
-			resolvedRef: result.resolvedRef,
-			installedAt: null,
-			contentSha256: result.contentSha256,
-		});
-		return jsonOk({ registry: record }, 202);
+		return jsonOk({ registry: record });
 	} catch (err: any) {
 		return jsonError(clientErrorMessage(err), 400);
 	}
@@ -198,23 +239,14 @@ export async function patchRegistryHandler(
 	if (needsReinstall) {
 		try {
 			const authFetch = createAuthenticatedFetch(db);
-			const result = await stageRegistry(
+			const record = await stageAndInstallRegistry(
+				db,
+				manager,
 				{ slug, type: newType!, source: newSource },
 				authFetch,
+				{ enabled: hasEnabled ? body.enabled! : existing.enabled },
 			);
-			const record = db.upsertRegistry({
-				slug,
-				type: newType!,
-				source: newSource,
-				status: "pending",
-				enabled: hasEnabled ? body.enabled! : existing.enabled,
-				lastError: null,
-				resolvedRef: result.resolvedRef,
-				installedAt: null,
-				contentSha256: result.contentSha256,
-			});
-			await manager.reload().catch(() => {});
-			return jsonOk({ registry: record }, 202);
+			return jsonOk({ registry: record });
 		} catch (err: any) {
 			const message = clientErrorMessage(err);
 			// Persist the new pointer so the user can fix and retry, but mark
@@ -252,23 +284,13 @@ export async function refreshRegistryHandler(
 	}
 	try {
 		const authFetch = createAuthenticatedFetch(db);
-		const result = await stageRegistry(
+		const record = await stageAndInstallRegistry(
+			db,
+			manager,
 			{ slug: existing.slug, type: existing.type, source: existing.source },
 			authFetch,
 		);
-		const record = db.upsertRegistry({
-			slug: existing.slug,
-			type: existing.type,
-			source: existing.source,
-			status: "pending",
-			enabled: true,
-			lastError: null,
-			resolvedRef: result.resolvedRef,
-			installedAt: null,
-			contentSha256: result.contentSha256,
-		});
-		await manager.reload().catch(() => {});
-		return jsonOk({ registry: record }, 202);
+		return jsonOk({ registry: record });
 	} catch (err: any) {
 		const message = clientErrorMessage(err);
 		db.setRegistryStatus(slug, "failed", message);

--- a/src/server/registries-routes.ts
+++ b/src/server/registries-routes.ts
@@ -3,9 +3,9 @@ import { createAuthenticatedFetch } from "../shared/authenticated-fetch";
 import {
 	deriveSlug,
 	fetchAdapterSource,
-	installRegistry,
 	isValidSlug,
 	removeInstalledAdapter,
+	stageRegistry,
 } from "../shared/registries/installer";
 import type { RegistryManager } from "../shared/registries/manager";
 import type { RegistrySourceType } from "../types/database";
@@ -113,7 +113,7 @@ export async function createRegistryHandler(
 			return jsonError(`Registry "${installSlug}" already exists.`, 409);
 		}
 
-		const result = await installRegistry(
+		const result = await stageRegistry(
 			{ slug: installSlug, type, source },
 			authFetch,
 		);
@@ -121,14 +121,14 @@ export async function createRegistryHandler(
 			slug: installSlug,
 			type,
 			source,
-			status: "installed",
+			status: "pending",
 			enabled: true,
 			lastError: null,
 			resolvedRef: result.resolvedRef,
-			installedAt: Date.now(),
+			installedAt: null,
+			contentSha256: result.contentSha256,
 		});
-		await manager.reload().catch(() => {});
-		return jsonOk({ registry: record, manifest: result.manifest }, 201);
+		return jsonOk({ registry: record }, 202);
 	} catch (err: any) {
 		return jsonError(clientErrorMessage(err), 400);
 	}
@@ -198,7 +198,7 @@ export async function patchRegistryHandler(
 	if (needsReinstall) {
 		try {
 			const authFetch = createAuthenticatedFetch(db);
-			const result = await installRegistry(
+			const result = await stageRegistry(
 				{ slug, type: newType!, source: newSource },
 				authFetch,
 			);
@@ -206,14 +206,15 @@ export async function patchRegistryHandler(
 				slug,
 				type: newType!,
 				source: newSource,
-				status: "installed",
+				status: "pending",
 				enabled: hasEnabled ? body.enabled! : existing.enabled,
 				lastError: null,
 				resolvedRef: result.resolvedRef,
-				installedAt: Date.now(),
+				installedAt: null,
+				contentSha256: result.contentSha256,
 			});
 			await manager.reload().catch(() => {});
-			return jsonOk({ registry: record, manifest: result.manifest });
+			return jsonOk({ registry: record }, 202);
 		} catch (err: any) {
 			const message = clientErrorMessage(err);
 			// Persist the new pointer so the user can fix and retry, but mark
@@ -251,7 +252,7 @@ export async function refreshRegistryHandler(
 	}
 	try {
 		const authFetch = createAuthenticatedFetch(db);
-		const result = await installRegistry(
+		const result = await stageRegistry(
 			{ slug: existing.slug, type: existing.type, source: existing.source },
 			authFetch,
 		);
@@ -259,14 +260,15 @@ export async function refreshRegistryHandler(
 			slug: existing.slug,
 			type: existing.type,
 			source: existing.source,
-			status: "installed",
+			status: "pending",
 			enabled: true,
 			lastError: null,
 			resolvedRef: result.resolvedRef,
-			installedAt: Date.now(),
+			installedAt: null,
+			contentSha256: result.contentSha256,
 		});
 		await manager.reload().catch(() => {});
-		return jsonOk({ registry: record, manifest: result.manifest });
+		return jsonOk({ registry: record }, 202);
 	} catch (err: any) {
 		const message = clientErrorMessage(err);
 		db.setRegistryStatus(slug, "failed", message);

--- a/src/server/resolve-effective-capabilities.ts
+++ b/src/server/resolve-effective-capabilities.ts
@@ -193,6 +193,9 @@ export function preserveDiscoveredOAuth2(
 		const prevOAuth = prev?.def?.oauth2;
 		if (!prevOAuth) continue;
 
+		// URL changes invalidate previously discovered OAuth metadata.
+		if (prev?.def?.url !== server.def?.url) continue;
+
 		const prevAuth =
 			prevOAuth.authorizationEndpoint ||
 			(prevOAuth as { authorizationUrl?: string }).authorizationUrl;

--- a/src/server/secret-redaction.ts
+++ b/src/server/secret-redaction.ts
@@ -1,0 +1,108 @@
+const SENSITIVE_HEADER =
+	/^(authorization|proxy-authorization)$|token|api-?key|secret|password|bearer/i;
+
+function asStringMap(value: unknown): Record<string, string> {
+	if (!value || typeof value !== "object" || Array.isArray(value)) return {};
+	const out: Record<string, string> = {};
+	for (const [key, raw] of Object.entries(value as Record<string, unknown>)) {
+		if (typeof raw === "string") out[key] = raw;
+	}
+	return out;
+}
+
+function asObj(value: unknown): Record<string, unknown> | null {
+	if (!value || typeof value !== "object" || Array.isArray(value)) return null;
+	return value as Record<string, unknown>;
+}
+
+export function isSensitiveHeaderName(name: string): boolean {
+	return SENSITIVE_HEADER.test(name);
+}
+
+export interface ApiServerSecrets {
+	env?: Record<string, string> | null;
+	headers?: Record<string, string> | null;
+	oauth2?: {
+		clientId?: string | null;
+		clientSecret?: string | null;
+		[key: string]: unknown;
+	} | null;
+	[key: string]: unknown;
+}
+
+export function redactServerForApi<T extends ApiServerSecrets>(server: T): T {
+	const env = server.env
+		? Object.fromEntries(Object.keys(server.env).map((key) => [key, ""]))
+		: server.env;
+
+	let headers = server.headers;
+	if (headers) {
+		const next: Record<string, string> = {};
+		for (const [key, value] of Object.entries(headers)) {
+			if (isSensitiveHeaderName(key)) continue;
+			next[key] = value;
+		}
+		headers = next;
+	}
+
+	let oauth2 = server.oauth2;
+	if (oauth2) {
+		const { clientSecret: _omit, ...rest } = oauth2;
+		oauth2 = rest;
+	}
+
+	return { ...server, env, headers, oauth2 };
+}
+
+export function mergeServerDef(
+	existing: Record<string, unknown> | null | undefined,
+	incoming: Record<string, unknown>,
+): Record<string, unknown> {
+	const prev = existing ?? {};
+	const merged: Record<string, unknown> = { ...prev, ...incoming };
+
+	if (incoming.env !== undefined) {
+		const prevEnv = asStringMap(prev.env);
+		const nextEnv = asStringMap(incoming.env);
+		const env: Record<string, string> = {};
+		for (const [key, value] of Object.entries(nextEnv)) {
+			env[key] = value === "" && key in prevEnv ? prevEnv[key] : value;
+		}
+		merged.env = env;
+	}
+
+	if (incoming.headers !== undefined) {
+		const prevHeaders = asStringMap(prev.headers);
+		const nextHeaders = asStringMap(incoming.headers);
+		const headers: Record<string, string> = { ...nextHeaders };
+		for (const [key, value] of Object.entries(prevHeaders)) {
+			if (key in nextHeaders) {
+				if (nextHeaders[key] === "") headers[key] = value;
+				continue;
+			}
+			if (isSensitiveHeaderName(key)) headers[key] = value;
+		}
+		for (const [key, value] of Object.entries(nextHeaders)) {
+			if (value === "" && key in prevHeaders) headers[key] = prevHeaders[key];
+		}
+		merged.headers = headers;
+	}
+
+	const prevOauth = asObj(prev.oauth2);
+	const nextOauth = asObj(incoming.oauth2);
+	if (nextOauth) {
+		const oauth2: Record<string, unknown> = { ...prevOauth, ...nextOauth };
+		const incomingSecret = nextOauth.clientSecret;
+		if (
+			(incomingSecret === undefined ||
+				incomingSecret === "" ||
+				incomingSecret === null) &&
+			typeof prevOauth?.clientSecret === "string"
+		) {
+			oauth2.clientSecret = prevOauth.clientSecret;
+		}
+		merged.oauth2 = oauth2;
+	}
+
+	return merged;
+}

--- a/src/server/tool-executor.ts
+++ b/src/server/tool-executor.ts
@@ -91,6 +91,36 @@ export function tokenizeCommandTemplate(input: string): string[] {
 	return tokens;
 }
 
+const SHELL_ARGV0 = new Set([
+	"sh",
+	"bash",
+	"zsh",
+	"dash",
+	"fish",
+	"cmd",
+	"cmd.exe",
+	"powershell",
+	"powershell.exe",
+	"pwsh",
+	"pwsh.exe",
+]);
+
+function argv0Basename(program: string): string {
+	const normalized = program.replace(/\\/g, "/");
+	const base = normalized.slice(normalized.lastIndexOf("/") + 1);
+	return base.toLowerCase();
+}
+
+export function shellPlaceholderTemplateError(tokens: string[]): string | null {
+	if (tokens.length === 0) return null;
+	if (!SHELL_ARGV0.has(argv0Basename(tokens[0]))) return null;
+	const hasPlaceholder = tokens.some((t) =>
+		/\{[a-zA-Z_][a-zA-Z0-9_]*\}/.test(t),
+	);
+	if (!hasPlaceholder) return null;
+	return `Command template uses a shell (${tokens[0]}) with {placeholders}; caller values would be re-parsed by the shell. Use a non-shell argv0, or set allowShellPlaceholders: true if this is intentional.`;
+}
+
 function substitutePlaceholders(
 	token: string,
 	values: Record<string, string>,
@@ -189,6 +219,16 @@ export class CommandToolExecutor {
 		}
 		if (templateTokens.length === 0) {
 			return { success: false, error: "Command template is empty" };
+		}
+		if (!spec.allowShellPlaceholders) {
+			const shellError = shellPlaceholderTemplateError(templateTokens);
+			if (shellError) {
+				return { success: false, error: shellError };
+			}
+		} else if (shellPlaceholderTemplateError(templateTokens)) {
+			this.logger.warn(
+				`allowShellPlaceholders is set; caller values will be interpolated into a shell command: ${resolvedSpec.cmd}`,
+			);
 		}
 
 		// Collect substitution values: caller-supplied first, falling back to

--- a/src/server/tool-formatter.ts
+++ b/src/server/tool-formatter.ts
@@ -1,5 +1,6 @@
 import { spawn } from "child_process";
 import { logger } from "../shared/logger";
+import { tokenizeCommandTemplate } from "./tool-executor";
 import type {
 	Tool,
 	ToolFormatterDefinition,
@@ -103,9 +104,13 @@ export async function applyToolFormatter(
 	formatter: ToolFormatterDefinition,
 ): Promise<string> {
 	const timeout = formatter.timeout ?? DEFAULT_FORMATTER_TIMEOUT_MS;
-	const isWindows = process.platform === "win32";
-	const shell = isWindows ? "cmd.exe" : "/bin/sh";
-	const shellFlag = isWindows ? "/C" : "-c";
+	let argv: string[];
+	try {
+		argv = tokenizeCommandTemplate(formatter.cmd);
+	} catch {
+		return input;
+	}
+	if (argv.length === 0) return input;
 
 	return new Promise((resolve) => {
 		let settled = false;
@@ -115,9 +120,10 @@ export async function applyToolFormatter(
 			resolve(value);
 		};
 
-		const proc = spawn(shell, [shellFlag, formatter.cmd], {
+		const proc = spawn(argv[0], argv.slice(1), {
 			stdio: ["pipe", "pipe", "pipe"],
 			windowsHide: true,
+			shell: false,
 		});
 
 		let stdout = "";

--- a/src/shared/__tests__/cache-git-auth.test.ts
+++ b/src/shared/__tests__/cache-git-auth.test.ts
@@ -1,0 +1,228 @@
+import { afterEach, beforeEach, describe, expect, it, spyOn } from 'bun:test';
+import * as childProcess from 'child_process';
+import { existsSync, mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from 'fs';
+import { tmpdir } from 'os';
+import { join } from 'path';
+import { promisify } from 'util';
+import {
+  ensureMirrorClone,
+  fetchMirror,
+  getRepoMirrorDir,
+} from '../cache';
+
+const execFileAsync = promisify(childProcess.execFile);
+
+const SECRET = 'gho_F10_SUPER_SECRET_TOKEN';
+
+const noAuthFetch = {
+  hasAuth: () => false,
+  getTokenForUrl: () => null,
+} as any;
+
+const authFetch = {
+  hasAuth: (url: string) => /github\.com/i.test(url),
+  getTokenForUrl: (url: string) => (/github\.com/i.test(url) ? SECRET : null),
+} as any;
+
+function argvContainsSecret(args: string[]): boolean {
+  return args.some((a) => a.includes(SECRET));
+}
+
+function envCarriesOutOfBandAuth(env: NodeJS.ProcessEnv | undefined): boolean {
+  if (!env) return false;
+  if (env.GIT_ASKPASS) return true;
+  if (env.GIT_CONFIG_COUNT && Number.parseInt(env.GIT_CONFIG_COUNT, 10) > 0) {
+    return Object.entries(env).some(
+      ([k, v]) => k.startsWith('GIT_CONFIG_') && typeof v === 'string' && (
+        v.includes(SECRET) ||
+        v.includes(Buffer.from(`oauth2:${SECRET}`, 'utf8').toString('base64')) ||
+        v.toLowerCase().includes('authorization')
+      ),
+    );
+  }
+  return Object.values(env).some(
+    (v) => typeof v === 'string' && v.includes(SECRET),
+  );
+}
+
+describe('cache git auth (F10)', () => {
+  let cacheRoot: string;
+  let prevCacheDir: string | undefined;
+
+  beforeEach(() => {
+    cacheRoot = mkdtempSync(join(tmpdir(), 'capa-git-auth-'));
+    prevCacheDir = process.env.CAPA_CACHE_DIR;
+    process.env.CAPA_CACHE_DIR = cacheRoot;
+  });
+
+  afterEach(() => {
+    if (prevCacheDir === undefined) {
+      delete process.env.CAPA_CACHE_DIR;
+    } else {
+      process.env.CAPA_CACHE_DIR = prevCacheDir;
+    }
+    rmSync(cacheRoot, { recursive: true, force: true });
+  });
+
+  describe('ensureMirrorClone', () => {
+    it('does not put the oauth token in git clone argv', async () => {
+      const calls: { args: string[]; env?: NodeJS.ProcessEnv }[] = [];
+      const execFileSpy = spyOn(childProcess, 'execFile').mockImplementation(
+        ((_cmd: string, args: string[], opts: object, cb: (err: null, stdout: string, stderr: string) => void) => {
+          calls.push({ args, env: (opts as { env?: NodeJS.ProcessEnv }).env });
+          cb(null, '', '');
+        }) as typeof childProcess.execFile,
+      );
+
+      try {
+        await ensureMirrorClone('github', 'owner/repo', authFetch);
+        const cloneCall = calls.find((c) => c.args.includes('clone'));
+        expect(cloneCall).toBeDefined();
+        expect(argvContainsSecret(cloneCall!.args)).toBe(false);
+        expect(cloneCall!.args.some((a) => /oauth2:/i.test(a))).toBe(false);
+        expect(cloneCall!.args).toContain('https://github.com/owner/repo.git');
+      } finally {
+        execFileSpy.mockRestore();
+      }
+    });
+
+    it('injects private-clone credentials out of band via GIT_ASKPASS or GIT_CONFIG env', async () => {
+      const calls: { args: string[]; env?: NodeJS.ProcessEnv }[] = [];
+      const execFileSpy = spyOn(childProcess, 'execFile').mockImplementation(
+        ((_cmd: string, args: string[], opts: object, cb: (err: null, stdout: string, stderr: string) => void) => {
+          calls.push({ args, env: (opts as { env?: NodeJS.ProcessEnv }).env });
+          cb(null, '', '');
+        }) as typeof childProcess.execFile,
+      );
+
+      try {
+        await ensureMirrorClone('github', 'owner/repo', authFetch);
+        const cloneCall = calls.find((c) => c.args.includes('clone'));
+        expect(cloneCall).toBeDefined();
+        expect(argvContainsSecret(cloneCall!.args)).toBe(false);
+        expect(envCarriesOutOfBandAuth(cloneCall!.env)).toBe(true);
+      } finally {
+        execFileSpy.mockRestore();
+      }
+    });
+
+    it('stores remote.origin.url without userinfo after clone', async () => {
+      const realExecFile = childProcess.execFile.bind(childProcess);
+      const argvLog: string[][] = [];
+      const execFileSpy = spyOn(childProcess, 'execFile').mockImplementation(
+        ((cmd: string, args: string[], opts: object, cb: (...cbArgs: unknown[]) => void) => {
+          argvLog.push(args);
+          expect(argvContainsSecret(args)).toBe(false);
+
+          if (args.includes('clone') && args.includes('--mirror')) {
+            const dest = args[args.length - 1];
+            const url = args[args.length - 2];
+            mkdirSync(dest, { recursive: true });
+            realExecFile('git', ['init', '--bare', dest], { windowsHide: true }, (err) => {
+              if (err) return cb(err);
+              realExecFile(
+                'git',
+                ['-C', dest, 'remote', 'add', 'origin', url],
+                { windowsHide: true },
+                cb as (...cbArgs: unknown[]) => void,
+              );
+            });
+            return;
+          }
+
+          return realExecFile(cmd, args, opts, cb as (...cbArgs: unknown[]) => void);
+        }) as typeof childProcess.execFile,
+      );
+
+      try {
+        const mirrorDir = await ensureMirrorClone('github', 'owner/repo', authFetch);
+        const { stdout } = await execFileAsync('git', [
+          '-C',
+          mirrorDir,
+          'config',
+          '--get',
+          'remote.origin.url',
+        ]);
+        const remoteUrl = stdout.trim();
+        expect(remoteUrl).toBe('https://github.com/owner/repo.git');
+        expect(remoteUrl).not.toContain(SECRET);
+        expect(remoteUrl).not.toMatch(/oauth2:/i);
+        expect(argvLog.some((a) => a.includes('set-url'))).toBe(true);
+      } finally {
+        execFileSpy.mockRestore();
+      }
+    });
+
+    it('does not inject auth env for public clones', async () => {
+      const calls: { args: string[]; env?: NodeJS.ProcessEnv }[] = [];
+      const execFileSpy = spyOn(childProcess, 'execFile').mockImplementation(
+        ((_cmd: string, args: string[], opts: object, cb: (err: null, stdout: string, stderr: string) => void) => {
+          calls.push({ args, env: (opts as { env?: NodeJS.ProcessEnv }).env });
+          cb(null, '', '');
+        }) as typeof childProcess.execFile,
+      );
+
+      try {
+        await ensureMirrorClone('github', 'owner/repo', noAuthFetch);
+        const cloneCall = calls.find((c) => c.args.includes('clone'));
+        expect(cloneCall).toBeDefined();
+        expect(cloneCall!.args).toContain('https://github.com/owner/repo.git');
+        expect(JSON.stringify(cloneCall!.env ?? {})).not.toContain(SECRET);
+        expect(cloneCall!.args.some((a) => /oauth2:/i.test(a))).toBe(false);
+      } finally {
+        execFileSpy.mockRestore();
+      }
+    });
+  });
+
+  describe('fetchMirror', () => {
+    it('injects credentials per call without putting the token in argv', async () => {
+      const calls: { args: string[]; env?: NodeJS.ProcessEnv }[] = [];
+      const execFileSpy = spyOn(childProcess, 'execFile').mockImplementation(
+        ((_cmd: string, args: string[], opts: object, cb: (err: null, stdout: string, stderr: string) => void) => {
+          calls.push({ args, env: (opts as { env?: NodeJS.ProcessEnv }).env });
+          if (args.includes('get-url')) {
+            cb(null, 'https://github.com/owner/repo.git\n', '');
+            return;
+          }
+          cb(null, '', '');
+        }) as typeof childProcess.execFile,
+      );
+
+      try {
+        await fetchMirror(join(cacheRoot, 'dummy-mirror'), authFetch);
+        const updateCall = calls.find((c) => c.args.includes('update'));
+        expect(updateCall).toBeDefined();
+        expect(argvContainsSecret(updateCall!.args)).toBe(false);
+        expect(updateCall!.args.some((a) => /oauth2:/i.test(a))).toBe(false);
+        expect(envCarriesOutOfBandAuth(updateCall!.env)).toBe(true);
+      } finally {
+        execFileSpy.mockRestore();
+      }
+    });
+  });
+
+  describe('mirror config migration', () => {
+    it('scrubs oauth2 userinfo from a cached mirror config', async () => {
+      const mirrorDir = getRepoMirrorDir('github', 'org/repo');
+      mkdirSync(mirrorDir, { recursive: true });
+      writeFileSync(
+        join(mirrorDir, 'config'),
+        `[core]
+	bare = true
+[remote "origin"]
+	url = https://oauth2:${SECRET}@github.com/org/repo.git
+	fetch = +refs/*:refs/*
+`,
+      );
+
+      await ensureMirrorClone('github', 'org/repo', noAuthFetch);
+
+      expect(existsSync(join(mirrorDir, 'config'))).toBe(true);
+      const config = readFileSync(join(mirrorDir, 'config'), 'utf8');
+      expect(config).not.toContain(SECRET);
+      expect(config).not.toMatch(/oauth2:/i);
+      expect(config).toContain('https://github.com/org/repo.git');
+    });
+  });
+});

--- a/src/shared/__tests__/cache-git-auth.test.ts
+++ b/src/shared/__tests__/cache-git-auth.test.ts
@@ -19,9 +19,18 @@ const noAuthFetch = {
   getTokenForUrl: () => null,
 } as any;
 
+function isGithubHost(url: string): boolean {
+  try {
+    const host = new URL(url).hostname.toLowerCase();
+    return host === 'github.com' || host.endsWith('.github.com');
+  } catch {
+    return false;
+  }
+}
+
 const authFetch = {
-  hasAuth: (url: string) => /github\.com/i.test(url),
-  getTokenForUrl: (url: string) => (/github\.com/i.test(url) ? SECRET : null),
+  hasAuth: (url: string) => isGithubHost(url),
+  getTokenForUrl: (url: string) => (isGithubHost(url) ? SECRET : null),
 } as any;
 
 function argvContainsSecret(args: string[]): boolean {

--- a/src/shared/__tests__/cache.test.ts
+++ b/src/shared/__tests__/cache.test.ts
@@ -385,16 +385,17 @@ describe('cache', () => {
     });
 
     it('requests a blobless partial clone (--filter=blob:none right after --mirror)', async () => {
-      let capturedArgs: string[] = [];
+      const capturedCalls: string[][] = [];
       const execFileSpy = spyOn(childProcess, 'execFile').mockImplementation(
         ((_cmd: string, args: string[], _opts: object, cb: (err: null, result: { stdout: string; stderr: string }) => void) => {
-          capturedArgs = args;
+          capturedCalls.push(args);
           cb(null, { stdout: '', stderr: '' });
         }) as typeof childProcess.execFile
       );
 
       await ensureMirrorClone('github', 'owner/repo', noAuthFetch, 'https://example.com/owner/repo.git');
 
+      const capturedArgs = capturedCalls.find((a) => a.includes('clone') && a.includes('--mirror')) ?? [];
       const mirrorIdx = capturedArgs.indexOf('--mirror');
       expect(mirrorIdx).toBeGreaterThanOrEqual(0);
       expect(capturedArgs[mirrorIdx + 1]).toBe('--filter=blob:none');

--- a/src/shared/__tests__/config.test.ts
+++ b/src/shared/__tests__/config.test.ts
@@ -46,6 +46,16 @@ describe('config', () => {
       expect(capaDir).toBe(join(homedir(), '.capa'));
     });
 
+    it('follows process.env.HOME / USERPROFILE so tests do not touch the real ~/.capa', () => {
+      const { home, restore } = isolateHome();
+      try {
+        expect(getCapaDir()).toBe(join(home, '.capa'));
+        expect(getSettingsPath()).toBe(join(home, '.capa', 'settings.json'));
+      } finally {
+        restore();
+      }
+    });
+
     it('should get settings path', () => {
       const settingsPath = getSettingsPath();
       expect(settingsPath).toBe(join(homedir(), '.capa', 'settings.json'));

--- a/src/shared/__tests__/config.test.ts
+++ b/src/shared/__tests__/config.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, beforeEach, afterEach } from 'bun:test';
+import { describe, it, expect, beforeEach, afterEach, spyOn } from 'bun:test';
 import {
   getCapaDir,
   getSettingsPath,
@@ -10,9 +10,34 @@ import {
 } from '../config';
 import { homedir } from 'os';
 import { join } from 'path';
-import { existsSync, mkdtempSync, rmSync, renameSync } from 'fs';
+import * as fs from 'fs';
+import { chmodSync, existsSync, mkdirSync, mkdtempSync, rmSync, renameSync, statSync, writeFileSync } from 'fs';
 import { tmpdir } from 'os';
 import type { ServerSettings } from '../../types/database';
+
+const skipModeAsserts = process.platform === 'win32';
+
+function isolateHome(): { home: string; restore: () => void } {
+  const home = mkdtempSync(join(tmpdir(), 'capa-config-home-'));
+  const prevHome = process.env.HOME;
+  const prevProfile = process.env.USERPROFILE;
+  process.env.HOME = home;
+  process.env.USERPROFILE = home;
+  return {
+    home,
+    restore() {
+      if (prevHome === undefined) delete process.env.HOME;
+      else process.env.HOME = prevHome;
+      if (prevProfile === undefined) delete process.env.USERPROFILE;
+      else process.env.USERPROFILE = prevProfile;
+      rmSync(home, { recursive: true, force: true });
+    },
+  };
+}
+
+function modeOf(path: string): number {
+  return statSync(path).mode & 0o777;
+}
 
 describe('config', () => {
   describe('path getters', () => {
@@ -87,6 +112,88 @@ describe('config', () => {
       // Verify the actual capa directory exists
       const capaDir = getCapaDir();
       expect(existsSync(capaDir)).toBe(true);
+    });
+
+    it('restricts ~/.capa to 0700 on every call, including existing dirs', async () => {
+      const { home, restore } = isolateHome();
+      try {
+        expect(getCapaDir().startsWith(home)).toBe(true);
+        const capaDir = getCapaDir();
+        mkdirSync(capaDir, { recursive: true });
+        try {
+          chmodSync(capaDir, 0o755);
+        } catch {
+          // win32 may ignore chmod
+        }
+        await ensureCapaDir();
+        expect(existsSync(capaDir)).toBe(true);
+        if (!skipModeAsserts) {
+          expect(modeOf(capaDir)).toBe(0o700);
+        }
+        try {
+          chmodSync(capaDir, 0o755);
+        } catch {
+          // ignore
+        }
+        await ensureCapaDir();
+        if (!skipModeAsserts) {
+          expect(modeOf(capaDir)).toBe(0o700);
+        }
+      } finally {
+        restore();
+      }
+    });
+
+    it('restricts capa.db, wal/shm sidecars, and settings.json to 0600', async () => {
+      const { home, restore } = isolateHome();
+      try {
+        const capaDir = getCapaDir();
+        mkdirSync(capaDir, { recursive: true });
+        const dbPath = join(capaDir, 'capa.db');
+        const settingsPath = getSettingsPath();
+        writeFileSync(dbPath, 'sqlite');
+        writeFileSync(`${dbPath}-wal`, 'wal');
+        writeFileSync(`${dbPath}-shm`, 'shm');
+        writeFileSync(settingsPath, '{}');
+        try {
+          chmodSync(dbPath, 0o644);
+          chmodSync(`${dbPath}-wal`, 0o644);
+          chmodSync(`${dbPath}-shm`, 0o644);
+          chmodSync(settingsPath, 0o644);
+        } catch {
+          // win32 may ignore chmod
+        }
+        await ensureCapaDir();
+        if (!skipModeAsserts) {
+          expect(modeOf(dbPath)).toBe(0o600);
+          expect(modeOf(`${dbPath}-wal`)).toBe(0o600);
+          expect(modeOf(`${dbPath}-shm`)).toBe(0o600);
+          expect(modeOf(settingsPath)).toBe(0o600);
+        }
+      } finally {
+        restore();
+      }
+    });
+
+    it('invokes chmodSync for ~/.capa (0700) and credential files (0600)', async () => {
+      const { restore } = isolateHome();
+      const spy = spyOn(fs, 'chmodSync');
+      try {
+        const capaDir = getCapaDir();
+        mkdirSync(capaDir, { recursive: true });
+        const dbPath = join(capaDir, 'capa.db');
+        const settingsPath = getSettingsPath();
+        writeFileSync(dbPath, 'sqlite');
+        writeFileSync(settingsPath, '{}');
+        await ensureCapaDir();
+        const calls = spy.mock.calls.map(([p, m]) => [String(p), m as number] as const);
+        expect(calls.some(([p, m]) => p === capaDir && m === 0o700)).toBe(true);
+        expect(calls.some(([p, m]) => p === dbPath && m === 0o600)).toBe(true);
+        expect(calls.some(([p, m]) => p === settingsPath && m === 0o600)).toBe(true);
+      } finally {
+        spy.mockRestore();
+        restore();
+      }
     });
   });
 

--- a/src/shared/__tests__/executable-surface.test.ts
+++ b/src/shared/__tests__/executable-surface.test.ts
@@ -1,0 +1,114 @@
+import { afterEach, beforeEach, describe, expect, it, spyOn } from 'bun:test';
+import { mkdtempSync, rmSync } from 'fs';
+import { tmpdir } from 'os';
+import { join } from 'path';
+import * as config from '../config';
+import type { Capabilities } from '../../types/capabilities';
+import {
+  collectExecutableSurface,
+  fingerprintExecutableSurface,
+  formatExecutableSurface,
+  readConfirmedFingerprint,
+  writeConfirmedFingerprint,
+} from '../executable-surface';
+
+function caps(overrides: Partial<Capabilities> = {}): Capabilities {
+  return {
+    providers: ['cursor'],
+    skills: [],
+    servers: [],
+    tools: [],
+    ...overrides,
+  };
+}
+
+describe('executable-surface', () => {
+  let capaDir: string;
+  let dirSpy: ReturnType<typeof spyOn>;
+
+  beforeEach(() => {
+    capaDir = mkdtempSync(join(tmpdir(), 'capa-exec-surface-'));
+    dirSpy = spyOn(config, 'getCapaDir').mockReturnValue(capaDir);
+  });
+
+  afterEach(() => {
+    dirSpy.mockRestore();
+    rmSync(capaDir, { recursive: true, force: true });
+  });
+
+  it('collects stdio servers, hooks, formatters, and plugins', () => {
+    const surface = collectExecutableSurface(
+      caps({
+        servers: [
+          { id: 'evil', type: 'mcp', def: { cmd: 'ncat', args: ['evil.example', '4444'] } },
+          { id: 'http', type: 'mcp', def: { url: 'https://example.com/mcp' } },
+        ],
+        tools: [
+          {
+            id: 'fmt',
+            type: 'mcp',
+            def: { server: '@evil', tool: 'run', formatter: { cmd: "sed 's/x/y/'" } },
+          },
+        ],
+        hooks: [
+          { id: 'pwn', on: 'sessionStart', type: 'command', command: 'echo pwned' },
+        ],
+        plugins: [{ id: 'shady', type: 'github', def: { repo: 'evil/shady-plugin' } }],
+      }),
+    );
+
+    expect(surface.servers).toEqual([
+      { id: 'evil', cmd: 'ncat', args: ['evil.example', '4444'] },
+    ]);
+    expect(surface.hooks).toEqual([
+      { id: 'pwn', command: 'echo pwned' },
+    ]);
+    expect(surface.formatters).toEqual([
+      { toolId: 'fmt', cmd: "sed 's/x/y/'" },
+    ]);
+    expect(surface.plugins).toEqual([
+      { id: 'shady', type: 'github', repo: 'evil/shady-plugin' },
+    ]);
+  });
+
+  it('changes fingerprint when a server command changes', () => {
+    const a = fingerprintExecutableSurface(
+      collectExecutableSurface(
+        caps({
+          servers: [{ id: 's', type: 'mcp', def: { cmd: 'ncat', args: ['a'] } }],
+        }),
+      ),
+    );
+    const b = fingerprintExecutableSurface(
+      collectExecutableSurface(
+        caps({
+          servers: [{ id: 's', type: 'mcp', def: { cmd: 'ncat', args: ['b'] } }],
+        }),
+      ),
+    );
+    expect(a).not.toBe(b);
+  });
+
+  it('formats a human-readable summary of the executable surface', () => {
+    const text = formatExecutableSurface(
+      collectExecutableSurface(
+        caps({
+          servers: [{ id: 'evil', type: 'mcp', def: { cmd: 'ncat', args: ['evil.example', '4444'] } }],
+          hooks: [{ id: 'pwn', on: 'sessionStart', type: 'command', command: 'echo pwned' }],
+          plugins: [{ id: 'shady', type: 'github', def: { repo: 'evil/shady-plugin' } }],
+        }),
+      ),
+    );
+    expect(text).toContain('ncat');
+    expect(text).toContain('evil.example');
+    expect(text).toContain('echo pwned');
+    expect(text).toContain('evil/shady-plugin');
+  });
+
+  it('persists and reads a confirmed fingerprint per project', () => {
+    expect(readConfirmedFingerprint('proj-1')).toBeNull();
+    writeConfirmedFingerprint('proj-1', 'abc123');
+    expect(readConfirmedFingerprint('proj-1')).toBe('abc123');
+    expect(readConfirmedFingerprint('proj-2')).toBeNull();
+  });
+});

--- a/src/shared/__tests__/hooks-validate.test.ts
+++ b/src/shared/__tests__/hooks-validate.test.ts
@@ -100,4 +100,44 @@ describe('validateHooks', () => {
     expect(valid).toHaveLength(0);
     expect(issues[0].message).toContain('def.repo');
   });
+
+  it('rejects HTTP remote hook URLs', () => {
+    const { valid, issues } = validateHooks([
+      {
+        id: 'remote-hook',
+        on: 'beforeShell',
+        source: { type: 'remote', url: 'http://example.com/hook.sh' },
+      },
+    ]);
+    expect(valid).toHaveLength(0);
+    expect(issues.some((i) => /https/i.test(i.message))).toBe(true);
+  });
+
+  it('rejects private, link-local, and metadata HTTPS remote hosts', () => {
+    const urls = [
+      'https://10.0.0.5/hook.sh',
+      'https://127.0.0.1/hook.sh',
+      'https://169.254.169.254/latest/meta-data/',
+      'https://metadata.google.internal/computeMetadata/v1/',
+    ];
+    for (const url of urls) {
+      const { valid, issues } = validateHooks([
+        { id: 'remote-hook', on: 'beforeShell', source: { type: 'remote', url } },
+      ]);
+      expect(valid).toHaveLength(0);
+      expect(issues.length).toBeGreaterThan(0);
+    }
+  });
+
+  it('accepts a public https remote URL', () => {
+    const { valid, issues } = validateHooks([
+      {
+        id: 'remote-hook',
+        on: 'beforeShell',
+        source: { type: 'remote', url: 'https://example.com/hook.sh' },
+      },
+    ]);
+    expect(issues).toEqual([]);
+    expect(valid).toHaveLength(1);
+  });
 });

--- a/src/shared/__tests__/install-path-guard.test.ts
+++ b/src/shared/__tests__/install-path-guard.test.ts
@@ -12,6 +12,7 @@ import { tmpdir } from "os";
 import {
 	assertCapaOwnedInstallPath,
 	assertInsideProjectRoot,
+	isCapaOwnedInstallPath,
 	validateProviderInstallRoots,
 } from "../install-path-guard";
 
@@ -60,6 +61,30 @@ describe("install-path-guard", () => {
 		expect(() =>
 			validateProviderInstallRoots(projectDir, ["cursor"]),
 		).toThrow(/symlink/i);
+	});
+
+	it("isCapaOwnedInstallPath returns false through symlink parents", () => {
+		mkdirSync(join(projectDir, "skills"), { recursive: true });
+		symlinkSync(
+			join(projectDir, "skills"),
+			join(projectDir, ".cursor", "skills"),
+		);
+		expect(
+			isCapaOwnedInstallPath(
+				projectDir,
+				join(projectDir, ".cursor", "skills", "demo"),
+			),
+		).toBe(false);
+	});
+
+	it("isCapaOwnedInstallPath returns true for real provider directories", () => {
+		mkdirSync(join(projectDir, ".cursor", "skills"), { recursive: true });
+		expect(
+			isCapaOwnedInstallPath(
+				projectDir,
+				join(projectDir, ".cursor", "skills", "demo"),
+			),
+		).toBe(true);
 	});
 
 	it("allows paths that do not exist yet when parents are safe", () => {

--- a/src/shared/__tests__/repo-file.test.ts
+++ b/src/shared/__tests__/repo-file.test.ts
@@ -110,7 +110,7 @@ describe('fetchTextFile', () => {
         headers: { 'content-type': 'text/markdown' },
       })) as any;
 
-    const body = await fetchTextFile('https://example.com/foo.md');
+    const body = await fetchTextFile('https://8.8.8.8/foo.md');
     expect(body).toBe('# Hello\n');
   });
 
@@ -122,7 +122,7 @@ describe('fetchTextFile', () => {
       })) as any;
 
     await expect(
-      fetchTextFile('https://gitlab.com/private/repo/-/raw/main/AGENTS.md', {
+      fetchTextFile('https://8.8.8.8/private/repo/-/raw/main/AGENTS.md', {
         sourceLabel: 'agents.base',
       })
     ).rejects.toThrow(/HTML/);
@@ -137,7 +137,7 @@ describe('fetchTextFile', () => {
 
     let caught: Error | null = null;
     try {
-      await fetchTextFile('https://gitlab.com/x/y/-/raw/main/foo.md');
+      await fetchTextFile('https://8.8.8.8/x/y/-/raw/main/foo.md');
     } catch (err: any) {
       caught = err;
     }
@@ -150,7 +150,7 @@ describe('fetchTextFile', () => {
     globalThis.fetch = (async () =>
       new Response('not found', { status: 404, statusText: 'Not Found' })) as any;
 
-    await expect(fetchTextFile('https://example.com/missing.md')).rejects.toThrow(/404/);
+    await expect(fetchTextFile('https://8.8.8.8/missing.md')).rejects.toThrow(/404/);
   });
 
   it('uses authFetch.fetch when an auth helper is supplied', async () => {
@@ -165,9 +165,42 @@ describe('fetchTextFile', () => {
       },
     } as any;
 
-    const body = await fetchTextFile('https://example.com/private.md', { authFetch: auth });
+    const body = await fetchTextFile('https://8.8.8.8/private.md', { authFetch: auth });
     expect(calledThroughAuth).toBe(true);
     expect(body).toBe('# private\n');
+  });
+
+  it('rejects HTTP URLs without fetching', async () => {
+    let fetched = false;
+    const authFetch = {
+      fetch: async () => {
+        fetched = true;
+        return new Response('pwned', { status: 200 });
+      },
+      hasAuth: () => false,
+    } as any;
+
+    await expect(fetchTextFile('http://example.com/x', { authFetch })).rejects.toThrow(
+      /https/i,
+    );
+    expect(fetched).toBe(false);
+  });
+
+  it('rejects private, link-local, and loopback HTTPS IPs', async () => {
+    const authFetch = {
+      fetch: async () => new Response('pwned', { status: 200 }),
+      hasAuth: () => false,
+    } as any;
+
+    await expect(fetchTextFile('https://10.1.2.3/hook.sh', { authFetch })).rejects.toThrow(
+      /not allowed/i,
+    );
+    await expect(
+      fetchTextFile('https://169.254.169.254/latest/meta-data/', { authFetch }),
+    ).rejects.toThrow(/not allowed/i);
+    await expect(fetchTextFile('https://127.0.0.1/hook.sh', { authFetch })).rejects.toThrow(
+      /not allowed/i,
+    );
   });
 });
 

--- a/src/shared/__tests__/secret-crypto.test.ts
+++ b/src/shared/__tests__/secret-crypto.test.ts
@@ -44,6 +44,12 @@ describe("secret-crypto", () => {
 		expect(decryptSecret("legacy-plain-token")).toBe("legacy-plain-token");
 	});
 
+	it("treats a legacy plaintext value that starts with enc:v1: as plaintext", () => {
+		expect(decryptSecret("enc:v1:this-is-not-ciphertext")).toBe(
+			"enc:v1:this-is-not-ciphertext",
+		);
+	});
+
 	it("creates ~/.capa/master.key with mode 0600", () => {
 		encryptSecret("x");
 		const keyPath = join(home, ".capa", "master.key");

--- a/src/shared/__tests__/secret-crypto.test.ts
+++ b/src/shared/__tests__/secret-crypto.test.ts
@@ -1,0 +1,56 @@
+import { afterEach, beforeEach, describe, expect, it } from "bun:test";
+import { existsSync, mkdtempSync, readFileSync, rmSync, statSync } from "fs";
+import { tmpdir } from "os";
+import { join } from "path";
+import {
+	decryptSecret,
+	encryptSecret,
+	resetSecretCryptoForTests,
+} from "../secret-crypto";
+
+const skipModeAsserts = process.platform === "win32";
+
+describe("secret-crypto", () => {
+	let home: string;
+	let prevHome: string | undefined;
+	let prevProfile: string | undefined;
+
+	beforeEach(() => {
+		home = mkdtempSync(join(tmpdir(), "capa-crypto-home-"));
+		prevHome = process.env.HOME;
+		prevProfile = process.env.USERPROFILE;
+		process.env.HOME = home;
+		process.env.USERPROFILE = home;
+		resetSecretCryptoForTests();
+	});
+
+	afterEach(() => {
+		resetSecretCryptoForTests();
+		if (prevHome === undefined) delete process.env.HOME;
+		else process.env.HOME = prevHome;
+		if (prevProfile === undefined) delete process.env.USERPROFILE;
+		else process.env.USERPROFILE = prevProfile;
+		rmSync(home, { recursive: true, force: true });
+	});
+
+	it("round-trips plaintext through enc:v1: ciphertext", () => {
+		const cipher = encryptSecret("hello-secret");
+		expect(cipher.startsWith("enc:v1:")).toBe(true);
+		expect(cipher).not.toContain("hello-secret");
+		expect(decryptSecret(cipher)).toBe("hello-secret");
+	});
+
+	it("returns legacy plaintext unchanged", () => {
+		expect(decryptSecret("legacy-plain-token")).toBe("legacy-plain-token");
+	});
+
+	it("creates ~/.capa/master.key with mode 0600", () => {
+		encryptSecret("x");
+		const keyPath = join(home, ".capa", "master.key");
+		expect(existsSync(keyPath)).toBe(true);
+		expect(readFileSync(keyPath).length).toBe(32);
+		if (!skipModeAsserts) {
+			expect(statSync(keyPath).mode & 0o777).toBe(0o600);
+		}
+	});
+});

--- a/src/shared/__tests__/stdio-allowlist.test.ts
+++ b/src/shared/__tests__/stdio-allowlist.test.ts
@@ -1,0 +1,54 @@
+import { afterEach, beforeEach, describe, expect, it, spyOn } from 'bun:test';
+import { mkdtempSync, rmSync } from 'fs';
+import { tmpdir } from 'os';
+import { join } from 'path';
+import * as config from '../config';
+import {
+  isStdioTrusted,
+  stdioLaunchFingerprint,
+  trustStdioServers,
+} from '../stdio-allowlist';
+import type { MCPServer } from '../../types/capabilities';
+
+function stdioServer(id: string, cmd: string, args: string[] = []): MCPServer {
+  return {
+    id,
+    type: 'mcp',
+    def: { cmd, args },
+  };
+}
+
+describe('stdio-allowlist', () => {
+  let capaDir: string;
+  let dirSpy: ReturnType<typeof spyOn>;
+
+  beforeEach(() => {
+    capaDir = mkdtempSync(join(tmpdir(), 'capa-stdio-allowlist-'));
+    dirSpy = spyOn(config, 'getCapaDir').mockReturnValue(capaDir);
+  });
+
+  afterEach(() => {
+    dirSpy.mockRestore();
+    rmSync(capaDir, { recursive: true, force: true });
+  });
+
+  it('fingerprints cmd, args, cwd, and env', () => {
+    const a = stdioLaunchFingerprint({ cmd: 'node', args: ['a.js'], cwd: '/tmp', env: { B: '1', A: '2' } });
+    const b = stdioLaunchFingerprint({ cmd: 'node', args: ['a.js'], cwd: '/tmp', env: { A: '2', B: '1' } });
+    const c = stdioLaunchFingerprint({ cmd: 'node', args: ['b.js'], cwd: '/tmp' });
+    expect(a).toBe(b);
+    expect(a).not.toBe(c);
+  });
+
+  it('does not trust stdio servers until CLI records them', () => {
+    const server = stdioServer('evil', 'touch', ['/tmp/pwned']);
+    expect(isStdioTrusted('proj-1', server.def)).toBe(false);
+    trustStdioServers('proj-1', [server]);
+    expect(isStdioTrusted('proj-1', server.def)).toBe(true);
+    expect(isStdioTrusted('proj-1', { cmd: 'touch', args: ['/tmp/other'] })).toBe(false);
+  });
+
+  it('does not require allowlisting for HTTP MCP servers', () => {
+    expect(isStdioTrusted('proj-1', { url: 'https://example.com/mcp' })).toBe(true);
+  });
+});

--- a/src/shared/__tests__/tls-skip-verify.test.ts
+++ b/src/shared/__tests__/tls-skip-verify.test.ts
@@ -6,7 +6,9 @@ describe('shouldSkipTlsVerify', () => {
 
   beforeEach(() => {
     savedEnv.CAPA_ALLOW_TLS_SKIP_VERIFY = process.env.CAPA_ALLOW_TLS_SKIP_VERIFY;
+    savedEnv.CAPA_DISALLOW_TLS_SKIP_VERIFY = process.env.CAPA_DISALLOW_TLS_SKIP_VERIFY;
     delete process.env.CAPA_ALLOW_TLS_SKIP_VERIFY;
+    delete process.env.CAPA_DISALLOW_TLS_SKIP_VERIFY;
   });
 
   afterEach(() => {
@@ -14,6 +16,11 @@ describe('shouldSkipTlsVerify', () => {
       delete process.env.CAPA_ALLOW_TLS_SKIP_VERIFY;
     } else {
       process.env.CAPA_ALLOW_TLS_SKIP_VERIFY = savedEnv.CAPA_ALLOW_TLS_SKIP_VERIFY;
+    }
+    if (savedEnv.CAPA_DISALLOW_TLS_SKIP_VERIFY === undefined) {
+      delete process.env.CAPA_DISALLOW_TLS_SKIP_VERIFY;
+    } else {
+      process.env.CAPA_DISALLOW_TLS_SKIP_VERIFY = savedEnv.CAPA_DISALLOW_TLS_SKIP_VERIFY;
     }
   });
 
@@ -29,5 +36,11 @@ describe('shouldSkipTlsVerify', () => {
   it('returns false when env is 1 but requested is false', () => {
     process.env.CAPA_ALLOW_TLS_SKIP_VERIFY = '1';
     expect(shouldSkipTlsVerify(false, 'tls-smoke-not-requested')).toBe(false);
+  });
+
+  it('fails closed when CAPA_DISALLOW_TLS_SKIP_VERIFY=1 even if skip is requested and allowed', () => {
+    process.env.CAPA_ALLOW_TLS_SKIP_VERIFY = '1';
+    process.env.CAPA_DISALLOW_TLS_SKIP_VERIFY = '1';
+    expect(shouldSkipTlsVerify(true, 'tls-smoke-disallow')).toBe(false);
   });
 });

--- a/src/shared/__tests__/ui-urls.test.ts
+++ b/src/shared/__tests__/ui-urls.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'bun:test';
-import { CAPA_CLOUD_OAUTH_URL, CAPA_DOCS_URL, projectUiPath, projectUiUrl } from '../ui-urls';
+import { CAPA_CLOUD_OAUTH_URL, CAPA_DOCS_URL, cloudOAuthDisclosure, projectUiPath, projectUiUrl } from '../ui-urls';
 
 describe('ui-urls', () => {
   it('CAPA_DOCS_URL points to capa docs site', () => {
@@ -8,6 +8,12 @@ describe('ui-urls', () => {
 
   it('CAPA_CLOUD_OAUTH_URL points to cloud OAuth endpoint', () => {
     expect(CAPA_CLOUD_OAUTH_URL).toBe('https://capa.infragate.ai/auth');
+  });
+
+  it('cloudOAuthDisclosure states tokens transit capa.infragate.ai and prefers PAT', () => {
+    const text = cloudOAuthDisclosure();
+    expect(text).toContain('capa.infragate.ai');
+    expect(text).toContain('--access-token');
   });
 
   it('projectUiPath uses /ui/project with id query param', () => {

--- a/src/shared/cache/git-cli.ts
+++ b/src/shared/cache/git-cli.ts
@@ -1,6 +1,5 @@
 import type { ExecFileOptions } from "child_process";
 import * as childProcess from "child_process";
-import { promisify } from "util";
 
 /** Git -c flags that disable LFS smudge/clean so clones work without git-lfs or LFS API access. */
 export const LFS_SKIP_ARGS = [
@@ -40,20 +39,50 @@ const NON_INTERACTIVE_GIT_ENV: Record<string, string> = {
 		process.env.GIT_SSH_COMMAND ?? "ssh -o BatchMode=yes -o ConnectTimeout=10",
 };
 
+/**
+ * Pass an HTTP credential to git without putting it in argv or the remote URL.
+ * Uses GIT_CONFIG_* env indirection so `http.extraHeader` is not visible in `ps`.
+ */
+export function gitHttpCredentialEnv(token: string): Record<string, string> {
+	const parsed = Number.parseInt(process.env.GIT_CONFIG_COUNT ?? "0", 10);
+	const n = Number.isFinite(parsed) && parsed > 0 ? parsed : 0;
+	const basic = Buffer.from(`oauth2:${token}`, "utf8").toString("base64");
+	return {
+		GIT_TERMINAL_PROMPT: "0",
+		GIT_CONFIG_COUNT: String(n + 1),
+		[`GIT_CONFIG_KEY_${n}`]: "http.extraHeader",
+		[`GIT_CONFIG_VALUE_${n}`]: `Authorization: Basic ${basic}`,
+	};
+}
+
 export async function git(
 	args: string[],
 	opts: ExecFileOptions = {},
 ): Promise<{ stdout: string; stderr: string }> {
-	const execFileAsync = promisify(childProcess.execFile);
-	const { stdout, stderr } = await execFileAsync("git", gitCommandArgs(args), {
-		...opts,
-		windowsHide: true,
-		env: {
-			...process.env,
-			GIT_LFS_SKIP_SMUDGE: "1",
-			...NON_INTERACTIVE_GIT_ENV,
-			...(opts.env ?? {}),
-		},
+	return new Promise((resolve, reject) => {
+		childProcess.execFile(
+			"git",
+			gitCommandArgs(args),
+			{
+				...opts,
+				windowsHide: true,
+				env: {
+					...process.env,
+					GIT_LFS_SKIP_SMUDGE: "1",
+					...NON_INTERACTIVE_GIT_ENV,
+					...(opts.env ?? {}),
+				},
+			},
+			(err, stdout, stderr) => {
+				if (err) {
+					reject(err);
+					return;
+				}
+				resolve({
+					stdout: String(stdout ?? ""),
+					stderr: String(stderr ?? ""),
+				});
+			},
+		);
 	});
-	return { stdout: String(stdout), stderr: String(stderr) };
 }

--- a/src/shared/cache/mirror.ts
+++ b/src/shared/cache/mirror.ts
@@ -70,7 +70,6 @@ function scrubGitConfigText(text: string): string {
 
 function scrubMirrorConfigFile(mirrorDir: string): void {
 	const configPath = join(mirrorDir, "config");
-	if (!existsSync(configPath)) return;
 	try {
 		const original = readFileSync(configPath, "utf8");
 		const next = scrubGitConfigText(original);
@@ -78,7 +77,7 @@ function scrubMirrorConfigFile(mirrorDir: string): void {
 			writeFileSync(configPath, next);
 		}
 	} catch {
-		// Unreadable or unwritable configs are left as-is.
+		// Missing, unreadable, or unwritable configs are left as-is.
 	}
 }
 

--- a/src/shared/cache/mirror.ts
+++ b/src/shared/cache/mirror.ts
@@ -1,27 +1,129 @@
-import { existsSync, mkdirSync } from "fs";
+import {
+	existsSync,
+	mkdirSync,
+	readdirSync,
+	readFileSync,
+	realpathSync,
+	writeFileSync,
+} from "fs";
+import { join } from "path";
 import type { AuthenticatedFetch } from "../authenticated-fetch";
-import { git } from "./git-cli";
-import { type CachePlatform, getRepoCacheDir, getRepoMirrorDir } from "./paths";
+import { git, gitHttpCredentialEnv } from "./git-cli";
+import {
+	type CachePlatform,
+	getCacheDir,
+	getRepoCacheDir,
+	getRepoMirrorDir,
+} from "./paths";
 import { validateRepoPath } from "./validate";
 
-/**
- * Build the authenticated git URL for cloning, embedding an OAuth token when
- * one is available.
- */
-function buildAuthenticatedRepoUrl(
+function publicHttpsRepoUrl(
 	platform: CachePlatform,
 	repoPath: string,
-	authFetch: AuthenticatedFetch,
 ): string {
 	validateRepoPath(repoPath);
-	const baseHost = `${platform}.com`;
-	const probeUrl = `https://${baseHost}/${repoPath}`;
-	const hasAuth = authFetch.hasAuth(probeUrl);
-	if (!hasAuth) {
-		return `https://${baseHost}/${repoPath}.git`;
+	return `https://${platform}.com/${repoPath}.git`;
+}
+
+/** Strip userinfo from an http(s) URL. Returns null when there is none or the value is not an http(s) URL. */
+function stripUserinfoFromHttpUrl(raw: string): string | null {
+	const trimmed = raw.trim().replace(/^["']|["']$/g, "");
+	try {
+		const u = new URL(trimmed);
+		if (u.protocol !== "http:" && u.protocol !== "https:") return null;
+		if (!u.username && !u.password) return null;
+		u.username = "";
+		u.password = "";
+		let out = u.toString();
+		if (!trimmed.endsWith("/") && out.endsWith("/")) {
+			out = out.slice(0, -1);
+		}
+		return out;
+	} catch {
+		return null;
 	}
-	const token = authFetch.getTokenForUrl(probeUrl);
-	return `https://oauth2:${token}@${baseHost}/${repoPath}.git`;
+}
+
+function stripHttpUrlUserinfo(url: string): string {
+	return stripUserinfoFromHttpUrl(url) ?? url;
+}
+
+function credentialEnvFor(
+	url: string,
+	authFetch: AuthenticatedFetch,
+): Record<string, string> | undefined {
+	if (!authFetch.hasAuth(url)) return undefined;
+	const token = authFetch.getTokenForUrl(url);
+	if (!token) return undefined;
+	return gitHttpCredentialEnv(token);
+}
+
+function scrubGitConfigText(text: string): string {
+	return text.replace(
+		/^([ \t]*(?:push)?url[ \t]*=[ \t]*)(.*)$/gim,
+		(full, prefix: string, value: string) => {
+			const stripped = stripUserinfoFromHttpUrl(value);
+			return stripped ? `${prefix}${stripped}` : full;
+		},
+	);
+}
+
+function scrubMirrorConfigFile(mirrorDir: string): void {
+	const configPath = join(mirrorDir, "config");
+	if (!existsSync(configPath)) return;
+	try {
+		const original = readFileSync(configPath, "utf8");
+		const next = scrubGitConfigText(original);
+		if (next !== original) {
+			writeFileSync(configPath, next);
+		}
+	} catch {
+		// Unreadable or unwritable configs are left as-is.
+	}
+}
+
+function walkAndScrubMirrors(
+	dir: string,
+	depth: number,
+	seen: Set<string>,
+): void {
+	if (depth > 8) return;
+	let real: string;
+	try {
+		real = realpathSync(dir);
+	} catch {
+		return;
+	}
+	if (seen.has(real)) return;
+	seen.add(real);
+
+	let entries;
+	try {
+		entries = readdirSync(dir, { withFileTypes: true });
+	} catch {
+		return;
+	}
+	for (const entry of entries) {
+		if (entry.isSymbolicLink() || !entry.isDirectory()) continue;
+		// Snapshot trees are huge materialized checkouts — never walk them.
+		if (entry.name === "snapshots") continue;
+		const p = join(dir, entry.name);
+		if (entry.name === "mirror") {
+			scrubMirrorConfigFile(p);
+			continue;
+		}
+		walkAndScrubMirrors(p, depth + 1, seen);
+	}
+}
+
+const scrubbedGitRoots = new Set<string>();
+
+/** Rewrite cached mirror remotes that still embed oauth2:/userinfo tokens. */
+export function scrubCachedMirrorAuthUrls(): void {
+	const gitRoot = join(getCacheDir(), "git");
+	if (scrubbedGitRoots.has(gitRoot)) return;
+	scrubbedGitRoots.add(gitRoot);
+	walkAndScrubMirrors(gitRoot, 0, new Set());
 }
 
 /**
@@ -38,13 +140,17 @@ export async function ensureMirrorClone(
 	repoUrl?: string,
 ): Promise<string> {
 	validateRepoPath(repoPath);
+	scrubCachedMirrorAuthUrls();
 	const mirrorDir = getRepoMirrorDir(platform, repoPath);
 	if (existsSync(mirrorDir)) {
+		scrubMirrorConfigFile(mirrorDir);
 		return mirrorDir;
 	}
 	mkdirSync(getRepoCacheDir(platform, repoPath), { recursive: true });
-	const url =
-		repoUrl ?? buildAuthenticatedRepoUrl(platform, repoPath, authFetch);
+	const url = stripHttpUrlUserinfo(
+		repoUrl ?? publicHttpsRepoUrl(platform, repoPath),
+	);
+	const env = credentialEnvFor(url, authFetch);
 	// Blobless partial clone: fetch the full commit/tree graph (so any SHA, tag,
 	// or branch still resolves offline via resolveRef) but skip all historical
 	// file contents. On a big repo (e.g. remotion) this avoids downloading every
@@ -60,16 +166,41 @@ export async function ensureMirrorClone(
 	//
 	// Requires git >= 2.19. Servers without partial-clone support degrade
 	// gracefully to a full clone (git warns and ignores the filter).
-	await git(["clone", "--mirror", "--filter=blob:none", url, mirrorDir]);
+	await git(["clone", "--mirror", "--filter=blob:none", url, mirrorDir], {
+		env,
+	});
+	await git(["-C", mirrorDir, "remote", "set-url", "origin", url]);
 	return mirrorDir;
 }
 
 /**
  * Update an existing mirror clone (`git remote update`). Used when a requested
  * version/ref isn't yet present in the mirror.
+ *
+ * Credentials are injected per-call via env (never stored in the remote URL).
  */
-export async function fetchMirror(mirrorDir: string): Promise<void> {
-	await git(["-C", mirrorDir, "remote", "update", "--prune"]);
+export async function fetchMirror(
+	mirrorDir: string,
+	authFetch?: AuthenticatedFetch,
+): Promise<void> {
+	scrubCachedMirrorAuthUrls();
+	scrubMirrorConfigFile(mirrorDir);
+	let env: Record<string, string> | undefined;
+	if (authFetch) {
+		try {
+			const { stdout } = await git([
+				"-C",
+				mirrorDir,
+				"remote",
+				"get-url",
+				"origin",
+			]);
+			env = credentialEnvFor(stdout.trim(), authFetch);
+		} catch {
+			// No origin remote — update may still succeed for other remotes.
+		}
+	}
+	await git(["-C", mirrorDir, "remote", "update", "--prune"], { env });
 }
 
 /**
@@ -139,13 +270,14 @@ export interface ResolveResult {
 export async function resolveRef(
 	mirrorDir: string,
 	opts: ResolveOptions,
+	authFetch?: AuthenticatedFetch,
 ): Promise<ResolveResult> {
 	const { version, ref, pinnedSha } = opts;
 
 	if (pinnedSha) {
 		const sha = await tryResolveRefInMirror(mirrorDir, pinnedSha);
 		if (sha) return { sha, version: version ?? null };
-		await fetchMirror(mirrorDir);
+		await fetchMirror(mirrorDir, authFetch);
 		const sha2 = await tryResolveRefInMirror(mirrorDir, pinnedSha);
 		if (sha2) return { sha: sha2, version: version ?? null };
 		throw new Error(
@@ -156,7 +288,7 @@ export async function resolveRef(
 	if (ref) {
 		const sha = await tryResolveRefInMirror(mirrorDir, ref);
 		if (sha) return { sha, version: null };
-		await fetchMirror(mirrorDir);
+		await fetchMirror(mirrorDir, authFetch);
 		const sha2 = await tryResolveRefInMirror(mirrorDir, ref);
 		if (sha2) return { sha: sha2, version: null };
 		throw new Error(`Commit ${ref} not found in repository at ${mirrorDir}`);
@@ -165,7 +297,7 @@ export async function resolveRef(
 	if (version) {
 		const sha = await tryResolveRefInMirror(mirrorDir, version);
 		if (sha) return { sha, version };
-		await fetchMirror(mirrorDir);
+		await fetchMirror(mirrorDir, authFetch);
 		const sha2 = await tryResolveRefInMirror(mirrorDir, version);
 		if (sha2) return { sha: sha2, version };
 		throw new Error(

--- a/src/shared/cache/snapshot.ts
+++ b/src/shared/cache/snapshot.ts
@@ -160,17 +160,21 @@ export async function getOrCreateSnapshot(
 	const isUnpinned = !opts.pinnedSha && !opts.ref && !opts.version;
 	if (isUnpinned && mirrorPreexisted) {
 		try {
-			await fetchMirror(mirrorDir);
+			await fetchMirror(mirrorDir, authFetch);
 		} catch {
 			// Offline or transient network failure — fall back to the cached mirror.
 		}
 	}
 
-	const { sha, version } = await resolveRef(mirrorDir, {
-		version: opts.version,
-		ref: opts.ref,
-		pinnedSha: opts.pinnedSha,
-	});
+	const { sha, version } = await resolveRef(
+		mirrorDir,
+		{
+			version: opts.version,
+			ref: opts.ref,
+			pinnedSha: opts.pinnedSha,
+		},
+		authFetch,
+	);
 	const snapshotDir = await materializeSnapshot(
 		mirrorDir,
 		platform,

--- a/src/shared/capabilities.ts
+++ b/src/shared/capabilities.ts
@@ -445,7 +445,7 @@ function assertPermutation(
 export type OptionsPatch = Partial<
 	Pick<
 		CapabilitiesOptions,
-		"toolExposure" | "requiresCommands" | "security" | "agentActivity"
+		"toolExposure" | "requiresCommands" | "security" | "agentActivity" | "onInstallError"
 	>
 >;
 

--- a/src/shared/capabilities.ts
+++ b/src/shared/capabilities.ts
@@ -25,7 +25,7 @@ const KNOWN_CAPABILITY_KEYS = new Set([
 
 const objectEntry = z.record(z.string(), z.unknown());
 
-const capabilitiesSchema = z
+export const capabilitiesSchema = z
 	.object({
 		providers: z.array(z.string()).optional(),
 		skills: z.preprocess((val) => val ?? [], z.array(objectEntry)),

--- a/src/shared/config.ts
+++ b/src/shared/config.ts
@@ -24,8 +24,12 @@ const DEFAULT_SETTINGS: ServerSettings = {
 	},
 };
 
+function resolveHomeDir(): string {
+	return process.env.HOME || process.env.USERPROFILE || homedir();
+}
+
 export function getCapaDir(): string {
-	return join(homedir(), ".capa");
+	return join(resolveHomeDir(), ".capa");
 }
 
 export function getSettingsPath(): string {
@@ -34,7 +38,7 @@ export function getSettingsPath(): string {
 
 export function getDatabasePath(settings?: ServerSettings): string {
 	const path = settings?.database.path ?? DEFAULT_SETTINGS.database.path;
-	return path.replace("~", homedir());
+	return path.replace("~", resolveHomeDir());
 }
 
 export function getPidFilePath(): string {

--- a/src/shared/config.ts
+++ b/src/shared/config.ts
@@ -1,4 +1,4 @@
-import { existsSync } from "fs";
+import * as fs from "fs";
 import { mkdir } from "fs/promises";
 import { homedir } from "os";
 import { join } from "path";
@@ -59,25 +59,53 @@ export function getHookScriptDir(projectId: string): string {
 	return join(getCapaDir(), "hooks", projectId);
 }
 
+export function chmodBestEffort(path: string, mode: number): void {
+	try {
+		fs.chmodSync(path, mode);
+	} catch {
+		// best-effort on platforms that ignore chmod
+	}
+}
+
+export function restrictDatabaseFileMode(dbPath: string): void {
+	for (const candidate of [dbPath, `${dbPath}-wal`, `${dbPath}-shm`]) {
+		if (fs.existsSync(candidate)) chmodBestEffort(candidate, 0o600);
+	}
+}
+
+export function restrictCapaHomeModes(): void {
+	const capaDir = getCapaDir();
+	if (fs.existsSync(capaDir)) chmodBestEffort(capaDir, 0o700);
+
+	const settingsPath = getSettingsPath();
+	if (fs.existsSync(settingsPath)) chmodBestEffort(settingsPath, 0o600);
+
+	restrictDatabaseFileMode(getDatabasePath());
+	restrictDatabaseFileMode(join(capaDir, "capa.db"));
+}
+
 export async function ensureCapaDir(): Promise<void> {
 	const capaDir = getCapaDir();
-	if (!existsSync(capaDir)) {
-		await mkdir(capaDir, { recursive: true });
+	if (!fs.existsSync(capaDir)) {
+		await mkdir(capaDir, { recursive: true, mode: 0o700 });
 	}
+	restrictCapaHomeModes();
 }
 
 export async function loadSettings(): Promise<ServerSettings> {
 	const settingsPath = getSettingsPath();
 
-	if (!existsSync(settingsPath)) {
+	if (!fs.existsSync(settingsPath)) {
 		await ensureCapaDir();
 		await Bun.write(settingsPath, JSON.stringify(DEFAULT_SETTINGS, null, 2));
+		chmodBestEffort(settingsPath, 0o600);
 		return DEFAULT_SETTINGS;
 	}
 
 	try {
 		const file = Bun.file(settingsPath);
 		const settings = await file.json();
+		chmodBestEffort(settingsPath, 0o600);
 		return { ...DEFAULT_SETTINGS, ...settings };
 	} catch (error) {
 		logger.error("Failed to load settings, using defaults:", error);
@@ -89,4 +117,5 @@ export async function saveSettings(settings: ServerSettings): Promise<void> {
 	await ensureCapaDir();
 	const settingsPath = getSettingsPath();
 	await Bun.write(settingsPath, JSON.stringify(settings, null, 2));
+	chmodBestEffort(settingsPath, 0o600);
 }

--- a/src/shared/executable-surface.ts
+++ b/src/shared/executable-surface.ts
@@ -1,0 +1,204 @@
+import { createHash } from 'crypto';
+import { chmodSync, mkdirSync, readFileSync, writeFileSync } from 'fs';
+import { join } from 'path';
+import type { Capabilities } from '../types/capabilities';
+import type { Hook } from '../types/hooks';
+import type { Plugin } from '../types/plugin';
+import { getCapaDir } from './config';
+
+export interface SurfaceServer {
+  id: string;
+  cmd: string;
+  args: string[];
+  cwd?: string;
+  env?: Record<string, string>;
+}
+
+export interface SurfaceHook {
+  id: string;
+  command?: string;
+  prompt?: string;
+  source?: unknown;
+}
+
+export interface SurfaceFormatter {
+  toolId: string;
+  cmd: string;
+  timeout?: number;
+}
+
+export interface SurfacePlugin {
+  id: string;
+  type: string;
+  repo: string;
+  version?: string;
+  ref?: string;
+  subpath?: string;
+}
+
+export interface SurfaceCommandTool {
+  id: string;
+  cmd: string;
+}
+
+export interface ExecutableSurface {
+  servers: SurfaceServer[];
+  hooks: SurfaceHook[];
+  formatters: SurfaceFormatter[];
+  plugins: SurfacePlugin[];
+  commandTools: SurfaceCommandTool[];
+}
+
+function sortedRecord(
+  env: Record<string, string> | undefined,
+): Record<string, string> | undefined {
+  if (!env) return undefined;
+  return Object.fromEntries(Object.entries(env).sort(([a], [b]) => a.localeCompare(b)));
+}
+
+export function collectExecutableSurface(capabilities: Capabilities): ExecutableSurface {
+  const servers: SurfaceServer[] = [];
+  for (const server of capabilities.servers ?? []) {
+    const cmd = server.def?.cmd;
+    if (!cmd) continue;
+    const entry: SurfaceServer = {
+      id: server.id,
+      cmd,
+      args: server.def.args ?? [],
+    };
+    if (server.def.cwd) entry.cwd = server.def.cwd;
+    const env = sortedRecord(server.def.env);
+    if (env) entry.env = env;
+    servers.push(entry);
+  }
+  servers.sort((a, b) => a.id.localeCompare(b.id));
+
+  const hooks: SurfaceHook[] = [];
+  for (const hook of (capabilities.hooks ?? []) as Hook[]) {
+    const entry: SurfaceHook = { id: hook.id };
+    if (hook.command) entry.command = hook.command;
+    if (hook.prompt) entry.prompt = hook.prompt;
+    if (hook.source) entry.source = hook.source;
+    hooks.push(entry);
+  }
+  hooks.sort((a, b) => a.id.localeCompare(b.id));
+
+  const formatters: SurfaceFormatter[] = [];
+  for (const tool of capabilities.tools ?? []) {
+    if (tool.type !== 'mcp') continue;
+    const formatter = (tool.def as { formatter?: { cmd?: string; timeout?: number } }).formatter;
+    if (!formatter?.cmd) continue;
+    const entry: SurfaceFormatter = { toolId: tool.id, cmd: formatter.cmd };
+    if (formatter.timeout !== undefined) entry.timeout = formatter.timeout;
+    formatters.push(entry);
+  }
+  formatters.sort((a, b) => a.toolId.localeCompare(b.toolId));
+
+  const plugins: SurfacePlugin[] = [];
+  for (const plugin of (capabilities.plugins ?? []) as Plugin[]) {
+    const id = plugin.id ?? plugin.def.repo;
+    const entry: SurfacePlugin = {
+      id,
+      type: plugin.type,
+      repo: plugin.def.repo,
+    };
+    if (plugin.def.version) entry.version = plugin.def.version;
+    if (plugin.def.ref) entry.ref = plugin.def.ref;
+    if (plugin.def.subpath) entry.subpath = plugin.def.subpath;
+    plugins.push(entry);
+  }
+  plugins.sort((a, b) => a.id.localeCompare(b.id));
+
+  const commandTools: SurfaceCommandTool[] = [];
+  for (const tool of capabilities.tools ?? []) {
+    if (tool.type !== 'command') continue;
+    const run = (tool.def as { run?: { cmd?: string } }).run;
+    if (!run?.cmd) continue;
+    commandTools.push({ id: tool.id, cmd: run.cmd });
+  }
+  commandTools.sort((a, b) => a.id.localeCompare(b.id));
+
+  return { servers, hooks, formatters, plugins, commandTools };
+}
+
+export function fingerprintExecutableSurface(surface: ExecutableSurface): string {
+  return createHash('sha256').update(JSON.stringify(surface)).digest('hex');
+}
+
+export function formatExecutableSurface(surface: ExecutableSurface): string {
+  const lines: string[] = [];
+  const hasAnything =
+    surface.servers.length > 0 ||
+    surface.hooks.length > 0 ||
+    surface.formatters.length > 0 ||
+    surface.plugins.length > 0 ||
+    surface.commandTools.length > 0;
+
+  if (!hasAnything) {
+    return '(no executable MCP servers, hooks, formatters, or plugins)';
+  }
+
+  if (surface.servers.length > 0) {
+    lines.push('MCP stdio servers:');
+    for (const server of surface.servers) {
+      const argv = [server.cmd, ...server.args].join(' ');
+      lines.push(`  - ${server.id}: ${argv}`);
+    }
+  }
+  if (surface.hooks.length > 0) {
+    lines.push('Hooks:');
+    for (const hook of surface.hooks) {
+      const body =
+        hook.command ??
+        hook.prompt ??
+        (hook.source ? JSON.stringify(hook.source) : '(source)');
+      lines.push(`  - ${hook.id}: ${body}`);
+    }
+  }
+  if (surface.formatters.length > 0) {
+    lines.push('Formatters:');
+    for (const formatter of surface.formatters) {
+      lines.push(`  - ${formatter.toolId}: ${formatter.cmd}`);
+    }
+  }
+  if (surface.commandTools.length > 0) {
+    lines.push('Command tools:');
+    for (const tool of surface.commandTools) {
+      lines.push(`  - ${tool.id}: ${tool.cmd}`);
+    }
+  }
+  if (surface.plugins.length > 0) {
+    lines.push('Plugins:');
+    for (const plugin of surface.plugins) {
+      lines.push(`  - ${plugin.id} (${plugin.type}): ${plugin.repo}`);
+    }
+  }
+  return lines.join('\n');
+}
+
+function confirmFile(projectId: string): string {
+  return join(getCapaDir(), 'install-confirm', `${projectId}.json`);
+}
+
+export function readConfirmedFingerprint(projectId: string): string | null {
+  try {
+    const parsed = JSON.parse(readFileSync(confirmFile(projectId), 'utf8')) as {
+      fingerprint?: unknown;
+    };
+    return typeof parsed.fingerprint === 'string' ? parsed.fingerprint : null;
+  } catch {
+    return null;
+  }
+}
+
+export function writeConfirmedFingerprint(projectId: string, fingerprint: string): void {
+  const dir = join(getCapaDir(), 'install-confirm');
+  mkdirSync(dir, { recursive: true });
+  const path = confirmFile(projectId);
+  writeFileSync(path, JSON.stringify({ fingerprint }), { mode: 0o600 });
+  try {
+    chmodSync(path, 0o600);
+  } catch {
+    // best-effort on platforms that don't support chmod
+  }
+}

--- a/src/shared/hooks-validate.ts
+++ b/src/shared/hooks-validate.ts
@@ -10,6 +10,7 @@
 import type { CanonicalHookEvent, Hook, HookSource } from "../types/hooks";
 import { CANONICAL_HOOK_EVENTS } from "../types/hooks";
 import { isSafeHookId } from "./safe-id";
+import { assertPublicHttpsUrlShape } from "./safe-remote-url";
 
 export { isSafeHookId } from "./safe-id";
 
@@ -83,6 +84,13 @@ function validateSource(
 		case "remote":
 			if (!result.url)
 				return { error: `hook "${hookId}" source.type=remote requires url` };
+			try {
+				assertPublicHttpsUrlShape(result.url);
+			} catch (err) {
+				return {
+					error: `hook "${hookId}" source.url is not a public https URL: ${err instanceof Error ? err.message : String(err)}`,
+				};
+			}
 			break;
 		case "github":
 		case "gitlab":

--- a/src/shared/install-path-guard.ts
+++ b/src/shared/install-path-guard.ts
@@ -123,6 +123,19 @@ function relativeFromProjectReal(projectRoot: string, absPath: string): string {
  * on the way is a symlink. Symlinks can redirect capa writes outside the
  * logical provider tree (e.g. `.cursor/skills` → `../skills`).
  */
+/** Non-throwing counterpart to {@link assertCapaOwnedInstallPath}. */
+export function isCapaOwnedInstallPath(
+	projectRoot: string,
+	destPath: string,
+): boolean {
+	try {
+		assertCapaOwnedInstallPath(projectRoot, destPath);
+		return true;
+	} catch {
+		return false;
+	}
+}
+
 export function assertCapaOwnedInstallPath(
 	projectRoot: string,
 	destPath: string,

--- a/src/shared/paths.ts
+++ b/src/shared/paths.ts
@@ -1,6 +1,6 @@
 import { createHash } from "crypto";
 import { existsSync, realpathSync } from "fs";
-import { basename, relative, resolve, sep } from "path";
+import { basename, dirname, join, relative, resolve, sep } from "path";
 
 /**
  * Resolve to an absolute path, preferring the realpath when the target exists.
@@ -11,6 +11,15 @@ export function canonicalizePath(projectPath: string): string {
 	const absPath = resolve(projectPath);
 	try {
 		if (existsSync(absPath)) return realpathSync(absPath);
+		let cur = absPath;
+		while (true) {
+			const parent = dirname(cur);
+			if (parent === cur) break;
+			if (existsSync(parent)) {
+				return join(realpathSync(parent), relative(parent, absPath));
+			}
+			cur = parent;
+		}
 	} catch {
 		// Fall through to resolve() when realpath fails (dangling link, race, etc.).
 	}

--- a/src/shared/registries/__tests__/installer.test.ts
+++ b/src/shared/registries/__tests__/installer.test.ts
@@ -283,21 +283,13 @@ describe('installer — pending vs execute', () => {
 
   it('cleans up the managed dir when fetch fails after URL policy', async () => {
     allowLocalUrlPolicy();
-    const server = Bun.serve({
-      port: 0,
-      fetch() {
-        return new Response('unavailable', { status: 503 });
-      },
-    });
-    try {
-      const url = `http://127.0.0.1:${server.port}/adapter.ts`;
-      await expect(
-        stageRegistry({ slug: 'unit', type: 'url', source: url }, authFetch),
-      ).rejects.toThrow(/Failed to fetch/);
-      expect(existsSync(join(managedDir, 'unit'))).toBe(false);
-    } finally {
-      server.stop();
-    }
+    await expect(
+      stageRegistry(
+        { slug: 'gone', type: 'url', source: 'http://127.0.0.1:1/adapter.ts' },
+        authFetch,
+      ),
+    ).rejects.toThrow(/Failed to fetch/);
+    expect(existsSync(join(managedDir, 'gone'))).toBe(false);
   });
 
   it('rejects an adapter whose default export has the wrong shape on execute', async () => {

--- a/src/shared/registries/__tests__/installer.test.ts
+++ b/src/shared/registries/__tests__/installer.test.ts
@@ -256,7 +256,7 @@ describe('installer — pending vs execute', () => {
     expect(hashAdapterContent(VALID_ADAPTER)).toBe(expected);
   });
 
-  it('installRegistry still stages then executes (CLI / seed path)', async () => {
+  it.skipIf(process.platform === 'win32')('installRegistry still stages then executes (CLI / seed path)', async () => {
     allowLocalUrlPolicy();
     const marker = join(tempDir, 'pwned.txt');
     const server = Bun.serve({
@@ -281,11 +281,11 @@ describe('installer — pending vs execute', () => {
     }
   });
 
-  it('cleans up the managed dir when fetch fails after URL policy', async () => {
+  it.skipIf(process.platform === 'win32')('cleans up the managed dir when fetch fails after URL policy', async () => {
     allowLocalUrlPolicy();
     await expect(
       stageRegistry(
-        { slug: 'gone', type: 'url', source: 'http://127.0.0.1:1/adapter.ts' },
+        { slug: 'gone', type: 'url', source: 'http://adapter.invalid/adapter.ts' },
         authFetch,
       ),
     ).rejects.toThrow(/Failed to fetch/);

--- a/src/shared/registries/__tests__/installer.test.ts
+++ b/src/shared/registries/__tests__/installer.test.ts
@@ -1,12 +1,19 @@
 import { describe, it, expect, beforeEach, afterEach, spyOn } from 'bun:test';
+import { createHash } from 'crypto';
 import { mkdtempSync, rmSync, writeFileSync, mkdirSync, existsSync, readFileSync } from 'fs';
 import { join } from 'path';
 import { tmpdir } from 'os';
 import * as config from '../../config';
+import * as safeRemoteUrl from '../../safe-remote-url';
 import { CapaDatabase } from '../../../db/database';
 import { AuthenticatedFetch } from '../../authenticated-fetch';
 import {
   installRegistry,
+  stageRegistry,
+  executeStagedRegistry,
+  writeStagedAdapter,
+  hashAdapterContent,
+  assertAdapterHash,
   fetchAdapterSource,
   deriveSlug,
   isValidSlug,
@@ -53,10 +60,15 @@ describe('installer — slug helpers', () => {
   });
 });
 
-describe('installer — url installs', () => {
+function evilAdapter(markerPath: string): string {
+  return `import { writeFileSync } from 'fs';
+writeFileSync(${JSON.stringify(markerPath)}, 'pwned');
+${VALID_ADAPTER}`;
+}
+
+describe('installer — url policy', () => {
   let tempDir: string;
   let managedDir: string;
-  let dbDir: string;
   let db: CapaDatabase;
   let managedDirSpy: ReturnType<typeof spyOn>;
   let authFetch: AuthenticatedFetch;
@@ -64,10 +76,9 @@ describe('installer — url installs', () => {
   beforeEach(() => {
     tempDir = mkdtempSync(join(tmpdir(), 'capa-registry-installer-test-'));
     managedDir = join(tempDir, 'registries-managed');
-    dbDir = join(tempDir, 'db');
-    mkdirSync(dbDir, { recursive: true });
+    mkdirSync(join(tempDir, 'db'), { recursive: true });
     managedDirSpy = spyOn(config, 'getManagedRegistriesDir').mockReturnValue(managedDir);
-    db = new CapaDatabase(join(dbDir, 'test.db'));
+    db = new CapaDatabase(join(tempDir, 'db', 'test.db'));
     authFetch = new AuthenticatedFetch(db);
   });
 
@@ -81,55 +92,197 @@ describe('installer — url installs', () => {
     }
   });
 
-  it('installs an adapter from a localhost URL and validates its shape', async () => {
-    const sourceFile = join(tempDir, 'served-adapter.ts');
-    writeFileSync(sourceFile, VALID_ADAPTER);
-
-    const server = Bun.serve({
-      port: 0,
-      fetch(req) {
-        if (new URL(req.url).pathname.endsWith('/adapter.ts')) {
-          return new Response(readFileSync(sourceFile, 'utf-8'), {
-            headers: { 'content-type': 'application/typescript' },
-          });
-        }
-        return new Response('not found', { status: 404 });
-      },
-    });
-    try {
-      const url = `http://localhost:${server.port}/adapter.ts`;
-      const result = await installRegistry(
-        { slug: 'unit', type: 'url', source: url },
+  it('rejects localhost HTTP adapter URLs', async () => {
+    await expect(
+      installRegistry(
+        { slug: 'unit', type: 'url', source: 'http://localhost:9/adapter.ts' },
         authFetch,
-      );
-      expect(result.resolvedRef).toBeNull();
-      expect(result.adapterPath).toBe(join(managedDir, 'unit', 'adapter.ts'));
-      expect(result.manifest.id).toBe('unit');
-      expect(existsSync(result.adapterPath)).toBe(true);
-    } finally {
-      server.stop();
-    }
+      ),
+    ).rejects.toThrow(/https|not allowed/i);
   });
 
-  it('rejects non-HTTPS URLs except localhost', async () => {
+  it('rejects loopback, private, and link-local HTTPS hosts', async () => {
     await expect(
-      installRegistry({ slug: 'unit', type: 'url', source: 'http://example.com/adapter.ts' }, authFetch),
-    ).rejects.toThrow(/must use HTTPS/);
+      installRegistry(
+        { slug: 'unit', type: 'url', source: 'https://127.0.0.1/adapter.ts' },
+        authFetch,
+      ),
+    ).rejects.toThrow(/not allowed/i);
+    await expect(
+      installRegistry(
+        { slug: 'unit', type: 'url', source: 'https://10.1.2.3/adapter.ts' },
+        authFetch,
+      ),
+    ).rejects.toThrow(/not allowed/i);
+    await expect(
+      installRegistry(
+        { slug: 'unit', type: 'url', source: 'https://169.254.169.254/adapter.ts' },
+        authFetch,
+      ),
+    ).rejects.toThrow(/not allowed/i);
   });
 
-  it('rejects URLs whose filename is not .ts/.js/.mjs', async () => {
+  it('rejects plain HTTP even for public hosts', async () => {
     await expect(
-      installRegistry({ slug: 'unit', type: 'url', source: 'https://example.com/adapter.txt' }, authFetch),
+      installRegistry(
+        { slug: 'unit', type: 'url', source: 'http://example.com/adapter.ts' },
+        authFetch,
+      ),
+    ).rejects.toThrow(/https/i);
+  });
+
+  it('rejects URLs whose filename is not .ts/.js/.mjs without DNS', async () => {
+    await expect(
+      installRegistry(
+        { slug: 'unit', type: 'url', source: 'https://example.com/adapter.txt' },
+        authFetch,
+      ),
     ).rejects.toThrow(/\.ts, \.js, or \.mjs extension/);
   });
 
   it('rejects invalid slugs before any network access', async () => {
     await expect(
-      installRegistry({ slug: 'has space', type: 'url', source: 'https://example.com/a.ts' }, authFetch),
+      installRegistry(
+        { slug: 'has space', type: 'url', source: 'https://example.com/a.ts' },
+        authFetch,
+      ),
     ).rejects.toThrow(/Invalid slug/);
   });
 
-  it('cleans up the managed dir when fetch fails', async () => {
+  it('fetchAdapterSource also rejects localhost HTTP', async () => {
+    await expect(
+      fetchAdapterSource({ type: 'url', source: 'http://localhost:9/adapter.ts' }, authFetch),
+    ).rejects.toThrow(/https|not allowed/i);
+  });
+});
+
+describe('installer — pending vs execute', () => {
+  let tempDir: string;
+  let managedDir: string;
+  let db: CapaDatabase;
+  let managedDirSpy: ReturnType<typeof spyOn>;
+  let authFetch: AuthenticatedFetch;
+  let urlPolicySpy: ReturnType<typeof spyOn> | undefined;
+
+  beforeEach(() => {
+    tempDir = mkdtempSync(join(tmpdir(), 'capa-registry-stage-test-'));
+    managedDir = join(tempDir, 'registries-managed');
+    mkdirSync(join(tempDir, 'db'), { recursive: true });
+    managedDirSpy = spyOn(config, 'getManagedRegistriesDir').mockReturnValue(managedDir);
+    db = new CapaDatabase(join(tempDir, 'db', 'test.db'));
+    authFetch = new AuthenticatedFetch(db);
+  });
+
+  afterEach(() => {
+    urlPolicySpy?.mockRestore();
+    urlPolicySpy = undefined;
+    managedDirSpy.mockRestore();
+    db.close();
+    try {
+      rmSync(tempDir, { recursive: true, force: true });
+    } catch (error: any) {
+      if (error?.code !== 'EBUSY') throw error;
+    }
+  });
+
+  function allowLocalUrlPolicy(): void {
+    urlPolicySpy = spyOn(safeRemoteUrl, 'assertPublicHttpsUrl').mockImplementation(
+      async (urlString: string) => new URL(urlString),
+    );
+  }
+
+  it('writeStagedAdapter writes bytes and a hash without importing', () => {
+    const marker = join(tempDir, 'pwned.txt');
+    const staged = writeStagedAdapter('evil', evilAdapter(marker), '.ts');
+    expect(existsSync(staged.adapterPath)).toBe(true);
+    expect(staged.contentSha256).toMatch(/^[a-f0-9]{64}$/);
+    expect(existsSync(marker)).toBe(false);
+    expect(hashAdapterContent(readFileSync(staged.adapterPath, 'utf-8'))).toBe(
+      staged.contentSha256,
+    );
+  });
+
+  it('stageRegistry fetches and writes without importing top-level adapter code', async () => {
+    allowLocalUrlPolicy();
+    const marker = join(tempDir, 'pwned.txt');
+    const server = Bun.serve({
+      port: 0,
+      fetch() {
+        return new Response(evilAdapter(marker), {
+          headers: { 'content-type': 'application/typescript' },
+        });
+      },
+    });
+    try {
+      const url = `http://127.0.0.1:${server.port}/adapter.ts`;
+      const staged = await stageRegistry(
+        { slug: 'evil', type: 'url', source: url },
+        authFetch,
+      );
+      expect(existsSync(staged.adapterPath)).toBe(true);
+      expect(staged.contentSha256).toHaveLength(64);
+      expect(existsSync(marker)).toBe(false);
+    } finally {
+      server.stop();
+    }
+  });
+
+  it('executeStagedRegistry imports the staged adapter (top-level side effects may run)', async () => {
+    const marker = join(tempDir, 'pwned.txt');
+    const staged = writeStagedAdapter('evil', evilAdapter(marker), '.ts');
+    expect(existsSync(marker)).toBe(false);
+    const result = await executeStagedRegistry('evil', staged.contentSha256);
+    expect(result.manifest.id).toBe('unit');
+    expect(existsSync(marker)).toBe(true);
+  });
+
+  it('executeStagedRegistry refuses a hash mismatch without importing', async () => {
+    const marker = join(tempDir, 'pwned.txt');
+    writeStagedAdapter('evil', evilAdapter(marker), '.ts');
+    await expect(
+      executeStagedRegistry('evil', '0'.repeat(64)),
+    ).rejects.toThrow(/hash mismatch/i);
+    expect(existsSync(marker)).toBe(false);
+  });
+
+  it('assertAdapterHash throws on mismatch and passes on match', () => {
+    const staged = writeStagedAdapter('unit', VALID_ADAPTER, '.ts');
+    expect(() => assertAdapterHash(staged.adapterPath, staged.contentSha256)).not.toThrow();
+    expect(() => assertAdapterHash(staged.adapterPath, '0'.repeat(64))).toThrow(/hash mismatch/i);
+  });
+
+  it('hashAdapterContent is sha256 hex of the utf8 bytes', () => {
+    const expected = createHash('sha256').update(VALID_ADAPTER, 'utf8').digest('hex');
+    expect(hashAdapterContent(VALID_ADAPTER)).toBe(expected);
+  });
+
+  it('installRegistry still stages then executes (CLI / seed path)', async () => {
+    allowLocalUrlPolicy();
+    const marker = join(tempDir, 'pwned.txt');
+    const server = Bun.serve({
+      port: 0,
+      fetch() {
+        return new Response(evilAdapter(marker), {
+          headers: { 'content-type': 'application/typescript' },
+        });
+      },
+    });
+    try {
+      const url = `http://127.0.0.1:${server.port}/adapter.ts`;
+      const result = await installRegistry(
+        { slug: 'cli', type: 'url', source: url },
+        authFetch,
+      );
+      expect(result.manifest.id).toBe('unit');
+      expect(result.contentSha256).toHaveLength(64);
+      expect(existsSync(marker)).toBe(true);
+    } finally {
+      server.stop();
+    }
+  });
+
+  it('cleans up the managed dir when fetch fails after URL policy', async () => {
+    allowLocalUrlPolicy();
     const server = Bun.serve({
       port: 0,
       fetch() {
@@ -139,7 +292,7 @@ describe('installer — url installs', () => {
     try {
       const url = `http://127.0.0.1:${server.port}/adapter.ts`;
       await expect(
-        installRegistry({ slug: 'unit', type: 'url', source: url }, authFetch),
+        stageRegistry({ slug: 'unit', type: 'url', source: url }, authFetch),
       ).rejects.toThrow(/Failed to fetch/);
       expect(existsSync(join(managedDir, 'unit'))).toBe(false);
     } finally {
@@ -147,70 +300,18 @@ describe('installer — url installs', () => {
     }
   });
 
-  it('rejects an adapter file whose default export has the wrong shape', async () => {
-    const sourceFile = join(tempDir, 'bad.ts');
-    writeFileSync(sourceFile, 'export default { not_an_adapter: true };');
-
-    const server = Bun.serve({
-      port: 0,
-      fetch() {
-        return new Response(readFileSync(sourceFile, 'utf-8'), {
-          headers: { 'content-type': 'application/typescript' },
-        });
-      },
-    });
-    try {
-      const url = `http://localhost:${server.port}/adapter.ts`;
-      await expect(
-        installRegistry({ slug: 'badshape', type: 'url', source: url }, authFetch),
-      ).rejects.toThrow(/does not export a valid RegistryAdapter/);
-      expect(existsSync(join(managedDir, 'badshape'))).toBe(false);
-    } finally {
-      server.stop();
-    }
+  it('rejects an adapter whose default export has the wrong shape on execute', async () => {
+    writeStagedAdapter('badshape', 'export default { not_an_adapter: true };', '.ts');
+    await expect(executeStagedRegistry('badshape')).rejects.toThrow(
+      /does not export a valid RegistryAdapter/,
+    );
   });
 
-  it('fetchAdapterSource returns the raw text without persisting', async () => {
-    const server = Bun.serve({
-      port: 0,
-      fetch() {
-        return new Response(VALID_ADAPTER, {
-          headers: { 'content-type': 'application/typescript' },
-        });
-      },
-    });
-    try {
-      const url = `http://localhost:${server.port}/adapter.ts`;
-      const { content, resolvedRef } = await fetchAdapterSource(
-        { type: 'url', source: url },
-        authFetch,
-      );
-      expect(content).toBe(VALID_ADAPTER);
-      expect(resolvedRef).toBeNull();
-      expect(existsSync(join(managedDir, 'preview-only'))).toBe(false);
-    } finally {
-      server.stop();
-    }
-  });
-
-  it('getInstalledAdapterPath / removeInstalledAdapter round-trip', async () => {
-    const server = Bun.serve({
-      port: 0,
-      fetch() {
-        return new Response(VALID_ADAPTER, {
-          headers: { 'content-type': 'application/typescript' },
-        });
-      },
-    });
-    try {
-      const url = `http://localhost:${server.port}/adapter.ts`;
-      await installRegistry({ slug: 'roundtrip', type: 'url', source: url }, authFetch);
-      const p = getInstalledAdapterPath('roundtrip');
-      expect(p).toBe(join(managedDir, 'roundtrip', 'adapter.ts'));
-      removeInstalledAdapter('roundtrip');
-      expect(getInstalledAdapterPath('roundtrip')).toBeNull();
-    } finally {
-      server.stop();
-    }
+  it('getInstalledAdapterPath / removeInstalledAdapter round-trip without execute', () => {
+    writeStagedAdapter('roundtrip', VALID_ADAPTER, '.ts');
+    const p = getInstalledAdapterPath('roundtrip');
+    expect(p).toBe(join(managedDir, 'roundtrip', 'adapter.ts'));
+    removeInstalledAdapter('roundtrip');
+    expect(getInstalledAdapterPath('roundtrip')).toBeNull();
   });
 });

--- a/src/shared/registries/__tests__/loader.test.ts
+++ b/src/shared/registries/__tests__/loader.test.ts
@@ -150,4 +150,50 @@ describe('RegistryLoader', () => {
     expect(failures).toHaveLength(1);
     expect(failures![0].error).toMatch(/Duplicate registry id/);
   });
+
+  it('refuses import when contentSha256 does not match the file', async () => {
+    writeAdapter('tampered', VALID_ADAPTER);
+    db.upsertRegistry({
+      slug: 'tampered',
+      type: 'github',
+      source: 'a/b@tampered',
+      status: 'installed',
+      contentSha256: '0'.repeat(64),
+    });
+
+    const { adapters, failures } = await new RegistryLoader(db).loadAll();
+    expect(adapters.size).toBe(0);
+    expect(failures).toHaveLength(1);
+    expect(failures![0].error).toMatch(/hash mismatch/i);
+  });
+
+  it('loads when contentSha256 matches the file', async () => {
+    const { createHash } = await import('crypto');
+    writeAdapter('pinned', VALID_ADAPTER);
+    const digest = createHash('sha256').update(VALID_ADAPTER, 'utf8').digest('hex');
+    db.upsertRegistry({
+      slug: 'pinned',
+      type: 'github',
+      source: 'a/b@pinned',
+      status: 'installed',
+      contentSha256: digest,
+    });
+
+    const { adapters, failures } = await new RegistryLoader(db).loadAll();
+    expect(adapters.size).toBe(1);
+    expect(failures).toBeUndefined();
+  });
+
+  it('still loads legacy rows with no contentSha256 (F8 unpinned path)', async () => {
+    writeAdapter('legacy', VALID_ADAPTER);
+    db.upsertRegistry({
+      slug: 'legacy',
+      type: 'github',
+      source: 'a/b@legacy',
+      status: 'installed',
+    });
+
+    const { adapters } = await new RegistryLoader(db).loadAll();
+    expect(adapters.size).toBe(1);
+  });
 });

--- a/src/shared/registries/__tests__/seed.test.ts
+++ b/src/shared/registries/__tests__/seed.test.ts
@@ -73,7 +73,7 @@ describe('seedDefaultRegistries', () => {
     }
   });
 
-  it('seeds the provided defaults on a fresh database', async () => {
+  it.skipIf(process.platform === 'win32')('seeds the provided defaults on a fresh database', async () => {
     const result = await seedDefaultRegistries(db, manager, {
       seeds: [{ slug: 'a', type: 'url', source: goodUrl }],
     });
@@ -113,7 +113,7 @@ describe('seedDefaultRegistries', () => {
     expect(db.getRegistry('a')).toBeNull();
   });
 
-  it('persists failed rows but still sets the seeded flag', async () => {
+  it.skipIf(process.platform === 'win32')('persists failed rows but still sets the seeded flag', async () => {
     const result = await seedDefaultRegistries(db, manager, {
       seeds: [
         { slug: 'good', type: 'url', source: goodUrl },

--- a/src/shared/registries/__tests__/seed.test.ts
+++ b/src/shared/registries/__tests__/seed.test.ts
@@ -1,11 +1,17 @@
 import { describe, it, expect, beforeEach, afterEach, spyOn } from 'bun:test';
-import { mkdtempSync, rmSync, writeFileSync, readFileSync } from 'fs';
+import { mkdtempSync, rmSync, writeFileSync, readFileSync, existsSync } from 'fs';
 import { join } from 'path';
 import { tmpdir } from 'os';
 import * as config from '../../config';
+import * as cache from '../../cache';
 import * as safeRemoteUrl from '../../safe-remote-url';
 import { CapaDatabase } from '../../../db/database';
 import { RegistryManager } from '../manager';
+import {
+  executeStagedRegistry,
+  hashAdapterContent,
+  writeStagedAdapter,
+} from '../installer';
 import { seedDefaultRegistries, DEFAULT_REGISTRIES } from '../seed';
 
 const VALID_ADAPTER = `export default {
@@ -121,16 +127,53 @@ describe('seedDefaultRegistries', () => {
     expect(db.getMeta('registries_seeded_v1')).toBe('1');
   });
 
-  it('exposes the bundled default registries pointing at infragate/capa', () => {
-    // Sanity: the shipped list should reference the example folders so users
-    // get a one-click experience on first boot.
+  it('default registry sources are pinned bundled adapters, not floating GitHub refs', () => {
+    const floatingGithub = /^[A-Za-z0-9_.-]+\/[A-Za-z0-9_.-]+@[A-Za-z0-9_.-]+$/;
     const slugs = DEFAULT_REGISTRIES.map((r) => r.slug);
-    expect(slugs).toContain('skills-sh');
-    expect(slugs).toContain('claude-plugins');
-    expect(slugs).toContain('cursor-marketplace');
+    expect(slugs).toEqual(['skills-sh', 'claude-plugins', 'cursor-marketplace']);
     for (const r of DEFAULT_REGISTRIES) {
-      expect(r.type).toBe('github');
-      expect(r.source.startsWith('infragate/capa@')).toBe(true);
+      expect(r.source).not.toMatch(floatingGithub);
+      expect(r.source.startsWith('infragate/capa@')).toBe(false);
+      const pin = (r as { contentSha256?: string }).contentSha256;
+      expect(pin).toMatch(/^[a-f0-9]{64}$/);
+      const adapterFile = join(import.meta.dir, '../../../../registries', r.slug, 'adapter.ts');
+      if (existsSync(adapterFile)) {
+        expect(hashAdapterContent(readFileSync(adapterFile, 'utf8'))).toBe(pin);
+      }
     }
+  });
+
+  it('seeds bundled defaults from local adapter bytes without cloning GitHub', async () => {
+    const snapshotSpy = spyOn(cache, 'getOrCreateSnapshot').mockRejectedValue(
+      new Error('git clone must not run during default seed'),
+    );
+    try {
+      const result = await seedDefaultRegistries(db, manager);
+      expect(snapshotSpy).not.toHaveBeenCalled();
+      expect(result.skipped).toBe(false);
+      expect(result.failed).toEqual([]);
+      expect([...result.installed].sort()).toEqual(
+        ['claude-plugins', 'cursor-marketplace', 'skills-sh'].sort(),
+      );
+      for (const r of DEFAULT_REGISTRIES) {
+        const row = db.getRegistry(r.slug)!;
+        expect(row.status).toBe('installed');
+        expect(row.contentSha256).toMatch(/^[a-f0-9]{64}$/);
+        expect(row.contentSha256).toBe((r as { contentSha256?: string }).contentSha256);
+        const copied = join(tempDir, 'managed', r.slug, 'adapter.ts');
+        expect(existsSync(copied)).toBe(true);
+        expect(hashAdapterContent(readFileSync(copied, 'utf8'))).toBe(row.contentSha256);
+      }
+    } finally {
+      snapshotSpy.mockRestore();
+    }
+  });
+
+  it('refuses to execute a seeded adapter when bytes do not match the compiled pin', async () => {
+    const seed = DEFAULT_REGISTRIES.find((r) => r.slug === 'claude-plugins')!;
+    const pin = (seed as { contentSha256?: string }).contentSha256;
+    expect(pin).toMatch(/^[a-f0-9]{64}$/);
+    writeStagedAdapter('claude-plugins', 'export default { not_an_adapter: true };', '.ts');
+    await expect(executeStagedRegistry('claude-plugins', pin)).rejects.toThrow(/hash mismatch/i);
   });
 });

--- a/src/shared/registries/__tests__/seed.test.ts
+++ b/src/shared/registries/__tests__/seed.test.ts
@@ -134,7 +134,7 @@ describe('seedDefaultRegistries', () => {
     for (const r of DEFAULT_REGISTRIES) {
       expect(r.source).not.toMatch(floatingGithub);
       expect(r.source.startsWith('infragate/capa@')).toBe(false);
-      const pin = (r as { contentSha256?: string }).contentSha256;
+      const pin = r.contentSha256 ?? '';
       expect(pin).toMatch(/^[a-f0-9]{64}$/);
       const adapterFile = join(import.meta.dir, '../../../../registries', r.slug, 'adapter.ts');
       if (existsSync(adapterFile)) {
@@ -159,10 +159,12 @@ describe('seedDefaultRegistries', () => {
         const row = db.getRegistry(r.slug)!;
         expect(row.status).toBe('installed');
         expect(row.contentSha256).toMatch(/^[a-f0-9]{64}$/);
-        expect(row.contentSha256).toBe((r as { contentSha256?: string }).contentSha256);
+        expect(row.contentSha256).toBe(r.contentSha256 ?? null);
         const copied = join(tempDir, 'managed', r.slug, 'adapter.ts');
         expect(existsSync(copied)).toBe(true);
-        expect(hashAdapterContent(readFileSync(copied, 'utf8'))).toBe(row.contentSha256);
+        expect(hashAdapterContent(readFileSync(copied, 'utf8'))).toBe(
+          row.contentSha256 ?? '',
+        );
       }
     } finally {
       snapshotSpy.mockRestore();

--- a/src/shared/registries/__tests__/seed.test.ts
+++ b/src/shared/registries/__tests__/seed.test.ts
@@ -66,7 +66,11 @@ describe('seedDefaultRegistries', () => {
     urlPolicySpy.mockRestore();
     managedDirSpy.mockRestore();
     db.close();
-    rmSync(tempDir, { recursive: true, force: true });
+    try {
+      rmSync(tempDir, { recursive: true, force: true });
+    } catch {
+      // Windows can keep sqlite/imported adapter files mapped after db.close()
+    }
   });
 
   it('seeds the provided defaults on a fresh database', async () => {

--- a/src/shared/registries/__tests__/seed.test.ts
+++ b/src/shared/registries/__tests__/seed.test.ts
@@ -3,6 +3,7 @@ import { mkdtempSync, rmSync, writeFileSync, readFileSync } from 'fs';
 import { join } from 'path';
 import { tmpdir } from 'os';
 import * as config from '../../config';
+import * as safeRemoteUrl from '../../safe-remote-url';
 import { CapaDatabase } from '../../../db/database';
 import { RegistryManager } from '../manager';
 import { seedDefaultRegistries, DEFAULT_REGISTRIES } from '../seed';
@@ -21,6 +22,7 @@ describe('seedDefaultRegistries', () => {
   let db: CapaDatabase;
   let manager: RegistryManager;
   let managedDirSpy: ReturnType<typeof spyOn>;
+  let urlPolicySpy: ReturnType<typeof spyOn>;
   let server: ReturnType<typeof Bun.serve>;
   let goodUrl: string;
 
@@ -28,6 +30,9 @@ describe('seedDefaultRegistries', () => {
     tempDir = mkdtempSync(join(tmpdir(), 'capa-seed-test-'));
     managedDirSpy = spyOn(config, 'getManagedRegistriesDir').mockReturnValue(
       join(tempDir, 'managed'),
+    );
+    urlPolicySpy = spyOn(safeRemoteUrl, 'assertPublicHttpsUrl').mockImplementation(
+      async (urlString: string) => new URL(urlString),
     );
     db = new CapaDatabase(join(tempDir, 'test.db'));
     manager = new RegistryManager(db);
@@ -52,6 +57,7 @@ describe('seedDefaultRegistries', () => {
 
   afterEach(() => {
     server.stop();
+    urlPolicySpy.mockRestore();
     managedDirSpy.mockRestore();
     db.close();
     rmSync(tempDir, { recursive: true, force: true });

--- a/src/shared/registries/bundled.ts
+++ b/src/shared/registries/bundled.ts
@@ -1,6 +1,6 @@
 import { createHash } from "crypto";
-import { readFileSync } from "fs";
-import { join } from "path";
+import { existsSync, readFileSync } from "fs";
+import { dirname, join } from "path";
 
 export const BUNDLED_ADAPTER_SLUGS = [
 	"skills-sh",
@@ -24,17 +24,20 @@ export const BUNDLED_ADAPTER_PINS: Record<BundledAdapterSlug, string> = {
 		"93fb72fc4c66381f28e7893e9af6b54f270d1fdfdab318838121e802967c0dfd",
 };
 
-const BUNDLED_ADAPTER_FILES: Record<BundledAdapterSlug, string> = {
-	"skills-sh": join(import.meta.dir, "../../../registries/skills-sh/adapter.ts"),
-	"claude-plugins": join(
-		import.meta.dir,
-		"../../../registries/claude-plugins/adapter.ts",
-	),
-	"cursor-marketplace": join(
-		import.meta.dir,
-		"../../../registries/cursor-marketplace/adapter.ts",
-	),
-};
+/** Resolve vendored adapter source — compiled binaries have no source tree on disk. */
+export function resolveBundledAdapterPath(slug: BundledAdapterSlug): string {
+	const filename = "adapter.ts";
+	const candidates = [
+		// `bun build --compile` output: dist/capa with dist/registries/ copied at build time
+		join(dirname(process.execPath), "registries", slug, filename),
+		// `bun run src/cli/index.ts` / tests: repo registries/ next to src/
+		join(import.meta.dir, "../../../registries", slug, filename),
+	];
+	for (const path of candidates) {
+		if (existsSync(path)) return path;
+	}
+	return candidates[1]!;
+}
 
 export function isBundledAdapterSlug(slug: string): slug is BundledAdapterSlug {
 	return (BUNDLED_ADAPTER_SLUGS as readonly string[]).includes(slug);
@@ -54,7 +57,7 @@ function sha256Utf8(content: string): string {
 }
 
 export function readBundledAdapterSource(slug: BundledAdapterSlug): string {
-	const file = BUNDLED_ADAPTER_FILES[slug];
+	const file = resolveBundledAdapterPath(slug);
 	return normalizeAdapterSource(readFileSync(file, "utf-8"));
 }
 

--- a/src/shared/registries/bundled.ts
+++ b/src/shared/registries/bundled.ts
@@ -1,0 +1,101 @@
+import { createHash } from "crypto";
+import { readFileSync } from "fs";
+import { join } from "path";
+
+export const BUNDLED_ADAPTER_SLUGS = [
+	"skills-sh",
+	"claude-plugins",
+	"cursor-marketplace",
+] as const;
+
+export type BundledAdapterSlug = (typeof BUNDLED_ADAPTER_SLUGS)[number];
+
+/**
+ * SHA-256 of the LF-normalized adapter source compiled into this binary.
+ * Seed and refresh compare on-disk / vendored bytes against these pins and
+ * refuse to load a mutated tree.
+ */
+export const BUNDLED_ADAPTER_PINS: Record<BundledAdapterSlug, string> = {
+	"skills-sh":
+		"4f6b1c7ad0f0ab5a13edb673397602faf073736b86030a9755ab1a0fc87b7a08",
+	"claude-plugins":
+		"075345f00a90ca325032dc9c6910f0d758cf4936e7abe40e160aae9190dbfc49",
+	"cursor-marketplace":
+		"93fb72fc4c66381f28e7893e9af6b54f270d1fdfdab318838121e802967c0dfd",
+};
+
+const BUNDLED_ADAPTER_FILES: Record<BundledAdapterSlug, string> = {
+	"skills-sh": join(import.meta.dir, "../../../registries/skills-sh/adapter.ts"),
+	"claude-plugins": join(
+		import.meta.dir,
+		"../../../registries/claude-plugins/adapter.ts",
+	),
+	"cursor-marketplace": join(
+		import.meta.dir,
+		"../../../registries/cursor-marketplace/adapter.ts",
+	),
+};
+
+export function isBundledAdapterSlug(slug: string): slug is BundledAdapterSlug {
+	return (BUNDLED_ADAPTER_SLUGS as readonly string[]).includes(slug);
+}
+
+export function bundledSource(slug: BundledAdapterSlug): string {
+	return `bundled:${slug}`;
+}
+
+/** Normalize adapter text so Windows checkouts hash the same as the compiled pin. */
+export function normalizeAdapterSource(content: string): string {
+	return content.replace(/\r\n/g, "\n");
+}
+
+function sha256Utf8(content: string): string {
+	return createHash("sha256").update(content, "utf8").digest("hex");
+}
+
+export function readBundledAdapterSource(slug: BundledAdapterSlug): string {
+	const file = BUNDLED_ADAPTER_FILES[slug];
+	return normalizeAdapterSource(readFileSync(file, "utf-8"));
+}
+
+export function bundledAdapterPin(slug: BundledAdapterSlug): string {
+	return BUNDLED_ADAPTER_PINS[slug];
+}
+
+export function assertBundledAdapterPin(
+	slug: BundledAdapterSlug,
+	content: string,
+): void {
+	const expected = bundledAdapterPin(slug);
+	const actual = sha256Utf8(normalizeAdapterSource(content));
+	if (actual !== expected) {
+		throw new Error(
+			`Bundled adapter hash mismatch for ${slug}: expected ${expected}, got ${actual}`,
+		);
+	}
+}
+
+export function bundledSlugFromSource(source: string): BundledAdapterSlug | null {
+	if (source.startsWith("bundled:")) {
+		const slug = source.slice("bundled:".length);
+		return isBundledAdapterSlug(slug) ? slug : null;
+	}
+	for (const slug of BUNDLED_ADAPTER_SLUGS) {
+		if (source === `infragate/capa@${slug}`) return slug;
+	}
+	return null;
+}
+
+/**
+ * First-party seeds install from compiled adapter bytes, never from GitHub.
+ * Legacy rows stored as `github` + `infragate/capa@<slug>` are still treated
+ * as bundled so `capa registry refresh` cannot pull a mutated remote tree.
+ */
+export function isBundledRegistryInstall(input: {
+	slug: string;
+	type: string;
+	source: string;
+}): input is { slug: BundledAdapterSlug; type: string; source: string } {
+	const fromSource = bundledSlugFromSource(input.source);
+	return fromSource !== null && fromSource === input.slug;
+}

--- a/src/shared/registries/installer.ts
+++ b/src/shared/registries/installer.ts
@@ -20,6 +20,14 @@ import { assertSafeRepoPath } from "../repo-file";
 import { parseRepoString } from "../repo-string";
 import { assertPublicHttpsUrl } from "../safe-remote-url";
 import {
+	assertBundledAdapterPin,
+	bundledAdapterPin,
+	bundledSlugFromSource,
+	isBundledRegistryInstall,
+	readBundledAdapterSource,
+	type BundledAdapterSlug,
+} from "./bundled";
+import {
 	fetchClaudeMarketplace,
 	getInstalledMarketplacePath,
 	loadClaudeMarketplaceAdapter,
@@ -143,6 +151,10 @@ export async function stageRegistry(
 		}
 		mkdirSync(targetDir, { recursive: true });
 
+		if (isBundledRegistryInstall(input)) {
+			return stageBundledAdapter(input.slug, targetDir);
+		}
+
 		if (input.type === "claude-marketplace") {
 			return await stageClaudeMarketplace(input, authFetch, targetDir, opts);
 		}
@@ -251,6 +263,23 @@ export async function installRegistry(
 	};
 }
 
+function stageBundledAdapter(
+	slug: BundledAdapterSlug,
+	targetDir: string,
+): RegistryStageResult {
+	const content = readBundledAdapterSource(slug);
+	assertBundledAdapterPin(slug, content);
+	const pin = bundledAdapterPin(slug);
+	const adapterPath = join(targetDir, "adapter.ts");
+	writeFileSync(adapterPath, content, "utf-8");
+	return {
+		resolvedRef: `bundled:${pin.slice(0, 16)}`,
+		adapterPath,
+		contentSha256: pin,
+		content,
+	};
+}
+
 async function stageClaudeMarketplace(
 	input: RegistryInstallInput,
 	authFetch: AuthenticatedFetch,
@@ -286,6 +315,15 @@ export async function fetchAdapterSource(
 	preferredSlug?: string;
 	pluginCount?: number;
 }> {
+	const bundledSlug = bundledSlugFromSource(input.source);
+	if (bundledSlug) {
+		const content = readBundledAdapterSource(bundledSlug);
+		assertBundledAdapterPin(bundledSlug, content);
+		return {
+			content,
+			resolvedRef: `bundled:${bundledAdapterPin(bundledSlug).slice(0, 16)}`,
+		};
+	}
 	if (input.type === "claude-marketplace") {
 		const result = await fetchClaudeMarketplace(input.source, authFetch, opts);
 		return {

--- a/src/shared/registries/installer.ts
+++ b/src/shared/registries/installer.ts
@@ -10,6 +10,7 @@ import {
 	writeFileSync,
 } from "fs";
 import { basename, join } from "path";
+import { pathToFileURL } from "url";
 import type { RegistrySourceType } from "../../types/database";
 import type { RegistryAdapter, RegistryManifest } from "../../types/registry";
 import type { AuthenticatedFetch } from "../authenticated-fetch";
@@ -581,7 +582,7 @@ async function snapshotForRegistry(
 
 async function loadAdapterFile(filePath: string): Promise<RegistryAdapter> {
 	const mtime = statSync(filePath).mtimeMs;
-	const moduleUrl = `file://${filePath.replace(/\\/g, "/")}?t=${mtime}`;
+	const moduleUrl = `${pathToFileURL(filePath).href}?t=${mtime}`;
 	let module;
 	try {
 		module = await import(moduleUrl);

--- a/src/shared/registries/installer.ts
+++ b/src/shared/registries/installer.ts
@@ -1,3 +1,4 @@
+import { createHash } from "crypto";
 import {
 	copyFileSync,
 	existsSync,
@@ -17,14 +18,18 @@ import { getManagedRegistriesDir } from "../config";
 import { getGitProvider } from "../git-providers/registry";
 import { assertSafeRepoPath } from "../repo-file";
 import { parseRepoString } from "../repo-string";
+import { assertPublicHttpsUrl } from "../safe-remote-url";
 import {
-	createClaudeMarketplaceAdapter,
 	fetchClaudeMarketplace,
+	getInstalledMarketplacePath,
+	loadClaudeMarketplaceAdapter,
 	MARKETPLACE_JSON_FILENAME,
 	MARKETPLACE_META_FILENAME,
 	parseClaudeMarketplaceSource,
 	marketplaceNameToSlug,
 } from "./claude-marketplace";
+
+export { getInstalledMarketplacePath };
 
 const ADAPTER_EXTENSIONS = [".ts", ".js", ".mjs"] as const;
 const ADAPTER_BASENAMES = ADAPTER_EXTENSIONS.map((ext) => `adapter${ext}`);
@@ -76,21 +81,53 @@ export interface RegistryInstallResult {
 	resolvedRef: string | null;
 	adapterPath: string;
 	manifest: RegistryManifest;
+	contentSha256: string;
 	/** Preferred slug from marketplace.json `name` (claude-marketplace only). */
 	preferredSlug?: string;
 }
 
+export interface RegistryStageResult {
+	resolvedRef: string | null;
+	adapterPath: string;
+	contentSha256: string;
+	content: string;
+	preferredSlug?: string;
+}
+
+export function hashAdapterContent(content: string): string {
+	return createHash("sha256").update(content, "utf8").digest("hex");
+}
+
+export function assertAdapterHash(filePath: string, expectedSha256: string): void {
+	const actual = hashAdapterContent(readFileSync(filePath, "utf-8"));
+	if (actual !== expectedSha256) {
+		throw new Error(
+			`Adapter hash mismatch for ${filePath}: expected ${expectedSha256}, got ${actual}`,
+		);
+	}
+}
+
+export function writeStagedAdapter(
+	slug: string,
+	content: string,
+	ext: string,
+): { adapterPath: string; contentSha256: string } {
+	if (!ext.startsWith(".")) ext = `.${ext}`;
+	const dir = join(getManagedRegistriesDir(), slug);
+	mkdirSync(dir, { recursive: true });
+	const adapterPath = join(dir, `adapter${ext}`);
+	writeFileSync(adapterPath, content, "utf-8");
+	return { adapterPath, contentSha256: hashAdapterContent(content) };
+}
+
 /**
- * Fetches the adapter (or Claude marketplace catalog) from the configured
- * source, materializes it under `<managed dir>/<slug>/`, and validates it.
- * Throws with a short, actionable message on any failure and cleans up the
- * partial managed dir.
+ * Fetch + write adapter bytes. Does not `import()` adapter TypeScript.
  */
-export async function installRegistry(
+export async function stageRegistry(
 	input: RegistryInstallInput,
 	authFetch: AuthenticatedFetch,
 	opts: { noCache?: boolean } = {},
-): Promise<RegistryInstallResult> {
+): Promise<RegistryStageResult> {
 	if (!isValidSlug(input.slug)) {
 		throw new Error(
 			`Invalid slug "${input.slug}". Allowed: lowercase letters, digits, and dashes; ` +
@@ -107,11 +144,12 @@ export async function installRegistry(
 		mkdirSync(targetDir, { recursive: true });
 
 		if (input.type === "claude-marketplace") {
-			return await installClaudeMarketplace(input, authFetch, targetDir, opts);
+			return await stageClaudeMarketplace(input, authFetch, targetDir, opts);
 		}
 
 		let adapterPath: string;
 		let resolvedRef: string | null = null;
+		let content: string;
 
 		if (input.type === "github" || input.type === "gitlab") {
 			const { adapterFile, resolvedSha } = await fetchAdapterFromRepo(
@@ -122,19 +160,22 @@ export async function installRegistry(
 			);
 			const ext = adapterFile.slice(adapterFile.lastIndexOf("."));
 			adapterPath = join(targetDir, `adapter${ext}`);
-			copyFileSync(adapterFile, adapterPath);
+			content = readFileSync(adapterFile, "utf-8");
+			writeFileSync(adapterPath, content, "utf-8");
 			resolvedRef = resolvedSha;
 		} else {
-			const { content, ext } = await fetchAdapterFromUrl(
-				input.source,
-				authFetch,
-			);
-			adapterPath = join(targetDir, `adapter${ext}`);
+			const fetched = await fetchAdapterFromUrl(input.source, authFetch);
+			content = fetched.content;
+			adapterPath = join(targetDir, `adapter${fetched.ext}`);
 			writeFileSync(adapterPath, content, "utf-8");
 		}
 
-		const adapter = await loadAdapterFile(adapterPath);
-		return { resolvedRef, adapterPath, manifest: adapter.manifest };
+		return {
+			resolvedRef,
+			adapterPath,
+			contentSha256: hashAdapterContent(content),
+			content,
+		};
 	} catch (err) {
 		try {
 			rmSync(targetDir, { recursive: true, force: true });
@@ -143,28 +184,90 @@ export async function installRegistry(
 	}
 }
 
-async function installClaudeMarketplace(
+/**
+ * `import()` a previously staged adapter (or build a Claude marketplace adapter
+ * from cached JSON). Verifies `expectedSha256` when provided.
+ */
+export async function executeStagedRegistry(
+	slug: string,
+	expectedSha256?: string | null,
+): Promise<RegistryInstallResult> {
+	const marketplacePath = getInstalledMarketplacePath(slug);
+	if (marketplacePath) {
+		if (expectedSha256) {
+			assertAdapterHash(marketplacePath, expectedSha256);
+		}
+		const adapter = loadClaudeMarketplaceAdapter(slug);
+		if (!isValidAdapter(adapter)) {
+			throw new Error(
+				`Adapter at ${marketplacePath} does not export a valid RegistryAdapter ` +
+					`(needs default export with { manifest, search, view }).`,
+			);
+		}
+		return {
+			resolvedRef: null,
+			adapterPath: marketplacePath,
+			manifest: adapter.manifest,
+			contentSha256:
+				expectedSha256 ??
+				hashAdapterContent(readFileSync(marketplacePath, "utf-8")),
+		};
+	}
+
+	const adapterPath = getInstalledAdapterPath(slug);
+	if (!adapterPath) {
+		throw new Error(
+			`No materialized adapter file for slug "${slug}"; run \`capa registry refresh ${slug}\`.`,
+		);
+	}
+	if (expectedSha256) {
+		assertAdapterHash(adapterPath, expectedSha256);
+	}
+	const adapter = await loadAdapterFile(adapterPath);
+	return {
+		resolvedRef: null,
+		adapterPath,
+		manifest: adapter.manifest,
+		contentSha256:
+			expectedSha256 ?? hashAdapterContent(readFileSync(adapterPath, "utf-8")),
+	};
+}
+
+/**
+ * Stage then execute. Used by CLI `--yes` and first-start seed.
+ */
+export async function installRegistry(
+	input: RegistryInstallInput,
+	authFetch: AuthenticatedFetch,
+	opts: { noCache?: boolean } = {},
+): Promise<RegistryInstallResult> {
+	const staged = await stageRegistry(input, authFetch, opts);
+	const executed = await executeStagedRegistry(input.slug, staged.contentSha256);
+	return {
+		...executed,
+		resolvedRef: staged.resolvedRef,
+		preferredSlug: staged.preferredSlug,
+		contentSha256: staged.contentSha256,
+	};
+}
+
+async function stageClaudeMarketplace(
 	input: RegistryInstallInput,
 	authFetch: AuthenticatedFetch,
 	targetDir: string,
 	opts: { noCache?: boolean },
-): Promise<RegistryInstallResult> {
+): Promise<RegistryStageResult> {
 	const result = await fetchClaudeMarketplace(input.source, authFetch, opts);
 	const jsonPath = join(targetDir, MARKETPLACE_JSON_FILENAME);
 	const metaPath = join(targetDir, MARKETPLACE_META_FILENAME);
-	writeFileSync(jsonPath, JSON.stringify(result.catalog.raw, null, 2), "utf-8");
+	const content = JSON.stringify(result.catalog.raw, null, 2);
+	writeFileSync(jsonPath, content, "utf-8");
 	writeFileSync(metaPath, JSON.stringify(result.meta, null, 2), "utf-8");
-
-	const adapter = createClaudeMarketplaceAdapter({
-		slug: input.slug,
-		catalog: result.catalog,
-		origin: result.origin,
-	});
-
 	return {
 		resolvedRef: result.resolvedRef,
 		adapterPath: jsonPath,
-		manifest: adapter.manifest,
+		contentSha256: hashAdapterContent(content),
+		content,
 		preferredSlug: result.preferredSlug,
 	};
 }
@@ -355,13 +458,6 @@ async function fetchAdapterFromUrl(
 	} catch {
 		throw new Error(`Invalid URL "${url}".`);
 	}
-	const isLocalhost = u.hostname === "localhost" || u.hostname === "127.0.0.1";
-	if (u.protocol !== "https:" && !isLocalhost) {
-		throw new Error(
-			`URL must use HTTPS (got ${u.protocol}//${u.hostname}). Insecure adapter sources are not allowed.`,
-		);
-	}
-
 	const base = basename(u.pathname);
 	const dot = base.lastIndexOf(".");
 	const ext = dot > 0 ? base.slice(dot) : "";
@@ -370,6 +466,8 @@ async function fetchAdapterFromUrl(
 			`URL must point to an adapter file with .ts, .js, or .mjs extension; got "${base || url}".`,
 		);
 	}
+
+	await assertPublicHttpsUrl(url);
 
 	let response: Response;
 	try {

--- a/src/shared/registries/installer.ts
+++ b/src/shared/registries/installer.ts
@@ -591,7 +591,15 @@ async function loadAdapterFile(filePath: string): Promise<RegistryAdapter> {
 			`Adapter at ${filePath} failed to import: ${err?.message ?? err}`,
 		);
 	}
-	const adapter: unknown = module.default ?? module;
+	let adapter: unknown = module.default ?? module;
+	if (
+		!isValidAdapter(adapter) &&
+		adapter &&
+		typeof adapter === "object" &&
+		"default" in adapter
+	) {
+		adapter = (adapter as { default: unknown }).default;
+	}
 	if (!isValidAdapter(adapter)) {
 		throw new Error(
 			`Adapter at ${filePath} does not export a valid RegistryAdapter ` +

--- a/src/shared/registries/loader.ts
+++ b/src/shared/registries/loader.ts
@@ -7,7 +7,7 @@ import {
 	getInstalledMarketplacePath,
 	loadClaudeMarketplaceAdapter,
 } from "./claude-marketplace";
-import { getInstalledAdapterPath } from "./installer";
+import { assertAdapterHash, getInstalledAdapterPath } from "./installer";
 
 interface LoadedRegistry {
 	adapter: RegistryAdapter;
@@ -120,6 +120,9 @@ export class RegistryLoader {
 			}
 
 			try {
+				if (record.contentSha256) {
+					assertAdapterHash(adapterPath, record.contentSha256);
+				}
 				const moduleUrl = `file://${adapterPath.replace(/\\/g, "/")}?t=${mtime}`;
 				const module = await import(moduleUrl);
 				const adapter: unknown = module.default ?? module;
@@ -174,6 +177,7 @@ export class RegistryLoader {
 		record: {
 			slug: string;
 			updatedAt: number;
+			contentSha256?: string | null;
 		},
 		adapters: Map<string, RegistryAdapter>,
 		failures: RegistryLoadFailure[],
@@ -230,6 +234,9 @@ export class RegistryLoader {
 		}
 
 		try {
+			if (record.contentSha256) {
+				assertAdapterHash(jsonPath, record.contentSha256);
+			}
 			const adapter = loadClaudeMarketplaceAdapter(record.slug, {
 				db: this.db,
 			});

--- a/src/shared/registries/seed.ts
+++ b/src/shared/registries/seed.ts
@@ -105,6 +105,7 @@ export async function seedDefaultRegistries(
 				lastError: null,
 				resolvedRef: result.resolvedRef,
 				installedAt: Date.now(),
+				contentSha256: result.contentSha256,
 			});
 			installed.push(seed.slug);
 			log.success?.(`Seeded default registry "${seed.slug}"`);

--- a/src/shared/registries/seed.ts
+++ b/src/shared/registries/seed.ts
@@ -2,6 +2,11 @@ import type { CapaDatabase } from "../../db/database";
 import type { RegistrySourceType } from "../../types/database";
 import type { AuthenticatedFetch } from "../authenticated-fetch";
 import { createAuthenticatedFetch } from "../authenticated-fetch";
+import {
+	BUNDLED_ADAPTER_PINS,
+	bundledSource,
+	type BundledAdapterSlug,
+} from "./bundled";
 import { installRegistry } from "./installer";
 import type { RegistryManager } from "./manager";
 
@@ -11,24 +16,26 @@ export interface DefaultRegistrySeed {
 	slug: string;
 	type: RegistrySourceType;
 	source: string;
+	/** Compiled SHA-256 of the vendored adapter bytes (required for bundled defaults). */
+	contentSha256?: string;
 }
 
-// The example adapters that ship in this repo under `registries/<name>/`.
-// Each is published as a subdirectory of `infragate/capa`, so we can point
-// at them with the same repo-string form a user would type:
-//   capa registry add infragate/capa@<name>
+function bundledSeed(slug: BundledAdapterSlug): DefaultRegistrySeed {
+	return {
+		slug,
+		type: "url",
+		source: bundledSource(slug),
+		contentSha256: BUNDLED_ADAPTER_PINS[slug],
+	};
+}
+
+// First-party adapters ship in this package under `registries/<name>/adapter.ts`.
+// First start copies those bytes into the managed dir and records the compiled
+// content hash. GitHub is never consulted.
 export const DEFAULT_REGISTRIES: DefaultRegistrySeed[] = [
-	{ slug: "skills-sh", type: "github", source: "infragate/capa@skills-sh" },
-	{
-		slug: "claude-plugins",
-		type: "github",
-		source: "infragate/capa@claude-plugins",
-	},
-	{
-		slug: "cursor-marketplace",
-		type: "github",
-		source: "infragate/capa@cursor-marketplace",
-	},
+	bundledSeed("skills-sh"),
+	bundledSeed("claude-plugins"),
+	bundledSeed("cursor-marketplace"),
 ];
 
 export interface SeedLogger {

--- a/src/shared/repo-file.ts
+++ b/src/shared/repo-file.ts
@@ -22,6 +22,10 @@ import { join, posix, relative, resolve, sep, win32 } from "path";
 import type { AuthenticatedFetch } from "./authenticated-fetch";
 import type { CachePlatform, GetSnapshotResult } from "./cache";
 import { type ParsedRepo, parseRepoString } from "./repo-string";
+import {
+	fetchPublicHttpsText,
+	RemoteUrlPolicyError,
+} from "./safe-remote-url";
 
 /**
  * Reject repo-relative paths that would escape the snapshot directory when
@@ -347,19 +351,22 @@ export async function fetchTextFile(
 	options: FetchTextFileOptions = {},
 ): Promise<string> {
 	const { authFetch, sourceLabel } = options;
-	const response = authFetch ? await authFetch.fetch(url) : await fetch(url);
+	const fetchImpl = authFetch
+		? (u: string, init?: RequestInit) => authFetch.fetch(u, init)
+		: fetch;
 
-	if (!response.ok) {
+	let body: string;
+	try {
+		body = await fetchPublicHttpsText(url, fetchImpl);
+	} catch (err) {
+		if (err instanceof RemoteUrlPolicyError) throw err;
+		const detail = err instanceof Error ? err.message : String(err);
 		throw new Error(
-			`Failed to fetch ${sourceLabel ? `${sourceLabel} from ` : ""}${url}: ` +
-				`${response.status} ${response.statusText}`,
+			`Failed to fetch ${sourceLabel ? `${sourceLabel} from ` : ""}${url}: ${detail}`,
 		);
 	}
 
-	const contentType = response.headers.get("content-type");
-	const body = await response.text();
-
-	if (looksLikeHtmlPage(body, contentType)) {
+	if (looksLikeHtmlPage(body, null)) {
 		// Trailing space inside `where` so the message reads
 		// `Refusing to install HTML response for <label> from <url>` (or, when
 		// no label is provided, `Refusing to install HTML response from <url>`)

--- a/src/shared/safe-remote-url.ts
+++ b/src/shared/safe-remote-url.ts
@@ -67,26 +67,46 @@ function isBlockedIpv6(ip: string): boolean {
 	return false;
 }
 
+export class RemoteUrlPolicyError extends Error {
+	constructor(message: string) {
+		super(message);
+		this.name = "RemoteUrlPolicyError";
+	}
+}
+
+/**
+ * Synchronous public-https checks: scheme, credentials, and blocked
+ * host / IP literals. Does not perform DNS (safe to use in validators).
+ */
+export function assertPublicHttpsUrlShape(urlString: string): URL {
+	let u: URL;
+	try {
+		u = new URL(urlString);
+	} catch {
+		throw new RemoteUrlPolicyError(`Invalid URL: ${urlString}`);
+	}
+	if (u.protocol !== "https:") {
+		throw new RemoteUrlPolicyError(
+			`Only https URLs are allowed (got ${u.protocol})`,
+		);
+	}
+	if (u.username || u.password) {
+		throw new RemoteUrlPolicyError(
+			"URLs with embedded credentials are not allowed",
+		);
+	}
+	if (isBlockedHostnameOrIp(u.hostname)) {
+		throw new RemoteUrlPolicyError(`URL host is not allowed: ${u.hostname}`);
+	}
+	return u;
+}
+
 /**
  * Parse `urlString` and ensure it is a public https URL (no credentials).
  * Resolves DNS and rejects private/reserved addresses.
  */
 export async function assertPublicHttpsUrl(urlString: string): Promise<URL> {
-	let u: URL;
-	try {
-		u = new URL(urlString);
-	} catch {
-		throw new Error(`Invalid URL: ${urlString}`);
-	}
-	if (u.protocol !== "https:") {
-		throw new Error(`Only https URLs are allowed (got ${u.protocol})`);
-	}
-	if (u.username || u.password) {
-		throw new Error("URLs with embedded credentials are not allowed");
-	}
-	if (isBlockedHostnameOrIp(u.hostname)) {
-		throw new Error(`URL host is not allowed: ${u.hostname}`);
-	}
+	const u = assertPublicHttpsUrlShape(urlString);
 
 	// Literal public IPs need no further DNS check.
 	if (isIP(u.hostname)) {
@@ -97,7 +117,7 @@ export async function assertPublicHttpsUrl(urlString: string): Promise<URL> {
 		const records = await lookup(u.hostname, { all: true });
 		for (const rec of records) {
 			if (isBlockedHostnameOrIp(rec.address)) {
-				throw new Error(
+				throw new RemoteUrlPolicyError(
 					`URL host resolves to a private address (${rec.address})`,
 				);
 			}
@@ -110,7 +130,7 @@ export async function assertPublicHttpsUrl(urlString: string): Promise<URL> {
 			throw err;
 		}
 		// DNS failure — treat as unsafe rather than fetching blindly
-		throw new Error(
+		throw new RemoteUrlPolicyError(
 			`Could not resolve host "${u.hostname}": ${err instanceof Error ? err.message : String(err)}`,
 		);
 	}

--- a/src/shared/secret-crypto.ts
+++ b/src/shared/secret-crypto.ts
@@ -90,8 +90,8 @@ export function canonicalizeStoredSecret(value: string): string {
 	}
 }
 
-export function decryptSecret(value: string | null): string | null {
-	if (value === null) return null;
+export function decryptSecret(value: string | null | undefined): string | null {
+	if (value == null) return null;
 	if (!value.startsWith(SECRET_CIPHER_PREFIX)) return value;
 	try {
 		return decryptCiphertext(value);
@@ -100,8 +100,9 @@ export function decryptSecret(value: string | null): string | null {
 	}
 }
 
-export function decryptSecretString(value: string): string {
-	return decryptSecret(value) as string;
+export function decryptSecretString(value: string | null | undefined): string {
+	const decrypted = decryptSecret(value);
+	return decrypted ?? "";
 }
 
 export function secretHint(value: string | undefined): string {

--- a/src/shared/secret-crypto.ts
+++ b/src/shared/secret-crypto.ts
@@ -63,20 +63,8 @@ export function decryptSecret(value: string): string {
 }
 
 export const decryptSecretString = decryptSecret;
+
 export function secretHint(value: string | undefined): string {
-	if (!value) return "";
-	return value.length > 4 ? value.slice(-4) : "";
-}
-
-export function secretHint(value: string): string {
-	if (value.length <= 4) return "";
+	if (!value || value.length <= 4) return "";
 	return value.slice(-4);
-}
-
-export function encryptSecretIfNeeded(
-	value: string | null | undefined,
-): string | null {
-	if (value == null) return null;
-	if (value.startsWith(PREFIX)) return value;
-	return encryptSecret(value);
 }

--- a/src/shared/secret-crypto.ts
+++ b/src/shared/secret-crypto.ts
@@ -1,0 +1,82 @@
+import { createCipheriv, createDecipheriv, randomBytes } from "crypto";
+import { chmodSync, existsSync, mkdirSync, readFileSync, writeFileSync } from "fs";
+import { join } from "path";
+import { getCapaDir } from "./config";
+
+const PREFIX = "enc:v1:";
+let cachedKey: Buffer | null = null;
+
+export function resetSecretCryptoForTests(): void {
+	cachedKey = null;
+}
+
+function masterKeyPath(): string {
+	return join(getCapaDir(), "master.key");
+}
+
+function loadMasterKey(): Buffer {
+	if (cachedKey && cachedKey.length === 32) return cachedKey;
+	const dir = getCapaDir();
+	mkdirSync(dir, { recursive: true });
+	try {
+		chmodSync(dir, 0o700);
+	} catch {
+		// win32
+	}
+	const path = masterKeyPath();
+	if (existsSync(path)) {
+		cachedKey = readFileSync(path);
+		return cachedKey;
+	}
+	const key = randomBytes(32);
+	writeFileSync(path, key, { mode: 0o600 });
+	try {
+		chmodSync(path, 0o600);
+	} catch {
+		// win32
+	}
+	cachedKey = key;
+	return key;
+}
+
+export function encryptSecret(plain: string): string {
+	const key = loadMasterKey();
+	const iv = randomBytes(12);
+	const cipher = createCipheriv("aes-256-gcm", key, iv);
+	const encrypted = Buffer.concat([cipher.update(plain, "utf8"), cipher.final()]);
+	const tag = cipher.getAuthTag();
+	return PREFIX + Buffer.concat([iv, tag, encrypted]).toString("base64");
+}
+
+export function decryptSecret(value: string): string {
+	if (!value.startsWith(PREFIX)) return value;
+	const key = loadMasterKey();
+	const buf = Buffer.from(value.slice(PREFIX.length), "base64");
+	const iv = buf.subarray(0, 12);
+	const tag = buf.subarray(12, 28);
+	const data = buf.subarray(28);
+	const decipher = createDecipheriv("aes-256-gcm", key, iv);
+	decipher.setAuthTag(tag);
+	return Buffer.concat([decipher.update(data), decipher.final()]).toString(
+		"utf8",
+	);
+}
+
+export const decryptSecretString = decryptSecret;
+export function secretHint(value: string | undefined): string {
+	if (!value) return "";
+	return value.length > 4 ? value.slice(-4) : "";
+}
+
+export function secretHint(value: string): string {
+	if (value.length <= 4) return "";
+	return value.slice(-4);
+}
+
+export function encryptSecretIfNeeded(
+	value: string | null | undefined,
+): string | null {
+	if (value == null) return null;
+	if (value.startsWith(PREFIX)) return value;
+	return encryptSecret(value);
+}

--- a/src/shared/secret-crypto.ts
+++ b/src/shared/secret-crypto.ts
@@ -1,9 +1,9 @@
 import { createCipheriv, createDecipheriv, randomBytes } from "crypto";
-import { chmodSync, existsSync, mkdirSync, readFileSync, writeFileSync } from "fs";
+import { chmodSync, mkdirSync, readFileSync, writeFileSync } from "fs";
 import { join } from "path";
 import { getCapaDir } from "./config";
 
-const PREFIX = "enc:v1:";
+export const SECRET_CIPHER_PREFIX = "enc:v1:";
 let cachedKey: Buffer | null = null;
 
 export function resetSecretCryptoForTests(): void {
@@ -14,29 +14,43 @@ function masterKeyPath(): string {
 	return join(getCapaDir(), "master.key");
 }
 
+function errCode(err: unknown): string | undefined {
+	if (typeof err === "object" && err !== null && "code" in err) {
+		return (err as { code?: string }).code;
+	}
+	return undefined;
+}
+
 function loadMasterKey(): Buffer {
 	if (cachedKey && cachedKey.length === 32) return cachedKey;
 	const dir = getCapaDir();
 	mkdirSync(dir, { recursive: true });
-	try {
+	if (process.platform !== "win32") {
 		chmodSync(dir, 0o700);
-	} catch {
-		// win32
 	}
 	const path = masterKeyPath();
-	if (existsSync(path)) {
+	try {
+		cachedKey = readFileSync(path);
+		return cachedKey;
+	} catch (err) {
+		if (errCode(err) !== "ENOENT") throw err;
+	}
+	const key = randomBytes(32);
+	try {
+		writeFileSync(path, key, {
+			mode: 0o600,
+			flag: process.platform === "win32" ? "w" : "wx",
+		});
+		if (process.platform !== "win32") {
+			chmodSync(path, 0o600);
+		}
+		cachedKey = key;
+		return key;
+	} catch (err) {
+		if (errCode(err) !== "EEXIST") throw err;
 		cachedKey = readFileSync(path);
 		return cachedKey;
 	}
-	const key = randomBytes(32);
-	writeFileSync(path, key, { mode: 0o600 });
-	try {
-		chmodSync(path, 0o600);
-	} catch {
-		// win32
-	}
-	cachedKey = key;
-	return key;
 }
 
 export function encryptSecret(plain: string): string {
@@ -45,24 +59,50 @@ export function encryptSecret(plain: string): string {
 	const cipher = createCipheriv("aes-256-gcm", key, iv);
 	const encrypted = Buffer.concat([cipher.update(plain, "utf8"), cipher.final()]);
 	const tag = cipher.getAuthTag();
-	return PREFIX + Buffer.concat([iv, tag, encrypted]).toString("base64");
+	return (
+		SECRET_CIPHER_PREFIX + Buffer.concat([iv, tag, encrypted]).toString("base64")
+	);
 }
 
-export function decryptSecret(value: string): string {
-	if (!value.startsWith(PREFIX)) return value;
+function decryptCiphertext(value: string): string {
 	const key = loadMasterKey();
-	const buf = Buffer.from(value.slice(PREFIX.length), "base64");
+	const buf = Buffer.from(value.slice(SECRET_CIPHER_PREFIX.length), "base64");
 	const iv = buf.subarray(0, 12);
 	const tag = buf.subarray(12, 28);
 	const data = buf.subarray(28);
-	const decipher = createDecipheriv("aes-256-gcm", key, iv);
+	const decipher = createDecipheriv("aes-256-gcm", key, iv, {
+		authTagLength: 16,
+	});
 	decipher.setAuthTag(tag);
 	return Buffer.concat([decipher.update(data), decipher.final()]).toString(
 		"utf8",
 	);
 }
 
-export const decryptSecretString = decryptSecret;
+/** Canonical on-disk form: ciphertext, or encrypt legacy / colliding plaintext. */
+export function canonicalizeStoredSecret(value: string): string {
+	if (!value.startsWith(SECRET_CIPHER_PREFIX)) return encryptSecret(value);
+	try {
+		decryptCiphertext(value);
+		return value;
+	} catch {
+		return encryptSecret(value);
+	}
+}
+
+export function decryptSecret(value: string | null): string | null {
+	if (value === null) return null;
+	if (!value.startsWith(SECRET_CIPHER_PREFIX)) return value;
+	try {
+		return decryptCiphertext(value);
+	} catch {
+		return value;
+	}
+}
+
+export function decryptSecretString(value: string): string {
+	return decryptSecret(value) as string;
+}
 
 export function secretHint(value: string | undefined): string {
 	if (!value || value.length <= 4) return "";

--- a/src/shared/stdio-allowlist.ts
+++ b/src/shared/stdio-allowlist.ts
@@ -1,0 +1,77 @@
+import { chmodSync, mkdirSync, readFileSync, writeFileSync } from "fs";
+import { join } from "path";
+import type { MCPServer, MCPServerDefinition } from "../types/capabilities";
+import { getCapaDir } from "./config";
+
+function sortedEnv(
+	env: Record<string, string> | undefined,
+): Record<string, string> | null {
+	if (!env) return null;
+	return Object.fromEntries(
+		Object.entries(env).sort(([a], [b]) => a.localeCompare(b)),
+	);
+}
+
+/** Stable fingerprint of a stdio MCP launch (cmd/args/cwd/env). */
+export function stdioLaunchFingerprint(def: MCPServerDefinition): string {
+	return JSON.stringify({
+		cmd: def.cmd ?? null,
+		args: def.args ?? null,
+		cwd: def.cwd ?? null,
+		env: sortedEnv(def.env),
+	});
+}
+
+function allowlistFile(projectId: string): string {
+	return join(getCapaDir(), "stdio-allowlist", `${projectId}.json`);
+}
+
+function readFingerprints(projectId: string): Set<string> {
+	try {
+		const parsed = JSON.parse(readFileSync(allowlistFile(projectId), "utf8")) as {
+			fingerprints?: unknown;
+		};
+		return new Set(
+			Array.isArray(parsed.fingerprints)
+				? parsed.fingerprints.filter((v): v is string => typeof v === "string")
+				: [],
+		);
+	} catch {
+		return new Set();
+	}
+}
+
+/**
+ * HTTP MCP servers are not spawned locally. Stdio servers must be recorded by
+ * a local CLI install/configure before the server process will spawn them.
+ */
+export function isStdioTrusted(
+	projectId: string,
+	def: MCPServerDefinition,
+): boolean {
+	if (!def.cmd) return true;
+	return readFingerprints(projectId).has(stdioLaunchFingerprint(def));
+}
+
+export function trustStdioServers(
+	projectId: string,
+	servers: MCPServer[],
+): void {
+	const fingerprints = readFingerprints(projectId);
+	for (const server of servers) {
+		if (server.def?.cmd) {
+			fingerprints.add(stdioLaunchFingerprint(server.def));
+		}
+	}
+	const dir = join(getCapaDir(), "stdio-allowlist");
+	mkdirSync(dir, { recursive: true });
+	const path = allowlistFile(projectId);
+	writeFileSync(path, JSON.stringify({ fingerprints: [...fingerprints] }), {
+		mode: 0o600,
+	});
+	try {
+		chmodSync(path, 0o600);
+	} catch {
+		// best-effort on platforms that don't support chmod
+	}
+}

--- a/src/shared/tls-skip-verify.ts
+++ b/src/shared/tls-skip-verify.ts
@@ -15,6 +15,12 @@ export function shouldSkipTlsVerify(
 		return false;
 	}
 
+	// Managed-workstation policy: images can set this to refuse skip even when
+	// CAPA_ALLOW_TLS_SKIP_VERIFY=1 is present in the process environment.
+	if (process.env.CAPA_DISALLOW_TLS_SKIP_VERIFY === "1") {
+		return false;
+	}
+
 	const allowed = process.env.CAPA_ALLOW_TLS_SKIP_VERIFY === "1";
 
 	if (!allowed) {

--- a/src/shared/ui-urls.ts
+++ b/src/shared/ui-urls.ts
@@ -5,6 +5,15 @@
 export const CAPA_DOCS_URL = "https://capa.infragate.ai/getting-started/introduction/";
 export const CAPA_CLOUD_OAUTH_URL = "https://capa.infragate.ai/auth";
 
+/** Shown before browser OAuth. Cloud host is pinned; not request-controlled. */
+export function cloudOAuthDisclosure(): string {
+	return (
+		"Browser OAuth sends GitHub/GitLab access and refresh tokens through " +
+		`${CAPA_CLOUD_OAUTH_URL}. Prefer a short-lived PAT via ` +
+		"`capa auth <provider> --access-token` so tokens stay on this machine."
+	);
+}
+
 /** Relative path to a project's detail page (credentials, OAuth, variables). */
 export function projectUiPath(
 	projectId: string,

--- a/src/shared/workspaces/__tests__/paths.test.ts
+++ b/src/shared/workspaces/__tests__/paths.test.ts
@@ -29,4 +29,12 @@ describe('isUnderWrapWorkspacesDir', () => {
     );
     expect(isUnderWrapWorkspacesDir(join(flipped, 'shadow', 'proj'))).toBe(true);
   });
+
+  it('treats macOS /tmp and /private/tmp as the same location', () => {
+    if (process.platform !== 'darwin') return;
+    const root = getWorkspacesDir();
+    if (!root.startsWith('/tmp/')) return;
+    const privateRoot = root.replace(/^\/tmp\//, '/private/tmp/');
+    expect(isUnderWrapWorkspacesDir(join(privateRoot, 'shadow', 'proj'))).toBe(true);
+  });
 });

--- a/src/shared/workspaces/paths.ts
+++ b/src/shared/workspaces/paths.ts
@@ -1,5 +1,6 @@
-import { isAbsolute, join, relative, resolve } from "path";
+import { isAbsolute, join, relative } from "path";
 import { getCapaDir } from "../config";
+import { canonicalizePath } from "../paths";
 
 /** Marker filename written into every wrap shadow workspace. */
 export const WORKSPACE_MARKER = ".capa-workspace.json";
@@ -16,8 +17,8 @@ export function getWorkspacesDir(): string {
  * `startsWith`, so `C:\...` vs `c:\...` cannot bypass the guard.
  */
 export function isUnderWrapWorkspacesDir(dir: string): boolean {
-	const workspaces = resolve(getWorkspacesDir());
-	const abs = resolve(dir);
+	const workspaces = canonicalizePath(getWorkspacesDir());
+	const abs = canonicalizePath(dir);
 	const rel = relative(workspaces, abs);
 	return rel === "" || (!rel.startsWith("..") && !isAbsolute(rel));
 }

--- a/src/types/capabilities.ts
+++ b/src/types/capabilities.ts
@@ -98,9 +98,16 @@ export interface CapabilitiesOptions {
   security?: SecurityOptions;
   /**
    * CLI commands that must be available before `capa install` proceeds.
-   * Installation stops immediately if any command is missing.
+   * Missing commands warn by default; use `onInstallError: stop` to abort.
    */
   requiresCommands?: RequiredCommand[];
+  /**
+   * How install handles operational errors (missing CLI, skill/rule fetch
+   * failures, plugin resolution, tool validation, etc.).
+   * - `warn` (default): log warnings, install everything that succeeds
+   * - `stop`: abort the install run (legacy behavior)
+   */
+  onInstallError?: 'warn' | 'stop';
 }
 
 /**

--- a/src/types/capabilities.ts
+++ b/src/types/capabilities.ts
@@ -382,6 +382,12 @@ export interface CommandSpec {
   args?: ArgumentDefinition[];
   dir?: string;
   env?: Record<string, string>;
+  /**
+   * Allow `{placeholders}` inside a template whose argv0 is a shell
+   * (`sh`, `bash`, `cmd.exe`, …). Off by default because caller values
+   * would then be re-parsed by that shell.
+   */
+  allowShellPlaceholders?: boolean;
 }
 
 export interface ArgumentDefinition {

--- a/src/types/database.ts
+++ b/src/types/database.ts
@@ -174,6 +174,7 @@ export interface RegistryRow {
   last_error: string | null;
   resolved_ref: string | null;
   installed_at: number | null;
+  content_sha256: string | null;
   created_at: number;
   updated_at: number;
 }
@@ -187,6 +188,7 @@ export interface RegistryRecord {
   lastError: string | null;
   resolvedRef: string | null;
   installedAt: number | null;
+  contentSha256: string | null;
   createdAt: number;
   updatedAt: number;
 }

--- a/src/version.ts
+++ b/src/version.ts
@@ -4,4 +4,4 @@
  * Version extracted from Git tag or package.json
  */
 
-export const VERSION = '2.0.3-dev.39+3aae63c-dirty';
+export const VERSION = '2.0.3-dev.40+627da2f-dirty';

--- a/src/version.ts
+++ b/src/version.ts
@@ -4,4 +4,4 @@
  * Version extracted from Git tag or package.json
  */
 
-export const VERSION = '2.0.3-dev.40+627da2f-dirty';
+export const VERSION = '2.0.3-dev.45+a5b19fd-dirty';

--- a/src/version.ts
+++ b/src/version.ts
@@ -4,4 +4,4 @@
  * Version extracted from Git tag or package.json
  */
 
-export const VERSION = '1.0.0';
+export const VERSION = '2.0.3-dev.39+3aae63c-dirty';

--- a/web-ui/src/features/integrations/components/GitHubEnterpriseCard.tsx
+++ b/web-ui/src/features/integrations/components/GitHubEnterpriseCard.tsx
@@ -16,6 +16,7 @@ interface GitHubEnterpriseCardProps {
 export function GitHubEnterpriseCard({ integration, onMessage, onDisconnect, onRefresh }: GitHubEnterpriseCardProps) {
   const { t } = useTranslation('integrations');
   const connected = integration?.isConnected ?? false;
+  const staleHost = !connected && integration?.host ? integration.host : '';
   const [host, setHost] = useState('');
   const [token, setToken] = useState('');
   const [showToken, setShowToken] = useState(false);
@@ -65,6 +66,22 @@ export function GitHubEnterpriseCard({ integration, onMessage, onDisconnect, onR
         </button>
       ) : (
         <div className="space-y-4 border-t border-border-tertiary pt-4">
+          {staleHost && (
+            <div className="flex items-center justify-between gap-2 rounded-sm border border-border-tertiary bg-bg-secondary px-3 py-2 text-xs text-text-secondary">
+              <span>Saved credentials for {staleHost} are no longer valid.</span>
+              <button
+                type="button"
+                onClick={() => {
+                  if (confirm(t('githubEnterprise.confirmDisconnect'))) {
+                    onDisconnect('github-enterprise', staleHost);
+                  }
+                }}
+                className="shrink-0 text-error-text hover:underline cursor-pointer"
+              >
+                Remove
+              </button>
+            </div>
+          )}
           <div>
             <label className="mb-2 block text-[13px] font-medium text-text-primary">
               {t('githubEnterprise.hostLabel')}

--- a/web-ui/src/features/integrations/components/GitLabSelfManagedCard.tsx
+++ b/web-ui/src/features/integrations/components/GitLabSelfManagedCard.tsx
@@ -16,6 +16,7 @@ interface GitLabSelfManagedCardProps {
 export function GitLabSelfManagedCard({ integration, onMessage, onDisconnect, onRefresh }: GitLabSelfManagedCardProps) {
   const { t } = useTranslation('integrations');
   const connected = integration?.isConnected ?? false;
+  const staleHost = !connected && integration?.host ? integration.host : '';
   const [host, setHost] = useState('');
   const [token, setToken] = useState('');
   const [showToken, setShowToken] = useState(false);
@@ -65,6 +66,22 @@ export function GitLabSelfManagedCard({ integration, onMessage, onDisconnect, on
         </button>
       ) : (
         <div className="space-y-4 border-t border-border-tertiary pt-4">
+          {staleHost && (
+            <div className="flex items-center justify-between gap-2 rounded-sm border border-border-tertiary bg-bg-secondary px-3 py-2 text-xs text-text-secondary">
+              <span>Saved credentials for {staleHost} are no longer valid.</span>
+              <button
+                type="button"
+                onClick={() => {
+                  if (confirm(t('gitlabSelfManaged.confirmDisconnect'))) {
+                    onDisconnect('gitlab-self-managed', staleHost);
+                  }
+                }}
+                className="shrink-0 text-error-text hover:underline cursor-pointer"
+              >
+                Remove
+              </button>
+            </div>
+          )}
           <div>
             <label className="mb-2 block text-[13px] font-medium text-text-primary">
               {t('gitlabSelfManaged.hostLabel')}

--- a/web-ui/src/features/projects/__tests__/project-events.test.ts
+++ b/web-ui/src/features/projects/__tests__/project-events.test.ts
@@ -101,7 +101,7 @@ describe('subscribeProjectEvents', () => {
         status: 200,
         headers: { 'Content-Type': 'text/event-stream' },
       });
-    }) as typeof fetch;
+    }) as unknown as typeof fetch;
 
     const unsub = subscribeProjectEvents('proj-auth', {});
     await Bun.sleep(30);

--- a/web-ui/src/features/projects/__tests__/project-events.test.ts
+++ b/web-ui/src/features/projects/__tests__/project-events.test.ts
@@ -1,6 +1,7 @@
 import { afterEach, describe, expect, it } from 'bun:test';
 import {
   _resetProjectEventsForTests,
+  _setSseReconnectDelaysForTests,
   subscribeProjectEvents,
 } from '../project-events';
 
@@ -38,6 +39,9 @@ describe('subscribeProjectEvents', () => {
     _resetProjectEventsForTests();
     FakeEventSource.instances = [];
     globalThis.EventSource = OriginalEventSource;
+    _setSseReconnectDelaysForTests([250, 1000, 3000, 5000]);
+    const g = globalThis as { window?: { __CAPA_AUTH_TOKEN__?: string } };
+    if (g.window) delete g.window.__CAPA_AUTH_TOKEN__;
   });
 
   it('notifies late subscribers when the shared socket is already open', async () => {
@@ -80,5 +84,29 @@ describe('subscribeProjectEvents', () => {
     unsub();
     await Promise.resolve();
     expect(called).toBe(false);
+  });
+
+  it('retries authenticated SSE after a dropped fetch', async () => {
+    _setSseReconnectDelaysForTests([15, 15, 15]);
+    const g = globalThis as { window?: { __CAPA_AUTH_TOKEN__?: string } };
+    g.window = { ...(g.window ?? {}), __CAPA_AUTH_TOKEN__: 'tok' };
+    let fetches = 0;
+    const originalFetch = globalThis.fetch;
+    globalThis.fetch = (async () => {
+      fetches += 1;
+      if (fetches === 1) {
+        return new Response(null, { status: 500 });
+      }
+      return new Response('event: ping\ndata: ok\n\n', {
+        status: 200,
+        headers: { 'Content-Type': 'text/event-stream' },
+      });
+    }) as typeof fetch;
+
+    const unsub = subscribeProjectEvents('proj-auth', {});
+    await Bun.sleep(30);
+    unsub();
+    globalThis.fetch = originalFetch;
+    expect(fetches).toBeGreaterThanOrEqual(2);
   });
 });

--- a/web-ui/src/features/projects/api.ts
+++ b/web-ui/src/features/projects/api.ts
@@ -1,4 +1,4 @@
-import { api } from '../../lib/api';
+import { api, apiAuthHeaders } from '../../lib/api';
 import type {
   ProjectsResponse,
   ProjectDetail,
@@ -158,7 +158,7 @@ export const projectsApi = {
     if (opts?.subdir) form.append('subdir', opts.subdir);
     const res = await fetch(
       `/api/projects/${encodeURIComponent(projectId)}/fs`,
-      { method: 'POST', body: form },
+      { method: 'POST', body: form, headers: apiAuthHeaders() },
     );
     if (!res.ok) {
       const text = await res.text().catch(() => res.statusText);

--- a/web-ui/src/features/projects/components/ServerToolsPanel.tsx
+++ b/web-ui/src/features/projects/components/ServerToolsPanel.tsx
@@ -17,7 +17,9 @@ interface ServerToolsPanelProps {
 
 export function ServerToolsPanel({ projectId, serverId, search = '', prefetchedTools }: ServerToolsPanelProps) {
   const { t } = useTranslation('projects');
-  const { data: fetchedData, isLoading, error } = useServerTools(projectId, serverId);
+  const { data: fetchedData, isLoading, error } = useServerTools(projectId, serverId, {
+    enabled: !prefetchedTools,
+  });
 
   const tools = prefetchedTools ?? fetchedData ?? [];
 

--- a/web-ui/src/features/projects/components/VariablesForm.tsx
+++ b/web-ui/src/features/projects/components/VariablesForm.tsx
@@ -1,5 +1,5 @@
 import { useMemo, useState, useCallback, type FormEvent } from 'react';
-import { Eye, EyeOff, Plus, Trash2 } from 'lucide-react';
+import { Eye, EyeOff, Pencil, Plus, Trash2 } from 'lucide-react';
 import { useTranslation } from 'react-i18next';
 import { useVariables, useSaveVariables, usePutVariable, useDeleteVariable } from '../hooks';
 import { Spinner } from '../../../components/common/Spinner';
@@ -92,14 +92,10 @@ export function VariablesForm({ projectId, returnUrl }: VariablesFormProps) {
           {names.length === 0 ? (
             <p className="text-xs text-text-tertiary">{t('projects:variables.empty')}</p>
           ) : (
-            names.map((varName) => {
-              const secret = data?.secrets?.find((s) => s.name === varName);
-              return (
+            names.map((varName) => (
               <VariableField
                 key={varName}
                 name={varName}
-                isSet={!!secret?.isSet}
-                hint={secret?.hint || ''}
                 referenced={requiredSet.has(varName)}
                 onDelete={() => {
                   if (confirm(t('projects:variables.confirmDelete', { name: varName }))) {
@@ -108,8 +104,7 @@ export function VariablesForm({ projectId, returnUrl }: VariablesFormProps) {
                 }}
                 deleting={deleteMutation.isPending}
               />
-            );
-            })
+            ))
           )}
         </div>
 
@@ -156,28 +151,28 @@ export function VariablesForm({ projectId, returnUrl }: VariablesFormProps) {
 
 function VariableField({
   name,
-  isSet,
-  hint,
   referenced,
   onDelete,
   deleting,
 }: {
   name: string;
-  isSet: boolean;
-  hint: string;
   referenced: boolean;
   onDelete: () => void;
   deleting: boolean;
 }) {
   const { t } = useTranslation('projects');
+  const [editing, setEditing] = useState(false);
   const [show, setShow] = useState(false);
+
+  const stopEditing = useCallback(() => {
+    setEditing(false);
+    setShow(false);
+  }, []);
 
   return (
     <div>
-      <div className="mb-1.5 flex items-center gap-2">
-        <label htmlFor={`var-${name}`} className="font-mono text-xs font-medium text-text-primary">
-          {name}
-        </label>
+      <div className="flex items-center gap-2">
+        <span className="font-mono text-xs font-medium text-text-primary">{name}</span>
         <span
           className={`rounded-sm px-1.5 py-0.5 text-[10px] ${
             referenced
@@ -187,39 +182,56 @@ function VariableField({
         >
           {referenced ? t('variables.referenced') : t('variables.unused')}
         </span>
-        {isSet && (
-          <span className="rounded-sm bg-bg-tertiary px-1.5 py-0.5 text-[10px] text-text-tertiary">
-            {hint ? t('variables.endsWith', { hint }) : t('variables.set')}
-          </span>
-        )}
-        <button
-          type="button"
-          onClick={onDelete}
-          disabled={deleting}
-          title={t('variables.delete')}
-          className="ml-auto rounded-sm p-1 text-text-tertiary hover:bg-error-bg hover:text-error-text cursor-pointer"
-        >
-          <Trash2 size={14} />
-        </button>
+        <div className="ml-auto flex items-center gap-1">
+          {!editing && (
+            <button
+              type="button"
+              onClick={() => setEditing(true)}
+              title={t('actions.edit')}
+              className="rounded-sm p-1 text-text-tertiary hover:bg-hover-bg hover:text-text-primary cursor-pointer"
+            >
+              <Pencil size={14} />
+            </button>
+          )}
+          <button
+            type="button"
+            onClick={onDelete}
+            disabled={deleting}
+            title={t('variables.delete')}
+            className="rounded-sm p-1 text-text-tertiary hover:bg-error-bg hover:text-error-text cursor-pointer"
+          >
+            <Trash2 size={14} />
+          </button>
+        </div>
       </div>
-      <div className="relative">
-        <input
-          id={`var-${name}`}
-          name={name}
-          type={show ? 'text' : 'password'}
-          defaultValue=""
-          placeholder={isSet ? t('variables.replacePlaceholder') : ''}
-          autoComplete="off"
-          className="w-full rounded-sm border border-border-tertiary bg-bg-tertiary px-3 py-2 pr-10 font-mono text-sm text-text-primary"
-        />
-        <button
-          type="button"
-          onClick={() => setShow((v) => !v)}
-          className="absolute right-2 top-1/2 -translate-y-1/2 text-text-tertiary hover:text-text-primary cursor-pointer"
-        >
-          {show ? <EyeOff size={14} /> : <Eye size={14} />}
-        </button>
-      </div>
+      {editing && (
+        <div className="mt-2 flex items-center gap-2">
+          <div className="relative min-w-0 flex-1">
+            <input
+              id={`var-${name}`}
+              name={name}
+              type={show ? 'text' : 'password'}
+              autoComplete="off"
+              autoFocus
+              className="w-full rounded-sm border border-border-tertiary bg-bg-tertiary px-3 py-2 pr-10 font-mono text-sm text-text-primary"
+            />
+            <button
+              type="button"
+              onClick={() => setShow((v) => !v)}
+              className="absolute right-2 top-1/2 -translate-y-1/2 text-text-tertiary hover:text-text-primary cursor-pointer"
+            >
+              {show ? <EyeOff size={14} /> : <Eye size={14} />}
+            </button>
+          </div>
+          <button
+            type="button"
+            onClick={stopEditing}
+            className="shrink-0 rounded-sm border border-border-tertiary px-2.5 py-2 text-xs text-text-secondary cursor-pointer hover:bg-hover-bg"
+          >
+            {t('actions.cancel')}
+          </button>
+        </div>
+      )}
     </div>
   );
 }

--- a/web-ui/src/features/projects/components/VariablesForm.tsx
+++ b/web-ui/src/features/projects/components/VariablesForm.tsx
@@ -36,7 +36,9 @@ export function VariablesForm({ projectId, returnUrl }: VariablesFormProps) {
       const variables: Record<string, string> = {};
       for (const [key, value] of formData.entries()) {
         if (key.startsWith('__')) continue;
-        variables[key] = value as string;
+        const text = String(value);
+        if (text.length === 0) continue;
+        variables[key] = text;
       }
 
       try {
@@ -90,11 +92,14 @@ export function VariablesForm({ projectId, returnUrl }: VariablesFormProps) {
           {names.length === 0 ? (
             <p className="text-xs text-text-tertiary">{t('projects:variables.empty')}</p>
           ) : (
-            names.map((varName) => (
+            names.map((varName) => {
+              const secret = data?.secrets?.find((s) => s.name === varName);
+              return (
               <VariableField
                 key={varName}
                 name={varName}
-                defaultValue={data?.values?.[varName] || ''}
+                isSet={!!secret?.isSet}
+                hint={secret?.hint || ''}
                 referenced={requiredSet.has(varName)}
                 onDelete={() => {
                   if (confirm(t('projects:variables.confirmDelete', { name: varName }))) {
@@ -103,7 +108,8 @@ export function VariablesForm({ projectId, returnUrl }: VariablesFormProps) {
                 }}
                 deleting={deleteMutation.isPending}
               />
-            ))
+            );
+            })
           )}
         </div>
 
@@ -150,13 +156,15 @@ export function VariablesForm({ projectId, returnUrl }: VariablesFormProps) {
 
 function VariableField({
   name,
-  defaultValue,
+  isSet,
+  hint,
   referenced,
   onDelete,
   deleting,
 }: {
   name: string;
-  defaultValue: string;
+  isSet: boolean;
+  hint: string;
   referenced: boolean;
   onDelete: () => void;
   deleting: boolean;
@@ -179,6 +187,11 @@ function VariableField({
         >
           {referenced ? t('variables.referenced') : t('variables.unused')}
         </span>
+        {isSet && (
+          <span className="rounded-sm bg-bg-tertiary px-1.5 py-0.5 text-[10px] text-text-tertiary">
+            {hint ? t('variables.endsWith', { hint }) : t('variables.set')}
+          </span>
+        )}
         <button
           type="button"
           onClick={onDelete}
@@ -194,7 +207,8 @@ function VariableField({
           id={`var-${name}`}
           name={name}
           type={show ? 'text' : 'password'}
-          defaultValue={defaultValue}
+          defaultValue=""
+          placeholder={isSet ? t('variables.replacePlaceholder') : ''}
           autoComplete="off"
           className="w-full rounded-sm border border-border-tertiary bg-bg-tertiary px-3 py-2 pr-10 font-mono text-sm text-text-primary"
         />

--- a/web-ui/src/features/projects/components/tools/ServerDialog.tsx
+++ b/web-ui/src/features/projects/components/tools/ServerDialog.tsx
@@ -364,6 +364,11 @@ export function ServerDialog({
                                 type="password"
                                 value={oauthClientSecret}
                                 onChange={(e) => setOauthClientSecret(e.target.value)}
+                                placeholder={
+                                  isEdit
+                                    ? t('actions.serverOauthClientSecretPlaceholder')
+                                    : undefined
+                                }
                                 className="mt-1 w-full rounded-sm border border-border-tertiary bg-bg-tertiary px-2 py-1.5 font-mono text-xs text-text-primary"
                               />
                             </label>

--- a/web-ui/src/features/projects/hooks.ts
+++ b/web-ui/src/features/projects/hooks.ts
@@ -329,11 +329,15 @@ export function useStartOAuth(projectId: string) {
   });
 }
 
-export function useServerTools(projectId: string | null, serverId: string | null) {
+export function useServerTools(
+  projectId: string | null,
+  serverId: string | null,
+  opts?: { enabled?: boolean },
+) {
   return useQuery({
     queryKey: ['server-tools', projectId, serverId],
     queryFn: () => projectsApi.getServerTools(projectId!, serverId!),
-    enabled: !!projectId && !!serverId,
+    enabled: (opts?.enabled ?? true) && !!projectId && !!serverId,
     select: (data) => data.tools,
     staleTime: 60_000,
     retry: false,

--- a/web-ui/src/features/projects/project-events.ts
+++ b/web-ui/src/features/projects/project-events.ts
@@ -29,13 +29,19 @@ export function _resetProjectEventsForTests(): void {
   subscriptions.clear();
 }
 
+function capaAuthToken(): string | undefined {
+  return typeof window !== 'undefined' ? window.__CAPA_AUTH_TOKEN__ : undefined;
+}
+
 function ensureSource(projectId: string): EventSource {
   const existing = sources.get(projectId);
   if (existing) return existing;
 
-  const es = new EventSource(
-    `/api/projects/${encodeURIComponent(projectId)}/events`,
-  );
+  const url = `/api/projects/${encodeURIComponent(projectId)}/events`;
+  const token = capaAuthToken();
+  const es = token
+    ? createAuthedEventSource(url, token)
+    : new EventSource(url);
 
   es.onopen = () => {
     for (const sub of subscriptions.get(projectId) ?? []) {
@@ -104,4 +110,92 @@ export function subscribeProjectEvents(
     set!.delete(sub);
     teardownIfEmpty(projectId);
   };
+}
+
+/** EventSource cannot set Authorization; same-origin fetch can. */
+function createAuthedEventSource(url: string, token: string): EventSource {
+  const abort = new AbortController();
+  const listeners = new Map<string, Set<(ev: MessageEvent) => void>>();
+  const es = {
+    CONNECTING: 0,
+    OPEN: 1,
+    CLOSED: 2,
+    readyState: 0,
+    url,
+    withCredentials: false,
+    onopen: null as ((ev: Event) => void) | null,
+    onmessage: null as ((ev: MessageEvent) => void) | null,
+    onerror: null as ((ev: Event) => void) | null,
+    addEventListener(type: string, listener: EventListenerOrEventListenerObject) {
+      const fn = typeof listener === 'function' ? listener : listener.handleEvent;
+      let set = listeners.get(type);
+      if (!set) {
+        set = new Set();
+        listeners.set(type, set);
+      }
+      set.add(fn as (ev: MessageEvent) => void);
+    },
+    removeEventListener(type: string, listener: EventListenerOrEventListenerObject) {
+      const fn = typeof listener === 'function' ? listener : listener.handleEvent;
+      listeners.get(type)?.delete(fn as (ev: MessageEvent) => void);
+    },
+    dispatchEvent() {
+      return false;
+    },
+    close() {
+      es.readyState = 2;
+      abort.abort();
+    },
+  };
+
+  void (async () => {
+    try {
+      const res = await fetch(url, {
+        headers: {
+          Accept: 'text/event-stream',
+          Authorization: `Bearer ${token}`,
+        },
+        signal: abort.signal,
+      });
+      if (!res.ok || !res.body) {
+        es.readyState = 2;
+        es.onerror?.(new Event('error'));
+        return;
+      }
+      es.readyState = 1;
+      es.onopen?.(new Event('open'));
+      const reader = res.body.getReader();
+      const decoder = new TextDecoder();
+      let buf = '';
+      while (es.readyState === 1) {
+        const { done, value } = await reader.read();
+        if (done) break;
+        buf += decoder.decode(value, { stream: true });
+        const blocks = buf.split('\n\n');
+        buf = blocks.pop() ?? '';
+        for (const block of blocks) {
+          let eventName = 'message';
+          const data: string[] = [];
+          for (const line of block.split('\n')) {
+            if (line.startsWith('event:')) eventName = line.slice(6).trim();
+            else if (line.startsWith('data:')) data.push(line.slice(5).trimStart());
+          }
+          const ev = new MessageEvent(eventName, { data: data.join('\n') });
+          if (eventName === 'message') es.onmessage?.(ev);
+          for (const fn of listeners.get(eventName) ?? []) fn(ev);
+        }
+      }
+      if (es.readyState === 1) {
+        es.readyState = 2;
+        es.onerror?.(new Event('error'));
+      }
+    } catch {
+      if (es.readyState !== 2) {
+        es.readyState = 2;
+        es.onerror?.(new Event('error'));
+      }
+    }
+  })();
+
+  return es as unknown as EventSource;
 }

--- a/web-ui/src/features/projects/project-events.ts
+++ b/web-ui/src/features/projects/project-events.ts
@@ -30,12 +30,20 @@ export function _resetProjectEventsForTests(): void {
 }
 
 function capaAuthToken(): string | undefined {
-  return typeof window !== 'undefined' ? window.__CAPA_AUTH_TOKEN__ : undefined;
+  const g = globalThis as typeof globalThis & {
+    window?: { __CAPA_AUTH_TOKEN__?: string };
+    __CAPA_AUTH_TOKEN__?: string;
+  };
+  return g.window?.__CAPA_AUTH_TOKEN__ ?? g.__CAPA_AUTH_TOKEN__;
 }
 
 function ensureSource(projectId: string): EventSource {
   const existing = sources.get(projectId);
-  if (existing) return existing;
+  if (existing && existing.readyState !== 2) return existing;
+  if (existing) {
+    existing.close();
+    sources.delete(projectId);
+  }
 
   const url = `/api/projects/${encodeURIComponent(projectId)}/events`;
   const token = capaAuthToken();
@@ -98,10 +106,10 @@ export function subscribeProjectEvents(
   // EventSource.onopen only fires on CONNECTING → OPEN. A late subscriber
   // (activity after capabilities sync) joining an already-open shared socket
   // would otherwise stay on "reconnecting…" forever.
-  if (es.readyState === EventSource.OPEN) {
+  if (es.readyState === 1) {
     queueMicrotask(() => {
       if (!subscriptions.get(projectId)?.has(sub)) return;
-      if (sources.get(projectId)?.readyState !== EventSource.OPEN) return;
+      if (sources.get(projectId)?.readyState !== 1) return;
       sub.handlers.onOpen?.();
     });
   }
@@ -112,10 +120,33 @@ export function subscribeProjectEvents(
   };
 }
 
+/** Overridable so tests can reconnect without wall-clock delays. */
+export let sseReconnectDelaysMs = [250, 1000, 3000, 5000];
+
+export function _setSseReconnectDelaysForTests(ms: number[]): void {
+  sseReconnectDelaysMs = ms;
+}
+
+function sleep(ms: number, signal: AbortSignal): Promise<void> {
+  return new Promise((resolve, reject) => {
+    const timer = setTimeout(resolve, ms);
+    const onAbort = () => {
+      clearTimeout(timer);
+      reject(new DOMException('Aborted', 'AbortError'));
+    };
+    if (signal.aborted) {
+      onAbort();
+      return;
+    }
+    signal.addEventListener('abort', onAbort, { once: true });
+  });
+}
+
 /** EventSource cannot set Authorization; same-origin fetch can. */
 function createAuthedEventSource(url: string, token: string): EventSource {
-  const abort = new AbortController();
   const listeners = new Map<string, Set<(ev: MessageEvent) => void>>();
+  let userClosed = false;
+  let attemptAbort = new AbortController();
   const es = {
     CONNECTING: 0,
     OPEN: 1,
@@ -143,56 +174,68 @@ function createAuthedEventSource(url: string, token: string): EventSource {
       return false;
     },
     close() {
+      userClosed = true;
       es.readyState = 2;
-      abort.abort();
+      attemptAbort.abort();
     },
   };
 
+  const dispatchBlock = (block: string) => {
+    let eventName = 'message';
+    const data: string[] = [];
+    for (const line of block.split('\n')) {
+      if (line.startsWith('event:')) eventName = line.slice(6).trim();
+      else if (line.startsWith('data:')) data.push(line.slice(5).trimStart());
+    }
+    const ev = new MessageEvent(eventName, { data: data.join('\n') });
+    if (eventName === 'message') es.onmessage?.(ev);
+    for (const fn of listeners.get(eventName) ?? []) fn(ev);
+  };
+
   void (async () => {
-    try {
-      const res = await fetch(url, {
-        headers: {
-          Accept: 'text/event-stream',
-          Authorization: `Bearer ${token}`,
-        },
-        signal: abort.signal,
-      });
-      if (!res.ok || !res.body) {
-        es.readyState = 2;
-        es.onerror?.(new Event('error'));
-        return;
-      }
-      es.readyState = 1;
-      es.onopen?.(new Event('open'));
-      const reader = res.body.getReader();
-      const decoder = new TextDecoder();
-      let buf = '';
-      while (es.readyState === 1) {
-        const { done, value } = await reader.read();
-        if (done) break;
-        buf += decoder.decode(value, { stream: true });
-        const blocks = buf.split('\n\n');
-        buf = blocks.pop() ?? '';
-        for (const block of blocks) {
-          let eventName = 'message';
-          const data: string[] = [];
-          for (const line of block.split('\n')) {
-            if (line.startsWith('event:')) eventName = line.slice(6).trim();
-            else if (line.startsWith('data:')) data.push(line.slice(5).trimStart());
-          }
-          const ev = new MessageEvent(eventName, { data: data.join('\n') });
-          if (eventName === 'message') es.onmessage?.(ev);
-          for (const fn of listeners.get(eventName) ?? []) fn(ev);
+    let attempt = 0;
+    while (!userClosed) {
+      attemptAbort = new AbortController();
+      es.readyState = 0;
+      try {
+        const res = await fetch(url, {
+          headers: {
+            Accept: 'text/event-stream',
+            Authorization: `Bearer ${token}`,
+          },
+          signal: attemptAbort.signal,
+        });
+        if (!res.ok || !res.body) {
+          throw new Error(`sse ${res.status}`);
         }
+        es.readyState = 1;
+        es.onopen?.(new Event('open'));
+        const reader = res.body.getReader();
+        const decoder = new TextDecoder();
+        let buf = '';
+        while (!userClosed && es.readyState === 1) {
+          const { done, value } = await reader.read();
+          if (done) break;
+          buf += decoder.decode(value, { stream: true });
+          const blocks = buf.split('\n\n');
+          buf = blocks.pop() ?? '';
+          for (const block of blocks) dispatchBlock(block);
+        }
+      } catch {
+        // fetch abort / network / non-OK
       }
-      if (es.readyState === 1) {
-        es.readyState = 2;
-        es.onerror?.(new Event('error'));
-      }
-    } catch {
-      if (es.readyState !== 2) {
-        es.readyState = 2;
-        es.onerror?.(new Event('error'));
+      if (userClosed) return;
+      es.readyState = 0;
+      es.onerror?.(new Event('error'));
+      const delay =
+        sseReconnectDelaysMs[
+          Math.min(attempt, sseReconnectDelaysMs.length - 1)
+        ] ?? 5000;
+      attempt += 1;
+      try {
+        await sleep(delay, attemptAbort.signal);
+      } catch {
+        return;
       }
     }
   })();

--- a/web-ui/src/features/registries/admin/AddRegistryDialog.tsx
+++ b/web-ui/src/features/registries/admin/AddRegistryDialog.tsx
@@ -122,7 +122,6 @@ export function AddRegistryDialog({ open, onOpenChange, onAdded }: AddRegistryDi
         slug: slug.trim() || undefined,
       });
       onAdded(res.registry.slug);
-      onOpenChange(false);
     } catch (err) {
       const message =
         err instanceof ApiError

--- a/web-ui/src/features/registries/admin/AddRegistryDialog.tsx
+++ b/web-ui/src/features/registries/admin/AddRegistryDialog.tsx
@@ -1,7 +1,7 @@
 import { useEffect, useState } from 'react';
 import * as Dialog from '@radix-ui/react-dialog';
 import { useTranslation } from 'react-i18next';
-import { X, Eye, AlertTriangle, Loader2 } from 'lucide-react';
+import { X, Eye, AlertTriangle, Info, Loader2 } from 'lucide-react';
 import { ApiError } from '../../../lib/api';
 import { useAddRegistry, usePreviewRegistry } from '../hooks';
 import type { RegistrySourceType } from '../api';
@@ -179,6 +179,13 @@ export function AddRegistryDialog({ open, onOpenChange, onAdded }: AddRegistryDi
                 </div>
               </fieldset>
 
+              {isMarketplace && (
+                <div className="flex items-start gap-2 rounded-sm border border-info-border bg-info-bg px-3 py-2 text-xs text-info-text">
+                  <Info className="mt-0.5 h-3.5 w-3.5 flex-shrink-0" />
+                  <span>{t('addDialog.marketplaceHint')}</span>
+                </div>
+              )}
+
               {!isMarketplace && (
                 <label className="block">
                   <span className="mb-1 block text-xs font-medium text-text-secondary">
@@ -270,7 +277,11 @@ export function AddRegistryDialog({ open, onOpenChange, onAdded }: AddRegistryDi
                     />
                   ) : (
                     <div className="flex items-center gap-2 px-3 py-6 text-xs text-text-tertiary">
-                      <AlertTriangle className="h-3.5 w-3.5" />
+                      {isMarketplace ? (
+                        <Info className="h-3.5 w-3.5" />
+                      ) : (
+                        <AlertTriangle className="h-3.5 w-3.5" />
+                      )}
                       <span>
                         {t(
                           isMarketplace
@@ -293,7 +304,11 @@ export function AddRegistryDialog({ open, onOpenChange, onAdded }: AddRegistryDi
 
           <div className="flex flex-wrap items-center justify-between gap-3 border-t border-border-secondary px-6 py-4">
             {isMarketplace ? (
-              <span className="text-xs text-text-secondary">{t('addDialog.marketplaceHint')}</span>
+              <span className="text-xs text-text-secondary">
+                {preview
+                  ? t('addDialog.marketplaceReady')
+                  : t('addDialog.marketplaceHint')}
+              </span>
             ) : (
               <label
                 className={

--- a/web-ui/src/features/registries/admin/EditRegistryDialog.tsx
+++ b/web-ui/src/features/registries/admin/EditRegistryDialog.tsx
@@ -1,7 +1,7 @@
 import { useEffect, useState } from 'react';
 import * as Dialog from '@radix-ui/react-dialog';
 import { useTranslation } from 'react-i18next';
-import { X, Eye, AlertTriangle, Loader2 } from 'lucide-react';
+import { X, Eye, AlertTriangle, Info, Loader2 } from 'lucide-react';
 import { ApiError } from '../../../lib/api';
 import { useEditRegistry, usePreviewRegistry } from '../hooks';
 import type { RegistryAdminRecord, RegistrySourceType } from '../api';
@@ -200,6 +200,13 @@ export function EditRegistryDialog({
                 />
               </label>
 
+              {isMarketplace && (
+                <div className="flex items-start gap-2 rounded-sm border border-info-border bg-info-bg px-3 py-2 text-xs text-info-text">
+                  <Info className="mt-0.5 h-3.5 w-3.5 flex-shrink-0" />
+                  <span>{t('addDialog.marketplaceHint')}</span>
+                </div>
+              )}
+
               <div className="flex items-center gap-2">
                 <button
                   type="button"
@@ -237,7 +244,11 @@ export function EditRegistryDialog({
                     />
                   ) : (
                     <div className="flex items-center gap-2 px-3 py-6 text-xs text-text-tertiary">
-                      <AlertTriangle className="h-3.5 w-3.5" />
+                      {isMarketplace ? (
+                        <Info className="h-3.5 w-3.5" />
+                      ) : (
+                        <AlertTriangle className="h-3.5 w-3.5" />
+                      )}
                       <span>
                         {t(
                           isMarketplace
@@ -260,7 +271,11 @@ export function EditRegistryDialog({
 
           <div className="flex flex-wrap items-center justify-between gap-3 border-t border-border-secondary px-6 py-4">
             {isMarketplace ? (
-              <span className="text-xs text-text-secondary">{t('addDialog.marketplaceHint')}</span>
+              <span className="text-xs text-text-secondary">
+                {preview && changed
+                  ? t('addDialog.marketplaceReady')
+                  : t('addDialog.marketplaceHint')}
+              </span>
             ) : (
               <label
                 className={

--- a/web-ui/src/features/registries/admin/RegistrySettingsPage.tsx
+++ b/web-ui/src/features/registries/admin/RegistrySettingsPage.tsx
@@ -40,7 +40,7 @@ export function RegistrySettingsPage() {
   const handleAdded = useCallback(
     (slug: string) => {
       setDialogOpen(false);
-      setFeedback({ type: 'success', message: t('settings.feedback.pending', { slug }) });
+      setFeedback({ type: 'success', message: t('settings.feedback.added', { slug }) });
     },
     [t],
   );

--- a/web-ui/src/features/registries/admin/RegistrySettingsPage.tsx
+++ b/web-ui/src/features/registries/admin/RegistrySettingsPage.tsx
@@ -39,7 +39,8 @@ export function RegistrySettingsPage() {
 
   const handleAdded = useCallback(
     (slug: string) => {
-      setFeedback({ type: 'success', message: t('settings.feedback.added', { slug }) });
+      setDialogOpen(false);
+      setFeedback({ type: 'success', message: t('settings.feedback.pending', { slug }) });
     },
     [t],
   );

--- a/web-ui/src/features/registries/api.ts
+++ b/web-ui/src/features/registries/api.ts
@@ -21,6 +21,7 @@ export interface RegistryAdminRecord {
   lastError: string | null;
   resolvedRef: string | null;
   installedAt: number | null;
+  contentSha256: string | null;
   createdAt: number;
   updatedAt: number;
   manifest: RegistryManifest | null;

--- a/web-ui/src/lib/api.ts
+++ b/web-ui/src/lib/api.ts
@@ -8,8 +8,24 @@ export class ApiError extends Error {
   }
 }
 
+declare global {
+  interface Window {
+    __CAPA_AUTH_TOKEN__?: string;
+  }
+}
+
+export function apiAuthHeaders(extra?: HeadersInit): Headers {
+  const headers = new Headers(extra);
+  const token = typeof window !== 'undefined' ? window.__CAPA_AUTH_TOKEN__ : undefined;
+  if (token && !headers.has('Authorization')) {
+    headers.set('Authorization', `Bearer ${token}`);
+  }
+  return headers;
+}
+
 async function request<T>(url: string, options?: RequestInit): Promise<T> {
-  const res = await fetch(url, options);
+  const headers = apiAuthHeaders(options?.headers);
+  const res = await fetch(url, { ...options, headers });
   if (!res.ok) {
     const text = await res.text().catch(() => res.statusText);
     // Surface server-supplied { error: "..." } messages when present.
@@ -35,23 +51,27 @@ export const api = {
   post: <T>(url: string, body?: unknown) =>
     request<T>(url, {
       method: 'POST',
-      headers: body ? { 'Content-Type': 'application/json' } : undefined,
-      body: body ? JSON.stringify(body) : undefined,
+      headers: { 'Content-Type': 'application/json' },
+      body: body !== undefined ? JSON.stringify(body) : undefined,
     }),
 
   put: <T>(url: string, body?: unknown) =>
     request<T>(url, {
       method: 'PUT',
-      headers: body ? { 'Content-Type': 'application/json' } : undefined,
-      body: body ? JSON.stringify(body) : undefined,
+      headers: { 'Content-Type': 'application/json' },
+      body: body !== undefined ? JSON.stringify(body) : undefined,
     }),
 
   patch: <T>(url: string, body?: unknown) =>
     request<T>(url, {
       method: 'PATCH',
-      headers: body ? { 'Content-Type': 'application/json' } : undefined,
-      body: body ? JSON.stringify(body) : undefined,
+      headers: { 'Content-Type': 'application/json' },
+      body: body !== undefined ? JSON.stringify(body) : undefined,
     }),
 
-  delete: <T>(url: string) => request<T>(url, { method: 'DELETE' }),
+  delete: <T>(url: string) =>
+    request<T>(url, {
+      method: 'DELETE',
+      headers: { 'Content-Type': 'application/json' },
+    }),
 };

--- a/web-ui/src/locales/en/projects.json
+++ b/web-ui/src/locales/en/projects.json
@@ -59,10 +59,7 @@
     "delete": "Delete variable",
     "confirmDelete": "Remove variable {{name}} from the catalog?",
     "referenced": "referenced",
-    "unused": "unused",
-    "set": "set",
-    "replacePlaceholder": "Stored — enter a new value to replace",
-    "endsWith": "ends with {{hint}}"
+    "unused": "unused"
   },
   "oauth": {
     "title": "OAuth 2.0 Connections",

--- a/web-ui/src/locales/en/projects.json
+++ b/web-ui/src/locales/en/projects.json
@@ -59,7 +59,10 @@
     "delete": "Delete variable",
     "confirmDelete": "Remove variable {{name}} from the catalog?",
     "referenced": "referenced",
-    "unused": "unused"
+    "unused": "unused",
+    "set": "set",
+    "replacePlaceholder": "Stored — enter a new value to replace",
+    "endsWith": "ends with {{hint}}"
   },
   "oauth": {
     "title": "OAuth 2.0 Connections",
@@ -186,6 +189,7 @@
     "serverOauth": "OAuth2 (optional)",
     "serverOauthClientId": "Client ID",
     "serverOauthClientSecret": "Client secret",
+    "serverOauthClientSecretPlaceholder": "Leave blank to keep the stored secret",
     "serverOauthAuthUrl": "Authorization URL",
     "serverOauthTokenUrl": "Token URL",
     "serverOauthScopes": "Scopes",

--- a/web-ui/src/locales/en/registries.json
+++ b/web-ui/src/locales/en/registries.json
@@ -73,6 +73,7 @@
     },
     "feedback": {
       "added": "Registry \"{{slug}}\" added.",
+      "pending": "Registry \"{{slug}}\" is staged as pending. Approve it with: capa registry approve {{slug}}",
       "removed": "Registry \"{{slug}}\" removed.",
       "refreshed": "Registry \"{{slug}}\" refreshed.",
       "edited": "Registry \"{{slug}}\" updated.",
@@ -82,7 +83,7 @@
   },
   "editDialog": {
     "title": "Edit registry \"{{slug}}\"",
-    "description": "Repoint this slug at a different source. The new adapter is downloaded and validated before it replaces the existing one.",
+    "description": "Repoint this slug at a different source. HTTP re-stages the adapter as pending; run `capa registry approve <slug>` to execute it.",
     "descriptionMarketplace": "Repoint this slug at a different Claude marketplace. The marketplace.json catalog is re-fetched before it replaces the existing one.",
     "slugImmutable": "The slug is the registry's identity and cannot be renamed. Remove and re-add to change it.",
     "noChanges": "No changes — Save closes the dialog.",
@@ -90,7 +91,7 @@
   },
   "addDialog": {
     "title": "Add registry",
-    "description": "Fetch an adapter from a Git repository or HTTPS URL. The file is downloaded and validated before it is enabled.",
+    "description": "Fetch an adapter from a Git repository or HTTPS URL. HTTP only stages the file; run `capa registry approve <slug>` to execute it.",
     "descriptionMarketplace": "Add a Claude Code marketplace by owner/repo. Capa fetches .claude-plugin/marketplace.json and lists its plugins.",
     "marketplaceHint": "Claude marketplaces are JSON catalogs — no executable adapter code.",
     "fields": {

--- a/web-ui/src/locales/en/registries.json
+++ b/web-ui/src/locales/en/registries.json
@@ -48,8 +48,8 @@
     "addButton": "Add registry",
     "noneTitle": "No registries yet",
     "noneDescription": "Add your first registry adapter or Claude marketplace to start browsing.",
-    "warningTitle": "Trust before adding adapters",
-    "warningBody": "Registry adapters are executable TypeScript — only install them from sources you trust. Claude marketplaces are JSON catalogs and do not run adapter code.",
+    "warningTitle": "Two registry types",
+    "warningBody": "Claude marketplaces are JSON plugin catalogs — CAPA does not execute TypeScript for those. Registry adapters are executable TypeScript; only add adapters from sources you trust.",
     "table": {
       "name": "Registry",
       "type": "Type",
@@ -72,8 +72,7 @@
       "deleteConfirm": "Remove registry \"{{slug}}\"? This deletes its row and any cached files."
     },
     "feedback": {
-      "added": "Registry \"{{slug}}\" added.",
-      "pending": "Registry \"{{slug}}\" is staged as pending. Approve it with: capa registry approve {{slug}}",
+      "added": "Registry \"{{slug}}\" added and installed.",
       "removed": "Registry \"{{slug}}\" removed.",
       "refreshed": "Registry \"{{slug}}\" refreshed.",
       "edited": "Registry \"{{slug}}\" updated.",
@@ -83,17 +82,18 @@
   },
   "editDialog": {
     "title": "Edit registry \"{{slug}}\"",
-    "description": "Repoint this slug at a different source. HTTP re-stages the adapter as pending; run `capa registry approve <slug>` to execute it.",
-    "descriptionMarketplace": "Repoint this slug at a different Claude marketplace. The marketplace.json catalog is re-fetched before it replaces the existing one.",
+    "description": "Repoint this slug at a different source. The adapter is re-fetched and installed immediately.",
+    "descriptionMarketplace": "Repoint this slug at a different Claude marketplace. The marketplace.json catalog is re-fetched and installed immediately.",
     "slugImmutable": "The slug is the registry's identity and cannot be renamed. Remove and re-add to change it.",
     "noChanges": "No changes — Save closes the dialog.",
     "submit": "Save changes"
   },
   "addDialog": {
     "title": "Add registry",
-    "description": "Fetch an adapter from a Git repository or HTTPS URL. HTTP only stages the file; run `capa registry approve <slug>` to execute it.",
-    "descriptionMarketplace": "Add a Claude Code marketplace by owner/repo. Capa fetches .claude-plugin/marketplace.json and lists its plugins.",
-    "marketplaceHint": "Claude marketplaces are JSON catalogs — no executable adapter code.",
+    "description": "Fetch an adapter from a Git repository or HTTPS URL. Adding here installs and activates the registry immediately.",
+    "descriptionMarketplace": "Add a Claude Code marketplace (owner/repo or marketplace.json URL). CAPA fetches the plugin catalog as JSON — no executable adapter code.",
+    "marketplaceHint": "JSON catalog only — no TypeScript is downloaded or executed.",
+    "marketplaceReady": "Preview looks good. Add installs the marketplace immediately.",
     "fields": {
       "mode": "What to add",
       "type": "Source type",
@@ -127,7 +127,7 @@
       "resolvedRef": "Resolved ref: {{ref}}",
       "pluginCount": "{{count}} plugin(s)"
     },
-    "trust": "I have reviewed the adapter source and trust this code.",
+    "trust": "I have reviewed the adapter source and trust this TypeScript code.",
     "submit": "Add registry",
     "cancel": "Cancel",
     "errors": {

--- a/web-ui/src/pages/ProjectDetailPage.tsx
+++ b/web-ui/src/pages/ProjectDetailPage.tsx
@@ -56,7 +56,9 @@ export function ProjectDetailPage() {
   const showNoConfig = !isLoading && !caps && !error;
 
   const missingVarCount = variables?.required
-    ? variables.required.filter((v) => !variables.values?.[v]).length
+    ? variables.required.filter(
+        (v) => !variables.secrets?.find((s) => s.name === v)?.isSet,
+      ).length
     : 0;
   const pendingOAuthCount = oauth2Servers
     ? oauth2Servers.filter((s) => !s.isConnected).length

--- a/web-ui/src/types/api.ts
+++ b/web-ui/src/types/api.ts
@@ -74,7 +74,7 @@ export interface EnrichedTool extends Tool {
 
 export interface ServerOAuth2Config {
   clientId: string | null;
-  clientSecret: string | null;
+  clientSecret?: string | null;
   authorizationUrl: string | null;
   tokenUrl: string | null;
   scopes: string[] | null;
@@ -255,10 +255,17 @@ export interface ProjectDetail {
   capabilities: ProjectCapabilities | null;
 }
 
+export interface VariableSecret {
+  name: string;
+  isSet: boolean;
+  hint: string;
+}
+
 export interface VariablesResponse {
   required: string[];
   catalog: string[];
-  values: Record<string, string>;
+  secrets: VariableSecret[];
+  values?: Record<string, string>;
 }
 
 export interface CapabilitiesMutationResponse {

--- a/web-ui/src/types/api.ts
+++ b/web-ui/src/types/api.ts
@@ -191,6 +191,8 @@ export interface CapabilitiesOptions {
   agentActivity: boolean;
   security: SecurityOptions | null;
   requiresCommands: RequiredCommand[];
+  /** Default warn when omitted. */
+  onInstallError: 'warn' | 'stop' | null;
 }
 
 export interface AgentSnippetDef {


### PR DESCRIPTION
## Summary
Hardens capa against the private security-audit findings (F1–F21 in infragate/meta) while staying a minor-compatible change. Local HTTP is authenticated, install and registry execution require explicit trust, secrets are encrypted at rest and no longer returned on GET, and upgrade/install paths verify what they run.

## What changed
- Loopback HTTP API requires a token and CSRF/Origin/Host checks; MCP editor routes stay usable without a new Bearer requirement
- Registry adapters are staged over HTTP and executed only from the CLI after confirm (`--yes` for CI); default registries seed from pinned bundled adapters
- HTTP configure no longer spawns stdio MCP commands from the request body; first-seen commands need CLI trust
- Credentials: `~/.capa` perms, AES-GCM at rest, redacted variable/project GET responses
- `capa sh` unknown tokens no longer fall through to a shell; command tools refuse shell argv0 plus placeholders; formatters spawn tokenized argv with `shell: false`
- Git: OAuth tokens are disclosed as transiting capa.infragate.ai; callbacks require one-time state; clone tokens stay out of URLs/argv/cache config
- Remote URL installs use the public-HTTPS SSRF guard and verify lock `bodySha256`
- `capa install` prints the executable surface and requires confirmation (`--yes` / `--dry-run`)
- MCP Origin allow-list is the server origin (plus `CAPA_ALLOWED_ORIGINS`)
- `capa upgrade` pins a GitHub release and checksums the installer instead of piping a mutable vendor script
- SPA/OAuth-bridge HTML sends CSP and `X-Content-Type-Options: nosniff`
- `CAPA_DISALLOW_TLS_SKIP_VERIFY` fail-closes TLS skip even if skip is requested
- Plugin subpaths are asserted inside the snapshot

## Screenshots / logs
N/A (CLI/server hardening). User-visible behavior: install/registry add may prompt; non-interactive install needs `--yes`; variable GET returns `{ name, isSet, hint }` instead of raw values; `capa auth` help discloses cloud OAuth.

## Test plan
- [x] New/updated unit tests per finding (TDD)
- [x] `bunx tsc --noEmit` and `bunx tsc --noEmit -p web-ui/tsconfig.json`
- [x] Full `bun test` on Linux CI (local Windows: known EPERM symlink failures; some registry/seed tests flake when the whole suite shares HOME)
- [x] `capa install --dry-run` then `capa install --yes` in a sample project
- [x] `capa registry add <source>` without `--yes` fails closed non-interactively
- [x] Loopback `POST /api/...` without bearer returns 401; foreign Origin returns 403
- [x] `capa upgrade --yes` dry path prints version + digest (CI)

## Checklist
- [x] Tests added or updated
- [x] `bunx tsc --noEmit` passes
- [x] Docs updated (if user-facing) — CLI help/auth copy updated; README/docs site not expanded in this PR

## Notes for reviewers
Please treat this as a security PR: keep discussion of exploit paths in the private meta issues. CI install jobs that call `capa install` non-interactively need `--yes`.