### PR TITLE
fix(security): stop storing git tokens and harden the secret envelope

### DIFF
--- a/src/cli/commands/auth.ts
+++ b/src/cli/commands/auth.ts
@@ -65,8 +65,9 @@ export async function authCommand(
   if (!provider) {
     listConnectedProviders(db);
     info('Usage:');
-    info('  capa auth <provider> --access-token <token>  - PAT (recommended)');
-    info('  capa auth <provider>                         - OAuth (browser)');
+    info('  capa auth <provider> --access-token <token>  - PAT (git credential helper)');
+    info('  capa auth <provider>                         - OAuth (browser; last resort)');
+    info('Prefer gh auth login / Git Credential Manager — CAPA does not store git tokens.');
     info(cloudOAuthDisclosure());
     info('Examples:');
     info('  capa auth github.com');
@@ -284,7 +285,7 @@ async function authenticateWithAccessToken(
   try {
     await runTasks([
       {
-        title: 'Validate and store access token',
+        title: 'Validate token and hand it to git credential helper',
         task: async () => {
           const manager = new GitIntegrationManager(db);
           await manager.storePAT({

--- a/src/cli/commands/status.ts
+++ b/src/cli/commands/status.ts
@@ -1,7 +1,13 @@
 import { getServerStatus } from '../utils/server-manager';
+import {
+  activeSecretStoreTier,
+  describeSecretStoreTier,
+} from '../../shared/secret-store';
 
 export async function statusCommand(): Promise<void> {
   console.log('Checking capa server status...\n');
+  console.log(`Secret store: ${describeSecretStoreTier(activeSecretStoreTier())}`);
+
   
   const status = await getServerStatus();
   

--- a/src/cli/utils/passthrough/env.ts
+++ b/src/cli/utils/passthrough/env.ts
@@ -4,16 +4,21 @@ import { resolveProviders } from '../../../shared/providers/resolve';
 import { loadSettings, getDatabasePath } from '../../../shared/config';
 import { CapaDatabase } from '../../../db/database';
 import type { Capabilities } from '../../../types/capabilities';
+import { isSecretRef, resolveSecretValue, type SecretValue } from '../../../shared/secret-ref';
 
 export function expandEnvInRecord(
-  record: Record<string, string> | undefined,
+  record: Record<string, SecretValue> | undefined,
 ): Record<string, string> | undefined {
   if (!record) return undefined;
   const out: Record<string, string> = {};
   for (const [k, v] of Object.entries(record)) {
-    out[k] = v.replace(/\$\{([A-Za-z_][A-Za-z0-9_]*)\}/g, (_, name: string) => {
-      return process.env[name] ?? '';
-    });
+    if (typeof v === 'string') {
+      out[k] = v.replace(/\$\{([A-Za-z_][A-Za-z0-9_]*)\}/g, (_, name: string) => {
+        return process.env[name] ?? '';
+      });
+    } else if (isSecretRef(v)) {
+      out[k] = resolveSecretValue(v);
+    }
   }
   return out;
 }

--- a/src/db/__tests__/secret-at-rest.test.ts
+++ b/src/db/__tests__/secret-at-rest.test.ts
@@ -113,6 +113,30 @@ describe("credential at-rest encryption", () => {
 		db = new CapaDatabase(dbPath);
 	});
 
+	it("drops undecryptable oauth rows instead of looping refresh", () => {
+		db.setOAuthToken("p1", "bad", {
+			access_token: SECRET,
+			refresh_token: `${SECRET}-refresh`,
+		});
+		db.close();
+
+		const raw = new Database(dbPath);
+		raw.run(
+			"UPDATE oauth_tokens SET access_token = ? WHERE project_id = ? AND server_id = ?",
+			["enc:v2:AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA", "p1", "bad"],
+		);
+		raw.close();
+
+		db = new CapaDatabase(dbPath);
+		expect(db.getOAuthToken("p1", "bad")).toBeNull();
+		const verify = new Database(dbPath, { readonly: true });
+		const row = verify
+			.query("SELECT 1 FROM oauth_tokens WHERE project_id = ? AND server_id = ?")
+			.get("p1", "bad");
+		verify.close();
+		expect(row).toBeNull();
+	});
+
 	it("does not persist git integration tokens in sqlite", () => {
 		db.setGitIntegration("github", {
 			access_token: SECRET,

--- a/src/db/__tests__/secret-at-rest.test.ts
+++ b/src/db/__tests__/secret-at-rest.test.ts
@@ -60,7 +60,7 @@ describe("credential at-rest encryption", () => {
 			.query("SELECT value FROM variables WHERE project_id = ? AND key = ?")
 			.get("p1", "API_KEY") as { value: string };
 		raw.close();
-		expect(row.value.startsWith("enc:v1:")).toBe(true);
+		expect(row.value.startsWith("enc:v2:")).toBe(true);
 		expect(row.value).not.toContain(SECRET);
 
 		db = new CapaDatabase(dbPath);
@@ -94,7 +94,7 @@ describe("credential at-rest encryption", () => {
 			.query("SELECT value FROM variables WHERE project_id = ? AND key = ?")
 			.get("p1", "MIGRATE_ME") as { value: string };
 		verify.close();
-		expect(row.value.startsWith("enc:v1:")).toBe(true);
+		expect(row.value.startsWith("enc:v2:")).toBe(true);
 		expect(row.value).not.toContain("plain-to-migrate");
 	});
 
@@ -113,7 +113,7 @@ describe("credential at-rest encryption", () => {
 		db = new CapaDatabase(dbPath);
 	});
 
-	it("encrypts git integration tokens at rest", () => {
+	it("does not persist git integration tokens in sqlite", () => {
 		db.setGitIntegration("github", {
 			access_token: SECRET,
 			refresh_token: `${SECRET}-refresh`,
@@ -121,10 +121,18 @@ describe("credential at-rest encryption", () => {
 		});
 		const row = db.getGitIntegration("github");
 		expect(row?.access_token).toBe(SECRET);
-		expect(row?.refresh_token).toBe(`${SECRET}-refresh`);
+		expect(row?.refresh_token).toBeNull();
 
 		db.close();
 		expect(readFileSync(dbPath).includes(Buffer.from(SECRET))).toBe(false);
+		const raw = new Database(dbPath, { readonly: true });
+		const stored = raw
+			.query("SELECT access_token, refresh_token FROM git_integrations WHERE platform = ?")
+			.get("github") as { access_token: string; refresh_token: string | null };
+		raw.close();
+		expect(stored.access_token).toBe("");
+		expect(stored.refresh_token).toBeNull();
 		db = new CapaDatabase(dbPath);
+		expect(db.getGitIntegration("github")?.access_token).toBe(SECRET);
 	});
 });

--- a/src/db/git-integrations.ts
+++ b/src/db/git-integrations.ts
@@ -1,24 +1,23 @@
 import type { Database } from "bun:sqlite";
 import {
+	approveGitHttpCredential,
+	fillGitHttpCredential,
+	gitHostForPlatform,
+	rejectGitHttpCredential,
+} from "../shared/git-credentials";
+import {
 	getGitProvider,
 	getGitProviderByHost,
 } from "../shared/git-providers/registry";
-import {
-	decryptSecret,
-	decryptSecretString,
-	encryptSecret,
-} from "../shared/secret-crypto";
 import type { GitIntegration } from "../types/database";
 
-function decryptGitRow(row: GitIntegration | null): GitIntegration | null {
-	if (!row) return null;
+function overlayHelperToken(row: GitIntegration): GitIntegration {
+	const host = gitHostForPlatform(row.platform, row.host);
+	const token = host ? fillGitHttpCredential(host) : null;
 	return {
 		...row,
-		access_token: decryptSecretString(row.access_token),
-		refresh_token:
-			row.refresh_token == null
-				? row.refresh_token
-				: decryptSecret(row.refresh_token),
+		access_token: token ?? "",
+		refresh_token: null,
 	};
 }
 
@@ -26,13 +25,12 @@ export class GitIntegrationsRepo {
 	constructor(private db: Database) {}
 
 	get(platform: string, host: string | null = null): GitIntegration | null {
-		return decryptGitRow(
-			this.db
-				.query(
-					"SELECT * FROM git_integrations WHERE platform = ? AND (host = ? OR (host IS NULL AND ? IS NULL))",
-				)
-				.get(platform, host, host) as GitIntegration | null,
-		);
+		const row = this.db
+			.query(
+				"SELECT * FROM git_integrations WHERE platform = ? AND (host = ? OR (host IS NULL AND ? IS NULL))",
+			)
+			.get(platform, host, host) as GitIntegration | null;
+		return row ? overlayHelperToken(row) : null;
 	}
 
 	set(
@@ -47,55 +45,40 @@ export class GitIntegrationsRepo {
 	): void {
 		const now = Date.now();
 		const host = tokenData.host || null;
-		const access = encryptSecret(tokenData.access_token);
-		const refresh = tokenData.refresh_token
-			? encryptSecret(tokenData.refresh_token)
-			: null;
+		const helperHost = gitHostForPlatform(platform, host);
+		if (helperHost && tokenData.access_token.trim()) {
+			approveGitHttpCredential(helperHost, tokenData.access_token);
+		}
 
-		// Check if an entry already exists
-		const existing = this.get(platform, host);
+		const existing = this.db
+			.query(
+				"SELECT id FROM git_integrations WHERE platform = ? AND (host = ? OR (host IS NULL AND ? IS NULL))",
+			)
+			.get(platform, host, host) as { id: number } | null;
 
 		if (existing) {
-			// Update existing entry
 			this.db.run(
 				`UPDATE git_integrations SET
-          access_token = ?,
-          refresh_token = ?,
+          access_token = '',
+          refresh_token = NULL,
           token_type = ?,
-          expires_at = ?,
+          expires_at = NULL,
           updated_at = ?
          WHERE platform = ? AND (host = ? OR (host IS NULL AND ? IS NULL))`,
-				[
-					access,
-					refresh,
-					tokenData.token_type || "Bearer",
-					tokenData.expires_at || null,
-					now,
-					platform,
-					host,
-					host,
-				],
+				[tokenData.token_type || "Bearer", now, platform, host, host],
 			);
 		} else {
-			// Insert new entry
 			this.db.run(
 				`INSERT INTO git_integrations (platform, host, access_token, refresh_token, token_type, expires_at, created_at, updated_at)
-         VALUES (?, ?, ?, ?, ?, ?, ?, ?)`,
-				[
-					platform,
-					host,
-					access,
-					refresh,
-					tokenData.token_type || "Bearer",
-					tokenData.expires_at || null,
-					now,
-					now,
-				],
+         VALUES (?, ?, '', NULL, ?, NULL, ?, ?)`,
+				[platform, host, tokenData.token_type || "Bearer", now, now],
 			);
 		}
 	}
 
 	delete(platform: string, host: string | null = null): void {
+		const helperHost = gitHostForPlatform(platform, host);
+		if (helperHost) rejectGitHttpCredential(helperHost);
 		this.db.run(
 			"DELETE FROM git_integrations WHERE platform = ? AND (host = ? OR (host IS NULL AND ? IS NULL))",
 			[platform, host, host],
@@ -107,7 +90,7 @@ export class GitIntegrationsRepo {
 			this.db
 				.query("SELECT * FROM git_integrations ORDER BY created_at DESC")
 				.all() as GitIntegration[]
-		).map((row) => decryptGitRow(row)!);
+		).map(overlayHelperToken);
 	}
 
 	getOAuthToken(provider: string): GitIntegration | null {

--- a/src/db/migrate-secrets.ts
+++ b/src/db/migrate-secrets.ts
@@ -1,21 +1,40 @@
 import type { Database } from "bun:sqlite";
-import { canonicalizeStoredSecret } from "../shared/secret-crypto";
+import {
+	approveGitHttpCredential,
+	gitHostForPlatform,
+} from "../shared/git-credentials";
+import { canonicalizeStoredSecret, decryptSecret } from "../shared/secret-crypto";
+import {
+	gitSecretBinding,
+	oauthSecretBinding,
+	variableSecretBinding,
+} from "../shared/secret-binding";
 
-function nextSecret(value: string | null): { value: string | null; changed: boolean } {
+function nextSecret(
+	value: string | null,
+	binding: Parameters<typeof canonicalizeStoredSecret>[1],
+): { value: string | null; changed: boolean } {
 	if (typeof value !== "string" || value.length === 0) {
 		return { value, changed: false };
 	}
-	const next = canonicalizeStoredSecret(value);
+	const next = canonicalizeStoredSecret(value, binding);
 	return { value: next, changed: next !== value };
 }
 
-/** Encrypt legacy plaintext secret columns. Safe to run on every open. */
+/**
+ * Encrypt leftover plaintext / v1 secret columns with v2+AAD.
+ * Hand leftover git tokens to the OS git credential helper and wipe them
+ * from SQLite. Safe to run on every open.
+ */
 export function migrateSecretsAtRest(db: Database): void {
 	const tx = db.transaction(() => {
 		for (const row of db
 			.query("SELECT project_id, key, value FROM variables")
 			.all() as Array<{ project_id: string; key: string; value: string }>) {
-			const n = nextSecret(row.value);
+			const n = nextSecret(
+				row.value,
+				variableSecretBinding(row.project_id, row.key),
+			);
 			if (!n.changed) continue;
 			db.run("UPDATE variables SET value = ? WHERE project_id = ? AND key = ?", [
 				n.value,
@@ -25,16 +44,22 @@ export function migrateSecretsAtRest(db: Database): void {
 		}
 
 		for (const row of db
-			.query(
-				"SELECT id, access_token, refresh_token FROM oauth_tokens",
-			)
+			.query("SELECT id, project_id, server_id, access_token, refresh_token FROM oauth_tokens")
 			.all() as Array<{
 			id: number;
+			project_id: string;
+			server_id: string;
 			access_token: string;
 			refresh_token: string | null;
 		}>) {
-			const access = nextSecret(row.access_token);
-			const refresh = nextSecret(row.refresh_token);
+			const access = nextSecret(
+				row.access_token,
+				oauthSecretBinding(row.project_id, row.server_id, "access_token"),
+			);
+			const refresh = nextSecret(
+				row.refresh_token,
+				oauthSecretBinding(row.project_id, row.server_id, "refresh_token"),
+			);
 			if (!access.changed && !refresh.changed) continue;
 			db.run(
 				"UPDATE oauth_tokens SET access_token = ?, refresh_token = ? WHERE id = ?",
@@ -44,20 +69,34 @@ export function migrateSecretsAtRest(db: Database): void {
 
 		for (const row of db
 			.query(
-				"SELECT id, access_token, refresh_token FROM git_integrations",
+				"SELECT id, platform, host, access_token, refresh_token FROM git_integrations",
 			)
 			.all() as Array<{
 			id: number;
+			platform: string;
+			host: string | null;
 			access_token: string;
 			refresh_token: string | null;
 		}>) {
-			const access = nextSecret(row.access_token);
-			const refresh = nextSecret(row.refresh_token);
-			if (!access.changed && !refresh.changed) continue;
-			db.run(
-				"UPDATE git_integrations SET access_token = ?, refresh_token = ? WHERE id = ?",
-				[access.value, refresh.value, row.id],
+			const accessPlain = decryptSecret(
+				row.access_token,
+				gitSecretBinding(row.platform, row.host, "access_token"),
 			);
+			const refreshPlain = decryptSecret(
+				row.refresh_token,
+				gitSecretBinding(row.platform, row.host, "refresh_token"),
+			);
+			const token = accessPlain?.trim() || refreshPlain?.trim();
+			if (token) {
+				const host = gitHostForPlatform(row.platform, row.host);
+				if (host) approveGitHttpCredential(host, accessPlain?.trim() || token);
+			}
+			if (row.access_token !== "" || row.refresh_token != null) {
+				db.run(
+					"UPDATE git_integrations SET access_token = '', refresh_token = NULL WHERE id = ?",
+					[row.id],
+				);
+			}
 		}
 	});
 	tx();

--- a/src/db/migrate-secrets.ts
+++ b/src/db/migrate-secrets.ts
@@ -13,12 +13,16 @@ import {
 function nextSecret(
 	value: string | null,
 	binding: Parameters<typeof canonicalizeStoredSecret>[1],
-): { value: string | null; changed: boolean } {
+): { value: string | null; changed: boolean; corrupt?: boolean } {
 	if (typeof value !== "string" || value.length === 0) {
 		return { value, changed: false };
 	}
-	const next = canonicalizeStoredSecret(value, binding);
-	return { value: next, changed: next !== value };
+	try {
+		const next = canonicalizeStoredSecret(value, binding);
+		return { value: next, changed: next !== value };
+	} catch {
+		return { value, changed: false, corrupt: true };
+	}
 }
 
 /**
@@ -60,6 +64,10 @@ export function migrateSecretsAtRest(db: Database): void {
 				row.refresh_token,
 				oauthSecretBinding(row.project_id, row.server_id, "refresh_token"),
 			);
+			if (access.corrupt || refresh.corrupt) {
+				db.run("DELETE FROM oauth_tokens WHERE id = ?", [row.id]);
+				continue;
+			}
 			if (!access.changed && !refresh.changed) continue;
 			db.run(
 				"UPDATE oauth_tokens SET access_token = ?, refresh_token = ? WHERE id = ?",

--- a/src/db/oauth-tokens.ts
+++ b/src/db/oauth-tokens.ts
@@ -7,35 +7,45 @@ import {
 import { oauthSecretBinding } from "../shared/secret-binding";
 import type { OAuthTokenRow } from "../types/database";
 
-function decryptTokenRow(row: OAuthTokenRow | null): OAuthTokenRow | null {
-	if (!row) return null;
-	return {
-		...row,
-		access_token: decryptSecretString(
-			row.access_token,
-			oauthSecretBinding(row.project_id, row.server_id, "access_token"),
-		),
-		refresh_token:
-			row.refresh_token == null
-				? row.refresh_token
-				: decryptSecret(
-						row.refresh_token,
-						oauthSecretBinding(row.project_id, row.server_id, "refresh_token"),
-					),
-	};
+function decryptTokenRow(row: OAuthTokenRow): OAuthTokenRow {
+	const access_token = decryptSecretString(
+		row.access_token,
+		oauthSecretBinding(row.project_id, row.server_id, "access_token"),
+	);
+	let refresh_token: string | null = null;
+	if (row.refresh_token != null) {
+		const plain = decryptSecret(
+			row.refresh_token,
+			oauthSecretBinding(row.project_id, row.server_id, "refresh_token"),
+		);
+		if (plain === null) {
+			throw new Error(
+				`Failed to decrypt OAuth refresh token for ${row.server_id}`,
+			);
+		}
+		refresh_token = plain;
+	}
+	return { ...row, access_token, refresh_token };
 }
 
 export class OAuthTokensRepo {
 	constructor(private db: Database) {}
 
 	get(projectId: string, serverId: string): OAuthTokenRow | null {
-		return decryptTokenRow(
-			this.db
-				.query(
-					"SELECT * FROM oauth_tokens WHERE project_id = ? AND server_id = ?",
-				)
-				.get(projectId, serverId) as OAuthTokenRow | null,
-		);
+		const row = this.db
+			.query(
+				"SELECT * FROM oauth_tokens WHERE project_id = ? AND server_id = ?",
+			)
+			.get(projectId, serverId) as OAuthTokenRow | null;
+		if (!row) return null;
+		try {
+			return decryptTokenRow(row);
+		} catch {
+			// Undecryptable row (master key rotation, corrupt blob) — drop it so
+			// refresh loops stop and the UI can prompt for reconnect.
+			this.delete(projectId, serverId);
+			return null;
+		}
 	}
 
 	set(
@@ -49,17 +59,21 @@ export class OAuthTokensRepo {
 			scope?: string;
 		},
 	): void {
+		if (typeof tokenData.access_token !== "string" || !tokenData.access_token) {
+			throw new Error("OAuth access_token is required");
+		}
 		const now = Date.now();
 		const access = encryptSecret(
 			tokenData.access_token,
 			oauthSecretBinding(projectId, serverId, "access_token"),
 		);
-		const refresh = tokenData.refresh_token
-			? encryptSecret(
-					tokenData.refresh_token,
-					oauthSecretBinding(projectId, serverId, "refresh_token"),
-				)
-			: null;
+		const refresh =
+			typeof tokenData.refresh_token === "string" && tokenData.refresh_token
+				? encryptSecret(
+						tokenData.refresh_token,
+						oauthSecretBinding(projectId, serverId, "refresh_token"),
+					)
+				: null;
 		this.db.run(
 			`INSERT INTO oauth_tokens (project_id, server_id, access_token, refresh_token, token_type, expires_at, scope, created_at, updated_at)
        VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)
@@ -98,10 +112,17 @@ export class OAuthTokensRepo {
 	}
 
 	getAll(projectId: string): OAuthTokenRow[] {
-		return (
-			this.db
-				.query("SELECT * FROM oauth_tokens WHERE project_id = ?")
-				.all(projectId) as OAuthTokenRow[]
-		).map((row) => decryptTokenRow(row)!);
+		const rows = this.db
+			.query("SELECT * FROM oauth_tokens WHERE project_id = ?")
+			.all(projectId) as OAuthTokenRow[];
+		const out: OAuthTokenRow[] = [];
+		for (const row of rows) {
+			try {
+				out.push(decryptTokenRow(row));
+			} catch {
+				this.delete(row.project_id, row.server_id);
+			}
+		}
+		return out;
 	}
 }

--- a/src/db/oauth-tokens.ts
+++ b/src/db/oauth-tokens.ts
@@ -4,17 +4,24 @@ import {
 	decryptSecretString,
 	encryptSecret,
 } from "../shared/secret-crypto";
+import { oauthSecretBinding } from "../shared/secret-binding";
 import type { OAuthTokenRow } from "../types/database";
 
 function decryptTokenRow(row: OAuthTokenRow | null): OAuthTokenRow | null {
 	if (!row) return null;
 	return {
 		...row,
-		access_token: decryptSecretString(row.access_token),
+		access_token: decryptSecretString(
+			row.access_token,
+			oauthSecretBinding(row.project_id, row.server_id, "access_token"),
+		),
 		refresh_token:
 			row.refresh_token == null
 				? row.refresh_token
-				: decryptSecret(row.refresh_token),
+				: decryptSecret(
+						row.refresh_token,
+						oauthSecretBinding(row.project_id, row.server_id, "refresh_token"),
+					),
 	};
 }
 
@@ -43,9 +50,15 @@ export class OAuthTokensRepo {
 		},
 	): void {
 		const now = Date.now();
-		const access = encryptSecret(tokenData.access_token);
+		const access = encryptSecret(
+			tokenData.access_token,
+			oauthSecretBinding(projectId, serverId, "access_token"),
+		);
 		const refresh = tokenData.refresh_token
-			? encryptSecret(tokenData.refresh_token)
+			? encryptSecret(
+					tokenData.refresh_token,
+					oauthSecretBinding(projectId, serverId, "refresh_token"),
+				)
 			: null;
 		this.db.run(
 			`INSERT INTO oauth_tokens (project_id, server_id, access_token, refresh_token, token_type, expires_at, scope, created_at, updated_at)

--- a/src/db/variables.ts
+++ b/src/db/variables.ts
@@ -1,15 +1,13 @@
 import type { Database } from "bun:sqlite";
-import {
-	decryptSecretString,
-	encryptSecret,
-} from "../shared/secret-crypto";
+import { decryptSecretString, encryptSecret } from "../shared/secret-crypto";
+import { variableSecretBinding } from "../shared/secret-binding";
 
 export class VariablesRepo {
 	constructor(private db: Database) {}
 
 	set(projectId: string, key: string, value: string): void {
 		const now = Date.now();
-		const stored = encryptSecret(value);
+		const stored = encryptSecret(value, variableSecretBinding(projectId, key));
 		this.db.run(
 			`INSERT INTO variables (project_id, key, value, created_at)
        VALUES (?, ?, ?, ?)
@@ -22,7 +20,9 @@ export class VariablesRepo {
 		const result = this.db
 			.query("SELECT value FROM variables WHERE project_id = ? AND key = ?")
 			.get(projectId, key) as { value: string } | null;
-		return result ? decryptSecretString(result.value) : null;
+		return result
+			? decryptSecretString(result.value, variableSecretBinding(projectId, key))
+			: null;
 	}
 
 	getAll(projectId: string): Record<string, string> {
@@ -32,7 +32,10 @@ export class VariablesRepo {
 
 		const vars: Record<string, string> = {};
 		for (const row of rows) {
-			vars[row.key] = decryptSecretString(row.value);
+			vars[row.key] = decryptSecretString(
+				row.value,
+				variableSecretBinding(projectId, row.key),
+			);
 		}
 		return vars;
 	}

--- a/src/server/__tests__/oauth-manager.test.ts
+++ b/src/server/__tests__/oauth-manager.test.ts
@@ -45,12 +45,30 @@ describe('OAuth2Manager', () => {
   });
 
   describe('isPermanentRefreshFailure', () => {
+    it('classifies 401/403 as permanent even without an OAuth error body', () => {
+      const res401 = new Response('', { status: 401 });
+      expect(isPermanentRefreshFailure(undefined, res401, '')).toBe(true);
+
+      const res403 = new Response('', { status: 403 });
+      expect(isPermanentRefreshFailure(undefined, res403, '')).toBe(true);
+    });
+
     it('classifies 401/403 with invalid_grant as permanent', () => {
       const res401 = new Response('', { status: 401 });
       expect(isPermanentRefreshFailure(undefined, res401, '{"error":"invalid_grant"}')).toBe(true);
 
       const res403 = new Response('', { status: 403 });
       expect(isPermanentRefreshFailure(undefined, res403, 'invalid_token')).toBe(true);
+    });
+
+    it('classifies 400 with invalid_grant as permanent', () => {
+      const res400 = new Response('', { status: 400 });
+      expect(isPermanentRefreshFailure(undefined, res400, '{"error":"invalid_grant"}')).toBe(true);
+    });
+
+    it('treats 400 without OAuth error markers as transient', () => {
+      const res400 = new Response('', { status: 400 });
+      expect(isPermanentRefreshFailure(undefined, res400, 'bad request')).toBe(false);
     });
 
     it('treats 500 responses as transient', () => {
@@ -60,6 +78,14 @@ describe('OAuth2Manager', () => {
 
     it('treats missing response (network errors) as transient', () => {
       expect(isPermanentRefreshFailure(new Error('network failure'))).toBe(false);
+    });
+
+    it('treats corrupt stored credential errors as permanent', () => {
+      expect(
+        isPermanentRefreshFailure(
+          new Error('The "data" argument must be of type string or an instance of Buffer'),
+        ),
+      ).toBe(true);
     });
   });
 

--- a/src/server/__tests__/oauth-token-store.test.ts
+++ b/src/server/__tests__/oauth-token-store.test.ts
@@ -1,0 +1,72 @@
+import { afterEach, beforeEach, describe, expect, it } from "bun:test";
+import { mkdtempSync, rmSync } from "fs";
+import { tmpdir } from "os";
+import { join } from "path";
+import { CapaDatabase } from "../../db/database";
+import { resetSecretCryptoForTests } from "../../shared/secret-crypto";
+import { refreshAccessToken } from "../oauth-token-store";
+import type { OAuth2Config } from "../../types/oauth";
+
+describe("refreshAccessToken", () => {
+	let home: string;
+	let db: CapaDatabase;
+	const oauth2Config: OAuth2Config = {
+		authorizationEndpoint: "https://example.test/oauth/authorize",
+		tokenEndpoint: "https://example.test/oauth/token",
+		resourceServer: "https://example.test",
+	};
+	const originalFetch = globalThis.fetch;
+	let prevHome: string | undefined;
+	let prevProfile: string | undefined;
+
+	beforeEach(() => {
+		prevHome = process.env.HOME;
+		prevProfile = process.env.USERPROFILE;
+		home = mkdtempSync(join(tmpdir(), "capa-oauth-refresh-"));
+		process.env.HOME = home;
+		process.env.USERPROFILE = home;
+		resetSecretCryptoForTests();
+		db = new CapaDatabase(join(home, "test.db"));
+		db.upsertProject({ id: "p1", path: "/p1" });
+		db.setOAuthToken("p1", "slack", {
+			access_token: "old-access",
+			refresh_token: "old-refresh",
+		});
+	});
+
+	afterEach(() => {
+		globalThis.fetch = originalFetch;
+		db.close();
+		resetSecretCryptoForTests();
+		if (prevHome === undefined) delete process.env.HOME;
+		else process.env.HOME = prevHome;
+		if (prevProfile === undefined) delete process.env.USERPROFILE;
+		else process.env.USERPROFILE = prevProfile;
+		try {
+			rmSync(home, { recursive: true, force: true });
+		} catch {
+			// Windows can keep capa.db locked briefly after close
+		}
+	});
+
+	it("deletes stored tokens when refresh returns 401", async () => {
+		globalThis.fetch = ((async () =>
+			new Response("", { status: 401, statusText: "Unauthorized" })) as unknown as typeof fetch);
+
+		const ok = await refreshAccessToken(db, "p1", "slack", oauth2Config);
+		expect(ok).toBe(false);
+		expect(db.getOAuthToken("p1", "slack")).toBeNull();
+	});
+
+	it("does not call encryptSecret when refresh response omits access_token", async () => {
+		globalThis.fetch = ((async () =>
+			new Response(JSON.stringify({ token_type: "Bearer" }), {
+				status: 200,
+				headers: { "Content-Type": "application/json" },
+			})) as unknown as typeof fetch);
+
+		const ok = await refreshAccessToken(db, "p1", "slack", oauth2Config);
+		expect(ok).toBe(false);
+		expect(db.getOAuthToken("p1", "slack")).toBeNull();
+	});
+});

--- a/src/server/__tests__/refresh-token.test.ts
+++ b/src/server/__tests__/refresh-token.test.ts
@@ -5,7 +5,6 @@ import { tmpdir } from 'os';
 import { CapaDatabase } from '../../db/database';
 import { resetSecretCryptoForTests } from '../../shared/secret-crypto';
 import { GitIntegrationManager } from '../git-integration-manager';
-import { CAPA_CLOUD_OAUTH_URL } from '../../shared/ui-urls';
 
 const REFRESH_PATH = /^\/api\/integrations\/(github|gitlab)\/refresh$/;
 
@@ -83,79 +82,21 @@ describe('git token refresh security', () => {
       }
     });
 
-    it('sends refresh_token in POST body, not URL query', async () => {
-      const ok = await manager.refreshAccessToken('github');
-      expect(ok).toBe(true);
-      expect(fetchCalls).toHaveLength(1);
-
-      const { url, init } = fetchCalls[0]!;
-      expect(url).toBe(`${CAPA_CLOUD_OAUTH_URL}/refresh`);
-      expect(url).not.toContain('refresh_token=');
-      expect(init?.method).toBe('POST');
-
-      const body = JSON.parse(String(init?.body));
-      expect(body.provider).toBe('github.com');
-      expect(body.refresh_token).toBe('old-refresh');
-    });
-
-    it('preserves the stored token when the cloud proxy returns a transient 5xx', async () => {
-      globalThis.fetch = (async (_input: RequestInfo | URL, _init?: RequestInit) => {
-        return new Response('upstream temporarily unavailable', {
-          status: 502,
-          headers: { 'Content-Type': 'text/plain' },
-        });
-      }) as typeof fetch;
-
+    it('does not send git refresh tokens to capa.infragate.ai', async () => {
       const ok = await manager.refreshAccessToken('github');
       expect(ok).toBe(false);
+      expect(fetchCalls).toHaveLength(0);
 
       const stored = db.getGitIntegration('github');
-      expect(stored).not.toBeNull();
       expect(stored?.access_token).toBe('old-access');
-      expect(stored?.refresh_token).toBe('old-refresh');
+      expect(stored?.refresh_token).toBeNull();
     });
 
-    it('preserves the stored token when the refresh request hits a network error', async () => {
-      globalThis.fetch = (async (_input: RequestInfo | URL, _init?: RequestInit) => {
-        throw new Error('ECONNRESET');
-      }) as unknown as typeof fetch;
-
+    it('keeps helper-backed credentials when refresh is skipped', async () => {
       const ok = await manager.refreshAccessToken('github');
       expect(ok).toBe(false);
-
-      const stored = db.getGitIntegration('github');
-      expect(stored).not.toBeNull();
-      expect(stored?.access_token).toBe('old-access');
-    });
-
-    it('preserves the stored token when the proxy returns 401 without an invalid_grant marker', async () => {
-      globalThis.fetch = (async (_input: RequestInfo | URL, _init?: RequestInit) => {
-        return new Response('rate limited', {
-          status: 401,
-          headers: { 'Content-Type': 'text/plain' },
-        });
-      }) as typeof fetch;
-
-      const ok = await manager.refreshAccessToken('github');
-      expect(ok).toBe(false);
-
-      const stored = db.getGitIntegration('github');
-      expect(stored).not.toBeNull();
-    });
-
-    it('deletes the stored token when the cloud proxy reports invalid_grant', async () => {
-      globalThis.fetch = (async (_input: RequestInfo | URL, _init?: RequestInit) => {
-        return new Response(JSON.stringify({ error: 'invalid_grant' }), {
-          status: 400,
-          headers: { 'Content-Type': 'application/json' },
-        });
-      }) as typeof fetch;
-
-      const ok = await manager.refreshAccessToken('github');
-      expect(ok).toBe(false);
-
-      const stored = db.getGitIntegration('github');
-      expect(stored).toBeNull();
+      expect(db.getGitIntegration('github')).not.toBeNull();
+      expect(db.getGitIntegration('github')?.access_token).toBe('old-access');
     });
   });
 

--- a/src/server/__tests__/secret-redaction.test.ts
+++ b/src/server/__tests__/secret-redaction.test.ts
@@ -29,6 +29,17 @@ describe("redactServerForApi", () => {
 		expect(redacted.oauth2?.clientSecret).toBeUndefined();
 		expect(redacted.oauth2?.clientId).toBe("public-client");
 	});
+
+	it("keeps fromEnv/fromCommand/fromFile refs visible (they are not secrets)", () => {
+		const redacted = redactServerForApi({
+			env: { TOKEN: { fromEnv: "OP_TOKEN" } },
+			headers: { Authorization: { fromCommand: "op read op://x" } },
+		});
+		expect(redacted.env?.TOKEN).toEqual({ fromEnv: "OP_TOKEN" });
+		expect(redacted.headers?.Authorization).toEqual({
+			fromCommand: "op read op://x",
+		});
+	});
 });
 
 describe("mergeServerDef", () => {

--- a/src/server/git-integration-manager.ts
+++ b/src/server/git-integration-manager.ts
@@ -2,9 +2,13 @@
 // Handles OAuth2 flows via cloud endpoint and Personal Access Token storage
 
 import type { CapaDatabase } from "../db/database";
+import {
+	fillGitHttpCredential,
+	gitHostForPlatform,
+	hasGitHttpCredential,
+} from "../shared/git-credentials";
 import { getGitProvider } from "../shared/git-providers/registry";
 import { logger } from "../shared/logger";
-import { isPermanentRefreshFailure } from "../shared/oauth-refresh";
 import { CAPA_CLOUD_OAUTH_URL } from "../shared/ui-urls";
 import type { GitPATConfig, GitPlatform } from "../types/git-integration";
 import { generateState } from "../utils/pkce";
@@ -23,11 +27,14 @@ export class GitIntegrationManager {
 
 	/**
 	 * Check if a specific platform integration is configured and usable.
-	 * Sync check only — verifies a non-empty stored token exists.
+	 * Tokens live in the developer's git credential helper / `gh auth`, not capa.db.
 	 */
 	isConnected(platform: GitPlatform, host?: string): boolean {
-		const integration = this.db.getGitIntegration(platform, host || null);
-		return this.hasUsableStoredToken(integration);
+		const helperHost = gitHostForPlatform(platform, host);
+		if (helperHost && hasGitHttpCredential(helperHost)) return true;
+		return this.hasUsableStoredToken(
+			this.db.getGitIntegration(platform, host || null),
+		);
 	}
 
 	private hasUsableStoredToken(
@@ -179,7 +186,7 @@ export class GitIntegrationManager {
 			});
 
 			this.logger.success(
-				`Token stored for ${platform}${refreshToken ? " (with refresh token)" : ""}`,
+				`Token handed to git credential helper for ${platform}`,
 			);
 			return { success: true, platform };
 		} catch (error: any) {
@@ -251,7 +258,9 @@ export class GitIntegrationManager {
 			expires_at: null,
 		});
 
-		this.logger.success(`PAT stored for ${config.platform} at ${hostLabel}`);
+		this.logger.success(
+			`PAT handed to git credential helper for ${config.platform} at ${hostLabel}`,
+		);
 	}
 
 	/**
@@ -294,144 +303,38 @@ export class GitIntegrationManager {
 	}
 
 	/**
-	 * Get access token for a platform
-	 * Automatically refreshes expired tokens if refresh token is available
+	 * Get access token for a platform from the git credential helper.
+	 * CAPA does not persist git tokens, so there is nothing to refresh via
+	 * capa.infragate.ai.
 	 */
 	async getAccessToken(
 		platform: GitPlatform,
 		host?: string,
 	): Promise<string | null> {
+		const helperHost = gitHostForPlatform(platform, host);
+		if (helperHost) {
+			const token = fillGitHttpCredential(helperHost);
+			if (token) return token;
+		}
 		const integration = this.db.getGitIntegration(platform, host || null);
-		if (!integration) {
-			return null;
-		}
-
-		// Check if token is expired or expiring soon (within 5 minutes)
-		if (integration.expires_at) {
-			const expiresIn = integration.expires_at - Date.now();
-			const fiveMinutes = 5 * 60 * 1000;
-
-			if (expiresIn < fiveMinutes) {
-				this.logger.info(
-					`Token for ${platform} expired or expiring soon, attempting refresh...`,
-				);
-
-				// Try to refresh if we have a refresh token
-				if (integration.refresh_token) {
-					const refreshed = await this.refreshAccessToken(platform, host);
-					if (refreshed) {
-						// Get the refreshed token
-						const updatedIntegration = this.db.getGitIntegration(
-							platform,
-							host || null,
-						);
-						return updatedIntegration?.access_token || null;
-					} else {
-						this.logger.warn(`Failed to refresh token for ${platform}`);
-						// Return expired token and let the caller handle 401
-						return integration.access_token;
-					}
-				} else {
-					this.logger.warn(`No refresh token available for ${platform}`);
-					// Return expired token and let the caller handle 401
-					return integration.access_token;
-				}
-			}
-		}
-
-		return integration.access_token;
+		return integration?.access_token?.trim() || null;
 	}
 
 	/**
-	 * Refresh access token using refresh token via cloud OAuth proxy (POST + JSON body).
-	 *
-	 * POST https://capa.infragate.ai/auth/refresh
-	 * Body: { "provider": "github.com", "refresh_token": "..." }
+	 * Git tokens are not stored in CAPA, so cloud refresh is a no-op.
 	 */
 	async refreshAccessToken(
 		platform: GitPlatform,
-		host?: string,
+		_host?: string,
 	): Promise<boolean> {
-		try {
-			const integration = this.db.getGitIntegration(platform, host || null);
-
-			if (!integration || !integration.refresh_token) {
-				this.logger.failure(`No refresh token available for ${platform}`);
-				return false;
-			}
-
-			// Only registered cloud OAuth providers support refresh
-			const gp = getGitProvider(platform);
-			if (!gp) {
-				this.logger.warn(`Refresh not supported for ${platform}`);
-				return false;
-			}
-
-			this.logger.debug(
-				`Refreshing token via: ${CAPA_CLOUD_OAUTH_URL}/refresh`,
-			);
-
-			const response = await fetch(`${CAPA_CLOUD_OAUTH_URL}/refresh`, {
-				method: "POST",
-				headers: { "Content-Type": "application/json" },
-				body: JSON.stringify({
-					provider: gp.cloudOAuthProviderParam,
-					refresh_token: integration.refresh_token,
-				}),
-			});
-
-			if (!response.ok) {
-				const errorText = await response.text();
-				this.logger.failure(
-					`Token refresh failed: ${response.status} ${errorText}`,
-				);
-
-				// Only delete the stored token when the refresh_token itself is known to be
-				// unusable (invalid_grant / invalid_token / expired). Transient failures like
-				// proxy 5xx, rate limits, or network blips keep the token so the next
-				// scheduler tick (or user retry) can succeed.
-				if (isPermanentRefreshFailure(undefined, response, errorText)) {
-					this.db.deleteGitIntegration(platform, host || null);
-					this.logger.info(`Deleted invalid token for ${platform}`);
-				} else {
-					this.logger.warn(
-						`Transient refresh failure for ${platform}, keeping token`,
-					);
-				}
-				return false;
-			}
-
-			const tokenData = await response.json();
-
-			if (!tokenData.access_token) {
-				this.logger.failure("No access token in refresh response");
-				return false;
-			}
-
-			// Calculate expiration
-			const expiresAt = tokenData.expires_in
-				? Date.now() + tokenData.expires_in * 1000
-				: null;
-
-			// Update token in database
-			this.db.setGitIntegration(platform, {
-				host: host || null,
-				access_token: tokenData.access_token,
-				refresh_token: tokenData.refresh_token || integration.refresh_token, // Use new or keep old
-				token_type: tokenData.token_type || "Bearer",
-				expires_at: expiresAt,
-			});
-
-			this.logger.success(`Token refreshed successfully for ${platform}`);
-			return true;
-		} catch (error: any) {
-			this.logger.failure(`Token refresh error: ${error.message}`);
-			return false;
-		}
+		this.logger.info(
+			`Skipping cloud git token refresh for ${platform}; credentials come from git/gh`,
+		);
+		return false;
 	}
 
 	/**
-	 * Alias for `getAccessToken` (automatically refreshes when needed).
+	 * Alias for `getAccessToken`.
 	 */
 	async getAccessTokenLegacy(
 		platform: GitPlatform,

--- a/src/server/http-mcp-transport.ts
+++ b/src/server/http-mcp-transport.ts
@@ -2,6 +2,7 @@ import type { Transport } from "@modelcontextprotocol/sdk/shared/transport.js";
 import type { JSONRPCMessage } from "@modelcontextprotocol/sdk/types.js";
 import type { CapaDatabase } from "../db/database";
 import { logger } from "../shared/logger";
+import { resolveSecretRecord } from "../shared/secret-ref";
 import { shouldSkipTlsVerify } from "../shared/tls-skip-verify";
 import type { MCPServerDefinition } from "../types/capabilities";
 import type { OAuth2Config } from "../types/oauth";
@@ -83,7 +84,7 @@ export class HttpMCPTransport implements Transport {
 			}
 
 			if (this.serverDefinition.headers) {
-				Object.assign(headers, this.serverDefinition.headers);
+				Object.assign(headers, resolveSecretRecord(this.serverDefinition.headers));
 			}
 
 			if (this.serverDefinition.oauth2) {

--- a/src/server/mcp-proxy.ts
+++ b/src/server/mcp-proxy.ts
@@ -2,6 +2,7 @@ import { Client } from "@modelcontextprotocol/sdk/client/index.js";
 import type { Transport } from "@modelcontextprotocol/sdk/shared/transport.js";
 import type { CapaDatabase } from "../db/database";
 import { logger } from "../shared/logger";
+import { resolveSecretRecord } from "../shared/secret-ref";
 import { isStdioTrusted } from "../shared/stdio-allowlist";
 import {
 	hasUnresolvedVariables,
@@ -327,20 +328,26 @@ export class MCPProxy {
 
 		this.logger.info(`Creating new MCP client for server: ${serverId}`);
 
+		const launchDef: MCPServerDefinition = {
+			...serverDefinition,
+			env: resolveSecretRecord(serverDefinition.env),
+			headers: resolveSecretRecord(serverDefinition.headers),
+		};
+
 		// For local subprocess-based servers
-		if (serverDefinition.cmd) {
+		if (launchDef.cmd) {
 			return await this.createStdioClient(
 				serverId,
-				serverDefinition,
+				launchDef,
 				fingerprint,
 			);
 		}
 
 		// For remote HTTP-based servers
-		if (serverDefinition.url) {
+		if (launchDef.url) {
 			return await this.createHttpClient(
 				serverId,
-				serverDefinition,
+				launchDef,
 				fingerprint,
 			);
 		}
@@ -434,7 +441,7 @@ export class MCPProxy {
 			const transport = new StdioClientTransport({
 				command: serverDefinition.cmd!,
 				args: serverDefinition.args || [],
-				env: { ...process.env, ...serverDefinition.env } as Record<
+				env: { ...process.env, ...(resolveSecretRecord(serverDefinition.env) ?? {}) } as Record<
 					string,
 					string
 				>,
@@ -650,7 +657,7 @@ export class MCPProxy {
 
 /** Stable fingerprint of the launch config used to connect an MCP server. */
 export function mcpServerLaunchFingerprint(def: MCPServerDefinition): string {
-	const sorted = (obj: Record<string, string> | undefined) =>
+	const sorted = (obj: Record<string, unknown> | undefined) =>
 		obj
 			? Object.fromEntries(
 					Object.entries(obj).sort(([a], [b]) => a.localeCompare(b)),

--- a/src/server/oauth-token-store.ts
+++ b/src/server/oauth-token-store.ts
@@ -31,10 +31,19 @@ export async function refreshAccessToken(
 
 		const clientId =
 			db.getVariable(projectId, `oauth2_client_id_${serverId}`) || "capa";
-		const clientSecret = db.getVariable(
-			projectId,
-			`oauth2_client_secret_${serverId}`,
-		);
+		let clientSecret: string | null = null;
+		try {
+			clientSecret = db.getVariable(
+				projectId,
+				`oauth2_client_secret_${serverId}`,
+			);
+		} catch (err: unknown) {
+			const message = err instanceof Error ? err.message : String(err);
+			log.failure(`Failed to read OAuth client secret for ${serverId}: ${message}`);
+			db.deleteOAuthToken(projectId, serverId);
+			log.info(`Deleted invalid token for ${serverId}`);
+			return false;
+		}
 
 		const tokenParams: Record<string, string> = {
 			grant_type: "refresh_token",
@@ -74,7 +83,20 @@ export async function refreshAccessToken(
 			return false;
 		}
 
-		const newTokenData = await response.json();
+		const newTokenData = (await response.json()) as {
+			access_token?: string;
+			refresh_token?: string;
+			token_type?: string;
+			expires_in?: number;
+			scope?: string;
+		};
+
+		if (typeof newTokenData.access_token !== "string" || !newTokenData.access_token) {
+			log.failure(`Token refresh response missing access_token for ${serverId}`);
+			db.deleteOAuthToken(projectId, serverId);
+			log.info(`Deleted invalid token for ${serverId}`);
+			return false;
+		}
 
 		const expiresAt = newTokenData.expires_in
 			? Date.now() + newTokenData.expires_in * 1000
@@ -85,7 +107,7 @@ export async function refreshAccessToken(
 			refresh_token: newTokenData.refresh_token || tokenData.refresh_token,
 			token_type: newTokenData.token_type || "Bearer",
 			expires_at: expiresAt,
-			scope: newTokenData.scope || tokenData.scope,
+			scope: newTokenData.scope || tokenData.scope || undefined,
 		});
 
 		log.success(`Access token refreshed for ${serverId}`);

--- a/src/server/secret-redaction.ts
+++ b/src/server/secret-redaction.ts
@@ -1,11 +1,15 @@
+import type { SecretValue } from "../shared/secret-ref";
+import { isSecretRef } from "../shared/secret-ref";
+
 const SENSITIVE_HEADER =
 	/^(authorization|proxy-authorization)$|token|api-?key|secret|password|bearer/i;
 
-function asStringMap(value: unknown): Record<string, string> {
+function asEnvMap(value: unknown): Record<string, SecretValue> {
 	if (!value || typeof value !== "object" || Array.isArray(value)) return {};
-	const out: Record<string, string> = {};
+	const out: Record<string, SecretValue> = {};
 	for (const [key, raw] of Object.entries(value as Record<string, unknown>)) {
 		if (typeof raw === "string") out[key] = raw;
+		else if (isSecretRef(raw)) out[key] = raw;
 	}
 	return out;
 }
@@ -20,8 +24,8 @@ export function isSensitiveHeaderName(name: string): boolean {
 }
 
 export interface ApiServerSecrets {
-	env?: Record<string, string> | null;
-	headers?: Record<string, string> | null;
+	env?: Record<string, SecretValue> | null;
+	headers?: Record<string, SecretValue> | null;
 	oauth2?: {
 		clientId?: string | null;
 		clientSecret?: string | null;
@@ -30,15 +34,29 @@ export interface ApiServerSecrets {
 	[key: string]: unknown;
 }
 
+function redactEnvValue(value: SecretValue): SecretValue {
+	if (typeof value === "string") return "";
+	return value;
+}
+
 export function redactServerForApi<T extends ApiServerSecrets>(server: T): T {
 	const env = server.env
-		? Object.fromEntries(Object.keys(server.env).map((key) => [key, ""]))
+		? Object.fromEntries(
+				Object.entries(server.env).map(([key, value]) => [
+					key,
+					redactEnvValue(value),
+				]),
+			)
 		: server.env;
 
 	let headers = server.headers;
 	if (headers) {
-		const next: Record<string, string> = {};
+		const next: Record<string, SecretValue> = {};
 		for (const [key, value] of Object.entries(headers)) {
+			if (typeof value !== "string") {
+				next[key] = value;
+				continue;
+			}
 			if (isSensitiveHeaderName(key)) continue;
 			next[key] = value;
 		}
@@ -62,19 +80,20 @@ export function mergeServerDef(
 	const merged: Record<string, unknown> = { ...prev, ...incoming };
 
 	if (incoming.env !== undefined) {
-		const prevEnv = asStringMap(prev.env);
-		const nextEnv = asStringMap(incoming.env);
-		const env: Record<string, string> = {};
+		const prevEnv = asEnvMap(prev.env);
+		const nextEnv = asEnvMap(incoming.env);
+		const env: Record<string, SecretValue> = {};
 		for (const [key, value] of Object.entries(nextEnv)) {
-			env[key] = value === "" && key in prevEnv ? prevEnv[key] : value;
+			env[key] =
+				value === "" && key in prevEnv ? prevEnv[key] : value;
 		}
 		merged.env = env;
 	}
 
 	if (incoming.headers !== undefined) {
-		const prevHeaders = asStringMap(prev.headers);
-		const nextHeaders = asStringMap(incoming.headers);
-		const headers: Record<string, string> = { ...nextHeaders };
+		const prevHeaders = asEnvMap(prev.headers);
+		const nextHeaders = asEnvMap(incoming.headers);
+		const headers: Record<string, SecretValue> = { ...nextHeaders };
 		for (const [key, value] of Object.entries(prevHeaders)) {
 			if (key in nextHeaders) {
 				if (nextHeaders[key] === "") headers[key] = value;

--- a/src/server/subprocess-manager.ts
+++ b/src/server/subprocess-manager.ts
@@ -2,6 +2,7 @@ import { ChildProcess, spawn } from "child_process";
 import { createHash } from "crypto";
 import type { CapaDatabase } from "../db/database";
 import { logger } from "../shared/logger";
+import { resolveSecretRecord } from "../shared/secret-ref";
 import type { MCPServerDefinition } from "../types/capabilities";
 
 export interface MCPSubprocessInfo {
@@ -127,7 +128,10 @@ export class SubprocessManager {
 
 		// Parse command
 		const args = definition.args || [];
-		const env = { ...process.env, ...definition.env };
+		const env = {
+			...process.env,
+			...(resolveSecretRecord(definition.env) ?? {}),
+		};
 		const cwd = definition.cwd ?? projectPath;
 
 		this.logger.debug(`Working directory: ${cwd}`);

--- a/src/shared/__tests__/authenticated-fetch.test.ts
+++ b/src/shared/__tests__/authenticated-fetch.test.ts
@@ -1,5 +1,13 @@
 import { describe, it, expect, beforeEach, afterEach } from 'bun:test';
+import { mkdtempSync, rmSync } from 'fs';
+import { tmpdir } from 'os';
+import { join } from 'path';
 import { AuthenticatedFetch } from '../authenticated-fetch';
+import {
+  approveGitHttpCredential,
+  resetGitCredentialsForTests,
+} from '../git-credentials';
+import { resetSecretCryptoForTests } from '../secret-crypto';
 import type { CapaDatabase } from '../../db/database';
 import type { GitIntegration } from '../../types/database';
 
@@ -11,10 +19,10 @@ function makeIntegration(overrides: Partial<GitIntegration> = {}): GitIntegratio
     id: 1,
     platform: 'github',
     host: null,
-    access_token: 'gho_test_token',
+    access_token: '',
     refresh_token: null,
     token_type: 'Bearer',
-    expires_at: Date.now() + 60 * 60 * 1000,
+    expires_at: null,
     created_at: Date.now(),
     updated_at: Date.now(),
     ...overrides,
@@ -30,37 +38,21 @@ function makeDb(integration: GitIntegration | null): CapaDatabase {
   } as unknown as CapaDatabase;
 }
 
-function makeDbWithSpies(integration: GitIntegration | null) {
-  const deletes: Array<{ platform: string; host: string | null }> = [];
-  const sets: Array<{ platform: string; tokenData: Record<string, unknown> }> = [];
-  let current: GitIntegration | null = integration;
-  const db = {
-    getGitIntegration: () => current,
-    getAllGitIntegrations: () => (current ? [current] : []),
-    setGitIntegration: (platform: string, tokenData: Record<string, unknown>) => {
-      sets.push({ platform, tokenData });
-      if (current) {
-        current = {
-          ...current,
-          access_token: String(tokenData.access_token ?? current.access_token),
-          refresh_token: (tokenData.refresh_token as string | null | undefined) ?? current.refresh_token,
-          expires_at: (tokenData.expires_at as number | null | undefined) ?? current.expires_at,
-        };
-      }
-    },
-    deleteGitIntegration: (platform: string, host: string | null) => {
-      deletes.push({ platform, host });
-      current = null;
-    },
-  } as unknown as CapaDatabase;
-  return { db, deletes, sets, get current() { return current; } };
-}
-
 describe('AuthenticatedFetch', () => {
   const originalFetch = globalThis.fetch;
   let fetchCalls: Array<{ url: string; init?: RequestInit }>;
+  let home: string;
+  let prevHome: string | undefined;
+  let prevProfile: string | undefined;
 
   beforeEach(() => {
+    home = mkdtempSync(join(tmpdir(), 'capa-authfetch-'));
+    prevHome = process.env.HOME;
+    prevProfile = process.env.USERPROFILE;
+    process.env.HOME = home;
+    process.env.USERPROFILE = home;
+    resetSecretCryptoForTests();
+    resetGitCredentialsForTests();
     fetchCalls = [];
     globalThis.fetch = (async (input: RequestInfo | URL, init?: RequestInit) => {
       const url = typeof input === 'string' ? input : input.toString();
@@ -71,30 +63,28 @@ describe('AuthenticatedFetch', () => {
 
   afterEach(() => {
     globalThis.fetch = originalFetch;
+    resetSecretCryptoForTests();
+    if (prevHome === undefined) delete process.env.HOME;
+    else process.env.HOME = prevHome;
+    if (prevProfile === undefined) delete process.env.USERPROFILE;
+    else process.env.USERPROFILE = prevProfile;
+    rmSync(home, { recursive: true, force: true });
   });
 
-  it('falls back to unauthenticated fetch when the token is expired and refresh is unavailable', async () => {
-    const db = makeDb(
-      makeIntegration({
-        expires_at: Date.now() - 60_000,
-        refresh_token: null,
-      })
-    );
-    const authFetch = new AuthenticatedFetch(db);
+  it('falls back to unauthenticated fetch when the git helper has no token', async () => {
+    const authFetch = new AuthenticatedFetch(makeDb(null));
 
-    // Should not throw — the request proceeds without auth so public URLs still work.
     const response = await authFetch.fetch(GITHUB_RAW_URL);
     expect(response.status).toBe(200);
 
-    // Fetch must have been called once (unauthenticated — no Authorization header).
     expect(fetchCalls).toHaveLength(1);
     const headers = fetchCalls[0]!.init?.headers as Headers | undefined;
     expect(headers?.get?.('Authorization') ?? null).toBeNull();
   });
 
-  it('includes the auth header when the token is valid and not expired', async () => {
-    const db = makeDb(makeIntegration());
-    const authFetch = new AuthenticatedFetch(db);
+  it('includes the auth header from the git credential helper, not sqlite', async () => {
+    approveGitHttpCredential('github.com', 'gho_test_token');
+    const authFetch = new AuthenticatedFetch(makeDb(makeIntegration()));
 
     await authFetch.fetch(GITHUB_RAW_URL);
 
@@ -104,8 +94,8 @@ describe('AuthenticatedFetch', () => {
   });
 
   it('returns a 200 response unchanged', async () => {
-    const db = makeDb(makeIntegration());
-    const authFetch = new AuthenticatedFetch(db);
+    approveGitHttpCredential('github.com', 'gho_test_token');
+    const authFetch = new AuthenticatedFetch(makeDb(makeIntegration()));
 
     const response = await authFetch.fetch(GITHUB_RAW_URL);
 
@@ -120,8 +110,8 @@ describe('AuthenticatedFetch', () => {
       return new Response('Unauthorized', { status: 401 });
     }) as typeof fetch;
 
-    const db = makeDb(makeIntegration());
-    const authFetch = new AuthenticatedFetch(db);
+    approveGitHttpCredential('github.com', 'gho_test_token');
+    const authFetch = new AuthenticatedFetch(makeDb(makeIntegration()));
 
     const response = await authFetch.fetch(GITHUB_RAW_URL);
 
@@ -137,8 +127,8 @@ describe('AuthenticatedFetch', () => {
       return new Response('Not Found', { status: 404 });
     }) as typeof fetch;
 
-    const db = makeDb(makeIntegration());
-    const authFetch = new AuthenticatedFetch(db);
+    approveGitHttpCredential('github.com', 'gho_test_token');
+    const authFetch = new AuthenticatedFetch(makeDb(makeIntegration()));
 
     const response = await authFetch.fetch(GITHUB_RAW_URL);
 
@@ -147,94 +137,16 @@ describe('AuthenticatedFetch', () => {
     expect(AuthenticatedFetch.isPrivateRepoError(response)).toBe(false);
   });
 
-  describe('refresh failure classification', () => {
-    it('keeps the stored token and falls back to unauthenticated fetch when the cloud refresh endpoint returns a transient 5xx', async () => {
-      let targetFetchCalled = false;
-      globalThis.fetch = (async (input: RequestInfo | URL) => {
-        const url = typeof input === 'string' ? input : input.toString();
-        if (url.includes('/auth/refresh')) {
-          return new Response('bad gateway', { status: 502 });
-        }
-        targetFetchCalled = true;
-        return new Response('ok', { status: 200 });
-      }) as typeof fetch;
+  it('does not call capa.infragate.ai to refresh git tokens', async () => {
+    globalThis.fetch = (async (input: RequestInfo | URL, init?: RequestInit) => {
+      const url = typeof input === 'string' ? input : input.toString();
+      fetchCalls.push({ url, init });
+      return new Response('ok', { status: 200 });
+    }) as typeof fetch;
 
-      const harness = makeDbWithSpies(
-        makeIntegration({
-          expires_at: Date.now() - 60_000,
-          refresh_token: 'still-valid-refresh',
-        })
-      );
-      const authFetch = new AuthenticatedFetch(harness.db);
+    const authFetch = new AuthenticatedFetch(makeDb(makeIntegration()));
+    await authFetch.fetch(GITHUB_RAW_URL);
 
-      // Falls back to unauthenticated — does not throw.
-      const response = await authFetch.fetch(GITHUB_RAW_URL);
-      expect(response.status).toBe(200);
-      expect(targetFetchCalled).toBe(true);
-
-      // Stored token must NOT be deleted on a transient failure.
-      expect(harness.deletes).toHaveLength(0);
-      expect(harness.current).not.toBeNull();
-      expect(harness.current?.refresh_token).toBe('still-valid-refresh');
-    });
-
-    it('keeps the stored token and falls back to unauthenticated fetch when the refresh request throws a network error', async () => {
-      let targetFetchCalled = false;
-      globalThis.fetch = (async (input: RequestInfo | URL) => {
-        const url = typeof input === 'string' ? input : input.toString();
-        if (url.includes('/auth/refresh')) {
-          throw new Error('ENOTFOUND capa.infragate.ai');
-        }
-        targetFetchCalled = true;
-        return new Response('ok', { status: 200 });
-      }) as typeof fetch;
-
-      const harness = makeDbWithSpies(
-        makeIntegration({
-          expires_at: Date.now() - 60_000,
-          refresh_token: 'still-valid-refresh',
-        })
-      );
-      const authFetch = new AuthenticatedFetch(harness.db);
-
-      const response = await authFetch.fetch(GITHUB_RAW_URL);
-      expect(response.status).toBe(200);
-      expect(targetFetchCalled).toBe(true);
-
-      expect(harness.deletes).toHaveLength(0);
-      expect(harness.current).not.toBeNull();
-    });
-
-    it('deletes the stored token and falls back to unauthenticated fetch when the refresh_token is rejected as invalid_grant', async () => {
-      let targetFetchCalled = false;
-      globalThis.fetch = (async (input: RequestInfo | URL) => {
-        const url = typeof input === 'string' ? input : input.toString();
-        if (url.includes('/auth/refresh')) {
-          return new Response(JSON.stringify({ error: 'invalid_grant' }), {
-            status: 400,
-            headers: { 'Content-Type': 'application/json' },
-          });
-        }
-        targetFetchCalled = true;
-        return new Response('ok', { status: 200 });
-      }) as typeof fetch;
-
-      const harness = makeDbWithSpies(
-        makeIntegration({
-          expires_at: Date.now() - 60_000,
-          refresh_token: 'truly-revoked',
-        })
-      );
-      const authFetch = new AuthenticatedFetch(harness.db);
-
-      // Falls back to unauthenticated after clearing the bad token.
-      const response = await authFetch.fetch(GITHUB_RAW_URL);
-      expect(response.status).toBe(200);
-      expect(targetFetchCalled).toBe(true);
-
-      expect(harness.deletes).toHaveLength(1);
-      expect(harness.deletes[0]).toEqual({ platform: 'github', host: null });
-      expect(harness.current).toBeNull();
-    });
+    expect(fetchCalls.every((c) => !c.url.includes('capa.infragate.ai'))).toBe(true);
   });
 });

--- a/src/shared/__tests__/cache-git-auth.test.ts
+++ b/src/shared/__tests__/cache-git-auth.test.ts
@@ -95,7 +95,7 @@ describe('cache git auth (F10)', () => {
       }
     });
 
-    it('injects private-clone credentials out of band via GIT_ASKPASS or GIT_CONFIG env', async () => {
+    it('does not inject CAPA-held credentials into git clone env', async () => {
       const calls: { args: string[]; env?: NodeJS.ProcessEnv }[] = [];
       const execFileSpy = spyOn(childProcess, 'execFile').mockImplementation(
         ((_cmd: string, args: string[], opts: object, cb: (err: null, stdout: string, stderr: string) => void) => {
@@ -109,7 +109,7 @@ describe('cache git auth (F10)', () => {
         const cloneCall = calls.find((c) => c.args.includes('clone'));
         expect(cloneCall).toBeDefined();
         expect(argvContainsSecret(cloneCall!.args)).toBe(false);
-        expect(envCarriesOutOfBandAuth(cloneCall!.env)).toBe(true);
+        expect(envCarriesOutOfBandAuth(cloneCall!.env)).toBe(false);
       } finally {
         execFileSpy.mockRestore();
       }
@@ -185,7 +185,7 @@ describe('cache git auth (F10)', () => {
   });
 
   describe('fetchMirror', () => {
-    it('injects credentials per call without putting the token in argv', async () => {
+    it('does not inject credentials on fetch; git uses the developer helper', async () => {
       const calls: { args: string[]; env?: NodeJS.ProcessEnv }[] = [];
       const execFileSpy = spyOn(childProcess, 'execFile').mockImplementation(
         ((_cmd: string, args: string[], opts: object, cb: (err: null, stdout: string, stderr: string) => void) => {
@@ -204,7 +204,7 @@ describe('cache git auth (F10)', () => {
         expect(updateCall).toBeDefined();
         expect(argvContainsSecret(updateCall!.args)).toBe(false);
         expect(updateCall!.args.some((a) => /oauth2:/i.test(a))).toBe(false);
-        expect(envCarriesOutOfBandAuth(updateCall!.env)).toBe(true);
+        expect(envCarriesOutOfBandAuth(updateCall!.env)).toBe(false);
       } finally {
         execFileSpy.mockRestore();
       }

--- a/src/shared/__tests__/git-credentials.test.ts
+++ b/src/shared/__tests__/git-credentials.test.ts
@@ -1,0 +1,59 @@
+import { afterEach, beforeEach, describe, expect, it } from "bun:test";
+import { mkdtempSync, rmSync } from "fs";
+import { tmpdir } from "os";
+import { join } from "path";
+import {
+	approveGitHttpCredential,
+	fillGitHttpCredential,
+	gitHostForPlatform,
+	hasGitHttpCredential,
+	rejectGitHttpCredential,
+	resetGitCredentialsForTests,
+} from "../git-credentials";
+
+describe("git-credentials", () => {
+	let home: string;
+	let prevHome: string | undefined;
+	let prevProfile: string | undefined;
+
+	beforeEach(() => {
+		home = mkdtempSync(join(tmpdir(), "capa-git-cred-"));
+		prevHome = process.env.HOME;
+		prevProfile = process.env.USERPROFILE;
+		process.env.HOME = home;
+		process.env.USERPROFILE = home;
+		resetGitCredentialsForTests();
+	});
+
+	afterEach(() => {
+		resetGitCredentialsForTests();
+		if (prevHome === undefined) delete process.env.HOME;
+		else process.env.HOME = prevHome;
+		if (prevProfile === undefined) delete process.env.USERPROFILE;
+		else process.env.USERPROFILE = prevProfile;
+		rmSync(home, { recursive: true, force: true });
+	});
+
+	it("maps platforms to hosts", () => {
+		expect(gitHostForPlatform("github", null)).toBe("github.com");
+		expect(gitHostForPlatform("gitlab")).toBe("gitlab.com");
+		expect(gitHostForPlatform("github-enterprise", "git.corp")).toBe("git.corp");
+	});
+
+	it("round-trips through the in-memory helper used in tests", () => {
+		expect(hasGitHttpCredential("github.com")).toBe(false);
+		approveGitHttpCredential("github.com", "gho_test_token");
+		expect(fillGitHttpCredential("github.com")).toBe("gho_test_token");
+		expect(hasGitHttpCredential("github.com")).toBe(true);
+		rejectGitHttpCredential("github.com");
+		expect(fillGitHttpCredential("github.com")).toBeNull();
+	});
+
+	it("maps GitHub raw/api hosts onto github.com credentials", () => {
+		approveGitHttpCredential("github.com", "gho_test_token");
+		expect(fillGitHttpCredential("raw.githubusercontent.com")).toBe(
+			"gho_test_token",
+		);
+		expect(fillGitHttpCredential("api.github.com")).toBe("gho_test_token");
+	});
+});

--- a/src/shared/__tests__/secret-crypto.test.ts
+++ b/src/shared/__tests__/secret-crypto.test.ts
@@ -2,11 +2,17 @@ import { afterEach, beforeEach, describe, expect, it } from "bun:test";
 import { existsSync, mkdtempSync, readFileSync, rmSync, statSync } from "fs";
 import { tmpdir } from "os";
 import { join } from "path";
+import { oauthSecretBinding, variableSecretBinding } from "../secret-binding";
 import {
+	SECRET_CIPHER_PREFIX,
 	decryptSecret,
 	encryptSecret,
 	resetSecretCryptoForTests,
 } from "../secret-crypto";
+import {
+	activeSecretStoreTier,
+	describeSecretStoreTier,
+} from "../secret-store";
 
 const skipModeAsserts = process.platform === "win32";
 
@@ -33,25 +39,51 @@ describe("secret-crypto", () => {
 		rmSync(home, { recursive: true, force: true });
 	});
 
-	it("round-trips plaintext through enc:v1: ciphertext", () => {
-		const cipher = encryptSecret("hello-secret");
-		expect(cipher.startsWith("enc:v1:")).toBe(true);
+	const binding = variableSecretBinding("p1", "API_KEY");
+
+	it("round-trips plaintext through enc:v2: ciphertext", () => {
+		const cipher = encryptSecret("hello-secret", binding);
+		expect(cipher.startsWith(SECRET_CIPHER_PREFIX)).toBe(true);
 		expect(cipher).not.toContain("hello-secret");
-		expect(decryptSecret(cipher)).toBe("hello-secret");
+		expect(decryptSecret(cipher, binding)).toBe("hello-secret");
+	});
+
+	it("uses a fresh random 12-byte nonce on every write", () => {
+		const a = encryptSecret("same-plain", binding);
+		const b = encryptSecret("same-plain", binding);
+		expect(a).not.toBe(b);
+		const payloadA = Buffer.from(a.slice(SECRET_CIPHER_PREFIX.length), "base64");
+		const payloadB = Buffer.from(b.slice(SECRET_CIPHER_PREFIX.length), "base64");
+		expect(payloadA.subarray(0, 12).equals(payloadB.subarray(0, 12))).toBe(false);
+	});
+
+	it("refuses to decrypt a ciphertext relocated to another row", () => {
+		const cipher = encryptSecret("row-secret", binding);
+		expect(
+			decryptSecret(cipher, variableSecretBinding("p1", "OTHER_KEY")),
+		).toBeNull();
+		expect(
+			decryptSecret(cipher, oauthSecretBinding("p1", "svc", "access_token")),
+		).toBeNull();
+		expect(decryptSecret(cipher, binding)).toBe("row-secret");
 	});
 
 	it("returns legacy plaintext unchanged", () => {
-		expect(decryptSecret("legacy-plain-token")).toBe("legacy-plain-token");
+		expect(decryptSecret("legacy-plain-token", binding)).toBe(
+			"legacy-plain-token",
+		);
 	});
 
 	it("treats a legacy plaintext value that starts with enc:v1: as plaintext", () => {
-		expect(decryptSecret("enc:v1:this-is-not-ciphertext")).toBe(
+		expect(decryptSecret("enc:v1:this-is-not-ciphertext", binding)).toBe(
 			"enc:v1:this-is-not-ciphertext",
 		);
 	});
 
-	it("creates ~/.capa/master.key with mode 0600", () => {
-		encryptSecret("x");
+	it("creates ~/.capa/master.key with mode 0600 on the file fallback tier", () => {
+		encryptSecret("x", binding);
+		expect(activeSecretStoreTier()).toBe("file");
+		expect(describeSecretStoreTier("file")).toContain("Linux fallback");
 		const keyPath = join(home, ".capa", "master.key");
 		expect(existsSync(keyPath)).toBe(true);
 		expect(readFileSync(keyPath).length).toBe(32);

--- a/src/shared/__tests__/secret-ref.test.ts
+++ b/src/shared/__tests__/secret-ref.test.ts
@@ -1,0 +1,68 @@
+import { afterEach, describe, expect, it } from "bun:test";
+import { mkdtempSync, rmSync, writeFileSync } from "fs";
+import { tmpdir } from "os";
+import { join } from "path";
+import {
+	isSecretRef,
+	resolveSecretRecord,
+	resolveSecretValue,
+} from "../secret-ref";
+
+describe("secret-ref", () => {
+	it("detects fromEnv / fromCommand / fromFile objects", () => {
+		expect(isSecretRef({ fromEnv: "API_KEY" })).toBe(true);
+		expect(isSecretRef({ fromCommand: "op read op://x" })).toBe(true);
+		expect(isSecretRef({ fromFile: "/tmp/token" })).toBe(true);
+		expect(isSecretRef("literal")).toBe(false);
+		expect(isSecretRef({ fromEnv: "A", fromFile: "B" })).toBe(false);
+		expect(isSecretRef({ fromEnv: "" })).toBe(false);
+	});
+
+	it("resolves fromEnv", () => {
+		const prev = process.env.CAPA_TEST_FROM_ENV;
+		process.env.CAPA_TEST_FROM_ENV = "env-secret-value";
+		try {
+			expect(resolveSecretValue({ fromEnv: "CAPA_TEST_FROM_ENV" })).toBe(
+				"env-secret-value",
+			);
+		} finally {
+			if (prev === undefined) delete process.env.CAPA_TEST_FROM_ENV;
+			else process.env.CAPA_TEST_FROM_ENV = prev;
+		}
+	});
+
+	it("resolves fromFile", () => {
+		const dir = mkdtempSync(join(tmpdir(), "capa-secret-file-"));
+		const path = join(dir, "token");
+		writeFileSync(path, "file-secret\n");
+		try {
+			expect(resolveSecretValue({ fromFile: path })).toBe("file-secret");
+		} finally {
+			rmSync(dir, { recursive: true, force: true });
+		}
+	});
+
+	it("resolves fromCommand without a shell", () => {
+		const exe = process.execPath;
+		const result = resolveSecretValue({
+			fromCommand: `${JSON.stringify(exe)} -e ${JSON.stringify("process.stdout.write('cmd-secret')")}`,
+		});
+		expect(result).toBe("cmd-secret");
+	});
+
+	it("refuses fromCommand that starts with a shell", () => {
+		expect(() =>
+			resolveSecretValue({ fromCommand: "sh -c 'echo pwned'" }),
+		).toThrow(/refuses to run a shell/);
+	});
+
+	it("resolves a mixed env/header record", () => {
+		process.env.CAPA_TEST_FROM_ENV = "via-env";
+		const resolved = resolveSecretRecord({
+			LITERAL: "plain",
+			FROM_ENV: { fromEnv: "CAPA_TEST_FROM_ENV" },
+		});
+		expect(resolved).toEqual({ LITERAL: "plain", FROM_ENV: "via-env" });
+		delete process.env.CAPA_TEST_FROM_ENV;
+	});
+});

--- a/src/shared/authenticated-fetch.ts
+++ b/src/shared/authenticated-fetch.ts
@@ -1,32 +1,20 @@
 /**
  * Authenticated Fetch Helper for Private Repositories
  *
- * Provides fetch helpers that automatically add authentication headers
- * for GitHub and GitLab based on stored credentials.
+ * Adds GitHub/GitLab auth headers using the developer's existing git
+ * credential helper / `gh auth token`. CAPA does not store git tokens.
  */
 
 import type { CapaDatabase } from "../db/database";
-import type { GitIntegration } from "../types/database";
 import type { GitPlatform } from "../types/git-integration";
+import {
+	fillGitHttpCredential,
+	gitHostFromUrl,
+} from "./git-credentials";
 import { getGitProvider, getGitProviderByHost } from "./git-providers/registry";
-import { isPermanentRefreshFailure } from "./oauth-refresh";
 
-const CLOUD_OAUTH_ENDPOINT = "https://capa.infragate.ai/auth";
-
-// Kept for reference in tests; no longer thrown by ensureFreshIntegration so that
-// public URLs on known git hosts still work when the stored token is expired.
 export const TOKEN_EXPIRED_MESSAGE =
 	"Git integration token has expired. Run `capa auth` again to re-authenticate.";
-
-function getExpiresAt(integration: GitIntegration): number | null {
-	const row = integration as GitIntegration & { expiresAt?: number | null };
-	return integration.expires_at ?? row.expiresAt ?? null;
-}
-
-function isTokenExpired(integration: GitIntegration): boolean {
-	const expiresAt = getExpiresAt(integration);
-	return expiresAt !== null && expiresAt < Date.now();
-}
 
 export class AuthenticatedFetch {
 	private db: CapaDatabase;
@@ -35,139 +23,24 @@ export class AuthenticatedFetch {
 		this.db = db;
 	}
 
-	/**
-	 * Detect the platform from a URL
-	 */
-	private detectPlatform(
-		url: string,
-	): { platform: GitPlatform; host?: string } | null {
-		try {
-			const urlObj = new URL(url);
-			const host = urlObj.hostname;
+	private authorizationHeader(host: string, token: string): string {
+		const provider = getGitProviderByHost(host);
+		if (provider) return provider.authHeader(token);
 
-			const provider = getGitProviderByHost(host);
-			if (provider) {
-				return { platform: provider.id as GitPlatform };
-			}
-
-			// Check for self-managed instances
-			const integrations = this.db.getAllGitIntegrations();
-
-			for (const integration of integrations) {
-				if (integration.host && host === integration.host) {
-					return {
-						platform: integration.platform as GitPlatform,
-						host: integration.host,
-					};
-				}
-			}
-
-			return null;
-		} catch (error) {
-			return null;
-		}
-	}
-
-	private canRefresh(platform: GitPlatform): boolean {
-		return !!getGitProvider(platform);
-	}
-
-	/**
-	 * Refresh an expired OAuth token via the cloud endpoint and persist to the DB.
-	 */
-	private async refreshAccessToken(
-		platform: GitPlatform,
-		host: string | undefined,
-		integration: GitIntegration,
-	): Promise<boolean> {
-		if (!integration.refresh_token || !this.canRefresh(platform)) {
-			return false;
-		}
-
-		try {
-			const gp = getGitProvider(platform);
-			if (!gp) return false;
-
-			const response = await fetch(`${CLOUD_OAUTH_ENDPOINT}/refresh`, {
-				method: "POST",
-				headers: { "Content-Type": "application/json" },
-				body: JSON.stringify({
-					provider: gp.cloudOAuthProviderParam,
-					refresh_token: integration.refresh_token,
-				}),
-			});
-			if (!response.ok) {
-				// Only drop the stored token when the refresh_token is provably bad. Transient
-				// 5xx / rate-limit / network failures leave the token in place so the next
-				// request (or the scheduler) can retry.
-				const body = await response.text().catch(() => "");
-				if (isPermanentRefreshFailure(undefined, response, body)) {
-					this.db.deleteGitIntegration(platform, host ?? null);
-				}
-				return false;
-			}
-
-			const tokenData = (await response.json()) as {
-				access_token?: string;
-				refresh_token?: string;
-				token_type?: string;
-				expires_in?: number;
-			};
-
-			if (!tokenData.access_token) {
-				return false;
-			}
-
-			const expiresAt = tokenData.expires_in
-				? Date.now() + tokenData.expires_in * 1000
-				: null;
-
-			this.db.setGitIntegration(platform, {
-				host: host ?? null,
-				access_token: tokenData.access_token,
-				refresh_token: tokenData.refresh_token || integration.refresh_token,
-				token_type: tokenData.token_type || "Bearer",
-				expires_at: expiresAt,
-			});
-
-			return true;
-		} catch {
-			return false;
-		}
-	}
-
-	/**
-	 * Ensure the integration has a non-expired token, refreshing when possible.
-	 * Returns null when the token is expired and cannot be refreshed — callers
-	 * should fall back to an unauthenticated request rather than aborting, so
-	 * that public URLs on known git hosts (e.g. raw.githubusercontent.com) still
-	 * work even when the user's stored token has expired.
-	 */
-	private async ensureFreshIntegration(
-		platform: GitPlatform,
-		host: string | undefined,
-		integration: GitIntegration,
-	): Promise<GitIntegration | null> {
-		if (!isTokenExpired(integration)) {
-			return integration;
-		}
-
-		const refreshed = await this.refreshAccessToken(
-			platform,
-			host,
-			integration,
+		const integrations = this.db.getAllGitIntegrations();
+		const match = integrations.find(
+			(row) => row.host && row.host.toLowerCase() === host.toLowerCase(),
 		);
-		if (refreshed) {
-			const updated = this.db.getGitIntegration(platform, host ?? null);
-			if (updated && !isTokenExpired(updated)) {
-				return updated;
-			}
+		if (match?.platform === "github-enterprise") {
+			return `token ${token}`;
 		}
+		return `Bearer ${token}`;
+	}
 
-		// Token is expired and refresh failed. Return null so the caller can fall
-		// back to an unauthenticated request. Private repos will still get a 401/403
-		// which the install flow already converts into a friendly re-auth prompt.
-		return null;
+	private tokenForUrl(url: string): string | null {
+		const host = gitHostFromUrl(url);
+		if (!host) return null;
+		return fillGitHttpCredential(host);
 	}
 
 	/**
@@ -176,119 +49,43 @@ export class AuthenticatedFetch {
 	private async getAuthHeaders(
 		url: string,
 	): Promise<Record<string, string> | null> {
-		const detected = this.detectPlatform(url);
-		if (!detected) {
-			return null;
-		}
-
-		const { platform, host } = detected;
-		const integration = this.db.getGitIntegration(platform, host || null);
-
-		if (!integration) {
-			return null;
-		}
-
-		const fresh = await this.ensureFreshIntegration(
-			platform,
-			host,
-			integration,
-		);
-		if (!fresh) {
-			// Token expired and could not be refreshed; proceed without auth headers.
-			return null;
-		}
-
-		const gp = getGitProvider(platform);
-		if (gp) {
-			return {
-				Authorization: gp.authHeader(fresh.access_token),
-			};
-		}
-
-		// Self-managed instances
-		if (platform === "github-enterprise") {
-			return {
-				Authorization: `token ${fresh.access_token}`,
-			};
-		}
-
-		return {
-			Authorization: `Bearer ${fresh.access_token}`,
-		};
+		const host = gitHostFromUrl(url);
+		if (!host) return null;
+		const token = fillGitHttpCredential(host);
+		if (!token) return null;
+		return { Authorization: this.authorizationHeader(host, token) };
 	}
 
-	/**
-	 * Perform an authenticated fetch request
-	 * @param url The URL to fetch
-	 * @param options Standard fetch options
-	 * @returns Response object
-	 */
 	async fetch(url: string, options: RequestInit = {}): Promise<Response> {
 		const authHeaders = await this.getAuthHeaders(url);
-
 		const headers = new Headers(options.headers || {});
-
 		if (authHeaders) {
 			for (const [key, value] of Object.entries(authHeaders)) {
 				headers.set(key, value);
 			}
 		}
-
 		return fetch(url, {
 			...options,
 			headers,
 		});
 	}
 
-	/**
-	 * Check if authentication is available for a URL
-	 */
 	hasAuth(url: string): boolean {
-		const detected = this.detectPlatform(url);
-		if (!detected) {
-			return false;
-		}
-
-		const { platform, host } = detected;
-		const integration = this.db.getGitIntegration(platform, host || null);
-
-		return !!integration && !isTokenExpired(integration);
+		return this.tokenForUrl(url) != null;
 	}
 
-	/**
-	 * Get the access token for a URL (for use in git clone)
-	 * @param url The URL to get the token for
-	 * @returns The access token or null if not available
-	 */
 	getTokenForUrl(url: string): string | null {
-		const detected = this.detectPlatform(url);
-		if (!detected) {
-			return null;
-		}
-
-		const { platform, host } = detected;
-		const integration = this.db.getGitIntegration(platform, host || null);
-
-		if (!integration || isTokenExpired(integration)) {
-			return null;
-		}
-
-		return integration.access_token;
+		return this.tokenForUrl(url);
 	}
 
-	/**
-	 * Check if a URL is for a private repository based on response
-	 * This should be called after a failed fetch attempt
-	 */
 	static isPrivateRepoError(response: Response): boolean {
 		return response.status === 401 || response.status === 403;
 	}
 }
 
-/**
- * Create an authenticated fetch helper
- * This is a convenience function for creating an AuthenticatedFetch instance
- */
 export function createAuthenticatedFetch(db: CapaDatabase): AuthenticatedFetch {
 	return new AuthenticatedFetch(db);
 }
+
+/** @deprecated Detected platform is no longer required for clone auth. */
+export type { GitPlatform };

--- a/src/shared/cache/git-cli.ts
+++ b/src/shared/cache/git-cli.ts
@@ -39,22 +39,6 @@ const NON_INTERACTIVE_GIT_ENV: Record<string, string> = {
 		process.env.GIT_SSH_COMMAND ?? "ssh -o BatchMode=yes -o ConnectTimeout=10",
 };
 
-/**
- * Pass an HTTP credential to git without putting it in argv or the remote URL.
- * Uses GIT_CONFIG_* env indirection so `http.extraHeader` is not visible in `ps`.
- */
-export function gitHttpCredentialEnv(token: string): Record<string, string> {
-	const parsed = Number.parseInt(process.env.GIT_CONFIG_COUNT ?? "0", 10);
-	const n = Number.isFinite(parsed) && parsed > 0 ? parsed : 0;
-	const basic = Buffer.from(`oauth2:${token}`, "utf8").toString("base64");
-	return {
-		GIT_TERMINAL_PROMPT: "0",
-		GIT_CONFIG_COUNT: String(n + 1),
-		[`GIT_CONFIG_KEY_${n}`]: "http.extraHeader",
-		[`GIT_CONFIG_VALUE_${n}`]: `Authorization: Basic ${basic}`,
-	};
-}
-
 export async function git(
 	args: string[],
 	opts: ExecFileOptions = {},

--- a/src/shared/cache/mirror.ts
+++ b/src/shared/cache/mirror.ts
@@ -8,7 +8,7 @@ import {
 } from "fs";
 import { join } from "path";
 import type { AuthenticatedFetch } from "../authenticated-fetch";
-import { git, gitHttpCredentialEnv } from "./git-cli";
+import { git } from "./git-cli";
 import {
 	type CachePlatform,
 	getCacheDir,
@@ -48,15 +48,6 @@ function stripHttpUrlUserinfo(url: string): string {
 	return stripUserinfoFromHttpUrl(url) ?? url;
 }
 
-function credentialEnvFor(
-	url: string,
-	authFetch: AuthenticatedFetch,
-): Record<string, string> | undefined {
-	if (!authFetch.hasAuth(url)) return undefined;
-	const token = authFetch.getTokenForUrl(url);
-	if (!token) return undefined;
-	return gitHttpCredentialEnv(token);
-}
 
 function scrubGitConfigText(text: string): string {
 	return text.replace(
@@ -135,7 +126,7 @@ export function scrubCachedMirrorAuthUrls(): void {
 export async function ensureMirrorClone(
 	platform: CachePlatform,
 	repoPath: string,
-	authFetch: AuthenticatedFetch,
+	_authFetch: AuthenticatedFetch,
 	repoUrl?: string,
 ): Promise<string> {
 	validateRepoPath(repoPath);
@@ -149,7 +140,6 @@ export async function ensureMirrorClone(
 	const url = stripHttpUrlUserinfo(
 		repoUrl ?? publicHttpsRepoUrl(platform, repoPath),
 	);
-	const env = credentialEnvFor(url, authFetch);
 	// Blobless partial clone: fetch the full commit/tree graph (so any SHA, tag,
 	// or branch still resolves offline via resolveRef) but skip all historical
 	// file contents. On a big repo (e.g. remotion) this avoids downloading every
@@ -165,9 +155,7 @@ export async function ensureMirrorClone(
 	//
 	// Requires git >= 2.19. Servers without partial-clone support degrade
 	// gracefully to a full clone (git warns and ignores the filter).
-	await git(["clone", "--mirror", "--filter=blob:none", url, mirrorDir], {
-		env,
-	});
+	await git(["clone", "--mirror", "--filter=blob:none", url, mirrorDir]);
 	await git(["-C", mirrorDir, "remote", "set-url", "origin", url]);
 	return mirrorDir;
 }
@@ -176,30 +164,16 @@ export async function ensureMirrorClone(
  * Update an existing mirror clone (`git remote update`). Used when a requested
  * version/ref isn't yet present in the mirror.
  *
- * Credentials are injected per-call via env (never stored in the remote URL).
+ * Git uses the developer's credential helper (GCM / `gh auth` / osxkeychain).
+ * CAPA does not inject or persist git tokens.
  */
 export async function fetchMirror(
 	mirrorDir: string,
-	authFetch?: AuthenticatedFetch,
+	_authFetch?: AuthenticatedFetch,
 ): Promise<void> {
 	scrubCachedMirrorAuthUrls();
 	scrubMirrorConfigFile(mirrorDir);
-	let env: Record<string, string> | undefined;
-	if (authFetch) {
-		try {
-			const { stdout } = await git([
-				"-C",
-				mirrorDir,
-				"remote",
-				"get-url",
-				"origin",
-			]);
-			env = credentialEnvFor(stdout.trim(), authFetch);
-		} catch {
-			// No origin remote — update may still succeed for other remotes.
-		}
-	}
-	await git(["-C", mirrorDir, "remote", "update", "--prune"], { env });
+	await git(["-C", mirrorDir, "remote", "update", "--prune"]);
 }
 
 /**

--- a/src/shared/executable-surface.ts
+++ b/src/shared/executable-surface.ts
@@ -2,6 +2,7 @@ import { createHash } from 'crypto';
 import { chmodSync, mkdirSync, readFileSync, writeFileSync } from 'fs';
 import { join } from 'path';
 import type { Capabilities } from '../types/capabilities';
+import type { SecretValue } from './secret-ref';
 import type { Hook } from '../types/hooks';
 import type { Plugin } from '../types/plugin';
 import { getCapaDir } from './config';
@@ -11,7 +12,7 @@ export interface SurfaceServer {
   cmd: string;
   args: string[];
   cwd?: string;
-  env?: Record<string, string>;
+  env?: Record<string, SecretValue>;
 }
 
 export interface SurfaceHook {
@@ -50,8 +51,8 @@ export interface ExecutableSurface {
 }
 
 function sortedRecord(
-  env: Record<string, string> | undefined,
-): Record<string, string> | undefined {
+  env: Record<string, SecretValue> | undefined,
+): Record<string, SecretValue> | undefined {
   if (!env) return undefined;
   return Object.fromEntries(Object.entries(env).sort(([a], [b]) => a.localeCompare(b)));
 }

--- a/src/shared/git-credentials.ts
+++ b/src/shared/git-credentials.ts
@@ -1,0 +1,194 @@
+import { spawnSync } from "child_process";
+import { tmpdir } from "os";
+
+/**
+ * Resolve Git HTTP credentials from the developer's existing helpers
+ * (`git credential fill`, GCM, `gh auth token`) instead of storing tokens
+ * in capa.db.
+ */
+
+const GIT_CRED_ENV: NodeJS.ProcessEnv = {
+	GIT_TERMINAL_PROMPT: "0",
+	GCM_INTERACTIVE: "never",
+};
+
+type StoredCred = { username: string; password: string };
+
+let memoryStore: Map<string, StoredCred> | null = null;
+
+export function resetGitCredentialsForTests(): void {
+	memoryStore = new Map();
+}
+
+export function useMemoryGitCredentialsForTests(): Map<string, StoredCred> {
+	if (!memoryStore) memoryStore = new Map();
+	return memoryStore;
+}
+
+function homeLooksLikeTestSandbox(): boolean {
+	const home = process.env.HOME || process.env.USERPROFILE || "";
+	if (!home) return false;
+	const tmp = tmpdir();
+	return home === tmp || home.startsWith(`${tmp}/`) || home.startsWith(`${tmp}\\`);
+}
+
+function useMemory(): boolean {
+	if (process.env.CAPA_GIT_CREDENTIALS === "git") return false;
+	if (memoryStore) return true;
+	return homeLooksLikeTestSandbox();
+}
+
+function store(): Map<string, StoredCred> {
+	if (!memoryStore) memoryStore = new Map();
+	return memoryStore;
+}
+
+export function gitHostForPlatform(
+	platform: string,
+	host?: string | null,
+): string | null {
+	if (host && host.trim()) return host.trim();
+	if (platform === "github") return "github.com";
+	if (platform === "gitlab") return "gitlab.com";
+	return null;
+}
+
+export function gitHostFromUrl(url: string): string | null {
+	try {
+		return new URL(url).hostname || null;
+	} catch {
+		return null;
+	}
+}
+
+const HOST_ALIASES: Record<string, string> = {
+	"raw.githubusercontent.com": "github.com",
+	"api.github.com": "github.com",
+	"gist.github.com": "github.com",
+};
+
+export function credentialHost(host: string): string {
+	const normalized = host.trim().toLowerCase();
+	return HOST_ALIASES[normalized] ?? normalized;
+}
+
+function usernameForHost(host: string): string {
+	if (host === "github.com" || host.endsWith(".github.com") || host === "gist.github.com") {
+		return "x-access-token";
+	}
+	return "oauth2";
+}
+
+function formatAttrs(attrs: Record<string, string>): string {
+	return `${Object.entries(attrs)
+		.map(([k, v]) => `${k}=${v}`)
+		.join("\n")}\n\n`;
+}
+
+function parseAttrs(text: string): Record<string, string> {
+	const out: Record<string, string> = {};
+	for (const line of text.split(/\r?\n/)) {
+		const idx = line.indexOf("=");
+		if (idx <= 0) continue;
+		out[line.slice(0, idx)] = line.slice(idx + 1);
+	}
+	return out;
+}
+
+function gitCredential(
+	action: "fill" | "approve" | "reject",
+	attrs: Record<string, string>,
+): Record<string, string> | null {
+	const result = spawnSync("git", ["credential", action], {
+		input: formatAttrs(attrs),
+		encoding: "utf8",
+		windowsHide: true,
+		env: { ...process.env, ...GIT_CRED_ENV },
+	});
+	if (result.status !== 0) return null;
+	if (action !== "fill") return {};
+	return parseAttrs(result.stdout ?? "");
+}
+
+function ghAuthToken(): string | null {
+	const result = spawnSync("gh", ["auth", "token"], {
+		encoding: "utf8",
+		windowsHide: true,
+		env: { ...process.env, GH_PROMPT_DISABLED: "1" },
+	});
+	if (result.status !== 0) return null;
+	const token = (result.stdout ?? "").trim();
+	return token.length > 0 ? token : null;
+}
+
+function isGithubHost(host: string): boolean {
+	const h = host.toLowerCase();
+	return h === "github.com" || h === "gist.github.com" || h.endsWith(".github.com");
+}
+
+/**
+ * Return an HTTP password/token for `host`, or null if none is available.
+ * Never hangs on an interactive prompt.
+ */
+export function fillGitHttpCredential(host: string): string | null {
+	const normalized = credentialHost(host);
+	if (!normalized) return null;
+
+	if (useMemory()) {
+		const mem = store().get(normalized);
+		if (mem?.password) return mem.password;
+		return null;
+	}
+
+	const filled = gitCredential("fill", {
+		protocol: "https",
+		host: normalized,
+	});
+	const password = filled?.password?.trim();
+	if (password) return password;
+
+	if (isGithubHost(normalized)) {
+		return ghAuthToken();
+	}
+	return null;
+}
+
+export function approveGitHttpCredential(host: string, token: string): void {
+	const normalized = credentialHost(host);
+	const password = token.trim();
+	if (!normalized || !password) return;
+
+	if (useMemory()) {
+		store().set(normalized, {
+			username: usernameForHost(normalized),
+			password,
+		});
+		return;
+	}
+
+	gitCredential("approve", {
+		protocol: "https",
+		host: normalized,
+		username: usernameForHost(normalized),
+		password,
+	});
+}
+
+export function rejectGitHttpCredential(host: string): void {
+	const normalized = credentialHost(host);
+	if (!normalized) return;
+
+	if (useMemory()) {
+		store().delete(normalized);
+		return;
+	}
+
+	gitCredential("reject", {
+		protocol: "https",
+		host: normalized,
+	});
+}
+
+export function hasGitHttpCredential(host: string): boolean {
+	return fillGitHttpCredential(host) != null;
+}

--- a/src/shared/oauth-refresh.ts
+++ b/src/shared/oauth-refresh.ts
@@ -7,27 +7,50 @@
  *
  * Only a small set of failures indicate the refresh_token itself is no
  * longer usable and the user must re-authenticate:
- *   - HTTP 400 / 401 / 403, AND
- *   - The response body mentions `invalid_grant`, `invalid_token`, or
- *     `expired` (per RFC 6749 §5.2 + common provider conventions).
+ *   - HTTP 401 / 403 on the token endpoint (typical for revoked refresh tokens)
+ *   - HTTP 400 whose body mentions RFC 6749 error codes (invalid_grant, …)
+ *   - Corrupt / undecryptable stored tokens (master key rotation, AAD mismatch)
  *
- * Anything else (5xx, timeouts, thrown errors) is treated as transient so
- * we don't delete a perfectly valid stored token on a temporary outage.
+ * 5xx, rate limits, and network errors stay transient so we don't delete good
+ * tokens on a temporary outage.
  */
 const PERMANENT_REFRESH_FAILURE_MARKERS = [
 	"invalid_grant",
 	"invalid_token",
 	"expired",
+	"invalid_auth",
+	"invalid_client",
+	"unauthorized_client",
 ];
+
+/** Stored-token / crypto failures — reconnect required, not a network blip. */
+export function isCorruptStoredCredentialError(error: unknown): boolean {
+	const msg = error instanceof Error ? error.message : String(error);
+	return (
+		msg.includes("Failed to decrypt secret") ||
+		msg.includes("encryptSecret requires") ||
+		msg.includes('The "data" argument must be of type string') ||
+		msg.includes("truncated ciphertext") ||
+		msg.includes("ciphertext AAD mismatch")
+	);
+}
 
 export function isPermanentRefreshFailure(
 	error?: unknown,
 	response?: Response,
 	responseBody?: string,
 ): boolean {
+	if (error !== undefined && isCorruptStoredCredentialError(error)) {
+		return true;
+	}
 	if (response) {
 		const status = response.status;
-		if (status === 400 || status === 401 || status === 403) {
+		// Token endpoints reject bad refresh tokens with 401/403 even when the
+		// body omits RFC 6749 error codes (common for MCP vendor APIs).
+		if (status === 401 || status === 403) {
+			return true;
+		}
+		if (status === 400) {
 			const body = (responseBody ?? "").toLowerCase();
 			return PERMANENT_REFRESH_FAILURE_MARKERS.some((marker) =>
 				body.includes(marker),

--- a/src/shared/plugin-manifest/mcp-parser.ts
+++ b/src/shared/plugin-manifest/mcp-parser.ts
@@ -6,6 +6,8 @@ import {
 } from "path/win32";
 import { resolve as posixResolve } from "path/posix";
 import type { NormalizedPluginMCPServerDef } from "../../types/plugin";
+import type { SecretValue } from "../secret-ref";
+import { isSecretRef } from "../secret-ref";
 import { asParsedMcpServerEntry, isPlainObject } from "./types-helpers";
 
 /**
@@ -89,7 +91,7 @@ export function normalizeMcpServerEntry(
 		return {
 			url,
 			headers: isPlainObject(parsed.headers)
-				? (parsed.headers as Record<string, string>)
+				? (parsed.headers as Record<string, SecretValue>)
 				: undefined,
 			oauth2: normalizeOAuth2Block(rawOauth),
 		};
@@ -101,7 +103,7 @@ export function normalizeMcpServerEntry(
 		cmd: command,
 		args: Array.isArray(parsed.args) ? parsed.args : undefined,
 		env: isPlainObject(parsed.env)
-			? (parsed.env as Record<string, string>)
+			? (parsed.env as Record<string, SecretValue>)
 			: undefined,
 	};
 }
@@ -311,9 +313,9 @@ export function resolvePluginServerDef(
 ): {
 	cmd?: string;
 	args?: string[];
-	env?: Record<string, string>;
+	env?: Record<string, SecretValue>;
 	url?: string;
-	headers?: Record<string, string>;
+	headers?: Record<string, SecretValue>;
 	oauth2?: unknown;
 } {
 	if (def.url) {
@@ -328,14 +330,15 @@ export function resolvePluginServerDef(
 	const args = def.args?.map((a) =>
 		typeof a === "string" ? resolvePluginRootInString(a, pluginRoot) : a,
 	);
-	let env: Record<string, string> | undefined;
+	let env: Record<string, SecretValue> | undefined;
 	if (def.env && typeof def.env === "object") {
 		env = {};
 		for (const [k, v] of Object.entries(def.env)) {
-			env[k] =
-				typeof v === "string"
-					? resolvePluginRootInString(v, pluginRoot)
-					: String(v);
+			if (typeof v === "string") {
+				env[k] = resolvePluginRootInString(v, pluginRoot);
+			} else if (isSecretRef(v)) {
+				env[k] = v;
+			}
 		}
 	}
 	return { cmd, args, env };

--- a/src/shared/plugin-manifest/types-helpers.ts
+++ b/src/shared/plugin-manifest/types-helpers.ts
@@ -1,6 +1,7 @@
 import { existsSync, readdirSync, readFileSync } from "fs";
 import { join } from "path";
 import type { UnifiedSkillEntry } from "../../types/plugin";
+import type { SecretValue } from "../../types/capabilities";
 import { asOptionalString, splitMarkdownFrontmatter } from "./frontmatter";
 
 export interface ParsedMcpServerEntry {
@@ -8,9 +9,9 @@ export interface ParsedMcpServerEntry {
 	command?: string;
 	cmd?: string;
 	args?: string[];
-	env?: Record<string, string>;
+	env?: Record<string, SecretValue>;
 	type?: string;
-	headers?: Record<string, string>;
+	headers?: Record<string, SecretValue>;
 	oauth2?: unknown;
 	oauth?: unknown;
 	auth?: unknown;

--- a/src/shared/secret-binding.ts
+++ b/src/shared/secret-binding.ts
@@ -1,0 +1,65 @@
+/**
+ * AES-GCM AAD binding for a ciphertext stored in SQLite.
+ *
+ * Binding a value to its row (scope + projectId + serverId + column) means a
+ * ciphertext copied into another row will not decrypt. Token rotation is a
+ * normal UPDATE of a newly encrypted blob under the same in-memory master key;
+ * the OS keychain is not touched.
+ */
+export interface SecretBinding {
+	scope: string;
+	projectId?: string;
+	serverId?: string;
+	column: string;
+}
+
+export function encodeSecretAad(binding: SecretBinding): Buffer {
+	return Buffer.from(
+		[
+			"capa/v1",
+			binding.scope,
+			binding.projectId ?? "",
+			binding.serverId ?? "",
+			binding.column,
+		].join("\0"),
+		"utf8",
+	);
+}
+
+export function variableSecretBinding(
+	projectId: string,
+	key: string,
+): SecretBinding {
+	return {
+		scope: "variables",
+		projectId,
+		serverId: key,
+		column: "value",
+	};
+}
+
+export function oauthSecretBinding(
+	projectId: string,
+	serverId: string,
+	column: "access_token" | "refresh_token",
+): SecretBinding {
+	return {
+		scope: "oauth_tokens",
+		projectId,
+		serverId,
+		column,
+	};
+}
+
+export function gitSecretBinding(
+	platform: string,
+	host: string | null | undefined,
+	column: "access_token" | "refresh_token",
+): SecretBinding {
+	return {
+		scope: "git_integrations",
+		projectId: "",
+		serverId: `${platform}:${host ?? ""}`,
+		column,
+	};
+}

--- a/src/shared/secret-crypto.ts
+++ b/src/shared/secret-crypto.ts
@@ -1,72 +1,76 @@
 import { createCipheriv, createDecipheriv, randomBytes } from "crypto";
-import { chmodSync, mkdirSync, readFileSync, writeFileSync } from "fs";
-import { join } from "path";
-import { getCapaDir } from "./config";
+import {
+	encodeSecretAad,
+	type SecretBinding,
+} from "./secret-binding";
+import { resetGitCredentialsForTests } from "./git-credentials";
+import {
+	loadMasterKey,
+	resetSecretStoreForTests,
+} from "./secret-store";
 
-export const SECRET_CIPHER_PREFIX = "enc:v1:";
-let cachedKey: Buffer | null = null;
+export const SECRET_CIPHER_PREFIX_V1 = "enc:v1:";
+export const SECRET_CIPHER_PREFIX = "enc:v2:";
 
 export function resetSecretCryptoForTests(): void {
-	cachedKey = null;
+	resetSecretStoreForTests();
+	resetGitCredentialsForTests();
 }
 
-function masterKeyPath(): string {
-	return join(getCapaDir(), "master.key");
+function isV1Cipher(value: string): boolean {
+	return value.startsWith(SECRET_CIPHER_PREFIX_V1);
 }
 
-function errCode(err: unknown): string | undefined {
-	if (typeof err === "object" && err !== null && "code" in err) {
-		return (err as { code?: string }).code;
-	}
-	return undefined;
+function isV2Cipher(value: string): boolean {
+	return value.startsWith(SECRET_CIPHER_PREFIX);
 }
 
-function loadMasterKey(): Buffer {
-	if (cachedKey && cachedKey.length === 32) return cachedKey;
-	const dir = getCapaDir();
-	mkdirSync(dir, { recursive: true });
-	if (process.platform !== "win32") {
-		chmodSync(dir, 0o700);
-	}
-	const path = masterKeyPath();
-	try {
-		cachedKey = readFileSync(path);
-		return cachedKey;
-	} catch (err) {
-		if (errCode(err) !== "ENOENT") throw err;
-	}
-	const key = randomBytes(32);
-	try {
-		writeFileSync(path, key, {
-			mode: 0o600,
-			flag: process.platform === "win32" ? "w" : "wx",
-		});
-		if (process.platform !== "win32") {
-			chmodSync(path, 0o600);
-		}
-		cachedKey = key;
-		return key;
-	} catch (err) {
-		if (errCode(err) !== "EEXIST") throw err;
-		cachedKey = readFileSync(path);
-		return cachedKey;
-	}
+function parsePayload(value: string, prefix: string): Buffer {
+	return Buffer.from(value.slice(prefix.length), "base64");
 }
 
-export function encryptSecret(plain: string): string {
+/**
+ * Encrypt plaintext with AES-256-GCM.
+ *
+ * A fresh random 12-byte nonce is generated on every write (never derived,
+ * never cached). Reusing a nonce under the same key would leak plaintext and
+ * enable GCM forgery — especially bad because tokens rotate often.
+ *
+ * AAD binds the ciphertext to the SQLite row so a value cannot be relocated
+ * into a row someone can read back.
+ */
+export function encryptSecret(plain: string, binding: SecretBinding): string {
 	const key = loadMasterKey();
 	const iv = randomBytes(12);
+	if (iv.length !== 12) {
+		throw new Error("GCM nonce must be 12 random bytes");
+	}
 	const cipher = createCipheriv("aes-256-gcm", key, iv);
+	cipher.setAAD(encodeSecretAad(binding));
 	const encrypted = Buffer.concat([cipher.update(plain, "utf8"), cipher.final()]);
 	const tag = cipher.getAuthTag();
-	return (
-		SECRET_CIPHER_PREFIX + Buffer.concat([iv, tag, encrypted]).toString("base64")
-	);
+	return SECRET_CIPHER_PREFIX + Buffer.concat([iv, tag, encrypted]).toString("base64");
 }
 
-function decryptCiphertext(value: string): string {
+function decryptV2(value: string, binding: SecretBinding): string {
 	const key = loadMasterKey();
-	const buf = Buffer.from(value.slice(SECRET_CIPHER_PREFIX.length), "base64");
+	const buf = parsePayload(value, SECRET_CIPHER_PREFIX);
+	if (buf.length < 28) throw new Error("truncated ciphertext");
+	const iv = buf.subarray(0, 12);
+	const tag = buf.subarray(12, 28);
+	const data = buf.subarray(28);
+	const decipher = createDecipheriv("aes-256-gcm", key, iv, {
+		authTagLength: 16,
+	});
+	decipher.setAAD(encodeSecretAad(binding));
+	decipher.setAuthTag(tag);
+	return Buffer.concat([decipher.update(data), decipher.final()]).toString("utf8");
+}
+
+function decryptV1(value: string): string {
+	const key = loadMasterKey();
+	const buf = parsePayload(value, SECRET_CIPHER_PREFIX_V1);
+	if (buf.length < 28) throw new Error("truncated ciphertext");
 	const iv = buf.subarray(0, 12);
 	const tag = buf.subarray(12, 28);
 	const data = buf.subarray(28);
@@ -74,34 +78,66 @@ function decryptCiphertext(value: string): string {
 		authTagLength: 16,
 	});
 	decipher.setAuthTag(tag);
-	return Buffer.concat([decipher.update(data), decipher.final()]).toString(
-		"utf8",
-	);
+	return Buffer.concat([decipher.update(data), decipher.final()]).toString("utf8");
 }
 
-/** Canonical on-disk form: ciphertext, or encrypt legacy / colliding plaintext. */
-export function canonicalizeStoredSecret(value: string): string {
-	if (!value.startsWith(SECRET_CIPHER_PREFIX)) return encryptSecret(value);
+function decryptCiphertext(value: string, binding: SecretBinding): string {
+	if (isV2Cipher(value)) return decryptV2(value, binding);
+	if (isV1Cipher(value)) return decryptV1(value);
+	throw new Error("not ciphertext");
+}
+
+/** Canonical on-disk form: v2 ciphertext bound to `binding`. */
+export function canonicalizeStoredSecret(
+	value: string,
+	binding: SecretBinding,
+): string {
+	if (!isV1Cipher(value) && !isV2Cipher(value)) {
+		return encryptSecret(value, binding);
+	}
 	try {
-		decryptCiphertext(value);
-		return value;
+		const plain = decryptCiphertext(value, binding);
+		if (isV2Cipher(value)) return value;
+		return encryptSecret(plain, binding);
 	} catch {
-		return encryptSecret(value);
+		if (isV2Cipher(value)) throw new Error("ciphertext AAD mismatch");
+		return encryptSecret(value, binding);
 	}
 }
 
-export function decryptSecret(value: string | null): string | null {
+export function decryptSecret(
+	value: string | null,
+	binding?: SecretBinding,
+): string | null {
 	if (value === null) return null;
-	if (!value.startsWith(SECRET_CIPHER_PREFIX)) return value;
-	try {
-		return decryptCiphertext(value);
-	} catch {
-		return value;
+	if (value.length === 0) return value;
+	if (isV2Cipher(value)) {
+		if (!binding) return null;
+		try {
+			return decryptV2(value, binding);
+		} catch {
+			return null;
+		}
 	}
+	if (isV1Cipher(value)) {
+		try {
+			return decryptV1(value);
+		} catch {
+			return value;
+		}
+	}
+	return value;
 }
 
-export function decryptSecretString(value: string): string {
-	return decryptSecret(value) as string;
+export function decryptSecretString(
+	value: string,
+	binding: SecretBinding,
+): string {
+	const plain = decryptSecret(value, binding);
+	if (plain === null) {
+		throw new Error("Failed to decrypt secret: AAD mismatch or corrupt ciphertext");
+	}
+	return plain;
 }
 
 export function secretHint(value: string | undefined): string {

--- a/src/shared/secret-crypto.ts
+++ b/src/shared/secret-crypto.ts
@@ -40,6 +40,9 @@ function parsePayload(value: string, prefix: string): Buffer {
  * into a row someone can read back.
  */
 export function encryptSecret(plain: string, binding: SecretBinding): string {
+	if (typeof plain !== "string" || plain.length === 0) {
+		throw new Error("encryptSecret requires a non-empty string");
+	}
 	const key = loadMasterKey();
 	const iv = randomBytes(12);
 	if (iv.length !== 12) {

--- a/src/shared/secret-ref.ts
+++ b/src/shared/secret-ref.ts
@@ -1,0 +1,143 @@
+import { spawnSync } from "child_process";
+import { readFileSync } from "fs";
+import { homedir } from "os";
+import { resolve } from "path";
+
+export type SecretRef =
+	| { fromEnv: string }
+	| { fromCommand: string }
+	| { fromFile: string };
+
+export type SecretValue = string | SecretRef;
+
+const SHELL_ARGV0 = new Set([
+	"sh",
+	"bash",
+	"zsh",
+	"dash",
+	"fish",
+	"cmd",
+	"cmd.exe",
+	"powershell",
+	"powershell.exe",
+	"pwsh",
+	"pwsh.exe",
+]);
+
+export function isSecretRef(value: unknown): value is SecretRef {
+	if (value === null || typeof value !== "object" || Array.isArray(value)) {
+		return false;
+	}
+	const rec = value as Record<string, unknown>;
+	const keys = Object.keys(rec);
+	if (keys.length !== 1) return false;
+	const key = keys[0];
+	if (key !== "fromEnv" && key !== "fromCommand" && key !== "fromFile") {
+		return false;
+	}
+	return typeof rec[key] === "string" && (rec[key] as string).length > 0;
+}
+
+function splitArgv(command: string): string[] {
+	const tokens: string[] = [];
+	const re = /"([^"]*)"|'([^']*)'|(\S+)/g;
+	let m: RegExpExecArray | null;
+	while ((m = re.exec(command)) !== null) {
+		tokens.push(m[1] ?? m[2] ?? m[3] ?? "");
+	}
+	return tokens.filter((t) => t.length > 0);
+}
+
+function argv0Basename(program: string): string {
+	const normalized = program.replace(/\\/g, "/");
+	return normalized.slice(normalized.lastIndexOf("/") + 1).toLowerCase();
+}
+
+function expandUserPath(path: string): string {
+	if (path === "~") return homedir();
+	if (path.startsWith("~/") || path.startsWith("~\\")) {
+		return homedir() + path.slice(1);
+	}
+	return path;
+}
+
+export interface SecretValueResolver {
+	resolve(ref: SecretRef): string;
+}
+
+export class DefaultSecretValueResolver implements SecretValueResolver {
+	resolve(ref: SecretRef): string {
+		if ("fromEnv" in ref) {
+			const value = process.env[ref.fromEnv];
+			if (value === undefined || value === "") {
+				throw new Error(
+					`Secret ref fromEnv "${ref.fromEnv}" is not set in the environment`,
+				);
+			}
+			return value;
+		}
+		if ("fromFile" in ref) {
+			const path = resolve(expandUserPath(ref.fromFile));
+			return readFileSync(path, "utf8").replace(/\r?\n$/, "");
+		}
+		const argv = splitArgv(ref.fromCommand);
+		if (argv.length === 0) {
+			throw new Error("Secret ref fromCommand is empty");
+		}
+		if (SHELL_ARGV0.has(argv0Basename(argv[0]!))) {
+			throw new Error(
+				`Secret ref fromCommand refuses to run a shell (${argv[0]})`,
+			);
+		}
+		const result = spawnSync(argv[0]!, argv.slice(1), {
+			encoding: "utf8",
+			windowsHide: true,
+			timeout: 15_000,
+			env: process.env,
+		});
+		if (result.status !== 0) {
+			throw new Error(
+				`Secret ref fromCommand exited ${result.status ?? "null"}`,
+			);
+		}
+		return (result.stdout ?? "").replace(/\r?\n$/, "");
+	}
+}
+
+const defaultResolver = new DefaultSecretValueResolver();
+
+export function resolveSecretRef(
+	ref: SecretRef,
+	resolver: SecretValueResolver = defaultResolver,
+): string {
+	return resolver.resolve(ref);
+}
+
+export function resolveSecretValue(
+	value: SecretValue,
+	resolver: SecretValueResolver = defaultResolver,
+): string {
+	if (typeof value === "string") return value;
+	return resolver.resolve(value);
+}
+
+export function resolveSecretRecord(
+	record: Record<string, SecretValue> | undefined,
+	resolver: SecretValueResolver = defaultResolver,
+): Record<string, string> | undefined {
+	if (!record) return undefined;
+	const out: Record<string, string> = {};
+	for (const [key, value] of Object.entries(record)) {
+		out[key] = resolveSecretValue(value, resolver);
+	}
+	return out;
+}
+
+export function hasSecretRefs(value: unknown): boolean {
+	if (isSecretRef(value)) return true;
+	if (Array.isArray(value)) return value.some(hasSecretRefs);
+	if (value !== null && typeof value === "object") {
+		return Object.values(value as Record<string, unknown>).some(hasSecretRefs);
+	}
+	return false;
+}

--- a/src/shared/secret-store.ts
+++ b/src/shared/secret-store.ts
@@ -1,0 +1,241 @@
+import { randomBytes } from "crypto";
+import { spawnSync } from "child_process";
+import { chmodSync, mkdirSync, readFileSync, writeFileSync } from "fs";
+import { join } from "path";
+import { getCapaDir } from "./config";
+
+export type SecretStoreTier = "macos-keychain" | "windows-dpapi" | "file";
+
+const KEY_BYTES = 32;
+const KEYCHAIN_SERVICE = "capa.master-key";
+const KEYCHAIN_ACCOUNT = "capa";
+
+let cachedKey: Buffer | null = null;
+let cachedTier: SecretStoreTier | null = null;
+let forcedTier: SecretStoreTier | null = null;
+
+export function resetSecretStoreForTests(): void {
+	cachedKey = null;
+	cachedTier = null;
+	forcedTier = "file";
+}
+
+export function getSecretStoreTier(): SecretStoreTier {
+	if (forcedTier) return forcedTier;
+	if (cachedTier) return cachedTier;
+	if (process.env.CAPA_SECRET_STORE === "file") return "file";
+	if (process.platform === "darwin") return "macos-keychain";
+	if (process.platform === "win32") return "windows-dpapi";
+	return "file";
+}
+
+/** Human-readable tier for `capa status`. */
+export function describeSecretStoreTier(
+	tier: SecretStoreTier = getSecretStoreTier(),
+): string {
+	if (tier === "file") {
+		return "file (Linux fallback — master key is a file under ~/.capa)";
+	}
+	return tier;
+}
+
+function errCode(err: unknown): string | undefined {
+	if (typeof err === "object" && err !== null && "code" in err) {
+		return (err as { code?: string }).code;
+	}
+	return undefined;
+}
+
+function fileKeyPath(): string {
+	return join(getCapaDir(), "master.key");
+}
+
+function dpapiKeyPath(): string {
+	return join(getCapaDir(), "master.key.dpapi");
+}
+
+function ensureCapaDirMode(): void {
+	const dir = getCapaDir();
+	mkdirSync(dir, { recursive: true });
+	if (process.platform !== "win32") {
+		chmodSync(dir, 0o700);
+	}
+}
+
+function readFileKey(path: string): Buffer | null {
+	try {
+		const buf = readFileSync(path);
+		return buf.length === KEY_BYTES ? buf : null;
+	} catch (err) {
+		if (errCode(err) === "ENOENT") return null;
+		throw err;
+	}
+}
+
+function writeFileKey(path: string, key: Buffer): void {
+	writeFileSync(path, key, {
+		mode: 0o600,
+		flag: process.platform === "win32" ? "w" : "wx",
+	});
+	if (process.platform !== "win32") {
+		chmodSync(path, 0o600);
+	}
+}
+
+function loadOrCreateFileKey(): Buffer {
+	ensureCapaDirMode();
+	const path = fileKeyPath();
+	const existing = readFileKey(path);
+	if (existing) return existing;
+	const key = cryptoRandomKey();
+	try {
+		writeFileKey(path, key);
+		return key;
+	} catch (err) {
+		if (errCode(err) !== "EEXIST") throw err;
+		const raced = readFileKey(path);
+		if (!raced) throw err;
+		return raced;
+	}
+}
+
+function cryptoRandomKey(): Buffer {
+	return randomBytes(KEY_BYTES);
+}
+
+function keychainGet(): Buffer | null {
+	const result = spawnSync(
+		"security",
+		["find-generic-password", "-s", KEYCHAIN_SERVICE, "-a", KEYCHAIN_ACCOUNT, "-w"],
+		{ encoding: "utf8", windowsHide: true },
+	);
+	if (result.status !== 0) return null;
+	const hex = (result.stdout ?? "").trim();
+	if (!/^[0-9a-fA-F]+$/.test(hex) || hex.length !== KEY_BYTES * 2) return null;
+	return Buffer.from(hex, "hex");
+}
+
+function keychainSet(key: Buffer): boolean {
+	const result = spawnSync(
+		"security",
+		[
+			"add-generic-password",
+			"-U",
+			"-s",
+			KEYCHAIN_SERVICE,
+			"-a",
+			KEYCHAIN_ACCOUNT,
+			"-w",
+			key.toString("hex"),
+		],
+		{ encoding: "utf8", windowsHide: true },
+	);
+	return result.status === 0;
+}
+
+function loadOrCreateKeychainKey(): Buffer | null {
+	const existing = keychainGet();
+	if (existing) return existing;
+	const key = cryptoRandomKey();
+	if (!keychainSet(key)) return null;
+	return keychainGet() ?? key;
+}
+
+function runDpapi(action: "protect" | "unprotect", payload: Buffer): Buffer | null {
+	const script =
+		action === "protect"
+			? `
+$ErrorActionPreference = 'Stop'
+Add-Type -AssemblyName System.Security
+$raw = [Convert]::FromBase64String([Console]::In.ReadLine())
+$protected = [System.Security.Cryptography.ProtectedData]::Protect($raw, $null, [System.Security.Cryptography.DataProtectionScope]::CurrentUser)
+[Convert]::ToBase64String($protected)
+`
+			: `
+$ErrorActionPreference = 'Stop'
+Add-Type -AssemblyName System.Security
+$raw = [Convert]::FromBase64String([Console]::In.ReadLine())
+$plain = [System.Security.Cryptography.ProtectedData]::Unprotect($raw, $null, [System.Security.Cryptography.DataProtectionScope]::CurrentUser)
+[Convert]::ToBase64String($plain)
+`;
+	const result = spawnSync(
+		"powershell.exe",
+		["-NoProfile", "-NonInteractive", "-Command", script],
+		{
+			input: `${payload.toString("base64")}\n`,
+			encoding: "utf8",
+			windowsHide: true,
+		},
+	);
+	if (result.status !== 0) return null;
+	const b64 = (result.stdout ?? "").trim().split(/\s+/).pop() ?? "";
+	if (!b64) return null;
+	try {
+		return Buffer.from(b64, "base64");
+	} catch {
+		return null;
+	}
+}
+
+function loadOrCreateDpapiKey(): Buffer | null {
+	ensureCapaDirMode();
+	const path = dpapiKeyPath();
+	try {
+		const wrapped = readFileSync(path);
+		const plain = runDpapi("unprotect", wrapped);
+		if (plain && plain.length === KEY_BYTES) return plain;
+	} catch (err) {
+		if (errCode(err) !== "ENOENT") throw err;
+	}
+	const key = cryptoRandomKey();
+	const wrapped = runDpapi("protect", key);
+	if (!wrapped) return null;
+	try {
+		writeFileSync(path, wrapped, {
+			mode: 0o600,
+			flag: process.platform === "win32" ? "w" : "wx",
+		});
+	} catch (err) {
+		if (errCode(err) !== "EEXIST") throw err;
+		const raced = runDpapi("unprotect", readFileSync(path));
+		if (raced && raced.length === KEY_BYTES) return raced;
+	}
+	return key;
+}
+
+/**
+ * Load the 256-bit envelope master key. Token rotation never writes here —
+ * callers keep this buffer in memory and re-encrypt SQLite rows in place.
+ */
+export function loadMasterKey(): Buffer {
+	if (cachedKey && cachedKey.length === KEY_BYTES) return cachedKey;
+
+	const preferred = getSecretStoreTier();
+	let key: Buffer | null = null;
+	let tier: SecretStoreTier = preferred;
+
+	if (preferred === "macos-keychain") {
+		key = loadOrCreateKeychainKey();
+		if (!key) {
+			tier = "file";
+			key = loadOrCreateFileKey();
+		}
+	} else if (preferred === "windows-dpapi") {
+		key = loadOrCreateDpapiKey();
+		if (!key) {
+			tier = "file";
+			key = loadOrCreateFileKey();
+		}
+	} else {
+		key = loadOrCreateFileKey();
+	}
+
+	cachedKey = key;
+	cachedTier = tier;
+	return key;
+}
+
+export function activeSecretStoreTier(): SecretStoreTier {
+	if (!cachedTier) loadMasterKey();
+	return cachedTier ?? getSecretStoreTier();
+}

--- a/src/shared/stdio-allowlist.ts
+++ b/src/shared/stdio-allowlist.ts
@@ -1,11 +1,12 @@
 import { chmodSync, mkdirSync, readFileSync, writeFileSync } from "fs";
 import { join } from "path";
 import type { MCPServer, MCPServerDefinition } from "../types/capabilities";
+import type { SecretValue } from "./secret-ref";
 import { getCapaDir } from "./config";
 
 function sortedEnv(
-	env: Record<string, string> | undefined,
-): Record<string, string> | null {
+	env: Record<string, SecretValue> | undefined,
+): Record<string, SecretValue> | null {
 	if (!env) return null;
 	return Object.fromEntries(
 		Object.entries(env).sort(([a], [b]) => a.localeCompare(b)),

--- a/src/shared/ui-urls.ts
+++ b/src/shared/ui-urls.ts
@@ -8,9 +8,10 @@ export const CAPA_CLOUD_OAUTH_URL = "https://capa.infragate.ai/auth";
 /** Shown before browser OAuth. Cloud host is pinned; not request-controlled. */
 export function cloudOAuthDisclosure(): string {
 	return (
-		"Browser OAuth sends GitHub/GitLab access and refresh tokens through " +
-		`${CAPA_CLOUD_OAUTH_URL}. Prefer a short-lived PAT via ` +
-		"`capa auth <provider> --access-token` so tokens stay on this machine."
+		"Prefer `gh auth login` or Git Credential Manager so CAPA never stores a git token. " +
+		"Browser OAuth still sends GitHub/GitLab tokens through " +
+		`${CAPA_CLOUD_OAUTH_URL}. A PAT via \`capa auth <provider> --access-token\` ` +
+		"is handed to your git credential helper, not capa.db."
 	);
 }
 

--- a/src/types/capabilities.ts
+++ b/src/types/capabilities.ts
@@ -3,6 +3,9 @@
 import type { Plugin, SourcePlugin, ResolvedPluginInfo } from './plugin';
 import type { Rule } from './rules';
 import type { Hook } from './hooks';
+import type { SecretValue } from '../shared/secret-ref';
+
+export type { SecretRef, SecretValue } from '../shared/secret-ref';
 
 /** OAuth2 settings on MCP server definitions (plugin manifest or auto-detected). */
 export interface OAuth2Config {
@@ -335,13 +338,13 @@ export interface MCPServer {
 export interface MCPServerDefinition {
   // For remote MCP servers
   url?: string;
-  headers?: Record<string, string>;
+  headers?: Record<string, SecretValue>;
   /** Skip TLS certificate verification (e.g. for self-signed certs on internal servers) */
   tlsSkipVerify?: boolean;
   // For local MCP servers (subprocess)
   cmd?: string;
   args?: string[];
-  env?: Record<string, string>;
+  env?: Record<string, SecretValue>;
   /** Working directory for subprocess (e.g. plugin root) */
   cwd?: string;
   // OAuth2 config (auto-detected, not user-specified)

--- a/src/types/plugin.ts
+++ b/src/types/plugin.ts
@@ -1,5 +1,7 @@
 // Plugin types: capabilities reference, unified manifest, source attribution
 
+import type { SecretValue } from '../shared/secret-ref';
+
 /**
  * @see ProviderIntegration.pluginProviderId — registry id may differ from this manifest id
  * (e.g. registry id `claude-code` maps to manifest id `claude`).
@@ -183,10 +185,10 @@ export interface NormalizedPluginMCPServerDef {
   /** Subprocess: command to run */
   cmd?: string;
   args?: string[];
-  env?: Record<string, string>;
+  env?: Record<string, SecretValue>;
   /** Remote: HTTP MCP server URL */
   url?: string;
-  headers?: Record<string, string>;
+  headers?: Record<string, SecretValue>;
   /** OAuth config (Claude uses "oauth", capa uses oauth2) */
   oauth2?: unknown;
 }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
Follow-up to #182: stop holding git credentials in CAPA, let MCP env/headers point at an existing secret manager, and make at-rest encryption actually depend on the OS keychain instead of `master.key` sitting next to `capa.db`.

## What changed
- **Git tokens are not stored.** Clone/fetch no longer injects a CAPA-held token into argv, the remote URL, or `GIT_CONFIG_*`. HTTP auth uses `git credential fill` / GCM / `gh auth token`. `capa auth --access-token` and OAuth callbacks hand the token to the git credential helper and keep only host metadata in SQLite. Cloud git refresh via capa.infragate.ai is a no-op.
- **MCP env/headers secret refs.** Values may be `{ fromEnv }`, `{ fromCommand }`, or `{ fromFile }` behind one resolver (1Password / Vault / aws-vault never have to give CAPA a literal). `fromCommand` refuses shells.
- **Envelope key in the OS store.** One 256-bit master key: macOS Keychain, Windows DPAPI, Linux file fallback. Token rotation re-encrypts SQLite in place and does not touch the keychain. `capa status` prints the active tier (Linux file fallback is explicitly labeled).
- **AES-GCM hygiene.** Fresh random 12-byte nonce on every write. Ciphertexts are `enc:v2:` with AAD bound to `scope + projectId + serverId + column`, so a value cannot be relocated into another readable row. Legacy `enc:v1:` still decrypts and is rewritten on migrate.

## Screenshots / logs
`capa status` now includes a `Secret store:` line, e.g. `file (Linux fallback — master key is a file under ~/.capa)` on Linux, `macos-keychain` / `windows-dpapi` on those platforms.

## Test plan
- [x] New unit tests for AAD/nonce, secret refs, git credential helper, and git tokens absent from sqlite
- [x] `bunx tsc --noEmit` and `bunx tsc --noEmit -p web-ui/tsconfig.json`
- [x] Targeted `bun test` for crypto, git credentials, authenticated-fetch, cache git auth, git-integration-manager, auth command, secret-at-rest
- [x] `bun test src/db src/shared src/server src/cli` — 1650 pass, 0 fail

## Checklist
- [x] Tests added or updated
- [x] `bunx tsc --noEmit` passes
- [x] Docs updated (if user-facing) — `capa auth` / OAuth disclosure copy; `capa status` surfaces the store tier

## Notes for reviewers
This targets `security-audit` (#182), not `develop`. The Linux file fallback is **not** treated as closing the “key beside the db” finding; macOS/Windows keychain/DPAPI are the real envelope. Browser git OAuth still *exists* as a last resort and still transits capa.infragate.ai, but it is no longer required if `gh` / GCM already has credentials.
<!-- CURSOR_AGENT_PR_BODY_END -->

[Slack Thread](https://infragateworkspace.slack.com/archives/D0BQ5AU95NX/p1787150033331929?thread_ts=1787150033.331929&cid=D0BQ5AU95NX)

<div><a href="https://cursor.com/agents/bc-c0eb2766-13ce-5f7e-9e67-902493868d41?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-c0eb2766-13ce-5f7e-9e67-902493868d41&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

