### PR TITLE
fix: preserve plugin OAuth client_id during discovery sync

### DIFF
--- a/src/server/__tests__/oauth-server-sync.test.ts
+++ b/src/server/__tests__/oauth-server-sync.test.ts
@@ -4,6 +4,7 @@ import type { OAuth2Config } from "../../types/oauth";
 import type { OAuth2Manager } from "../oauth-manager";
 import {
 	mergeDetectedOAuth2,
+	mergePluginEmbeddedOAuth,
 	syncServerOAuth2Requirement,
 } from "../oauth-server-sync";
 import { preserveDiscoveredOAuth2 } from "../resolve-effective-capabilities";
@@ -68,6 +69,35 @@ describe("preserveDiscoveredOAuth2", () => {
 			"https://auth.example/authorize",
 		);
 	});
+
+	it("keeps plugin-embedded client_id when copying discovered endpoints", () => {
+		const previous: Capabilities = {
+			providers: [],
+			skills: [],
+			tools: [],
+			servers: [
+				mcpServer("slack", "https://mcp.example/mcp", DETECTED_OAUTH),
+			],
+		};
+		const fresh: Capabilities = {
+			providers: [],
+			skills: [],
+			tools: [],
+			servers: [
+				mcpServer("slack", "https://mcp.example/mcp", {
+					client_id: "plugin-app-id",
+					callback_port: 3118,
+				} as OAuth2Config),
+			],
+		};
+
+		const result = preserveDiscoveredOAuth2(fresh, previous);
+		expect(result.servers[0].def.oauth2?.client_id).toBe("plugin-app-id");
+		expect(result.servers[0].def.oauth2?.callback_port).toBe(3118);
+		expect(result.servers[0].def.oauth2?.authorizationEndpoint).toBe(
+			"https://auth.example/authorize",
+		);
+	});
 });
 
 describe("mergeDetectedOAuth2", () => {
@@ -79,6 +109,37 @@ describe("mergeDetectedOAuth2", () => {
 		expect(merged.client_id).toBe("embedded-app");
 		expect(merged.callback_port).toBe(3111);
 		expect(merged.authorizationEndpoint).toBe("https://auth.example/authorize");
+	});
+});
+
+describe("mergePluginEmbeddedOAuth", () => {
+	it("restores plugin client_id onto session capabilities missing embedded fields", () => {
+		const session: Capabilities = {
+			providers: [],
+			skills: [],
+			tools: [],
+			servers: [
+				mcpServer("slack", "https://mcp.example/mcp", DETECTED_OAUTH),
+			],
+		};
+		const plugins: Capabilities = {
+			providers: [],
+			skills: [],
+			tools: [],
+			servers: [
+				mcpServer("slack", "https://mcp.example/mcp", {
+					client_id: "plugin-app-id",
+					callback_port: 3118,
+				} as OAuth2Config),
+			],
+		};
+
+		mergePluginEmbeddedOAuth(session, plugins);
+		expect(session.servers[0].def.oauth2?.client_id).toBe("plugin-app-id");
+		expect(session.servers[0].def.oauth2?.callback_port).toBe(3118);
+		expect(session.servers[0].def.oauth2?.authorizationEndpoint).toBe(
+			"https://auth.example/authorize",
+		);
 	});
 });
 

--- a/src/server/__tests__/oauth-server-sync.test.ts
+++ b/src/server/__tests__/oauth-server-sync.test.ts
@@ -4,6 +4,7 @@ import type { OAuth2Config } from "../../types/oauth";
 import type { OAuth2Manager } from "../oauth-manager";
 import {
 	mergeDetectedOAuth2,
+	mergeEmbeddedOAuthFields,
 	mergePluginEmbeddedOAuth,
 	syncServerOAuth2Requirement,
 } from "../oauth-server-sync";
@@ -109,6 +110,20 @@ describe("mergeDetectedOAuth2", () => {
 		expect(merged.client_id).toBe("embedded-app");
 		expect(merged.callback_port).toBe(3111);
 		expect(merged.authorizationEndpoint).toBe("https://auth.example/authorize");
+	});
+});
+
+describe("mergeEmbeddedOAuthFields", () => {
+	it("does not copy clientSecret from embedded oauth", () => {
+		const merged = mergeEmbeddedOAuthFields(
+			{ authorizationEndpoint: "https://auth.example/authorize" },
+			{
+				client_id: "plugin-app-id",
+				clientSecret: "top-secret",
+			} as OAuth2Config,
+		);
+		expect(merged?.client_id).toBe("plugin-app-id");
+		expect(merged?.clientSecret).toBeUndefined();
 	});
 });
 

--- a/src/server/__tests__/secret-redaction.test.ts
+++ b/src/server/__tests__/secret-redaction.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "bun:test";
-import { mergeServerDef, redactServerForApi } from "../secret-redaction";
+import { mergeServerDef, redactOAuth2ConfigForApi, redactServerForApi } from "../secret-redaction";
 
 const ENV_SECRET = "mcp-env-secret-ABCDEFGH";
 const HEADER_SECRET = "Bearer mcp-header-secret-1234";
@@ -28,6 +28,21 @@ describe("redactServerForApi", () => {
 		expect(json).not.toContain("api-key-value-9999");
 		expect(redacted.oauth2?.clientSecret).toBeUndefined();
 		expect(redacted.oauth2?.clientId).toBe("public-client");
+	});
+});
+
+describe("redactOAuth2ConfigForApi", () => {
+	it("strips clientSecret and client_secret from oauth2 listing payloads", () => {
+		const redacted = redactOAuth2ConfigForApi({
+			client_id: "public-client",
+			clientSecret: OAUTH_SECRET,
+			client_secret: "snake-secret",
+			authorizationEndpoint: "https://auth.example/authorize",
+		});
+		expect(redacted?.client_id).toBe("public-client");
+		expect(redacted?.clientSecret).toBeUndefined();
+		expect(redacted?.client_secret).toBeUndefined();
+		expect(JSON.stringify(redacted)).not.toContain(OAUTH_SECRET);
 	});
 });
 

--- a/src/server/index.ts
+++ b/src/server/index.ts
@@ -87,7 +87,8 @@ import {
 	previewRegistryHandler,
 	refreshRegistryHandler,
 } from "./registries-routes";
-import { type EffectiveCapsCacheEntry } from "./resolve-effective-capabilities";
+import { detectCapabilitiesFile } from "../shared/paths";
+import { type EffectiveCapsCacheEntry, enrichCapabilitiesOAuthFromPlugins } from "./resolve-effective-capabilities";
 import { SessionManager } from "./session-manager";
 import { SubprocessManager } from "./subprocess-manager";
 import {
@@ -1058,6 +1059,21 @@ class CapaServer {
 					JSON.stringify({ error: "Project not configured" }),
 					{ status: 404, headers: { "Content-Type": "application/json" } },
 				);
+			}
+
+			const project = this.db.getProject(projectId);
+			if (project) {
+				const file = await detectCapabilitiesFile(project.path);
+				if (file) {
+					await enrichCapabilitiesOAuthFromPlugins(
+						capabilities,
+						project.path,
+						projectId,
+						file.path,
+						this.db,
+						this.effectiveCapsCache,
+					);
+				}
 			}
 
 			// Reconcile def.oauth2 with what each URL-based server actually requires.

--- a/src/server/index.ts
+++ b/src/server/index.ts
@@ -10,6 +10,7 @@ import {
 	loadSettings,
 } from "../shared/config";
 import { logger } from "../shared/logger";
+import { parseCapabilitiesFile } from "../shared/capabilities";
 import { RegistryManager } from "../shared/registries/manager";
 import { seedDefaultRegistries } from "../shared/registries/seed";
 import { projectUiUrl } from "../shared/ui-urls";
@@ -89,6 +90,7 @@ import {
 } from "./registries-routes";
 import { detectCapabilitiesFile } from "../shared/paths";
 import { type EffectiveCapsCacheEntry, enrichCapabilitiesOAuthFromPlugins } from "./resolve-effective-capabilities";
+import { redactOAuth2ConfigForApi } from "./secret-redaction";
 import { SessionManager } from "./session-manager";
 import { SubprocessManager } from "./subprocess-manager";
 import {
@@ -1063,15 +1065,26 @@ class CapaServer {
 
 			const project = this.db.getProject(projectId);
 			if (project) {
-				const file = await detectCapabilitiesFile(project.path);
-				if (file) {
-					await enrichCapabilitiesOAuthFromPlugins(
-						capabilities,
-						project.path,
-						projectId,
-						file.path,
-						this.db,
-						this.effectiveCapsCache,
+				try {
+					const file = await detectCapabilitiesFile(project.path);
+					if (file) {
+						const authored = await parseCapabilitiesFile(
+							file.path,
+							file.format,
+						);
+						await enrichCapabilitiesOAuthFromPlugins(
+							capabilities,
+							authored,
+							project.path,
+							projectId,
+							file.path,
+							this.db,
+							this.effectiveCapsCache,
+						);
+					}
+				} catch (error: unknown) {
+					apiLogger.warn(
+						`OAuth plugin enrichment skipped for ${projectId}: ${error instanceof Error ? error.message : String(error)}`,
 					);
 				}
 			}
@@ -1111,7 +1124,9 @@ class CapaServer {
 						displayName: s.displayName ?? s.id,
 						isConnected: isConnected,
 						expiresAt: expiresAt,
-						oauth2Config: s.def.oauth2,
+						oauth2Config: redactOAuth2ConfigForApi(
+							s.def.oauth2 as Record<string, unknown>,
+						),
 					};
 				});
 

--- a/src/server/oauth-server-sync.ts
+++ b/src/server/oauth-server-sync.ts
@@ -52,13 +52,6 @@ export function mergeEmbeddedOAuthFields(
 		merged.callback_port = callbackPort;
 	}
 
-	const clientSecret =
-		embedded?.clientSecret ??
-		(embedded as { client_secret?: string } | undefined)?.client_secret;
-	if (clientSecret && !merged.clientSecret) {
-		merged.clientSecret = clientSecret;
-	}
-
 	return merged;
 }
 

--- a/src/server/oauth-server-sync.ts
+++ b/src/server/oauth-server-sync.ts
@@ -5,6 +5,76 @@ import type {
 import type { OAuth2Config } from "../types/oauth";
 import type { OAuth2Manager } from "./oauth-manager";
 
+function readEmbeddedClientId(
+	oauth: CapabilitiesOAuth2Config | undefined,
+): string | undefined {
+	if (!oauth) return undefined;
+	return (
+		oauth.client_id ??
+		oauth.clientId ??
+		(oauth as { CLIENT_ID?: string }).CLIENT_ID ??
+		oauth.oauth?.clientId ??
+		(oauth.oauth as { client_id?: string } | undefined)?.client_id
+	);
+}
+
+function readEmbeddedCallbackPort(
+	oauth: CapabilitiesOAuth2Config | undefined,
+): number | undefined {
+	if (!oauth) return undefined;
+	const raw =
+		oauth.callback_port ??
+		oauth.callbackPort ??
+		(oauth as { CALLBACK_PORT?: number | string }).CALLBACK_PORT;
+	if (typeof raw === "number" && raw > 0) return raw;
+	if (typeof raw === "string") {
+		const parsed = Number(raw);
+		if (Number.isFinite(parsed) && parsed > 0) return parsed;
+	}
+	return undefined;
+}
+
+/** Copy plugin-embedded OAuth credentials onto an existing block without dropping discovery fields. */
+export function mergeEmbeddedOAuthFields(
+	target: CapabilitiesOAuth2Config | undefined,
+	embedded: CapabilitiesOAuth2Config | undefined,
+): CapabilitiesOAuth2Config | undefined {
+	if (!target && !embedded) return undefined;
+	const merged: CapabilitiesOAuth2Config = { ...(target ?? {}) };
+
+	const clientId = readEmbeddedClientId(embedded);
+	if (clientId && !readEmbeddedClientId(merged)) {
+		merged.client_id = clientId;
+	}
+
+	const callbackPort = readEmbeddedCallbackPort(embedded);
+	if (callbackPort != null && readEmbeddedCallbackPort(merged) == null) {
+		merged.callback_port = callbackPort;
+	}
+
+	const clientSecret =
+		embedded?.clientSecret ??
+		(embedded as { client_secret?: string } | undefined)?.client_secret;
+	if (clientSecret && !merged.clientSecret) {
+		merged.clientSecret = clientSecret;
+	}
+
+	return merged;
+}
+
+/** Restore plugin oauth2 credentials on session capabilities before OAuth sync/persist. */
+export function mergePluginEmbeddedOAuth(
+	capabilities: { servers: MCPServer[] },
+	pluginCapabilities: { servers: MCPServer[] },
+): void {
+	const pluginById = new Map(pluginCapabilities.servers.map((s) => [s.id, s]));
+	for (const server of capabilities.servers) {
+		const pluginOAuth = pluginById.get(server.id)?.def.oauth2;
+		if (!pluginOAuth) continue;
+		server.def.oauth2 = mergeEmbeddedOAuthFields(server.def.oauth2, pluginOAuth);
+	}
+}
+
 export function serverHasExplicitAuthHeader(server: MCPServer): boolean {
 	return !!(
 		server.def.headers &&
@@ -20,24 +90,11 @@ export function mergeDetectedOAuth2(
 	oauth2Config: OAuth2Config,
 ): OAuth2Config {
 	const merged: OAuth2Config = { ...(existingOAuth ?? {}), ...oauth2Config };
-	const embeddedClientId =
-		existingOAuth?.client_id ??
-		existingOAuth?.clientId ??
-		(existingOAuth as { CLIENT_ID?: string })?.CLIENT_ID ??
-		existingOAuth?.oauth?.clientId ??
-		(existingOAuth?.oauth as { client_id?: string } | undefined)?.client_id;
+	const embeddedClientId = readEmbeddedClientId(existingOAuth);
 	if (embeddedClientId) merged.client_id = embeddedClientId;
 
-	const embeddedCallbackPort =
-		existingOAuth?.callback_port ??
-		existingOAuth?.callbackPort ??
-		(existingOAuth as { CALLBACK_PORT?: number | string })?.CALLBACK_PORT;
-	if (typeof embeddedCallbackPort === "number" && embeddedCallbackPort > 0) {
-		merged.callback_port = embeddedCallbackPort;
-	} else if (typeof embeddedCallbackPort === "string") {
-		const parsed = Number(embeddedCallbackPort);
-		if (Number.isFinite(parsed) && parsed > 0) merged.callback_port = parsed;
-	}
+	const embeddedCallbackPort = readEmbeddedCallbackPort(existingOAuth);
+	if (embeddedCallbackPort != null) merged.callback_port = embeddedCallbackPort;
 	return merged;
 }
 

--- a/src/server/project-routes.ts
+++ b/src/server/project-routes.ts
@@ -26,7 +26,6 @@ import {
 } from "./resolve-effective-capabilities";
 import type { SessionManager } from "./session-manager";
 import type { McpServerStateManager } from "./mcp-server-state";
-import { syncAllServersOAuth2Requirements } from "./oauth-server-sync";
 import {
 	resolveSkillDescription,
 	resolveSkillSourceUrl,
@@ -111,18 +110,6 @@ export async function handleGetProject(
 				);
 				deps.sessionManager.setProjectCapabilities(projectId, capabilities);
 				void deps.capsWatcher.watchProject(projectId, project.path);
-
-				// capabilities.yaml may still declare oauth2 after the live URL stopped
-				// requiring it; reconcile before returning requiresOAuth to the UI.
-				const oauthSync = await syncAllServersOAuth2Requirements(
-					projectId,
-					capabilities,
-					deps.oauth2Manager,
-					{ onlyWithExistingOAuth: true },
-				);
-				if (oauthSync.changed) {
-					deps.sessionManager.setProjectCapabilities(projectId, capabilities);
-				}
 			}
 		} catch {
 			// ignore unreadable capabilities file; keep cached capabilities if any

--- a/src/server/resolve-effective-capabilities.ts
+++ b/src/server/resolve-effective-capabilities.ts
@@ -183,15 +183,16 @@ export async function loadEffectiveCapabilities(
  */
 export async function enrichCapabilitiesOAuthFromPlugins(
 	capabilities: Capabilities,
+	authored: Capabilities,
 	projectPath: string,
 	projectId: string,
 	capabilitiesFilePath: string,
 	db: CapaDatabase,
 	cache?: Map<string, EffectiveCapsCacheEntry>,
 ): Promise<void> {
-	if ((capabilities.plugins?.length ?? 0) === 0) return;
+	if ((authored.plugins?.length ?? 0) === 0) return;
 	const fromPlugins = await loadEffectiveCapabilities(
-		capabilities,
+		authored,
 		projectPath,
 		projectId,
 		capabilitiesFilePath,

--- a/src/server/resolve-effective-capabilities.ts
+++ b/src/server/resolve-effective-capabilities.ts
@@ -7,6 +7,7 @@ import { LockfileBuilder, loadLockfile } from "../shared/lockfile";
 import { logger } from "../shared/logger";
 import { validateProvider } from "../shared/providers/resolve";
 import type { Capabilities } from "../types/capabilities";
+import { mergeEmbeddedOAuthFields, mergePluginEmbeddedOAuth } from "./oauth-server-sync";
 
 const log = logger.child("plugin-resolve");
 
@@ -154,7 +155,7 @@ export async function loadEffectiveCapabilities(
 		cached.mtimeMs === mtimeMs &&
 		cached.pluginsKey === pluginsKey
 	) {
-		return cached.caps;
+		return structuredClone(cached.caps);
 	}
 
 	const { caps, warnings } = await resolveEffectiveCapabilities(
@@ -173,7 +174,31 @@ export async function loadEffectiveCapabilities(
 		pluginsKey,
 		caps,
 	});
-	return caps;
+	return structuredClone(caps);
+}
+
+/**
+ * Re-apply plugin-embedded OAuth credentials before probing/persisting so
+ * discovery merges never drop client_id / callback_port from plugin manifests.
+ */
+export async function enrichCapabilitiesOAuthFromPlugins(
+	capabilities: Capabilities,
+	projectPath: string,
+	projectId: string,
+	capabilitiesFilePath: string,
+	db: CapaDatabase,
+	cache?: Map<string, EffectiveCapsCacheEntry>,
+): Promise<void> {
+	if ((capabilities.plugins?.length ?? 0) === 0) return;
+	const fromPlugins = await loadEffectiveCapabilities(
+		capabilities,
+		projectPath,
+		projectId,
+		capabilitiesFilePath,
+		db,
+		cache,
+	);
+	mergePluginEmbeddedOAuth(capabilities, fromPlugins);
 }
 
 /**
@@ -234,7 +259,10 @@ export function preserveDiscoveredOAuth2(
 			nextOAuth.scope = prevOAuth.scope;
 		}
 
-		server.def.oauth2 = nextOAuth as typeof server.def.oauth2;
+		server.def.oauth2 = mergeEmbeddedOAuthFields(
+			nextOAuth as typeof server.def.oauth2,
+			prevOAuth,
+		);
 	}
 
 	return fresh;

--- a/src/server/secret-redaction.ts
+++ b/src/server/secret-redaction.ts
@@ -54,6 +54,15 @@ export function redactServerForApi<T extends ApiServerSecrets>(server: T): T {
 	return { ...server, env, headers, oauth2 };
 }
 
+/** Strip secrets from oauth2 blocks returned by OAuth listing APIs. */
+export function redactOAuth2ConfigForApi(
+	oauth2: Record<string, unknown> | null | undefined,
+): Record<string, unknown> | null | undefined {
+	if (!oauth2) return oauth2;
+	const { clientSecret: _a, client_secret: _b, ...rest } = oauth2;
+	return rest;
+}
+
 export function mergeServerDef(
 	existing: Record<string, unknown> | null | undefined,
 	incoming: Record<string, unknown>,


### PR DESCRIPTION
## Summary
- Stop persisting OAuth discovery metadata without plugin-embedded `client_id` / `callback_port` (fixes Slack auth sending `client_id=capa`)
- Remove OAuth reconciliation from project GET — it was overwriting plugin credentials on every page load
- Clone plugin capability cache entries before mutation so sync does not corrupt cached manifests
- Re-apply plugin OAuth credentials before `/oauth2/servers` sync and when preserving discovered endpoints

## Context
Follow-up to #186: project-page OAuth sync merged discovery-only blocks into the DB and dropped plugin manifest credentials.

## Test plan
- [x] `bun test src/server/__tests__/oauth-server-sync.test.ts`
- [x] `bunx tsc --noEmit`
- [ ] Reload project page, authenticate Slack — authorize URL uses plugin app id, not `capa`
- [ ] Confirm other plugin OAuth servers (e.g. Atlassian) still discover endpoints correctly after reload


Made with [Cursor](https://cursor.com)