### PR TITLE
fix: shadow-only artifact sync, agent instruction hardening, MCP auto-enable

### DIFF
--- a/src/cli/commands/install-tasks/check-removed-skills.ts
+++ b/src/cli/commands/install-tasks/check-removed-skills.ts
@@ -1,6 +1,7 @@
 import type { Task } from '../../ui';
 import type { InstallCtx } from './context';
 import { cleanupRemovedSkills } from './helpers/cleanup-removed-skills';
+import { materialInstallProviders } from './helpers/install-providers';
 
 export function checkRemovedSkillsTask(): Task<InstallCtx> {
   return {
@@ -8,9 +9,7 @@ export function checkRemovedSkillsTask(): Task<InstallCtx> {
     task: async (ctx) => {
       // Wrap shares projectId with the real install; cleanupRemovedSkills only
       // deletes provider skill dirs under ctx.projectPath (the shadow workspace).
-      const providers = ctx.isWrapInstall
-        ? ctx.resolvedProviders
-        : (ctx.capabilitiesToUse.providers ?? ctx.resolvedProviders);
+      const providers = materialInstallProviders(ctx);
       const stats = await cleanupRemovedSkills(
         ctx.projectPath,
         ctx.projectId,

--- a/src/cli/commands/install-tasks/check-removed-skills.ts
+++ b/src/cli/commands/install-tasks/check-removed-skills.ts
@@ -5,11 +5,12 @@ import { cleanupRemovedSkills } from './helpers/cleanup-removed-skills';
 export function checkRemovedSkillsTask(): Task<InstallCtx> {
   return {
     title: 'Checking for removed skills',
-    // Wrap shares project identity with the real install — never delete
-    // managed skill/rule paths that may live outside the shadow workspace.
-    enabled: (ctx) => !ctx.isWrapInstall,
     task: async (ctx) => {
-      const providers = ctx.capabilitiesToUse.providers ?? ctx.resolvedProviders;
+      // Wrap shares projectId with the real install; cleanupRemovedSkills only
+      // deletes provider skill dirs under ctx.projectPath (the shadow workspace).
+      const providers = ctx.isWrapInstall
+        ? ctx.resolvedProviders
+        : (ctx.capabilitiesToUse.providers ?? ctx.resolvedProviders);
       const stats = await cleanupRemovedSkills(
         ctx.projectPath,
         ctx.projectId,

--- a/src/cli/commands/install-tasks/context.ts
+++ b/src/cli/commands/install-tasks/context.ts
@@ -30,8 +30,9 @@ export interface InstallCtx {
   configureProviders: string[];
   /**
    * True when writing into a wrap shadow workspace under a different identity
-   * path. Wrap installs only materialize the wrap provider into the shadow;
-   * they never run orphan prune/cleanup against the shared project identity.
+   * path. Wrap installs materialize only the wrap provider under the shadow;
+   * prune/cleanup is scoped to that provider and shadow paths so shared
+   * identity state on the real project is never touched.
    */
   isWrapInstall: boolean;
   lockBuilder: LockfileBuilder;

--- a/src/cli/commands/install-tasks/helpers/__tests__/wrap-prune-rules.test.ts
+++ b/src/cli/commands/install-tasks/helpers/__tests__/wrap-prune-rules.test.ts
@@ -1,0 +1,53 @@
+import { afterEach, beforeEach, describe, expect, it } from 'bun:test';
+import { existsSync, mkdtempSync, mkdirSync, rmSync, writeFileSync } from 'fs';
+import { tmpdir } from 'os';
+import { join } from 'path';
+import { CapaDatabase } from '../../../../../db/database';
+import { getProvider } from '../../../../../shared/providers';
+import { pruneRules } from '../../../../utils/rules-installer';
+
+describe('pruneRules wrap shadow scope', () => {
+  let realDir: string;
+  let shadowDir: string;
+  let db: CapaDatabase;
+  const projectId = 'proj-wrap-rules';
+
+  beforeEach(() => {
+    realDir = mkdtempSync(join(tmpdir(), 'capa-wrap-rules-real-'));
+    shadowDir = mkdtempSync(join(tmpdir(), 'capa-wrap-rules-shadow-'));
+    db = new CapaDatabase(':memory:');
+    db.upsertProject({ id: projectId, path: realDir });
+  });
+
+  afterEach(() => {
+    rmSync(realDir, { recursive: true, force: true });
+    rmSync(shadowDir, { recursive: true, force: true });
+    db.close();
+  });
+
+  it('removes orphan rules under the shadow workspace only', () => {
+    const provider = getProvider('claude-code')!;
+    const shadowRuleDir = join(shadowDir, provider.rules!.dir);
+    mkdirSync(shadowRuleDir, { recursive: true });
+    const shadowRule = join(shadowRuleDir, `old-rule${provider.rules!.extension}`);
+    writeFileSync(shadowRule, 'stale');
+    db.addManagedFile(projectId, shadowRule);
+
+    const realRuleDir = join(realDir, provider.rules!.dir);
+    mkdirSync(realRuleDir, { recursive: true });
+    const realRule = join(realRuleDir, `keep-real${provider.rules!.extension}`);
+    writeFileSync(realRule, 'real project rule');
+    db.addManagedFile(projectId, realRule);
+
+    const { removedFiles } = pruneRules(
+      shadowDir,
+      ['claude-code'],
+      [],
+      db.getManagedFiles(projectId),
+    );
+
+    expect(removedFiles).toContain(shadowRule);
+    expect(existsSync(shadowRule)).toBe(false);
+    expect(existsSync(realRule)).toBe(true);
+  });
+});

--- a/src/cli/commands/install-tasks/helpers/__tests__/wrap-prune-rules.test.ts
+++ b/src/cli/commands/install-tasks/helpers/__tests__/wrap-prune-rules.test.ts
@@ -10,19 +10,21 @@ describe('pruneRules wrap shadow scope', () => {
   let realDir: string;
   let shadowDir: string;
   let db: CapaDatabase;
+  let dbPath: string;
   const projectId = 'proj-wrap-rules';
 
   beforeEach(() => {
     realDir = mkdtempSync(join(tmpdir(), 'capa-wrap-rules-real-'));
     shadowDir = mkdtempSync(join(tmpdir(), 'capa-wrap-rules-shadow-'));
-    db = new CapaDatabase(':memory:');
+    dbPath = join(realDir, 'test.db');
+    db = new CapaDatabase(dbPath);
     db.upsertProject({ id: projectId, path: realDir });
   });
 
   afterEach(() => {
+    db.close();
     rmSync(realDir, { recursive: true, force: true });
     rmSync(shadowDir, { recursive: true, force: true });
-    db.close();
   });
 
   it('removes orphan rules under the shadow workspace only', () => {

--- a/src/cli/commands/install-tasks/helpers/install-providers.ts
+++ b/src/cli/commands/install-tasks/helpers/install-providers.ts
@@ -1,0 +1,19 @@
+import type { PruneOrphanHooksOptions } from '../../../utils/hooks';
+import type { InstallCtx } from '../context';
+
+/** Providers whose project-local trees this install may create, update, or prune. */
+export function materialInstallProviders(ctx: InstallCtx): string[] {
+  if (ctx.isWrapInstall) {
+    return ctx.resolvedProviders;
+  }
+  return ctx.capabilitiesToUse.providers ?? ctx.resolvedProviders;
+}
+
+/** Scoped hook prune for wrap shadow installs (shared projectId, shadow paths only). */
+export function wrapHookPruneOptions(ctx: InstallCtx): PruneOrphanHooksOptions | undefined {
+  if (!ctx.isWrapInstall) return undefined;
+  return {
+    onlyDesiredProviders: true,
+    mutateRoot: ctx.projectPath,
+  };
+}

--- a/src/cli/commands/install-tasks/install-hooks.ts
+++ b/src/cli/commands/install-tasks/install-hooks.ts
@@ -6,6 +6,7 @@ import { raiseInstallError } from './install-error-policy';
 import type { CachePlatform } from '../../../shared/cache';
 import type { InstallCtx } from './context';
 import { getRepoSnapshot } from './helpers/repo-snapshot';
+import { materialInstallProviders } from './helpers/install-providers';
 
 export function installHooksTask(): Task<InstallCtx> {
   return {
@@ -23,7 +24,7 @@ export function installHooksTask(): Task<InstallCtx> {
         return;
       }
 
-      const providers = ctx.capabilitiesToUse.providers ?? ctx.resolvedProviders;
+      const providers = materialInstallProviders(ctx);
       const repoFetchAuth = createAuthenticatedFetch(ctx.db);
       task.output = `${valid.length} hook${valid.length === 1 ? '' : 's'} → ${providers.length} provider${providers.length === 1 ? '' : 's'}`;
 

--- a/src/cli/commands/install-tasks/install-rules.ts
+++ b/src/cli/commands/install-tasks/install-rules.ts
@@ -16,6 +16,7 @@ import {
 } from '../../../shared/skill-security';
 import type { InstallCtx } from './context';
 import { getRepoSnapshot } from './helpers/repo-snapshot';
+import { materialInstallProviders } from './helpers/install-providers';
 import { finishInstallBatch, recordInstallFailure } from './install-error-policy';
 
 /** Dependencies needed to resolve a rule's body content. */
@@ -84,7 +85,7 @@ export function installRulesTask(): Task<InstallCtx> {
       const repoFetchAuth = createAuthenticatedFetch(ctx.db);
       const snapshotResolver: RepoSnapshotResolver = (platform, repoPath, auth, opts) =>
         getRepoSnapshot(platform, repoPath, auth, opts);
-      const providers = ctx.capabilitiesToUse.providers ?? ctx.resolvedProviders;
+      const providers = materialInstallProviders(ctx);
       ctx.ruleBodies = new Map();
 
       const totalRules = currentRules.length;

--- a/src/cli/commands/install-tasks/install-skills.ts
+++ b/src/cli/commands/install-tasks/install-skills.ts
@@ -2,6 +2,7 @@ import type { Task } from '../../ui';
 import type { InstallCtx } from './context';
 import { checkGitInstalled, gitOAuthHelpText } from './helpers/git';
 import { installOneSkill } from './helpers/install-one-skill';
+import { materialInstallProviders } from './helpers/install-providers';
 import { indentLines } from './helpers/text';
 import { finishInstallBatch, raiseInstallError, recordInstallFailure } from './install-error-policy';
 
@@ -9,8 +10,9 @@ export function installSkillsTask(): Task<InstallCtx> {
   return {
     title: 'Installing skills',
     task: async (ctx, task) => {
-      const providers = ctx.capabilitiesToUse.providers ?? ctx.resolvedProviders;
-      const needsGit = ctx.capabilities.skills.some(
+      const providers = materialInstallProviders(ctx);
+      const skills = ctx.capabilitiesToUse.skills ?? [];
+      const needsGit = skills.some(
         (skill) => skill.type === 'github' || skill.type === 'gitlab',
       );
       if (needsGit) {
@@ -25,11 +27,11 @@ export function installSkillsTask(): Task<InstallCtx> {
           return;
         }
       }
-      const totalSkills = ctx.capabilities.skills.length;
+      const totalSkills = skills.length;
       const failedBefore = ctx.failed;
 
       for (let i = 0; i < totalSkills; i++) {
-        const skill = ctx.capabilities.skills[i];
+        const skill = skills[i];
         task.output = `[${i + 1}/${totalSkills}] ${skill.id}`;
 
         let outcome;

--- a/src/cli/commands/install-tasks/install-subagents.ts
+++ b/src/cli/commands/install-tasks/install-subagents.ts
@@ -13,6 +13,7 @@ import { installSubAgentInstructions, removeSubAgentInstructions } from '../../u
 import { parseSkillMd } from '../../../shared/skill-md';
 import type { Capabilities } from '../../../types/capabilities';
 import type { InstallCtx } from './context';
+import { materialInstallProviders } from './helpers/install-providers';
 
 /**
  * Strip a single pair of matching surrounding quotes (either `"` or `'`).
@@ -38,7 +39,7 @@ function stripSurroundingQuotes(value: string): string {
  * the renderer falls back to printing the bare skill id. A malformed SKILL.md
  * in one provider's dir does NOT block us from trying another provider's copy.
  */
-function buildSkillDescriptions(
+export function buildSkillDescriptions(
   projectPath: string,
   capabilities: Capabilities,
   providers: string[]
@@ -91,7 +92,7 @@ export function installSubagentsTask(): Task<InstallCtx> {
       return removedSubAgentIds.length > 0 || currentSubagents.length > 0;
     },
     task: async (ctx, task) => {
-      const providers = ctx.capabilitiesToUse.providers ?? ctx.resolvedProviders;
+      const providers = materialInstallProviders(ctx);
       const toolExposure = ctx.capabilitiesToUse.options?.toolExposure;
       const skipMcpWrites = toolExposure === 'none';
       const installedAgents = ctx.db.getSubAgents(ctx.projectId);

--- a/src/cli/commands/install-tasks/install-system-activity-hooks.ts
+++ b/src/cli/commands/install-tasks/install-system-activity-hooks.ts
@@ -1,6 +1,10 @@
 import type { Task } from "../../ui";
 import { syncSystemActivityHooks } from "../../../shared/agent-activity-sync";
 import type { InstallCtx } from "./context";
+import {
+	materialInstallProviders,
+	wrapHookPruneOptions,
+} from "./helpers/install-providers";
 
 /**
  * Inject or prune capa-owned agent-activity hooks based on
@@ -9,11 +13,9 @@ import type { InstallCtx } from "./context";
 export function installSystemActivityHooksTask(): Task<InstallCtx> {
 	return {
 		title: "Syncing agent activity hooks",
-		enabled: (ctx) =>
-			(ctx.capabilitiesToUse.providers ?? ctx.resolvedProviders).length > 0,
+		enabled: (ctx) => materialInstallProviders(ctx).length > 0,
 		task: async (ctx, task) => {
-			const providers =
-				ctx.capabilitiesToUse.providers ?? ctx.resolvedProviders;
+			const providers = materialInstallProviders(ctx);
 			try {
 				const result = await syncSystemActivityHooks({
 					projectPath: ctx.projectPath,
@@ -22,7 +24,7 @@ export function installSystemActivityHooksTask(): Task<InstallCtx> {
 					capabilities: ctx.capabilitiesToUse,
 					providers,
 					db: ctx.db,
-					skipPrune: ctx.isWrapInstall,
+					pruneOptions: wrapHookPruneOptions(ctx),
 				});
 				for (const w of result.warnings) ctx.warnings.push(w);
 				if (!result.enabled) {

--- a/src/cli/commands/install-tasks/prune-orphan-hooks.ts
+++ b/src/cli/commands/install-tasks/prune-orphan-hooks.ts
@@ -6,15 +6,19 @@ import {
   isAgentActivityEnabled,
 } from '../../../shared/agent-activity';
 import type { InstallCtx } from './context';
+import {
+  materialInstallProviders,
+  wrapHookPruneOptions,
+} from './helpers/install-providers';
 
 /**
  * Drop any `managed_hooks` entries whose hook is no longer declared in
  * `capabilities.hooks` (plus capa system activity hooks when enabled)
  * or whose provider is no longer in the active set.
  *
- * Skipped entirely on wrap shadow installs — wrap must only *add* provider
- * config under the shadow workspace and must never prune shared project
- * identity state (e.g. Cursor hooks on the real project).
+ * Wrap shadow installs scope prune to `resolvedProviders` and paths under
+ * the shadow workspace so shared identity rows (e.g. Cursor on the real
+ * project) are never touched.
  *
  * Runs *before* `install-hooks` so installs always converge on the
  * requested state — a hook moved from `cursor` to `claude-code` results
@@ -23,11 +27,9 @@ import type { InstallCtx } from './context';
 export function pruneOrphanHooksTask(): Task<InstallCtx> {
   return {
     title: 'Pruning orphan hooks',
-    enabled: (ctx) =>
-      !ctx.isWrapInstall &&
-      (ctx.capabilitiesToUse.providers ?? ctx.resolvedProviders).length > 0,
+    enabled: (ctx) => materialInstallProviders(ctx).length > 0,
     task: async (ctx) => {
-      const providers = ctx.capabilitiesToUse.providers ?? ctx.resolvedProviders;
+      const providers = materialInstallProviders(ctx);
       const rawHooks = ctx.capabilitiesToUse.hooks ?? [];
       // Validate at this point too so an invalid hook doesn't make the
       // prune think it's still desired (and skip the orphan).
@@ -43,6 +45,7 @@ export function pruneOrphanHooksTask(): Task<InstallCtx> {
           desiredHooks,
           providers,
           ctx.db,
+          wrapHookPruneOptions(ctx) ?? {},
         );
         for (const w of warnings) ctx.warnings.push(w);
         if (removed > 0) {

--- a/src/cli/commands/install-tasks/prune-orphan-rules.ts
+++ b/src/cli/commands/install-tasks/prune-orphan-rules.ts
@@ -1,15 +1,14 @@
 import type { Task } from '../../ui';
 import { pruneRules } from '../../utils/rules-installer';
 import type { InstallCtx } from './context';
+import { materialInstallProviders } from './helpers/install-providers';
 
 export function pruneOrphanRulesTask(): Task<InstallCtx> {
   return {
     title: 'Pruning orphan rules',
-    enabled: (ctx) =>
-      !ctx.isWrapInstall &&
-      (ctx.capabilitiesToUse.providers ?? ctx.resolvedProviders).length > 0,
+    enabled: (ctx) => materialInstallProviders(ctx).length > 0,
     task: async (ctx) => {
-      const providers = ctx.capabilitiesToUse.providers ?? ctx.resolvedProviders;
+      const providers = materialInstallProviders(ctx);
       const currentRules = ctx.capabilitiesToUse.rules ?? [];
       try {
         const previouslyManaged = ctx.db.getManagedFiles(ctx.projectId);

--- a/src/cli/commands/install-tasks/resolve-plugins.ts
+++ b/src/cli/commands/install-tasks/resolve-plugins.ts
@@ -14,7 +14,6 @@ import { raiseInstallError } from './install-error-policy';
 export function resolvePluginsTask(): Task<InstallCtx> {
   return {
     title: 'Resolving plugins',
-    enabled: (ctx) => !!(ctx.capabilities.plugins && ctx.capabilities.plugins.length > 0),
     task: async (ctx) => {
       const authFetch = createAuthenticatedFetch(ctx.db);
       try {

--- a/src/cli/commands/wrap-ensure-server.ts
+++ b/src/cli/commands/wrap-ensure-server.ts
@@ -5,9 +5,10 @@ import { VERSION } from '../../version';
  * Ensure the capa server is up before launching a wrap session.
  * Warm wrap skips install (which would otherwise start the server).
  */
-export async function ensureWrapServerRunning(): Promise<void> {
+export async function ensureWrapServerRunning(): Promise<{ url: string }> {
   const serverStatus = await ensureServer(VERSION);
   if (!serverStatus.running || !serverStatus.url) {
     throw new Error('Failed to start server');
   }
+  return { url: serverStatus.url };
 }

--- a/src/cli/commands/wrap.ts
+++ b/src/cli/commands/wrap.ts
@@ -11,7 +11,8 @@ import { clearWrapSession, writeWrapSession } from '../utils/wrap/session-file';
 import { ensureWrapBinaryOnPath } from './wrap-ensure-binary';
 import { ensureWrapServerRunning } from './wrap-ensure-server';
 import { resolveWrapProviderArg } from './wrap-prompt';
-import { info, error } from '../ui';
+import { syncWrapProjectConfigure } from '../utils/wrap/sync-configure';
+import { info, error, warn } from '../ui';
 
 export interface WrapOptions {
   project?: string;
@@ -104,8 +105,9 @@ export async function wrapCommand(
 
   // Warm wrap reuses the shadow workspace without install — still need the
   // server for MCP tools, capa sh, and activity/telemetry hooks.
+  let wrapServerUrl: string;
   try {
-    await ensureWrapServerRunning();
+    ({ url: wrapServerUrl } = await ensureWrapServerRunning());
   } catch (err) {
     error(err instanceof Error ? err.message : String(err));
     process.exit(1);
@@ -133,6 +135,22 @@ export async function wrapCommand(
         : `Reusing wrap workspace for ${provider.displayName}`,
   );
   info(prepared.workspacePath);
+
+  if (!prepared.installed) {
+    try {
+      await syncWrapProjectConfigure({
+        realProjectPath: prepared.realProjectPath,
+        wrapProviderId: provider.id,
+        serverUrl: wrapServerUrl,
+      });
+    } catch (err) {
+      warn(
+        `Could not sync MCP server enablement: ${
+          err instanceof Error ? err.message : String(err)
+        }`,
+      );
+    }
+  }
 
   if (!writeWrapSession(prepared.cachePath, {
     pid: process.pid,

--- a/src/cli/utils/__tests__/agents-file.test.ts
+++ b/src/cli/utils/__tests__/agents-file.test.ts
@@ -8,6 +8,7 @@ import {
   getTargetFilenames,
   installAgentsFile,
 } from '../agents-file/index';
+import { sanitizeAgentSourceContent } from '../agents-file/snippets';
 import { parseRepoString } from '../../../shared/repo-string';
 
 describe('detectRepoCoordsFromRawUrl', () => {
@@ -356,17 +357,26 @@ describe('installAgentsFile + cleanAgentsFile end-to-end', () => {
     expect(existsSync(agentsPath)).toBe(false);
   });
 
-  it('preserves user content outside markers while still removing the __base__ block on clean', async () => {
+  it('preserves user content outside markers when the file is already capa-managed', async () => {
     const basePath = join(projectDir, 'base.md');
     writeFileSync(basePath, 'Base content.\n', 'utf8');
 
     const capabilitiesPath = join(projectDir, 'capabilities.yaml');
     writeFileSync(capabilitiesPath, '# placeholder\n', 'utf8');
 
-    // Simulate a user who hand-edited their AGENTS.md before configuring
-    // `agents.base`. The pre-existing content must survive install and clean.
     const agentsPath = join(projectDir, 'AGENTS.md');
-    writeFileSync(agentsPath, '# My project\n\nHand-written notes.\n', 'utf8');
+    writeFileSync(
+      agentsPath,
+      `# My project
+
+Hand-written notes.
+
+<!-- capa:start:__base__ -->
+Old base.
+<!-- capa:end:__base__ -->
+`,
+      'utf8',
+    );
 
     await installAgentsFile(
       projectDir,
@@ -380,6 +390,7 @@ describe('installAgentsFile + cleanAgentsFile end-to-end', () => {
     expect(afterInstall).toContain('Hand-written notes.');
     expect(afterInstall).toContain('<!-- capa:start:__base__ -->');
     expect(afterInstall).toContain('Base content.');
+    expect(afterInstall).not.toContain('Old base.');
 
     cleanAgentsFile(projectDir, ['codex']);
 
@@ -421,6 +432,242 @@ describe('installAgentsFile + cleanAgentsFile end-to-end', () => {
     // Exactly one __base__ block — the upsert must not duplicate it.
     const starts = written.match(/<!-- capa:start:__base__ -->/g) ?? [];
     expect(starts).toHaveLength(1);
+  });
+
+  it('full re-render is idempotent across repeated installs', async () => {
+    const capabilitiesPath = join(projectDir, 'capabilities.yaml');
+    writeFileSync(capabilitiesPath, '# placeholder\n', 'utf8');
+
+    const config = {
+      additional: [
+        { id: 'alpha', type: 'inline' as const, content: 'Alpha instructions.' },
+        { id: 'beta', type: 'inline' as const, content: 'Beta instructions.' },
+      ],
+    };
+
+    for (let i = 0; i < 4; i++) {
+      await installAgentsFile(projectDir, config, ['codex'], undefined, capabilitiesPath);
+    }
+
+    const written = readFileSync(join(projectDir, 'AGENTS.md'), 'utf8');
+    expect((written.match(/<!-- capa:start:alpha -->/g) ?? []).length).toBe(1);
+    expect((written.match(/<!-- capa:start:beta -->/g) ?? []).length).toBe(1);
+    expect((written.match(/<!-- capa:end:__base__ -->/g) ?? []).length).toBe(0);
+  });
+
+  it('re-render preserves rule marker blocks in the same instructions file', async () => {
+    const agentsPath = join(projectDir, 'AGENTS.md');
+    writeFileSync(
+      agentsPath,
+      `<!-- capa:start:rule:keep-me -->
+Rule body
+<!-- capa:end:rule:keep-me -->
+`,
+      'utf8',
+    );
+
+    const capabilitiesPath = join(projectDir, 'capabilities.yaml');
+    writeFileSync(capabilitiesPath, '# placeholder\n', 'utf8');
+
+    await installAgentsFile(
+      projectDir,
+      {
+        additional: [{ id: 'team', type: 'inline', content: 'Team notes.' }],
+      },
+      ['codex'],
+      undefined,
+      capabilitiesPath,
+    );
+
+    const written = readFileSync(agentsPath, 'utf8');
+    expect(written).toContain('<!-- capa:start:rule:keep-me -->');
+    expect(written).toContain('Rule body');
+    expect(written).toContain('<!-- capa:start:team -->');
+    expect(written).toContain('Team notes.');
+  });
+
+  it('strips capa markers from agent source files before wrapping', () => {
+    const source = `<!-- capa:end:__base__ -->
+<!-- capa:end:__base__ -->
+
+# Team guide
+Keep this text.
+
+<!-- capa:start:old-snippet -->
+Legacy body
+<!-- capa:end:old-snippet -->
+<!-- capa:end:__base__ -->
+`;
+    expect(sanitizeAgentSourceContent(source)).toBe(
+      '# Team guide\nKeep this text.\n\nLegacy body',
+    );
+  });
+
+  it('ignores capa markers in a local base file when installing agents', async () => {
+    const basePath = join(projectDir, 'base.md');
+    writeFileSync(
+      basePath,
+      `<!-- capa:end:__base__ -->
+<!-- capa:end:__base__ -->
+
+# Project defaults
+Use bun for scripts.
+`,
+      'utf8',
+    );
+
+    const capabilitiesPath = join(projectDir, 'capabilities.yaml');
+    writeFileSync(capabilitiesPath, '# placeholder\n', 'utf8');
+
+    await installAgentsFile(
+      projectDir,
+      { base: { type: 'local', path: './base.md' } },
+      ['codex'],
+      undefined,
+      capabilitiesPath,
+    );
+
+    const written = readFileSync(join(projectDir, 'AGENTS.md'), 'utf8');
+    expect((written.match(/<!-- capa:end:__base__ -->/g) ?? []).length).toBe(1);
+    expect(written).toContain('# Project defaults');
+    expect(written).toContain('Use bun for scripts.');
+    expect(written).not.toMatch(/\n<!-- capa:end:__base__ -->\n<!-- capa:end:__base__ -->/);
+  });
+
+  it('ignores capa markers in inline snippet content', async () => {
+    const capabilitiesPath = join(projectDir, 'capabilities.yaml');
+    writeFileSync(capabilitiesPath, '# placeholder\n', 'utf8');
+
+    await installAgentsFile(
+      projectDir,
+      {
+        additional: [
+          {
+            id: 'team',
+            type: 'inline',
+            content: `<!-- capa:end:__base__ -->
+<!-- capa:start:stale -->
+Old notes
+<!-- capa:end:stale -->
+Ship small diffs.`,
+          },
+        ],
+      },
+      ['codex'],
+      undefined,
+      capabilitiesPath,
+    );
+
+    const written = readFileSync(join(projectDir, 'AGENTS.md'), 'utf8');
+    expect((written.match(/<!-- capa:start:team -->/g) ?? []).length).toBe(1);
+    expect(written).toContain('Old notes');
+    expect(written).toContain('Ship small diffs.');
+    expect(written).not.toContain('<!-- capa:end:__base__ -->');
+    expect(written).not.toContain('<!-- capa:start:stale -->');
+  });
+
+  it('recovers from orphan capa markers after repeated snippet add/remove syncs', async () => {
+    const basePath = join(projectDir, 'base.md');
+    writeFileSync(basePath, 'Base content.\n', 'utf8');
+
+    const capabilitiesPath = join(projectDir, 'capabilities.yaml');
+    writeFileSync(capabilitiesPath, '# placeholder\n', 'utf8');
+
+    const agentsPath = join(projectDir, 'AGENTS.md');
+    writeFileSync(
+      agentsPath,
+      `<!-- capa:end:__base__ -->
+<!-- capa:end:__base__ -->
+
+<!-- capa:start:example222 -->
+1323123123
+<!-- capa:end:example222 -->
+`,
+      'utf8',
+    );
+
+    const config = {
+      base: { type: 'local' as const, path: './base.md' },
+      additional: [{ id: 'example222', type: 'inline' as const, content: '1323123123' }],
+    };
+
+    for (let i = 0; i < 3; i++) {
+      await installAgentsFile(projectDir, config, ['codex'], undefined, capabilitiesPath);
+    }
+
+    const written = readFileSync(agentsPath, 'utf8');
+    expect((written.match(/<!-- capa:start:__base__ -->/g) ?? []).length).toBe(1);
+    expect((written.match(/<!-- capa:end:__base__ -->/g) ?? []).length).toBe(1);
+    expect((written.match(/<!-- capa:start:example222 -->/g) ?? []).length).toBe(1);
+    expect(written).toContain('Base content.');
+    expect(written).toContain('1323123123');
+  });
+
+  it('rejects agents.base when it resolves to the same file as AGENTS.md', async () => {
+    const agentsPath = join(projectDir, 'AGENTS.md');
+    writeFileSync(agentsPath, '# Hand-written AGENTS.md\n', 'utf8');
+
+    const workflowDir = join(projectDir, '.workflows');
+    mkdirSync(workflowDir, { recursive: true });
+    const workflowPath = join(workflowDir, 'WORKFLOW.md');
+    // Symlink the base source to the managed instructions file — feedback loop.
+    try {
+      const { symlinkSync } = await import('fs');
+      symlinkSync(join('..', 'AGENTS.md'), workflowPath);
+    } catch {
+      // Bun test on some platforms may need relative path differently
+      const { symlinkSync } = await import('fs');
+      symlinkSync(agentsPath, workflowPath);
+    }
+
+    const capabilitiesPath = join(projectDir, 'capabilities.yaml');
+    writeFileSync(capabilitiesPath, '# placeholder\n', 'utf8');
+
+    await expect(
+      installAgentsFile(
+        projectDir,
+        { base: { type: 'local', path: './.workflows/WORKFLOW.md' } },
+        ['codex'],
+        undefined,
+        capabilitiesPath,
+      ),
+    ).rejects.toThrow(/same file as AGENTS\.md/);
+  });
+
+  it('does not overwrite a user-owned AGENTS.md when agents are configured', async () => {
+    const agentsPath = join(projectDir, 'AGENTS.md');
+    const original = '# My project\n\nHand-written notes.\n';
+    writeFileSync(agentsPath, original, 'utf8');
+
+    const capabilitiesPath = join(projectDir, 'capabilities.yaml');
+    writeFileSync(capabilitiesPath, '# placeholder\n', 'utf8');
+
+    await installAgentsFile(
+      projectDir,
+      {
+        additional: [{ id: 'team', type: 'inline', content: 'Team notes.' }],
+      },
+      ['codex'],
+      undefined,
+      capabilitiesPath,
+    );
+
+    expect(readFileSync(agentsPath, 'utf8')).toBe(original);
+  });
+
+  it('does not touch a user-owned AGENTS.md when no agents are configured', async () => {
+    const agentsPath = join(projectDir, 'AGENTS.md');
+    const original = '# My project\n\nHand-written notes.\n';
+    writeFileSync(agentsPath, original, 'utf8');
+    const mtimeBefore = readFileSync(agentsPath).length;
+
+    const capabilitiesPath = join(projectDir, 'capabilities.yaml');
+    writeFileSync(capabilitiesPath, '# placeholder\n', 'utf8');
+
+    await installAgentsFile(projectDir, { additional: [] }, ['codex'], undefined, capabilitiesPath);
+
+    expect(readFileSync(agentsPath, 'utf8')).toBe(original);
+    expect(readFileSync(agentsPath, 'utf8').length).toBe(mtimeBefore);
   });
 
   it('resolves local additional snippets relative to the capabilities file', async () => {

--- a/src/cli/utils/agents-file/index.ts
+++ b/src/cli/utils/agents-file/index.ts
@@ -15,6 +15,7 @@ export {
   getTargetFilenames,
   installAgentsFile,
   cleanAgentsFile,
+  cleanAgentInstructionSnippets,
 } from './install';
 
 export {

--- a/src/cli/utils/agents-file/install.ts
+++ b/src/cli/utils/agents-file/install.ts
@@ -1,5 +1,5 @@
 import { existsSync, readFileSync } from 'fs';
-import { dirname } from 'path';
+import { dirname, join } from 'path';
 import type { AgentFileConfig, SecurityOptions } from '../../../types/capabilities';
 import {
   loadBlockedPhrases,
@@ -13,7 +13,14 @@ import {
 import { getProvider, getAllProviders } from '../../../shared/providers';
 import { fetchRepoFile, assertSafeRepoPath } from '../../../shared/repo-file';
 import { taskLog } from '../../ui';
-import { upsertSnippet, removeAllCapaSnippets, listCapaSnippetIds, removeSnippet } from './snippets';
+import {
+  renderAgentInstructionSnippets,
+  clearAgentInstructionSnippets as stripAgentInstructionSnippetsFromContent,
+  clearCapaSnippetMarkers,
+  fileHasManagedAgentInstructions,
+  sanitizeAgentSourceContent,
+  fileHasCapaInstructionsMarkers,
+} from './snippets';
 import { readMdFile, writeMdFile, deleteMdFile } from './md-io';
 import {
   fetchRemoteContent,
@@ -21,6 +28,7 @@ import {
   resolveRepoSnippet,
   type RepoFetchContext,
 } from './remote';
+import { assertAgentSourceNotInstructionsTarget } from './source-guard';
 
 const UNIVERSAL_AGENTS_FILENAME = 'AGENTS.md';
 
@@ -57,12 +65,19 @@ function applyConfigToFile(
   projectPath: string,
   filename: string,
   hasBase: boolean,
-  snippetBodies: Map<string, string>
-): void {
-  let content = readMdFile(projectPath, filename);
+  snippetBodies: Map<string, string>,
+  forceMaterialize: boolean,
+): boolean {
+  const existing = readMdFile(projectPath, filename);
+  if (
+    !forceMaterialize &&
+    existing !== '' &&
+    !fileHasCapaInstructionsMarkers(existing)
+  ) {
+    return false;
+  }
 
-  const snippetEntries = [...snippetBodies.entries()].filter(([id]) => id !== BASE_BLOCK_ID);
-  const currentIds = new Set<string>(snippetEntries.map(([id]) => id));
+  const snippets: Array<{ id: string; body: string }> = [];
 
   if (hasBase) {
     const baseBody = snippetBodies.get(BASE_BLOCK_ID);
@@ -71,22 +86,46 @@ function applyConfigToFile(
         `Internal error: hasBase=true but no '${BASE_BLOCK_ID}' entry in snippetBodies.`
       );
     }
-    content = upsertSnippet(content, BASE_BLOCK_ID, baseBody);
-    currentIds.add(BASE_BLOCK_ID);
+    snippets.push({ id: BASE_BLOCK_ID, body: baseBody });
   }
 
-  for (const [id, body] of snippetEntries) {
-    content = upsertSnippet(content, id, body);
+  for (const [id, body] of snippetBodies.entries()) {
+    if (id === BASE_BLOCK_ID) continue;
+    snippets.push({ id, body });
   }
 
-  for (const id of listCapaSnippetIds(content)) {
-    if (!currentIds.has(id)) {
-      taskLog(`  Removing stale agent snippet "${id}" from ${filename}`);
-      content = removeSnippet(content, id);
+  const content = renderAgentInstructionSnippets(existing, snippets);
+
+  if (content.trim() === '') {
+    deleteMdFile(projectPath, filename);
+    return true;
+  }
+  writeMdFile(projectPath, filename, content);
+  return true;
+}
+
+/** Remove agent instruction blocks from target files (rules / sub-agent blocks stay). */
+export function cleanAgentInstructionSnippets(
+  projectPath: string,
+  providers: string[],
+): number {
+  let removed = 0;
+  for (const filename of getTargetFilenames(providers)) {
+    const existing = readMdFile(projectPath, filename);
+    if (existing === '') continue;
+    if (!fileHasManagedAgentInstructions(existing)) continue;
+
+    const cleaned = stripAgentInstructionSnippetsFromContent(existing);
+    removed++;
+    if (cleaned.trim() === '') {
+      deleteMdFile(projectPath, filename);
+      taskLog(`  ✓ Removed ${filename} (no remaining content)`);
+    } else {
+      writeMdFile(projectPath, filename, cleaned + '\n');
+      taskLog(`  ✓ Cleared agent instruction snippets from ${filename}`);
     }
   }
-
-  writeMdFile(projectPath, filename, content);
+  return removed;
 }
 
 export async function installAgentsFile(
@@ -106,17 +145,24 @@ export async function installAgentsFile(
     : [];
   const allowedCharacters = sanitizeEnabled ? getAllowedCharacters(security) : null;
 
-  function applySecurityChecks(content: string, sourceLabel: string): string {
+  function prepareSnippetBody(content: string, sourceLabel: string): string {
+    let prepared = sanitizeAgentSourceContent(content);
     if (blockedEnabled && blockedPhrases.length > 0) {
-      const check = checkBlockedPhrases(content, blockedPhrases);
+      const check = checkBlockedPhrases(prepared, blockedPhrases);
       if (check.blocked) {
+        if (ctx.onBlockedPhrase) {
+          ctx.onBlockedPhrase(sourceLabel, check.phrase!);
+          throw new Error(
+            `Agent instructions blocked phrase "${check.phrase}" in ${sourceLabel}`,
+          );
+        }
         reportBlockedPhraseAndExit(sourceLabel, '(agents)', check.phrase!);
       }
     }
     if (sanitizeEnabled && allowedCharacters !== null) {
-      content = sanitizeContent(content, allowedCharacters);
+      prepared = sanitizeContent(prepared, allowedCharacters);
     }
-    return content;
+    return prepared;
   }
 
   const snippetBodies = new Map<string, string>();
@@ -143,6 +189,12 @@ export async function installAgentsFile(
           `agents.base local file not found: ${resolvedPath} (resolved from path "${config.base.path}")`
         );
       }
+      assertAgentSourceNotInstructionsTarget(
+        projectPath,
+        resolvedPath,
+        targetFiles,
+        'agents.base',
+      );
       taskLog(`  Using base agents file from ${resolvedPath}`);
       baseContent = readFileSync(resolvedPath, 'utf8');
     } else if (baseType === 'github' || baseType === 'gitlab') {
@@ -196,7 +248,7 @@ export async function installAgentsFile(
       );
     }
 
-    snippetBodies.set(BASE_BLOCK_ID, applySecurityChecks(baseContent, 'agents:base'));
+    snippetBodies.set(BASE_BLOCK_ID, prepareSnippetBody(baseContent, 'agents:base'));
   }
 
   for (const snippet of config.additional ?? []) {
@@ -256,6 +308,12 @@ export async function installAgentsFile(
             `(resolved from path "${snippet.path}")`,
         );
       }
+      assertAgentSourceNotInstructionsTarget(
+        projectPath,
+        resolvedPath,
+        targetFiles,
+        `agents snippet "${snippet.id}"`,
+      );
       taskLog(`  Reading local snippet "${resolvedId}" from ${resolvedPath}`);
       body = readFileSync(resolvedPath, 'utf8');
     } else if (snippet.type === 'github' || snippet.type === 'gitlab') {
@@ -266,13 +324,36 @@ export async function installAgentsFile(
       throw new Error(`Unknown agent snippet type: ${(snippet as any).type}`);
     }
 
-    snippetBodies.set(resolvedId, applySecurityChecks(body, `agents:${resolvedId}`));
+    snippetBodies.set(resolvedId, prepareSnippetBody(body, `agents:${resolvedId}`));
+  }
+
+  const hasContent = !!config.base || (config.additional?.length ?? 0) > 0;
+  if (!hasContent) {
+    cleanAgentInstructionSnippets(projectPath, providers);
+    return;
   }
 
   const hasBase = !!config.base;
+  const forceMaterialize = ctx.forceMaterialize === true;
+  let updatedAny = false;
   for (const filename of targetFiles) {
-    applyConfigToFile(projectPath, filename, hasBase, snippetBodies);
-    taskLog(`  ✓ ${filename} updated`);
+    if (
+      applyConfigToFile(
+        projectPath,
+        filename,
+        hasBase,
+        snippetBodies,
+        forceMaterialize,
+      )
+    ) {
+      updatedAny = true;
+      taskLog(`  ✓ ${filename} updated`);
+    }
+  }
+  if (!updatedAny && !ctx.quiet) {
+    taskLog(
+      '  · Skipped agent instruction files (existing user-owned content, no capa markers)',
+    );
   }
 }
 
@@ -287,7 +368,7 @@ export function cleanAgentsFile(projectPath: string, providers: string[]): void 
     const content = readMdFile(projectPath, filename);
     if (content === '') continue;
 
-    const cleaned = removeAllCapaSnippets(content);
+    const cleaned = clearCapaSnippetMarkers(content);
 
     if (cleaned.trim() === '') {
       deleteMdFile(projectPath, filename);

--- a/src/cli/utils/agents-file/remote.ts
+++ b/src/cli/utils/agents-file/remote.ts
@@ -29,6 +29,15 @@ export interface RepoFetchContext {
   authFetch?: AuthenticatedFetch;
   getRepoSnapshot?: RepoSnapshotResolver;
   noCache?: boolean;
+  /** Suppress CLI progress lines (server / quiet callers). */
+  quiet?: boolean;
+  /** When set, called instead of exiting the process on a blocked phrase. */
+  onBlockedPhrase?: (sourceLabel: string, phrase: string) => void;
+  /**
+   * Wrap shadow sync: always re-render managed instruction files.
+   * When false (default), skip existing files that have no capa agent markers.
+   */
+  forceMaterialize?: boolean;
 }
 
 /**

--- a/src/cli/utils/agents-file/snippets.ts
+++ b/src/cli/utils/agents-file/snippets.ts
@@ -1,14 +1,29 @@
 const MARKER_START = (id: string) => `<!-- capa:start:${id} -->`;
 const MARKER_END = (id: string) => `<!-- capa:end:${id} -->`;
 
-const blockPattern = (id: string) =>
-  new RegExp(
-    `${escapeRegex(MARKER_START(id))}[\\s\\S]*?${escapeRegex(MARKER_END(id))}`,
-    'g'
+/** Match a well-formed capa block; end marker id must match the start id. */
+const blockPattern = (id: string) => {
+  const escapedId = escapeRegex(id);
+  return new RegExp(
+    `<!-- capa:start:(${escapedId}) -->[\\s\\S]*?<!-- capa:end:\\1 -->`,
+    'g',
   );
+};
 
 const ANY_BLOCK_PATTERN =
   /<!-- capa:start:([^>]+?) -->[\s\S]*?<!-- capa:end:\1 -->/g;
+
+/** Unwrap a well-formed capa block, keeping only its inner body. */
+const CAPA_BLOCK_WITH_BODY =
+  /<!-- capa:start:([^>]+?) -->\n?([\s\S]*?)<!-- capa:end:\1 -->/g;
+
+const ORPHAN_MARKER_PATTERN = /<!-- capa:(?:start|end):[^>]+ -->\n?/g;
+
+/** Snippet ids owned by `agents.base` / `agents.additional` (not rules or sub-agents). */
+export function isAgentInstructionSnippetId(id: string): boolean {
+  if (id === '__base__') return true;
+  return !id.startsWith('rule:') && !id.startsWith('sub-agent:');
+}
 
 function escapeRegex(s: string): string {
   return s.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
@@ -21,7 +36,9 @@ export function buildBlock(id: string, body: string): string {
 
 export function upsertSnippet(content: string, id: string, body: string): string {
   const block = buildBlock(id, body);
-  if (blockPattern(id).test(content)) {
+  const pattern = blockPattern(id);
+  if (pattern.test(content)) {
+    // Fresh RegExp — `.test()` advances `lastIndex` on the `g` flag instance.
     return content.replace(blockPattern(id), block);
   }
   const base = content.trimEnd();
@@ -36,6 +53,72 @@ export function removeAllCapaSnippets(content: string): string {
   return content.replace(ANY_BLOCK_PATTERN, '').replace(/\n{3,}/g, '\n\n').trimEnd();
 }
 
+/** Drop stray capa marker lines left by partial edits or corrupted upserts. */
+export function stripOrphanCapaMarkers(content: string): string {
+  return content.replace(ORPHAN_MARKER_PATTERN, '').replace(/\n{3,}/g, '\n\n').trimEnd();
+}
+
+/**
+ * Remove every capa marker block (well-formed or orphan), preserving other content.
+ * Used before re-inserting the desired snippet set so sync is idempotent.
+ */
+export function clearCapaSnippetMarkers(content: string): string {
+  return stripOrphanCapaMarkers(removeAllCapaSnippets(content));
+}
+
+/**
+ * Strip capa marker scaffolding from a source file or inline snippet body before
+ * capa wraps it in its own blocks. Unwraps well-formed blocks (keeps inner text),
+ * then drops orphan start/end lines left by partial edits.
+ */
+export function sanitizeAgentSourceContent(content: string): string {
+  const unwrapped = content.replace(
+    CAPA_BLOCK_WITH_BODY,
+    (_match, _id: string, body: string) => body.trimEnd(),
+  );
+  return stripOrphanCapaMarkers(unwrapped).trimStart();
+}
+
+/** Remove only agent-instruction blocks; leave rule / sub-agent marker blocks intact. */
+export function clearAgentInstructionSnippets(content: string): string {
+  let result = content;
+  for (const id of listCapaSnippetIds(content)) {
+    if (isAgentInstructionSnippetId(id)) {
+      result = removeSnippet(result, id);
+    }
+  }
+  return stripOrphanAgentMarkers(result).replace(/\n{3,}/g, '\n\n').trimEnd();
+}
+
+/** Drop orphan start/end lines for agent instruction ids (e.g. stale `<!-- capa:end:__base__ -->`). */
+export function stripOrphanAgentMarkers(content: string): string {
+  return content
+    .replace(
+      /^<!-- capa:(?:start|end):(?!rule:|sub-agent:)[^>]+ -->\n?/gm,
+      '',
+    )
+    .replace(/\n{3,}/g, '\n\n')
+    .trimEnd();
+}
+
+/**
+ * Full re-render of agent instruction snippets: strip all agent-owned blocks,
+ * then write the desired set in order. Non-capa content and rule/sub-agent
+ * blocks are preserved.
+ */
+export function renderAgentInstructionSnippets(
+  content: string,
+  snippets: Array<{ id: string; body: string }>,
+): string {
+  const prefix = clearAgentInstructionSnippets(content);
+  if (snippets.length === 0) {
+    return prefix.length > 0 ? `${prefix}\n` : '';
+  }
+  const blocks = snippets.map(({ id, body }) => buildBlock(id, body));
+  const rendered = blocks.join('\n\n');
+  return prefix.length > 0 ? `${prefix}\n\n${rendered}\n` : `${rendered}\n`;
+}
+
 export function listCapaSnippetIds(content: string): string[] {
   const ids: string[] = [];
   let match: RegExpExecArray | null;
@@ -44,4 +127,20 @@ export function listCapaSnippetIds(content: string): string[] {
     ids.push(match[1]);
   }
   return ids;
+}
+
+/** True when the file contains capa-managed agent instruction blocks or stray agent markers. */
+export function fileHasManagedAgentInstructions(content: string): boolean {
+  if (!content.trim()) return false;
+  for (const id of listCapaSnippetIds(content)) {
+    if (isAgentInstructionSnippetId(id)) return true;
+  }
+  return /^<!-- capa:(?:start|end):(?!rule:|sub-agent:)/m.test(content);
+}
+
+/** True when capa already owns part of this instructions file (agents, rules, or sub-agents). */
+export function fileHasCapaInstructionsMarkers(content: string): boolean {
+  if (!content.trim()) return false;
+  if (listCapaSnippetIds(content).length > 0) return true;
+  return /^<!-- capa:(?:start|end):/m.test(content);
 }

--- a/src/cli/utils/agents-file/source-guard.ts
+++ b/src/cli/utils/agents-file/source-guard.ts
@@ -1,0 +1,43 @@
+import { existsSync, realpathSync } from 'fs';
+import { join, relative } from 'path';
+
+/**
+ * Reject agent instruction sources that resolve to the same file capa writes
+ * (e.g. `agents.base: .workflows/WORKFLOW.md` symlinked to `AGENTS.md`).
+ * That creates a feedback loop: each sync appends the managed file to itself.
+ */
+export function assertAgentSourceNotInstructionsTarget(
+  projectPath: string,
+  sourcePath: string,
+  targetFilenames: string[],
+  sourceLabel: string,
+): void {
+  let sourceReal: string;
+  try {
+    sourceReal = realpathSync(sourcePath);
+  } catch {
+    return;
+  }
+
+  for (const filename of targetFilenames) {
+    const targetPath = join(projectPath, filename);
+    if (!existsSync(targetPath)) continue;
+
+    let targetReal: string;
+    try {
+      targetReal = realpathSync(targetPath);
+    } catch {
+      continue;
+    }
+
+    if (sourceReal !== targetReal) continue;
+
+    const relSource = relative(projectPath, sourcePath) || sourcePath;
+    throw new Error(
+      `${sourceLabel} "${relSource}" resolves to the same file as ${filename}. ` +
+        `capa writes managed blocks into ${filename}; using it (or a symlink to it) as a ` +
+        `source creates a feedback loop that bloats the file on every sync. ` +
+        `Use a separate source file, or remove agents.base and keep ${filename} user-owned.`,
+    );
+  }
+}

--- a/src/cli/utils/configure-project.ts
+++ b/src/cli/utils/configure-project.ts
@@ -1,0 +1,28 @@
+import type { Capabilities } from '../../types/capabilities';
+import { localApiHeaders } from './local-api';
+
+export async function postProjectConfigure(opts: {
+  serverUrl: string;
+  projectId: string;
+  capabilities: Capabilities;
+  configureProviders: string[];
+}): Promise<Record<string, unknown>> {
+  const response = await fetch(
+    `${opts.serverUrl}/api/projects/${encodeURIComponent(opts.projectId)}/configure`,
+    {
+      method: 'POST',
+      headers: localApiHeaders({ 'Content-Type': 'application/json' }),
+      body: JSON.stringify({
+        ...opts.capabilities,
+        providers: opts.configureProviders,
+      }),
+    },
+  );
+
+  if (!response.ok) {
+    const errorText = await response.text();
+    throw new Error(`Failed to configure project: ${errorText}`);
+  }
+
+  return response.json();
+}

--- a/src/cli/utils/wrap/__tests__/workspace.test.ts
+++ b/src/cli/utils/wrap/__tests__/workspace.test.ts
@@ -12,7 +12,8 @@ import { tmpdir } from 'os';
 import { getWrappableProvider } from '../../../../shared/providers';
 import { WORKSPACE_MARKER } from '../../../../shared/workspaces/paths';
 import * as install from '../../../commands/install';
-import { prepareWorkspace, computeCapabilitiesFingerprint, workspaceDirName, workingDirName } from '../workspace';
+import { prepareWorkspace, computeCapabilitiesFingerprint, workspaceDirName, workingDirName, listWrapWorkspacesForProject } from '../workspace';
+import { getWorkspacesDir } from '../../../../shared/workspaces/paths';
 
 const installMock = mock(async () => {});
 
@@ -204,5 +205,37 @@ hooks: []
     );
     const b = await computeCapabilitiesFingerprint(realDir);
     expect(a).not.toBe(b);
+  });
+});
+
+describe('listWrapWorkspacesForProject', () => {
+  let realDir: string;
+  let homeCtx: { home: string; restore: () => void };
+
+  beforeEach(() => {
+    realDir = mkdtempSync(join(tmpdir(), 'capa-ws-list-real-'));
+    homeCtx = isolateHome();
+  });
+
+  afterEach(() => {
+    homeCtx.restore();
+    rmSync(realDir, { recursive: true, force: true });
+  });
+
+  it('ignores markers whose workingDir escapes the cache root', async () => {
+    const cachePath = join(getWorkspacesDir(), `escape-${Date.now()}`);
+    mkdirSync(cachePath, { recursive: true });
+    writeFileSync(
+      join(cachePath, WORKSPACE_MARKER),
+      JSON.stringify({
+        realProjectPath: realDir,
+        providerId: 'cursor',
+        workingDir: '..',
+      }),
+      'utf-8',
+    );
+
+    expect(await listWrapWorkspacesForProject(realDir)).toHaveLength(0);
+    rmSync(cachePath, { recursive: true, force: true });
   });
 });

--- a/src/cli/utils/wrap/sync-configure.ts
+++ b/src/cli/utils/wrap/sync-configure.ts
@@ -1,0 +1,52 @@
+import { parseCapabilitiesFile } from '../../../shared/capabilities';
+import { loadSettings, getDatabasePath } from '../../../shared/config';
+import { detectCapabilitiesFile, generateProjectId } from '../../../shared/paths';
+import { resolveProvidersForInstall } from '../../../shared/providers/resolve';
+import { CapaDatabase } from '../../../db/database';
+import { resolveWrapConfigureProviders } from '../../commands/install';
+import { postProjectConfigure } from '../configure-project';
+
+/**
+ * Warm wrap reuses the shadow workspace without running install, so POST
+ * /configure never runs and in-memory MCP server toggles stay off. Sync
+ * enablement from the identity project's capabilities before launch.
+ */
+export async function syncWrapProjectConfigure(opts: {
+  realProjectPath: string;
+  wrapProviderId: string;
+  serverUrl: string;
+}): Promise<void> {
+  const capsFile = await detectCapabilitiesFile(opts.realProjectPath);
+  if (!capsFile) {
+    throw new Error('No capabilities file found for wrap configure sync');
+  }
+
+  const capabilities = await parseCapabilitiesFile(capsFile.path, capsFile.format);
+  const projectId = generateProjectId(opts.realProjectPath);
+  const settings = await loadSettings();
+  const db = new CapaDatabase(getDatabasePath(settings));
+
+  try {
+    const authoredProviders = [...(capabilities.providers ?? [])];
+    const resolvedProviders = await resolveProvidersForInstall({
+      flagProvider: opts.wrapProviderId,
+      capabilitiesProviders: capabilities.providers,
+      db,
+      projectId,
+    });
+    const configureProviders = resolveWrapConfigureProviders({
+      authoredProviders,
+      storedProviders: db.getProjectProviders(projectId),
+      resolvedProviders,
+    });
+
+    await postProjectConfigure({
+      serverUrl: opts.serverUrl,
+      projectId,
+      capabilities,
+      configureProviders,
+    });
+  } finally {
+    db.close();
+  }
+}

--- a/src/cli/utils/wrap/workspace.ts
+++ b/src/cli/utils/wrap/workspace.ts
@@ -1,5 +1,5 @@
 import { createHash } from 'crypto';
-import { basename, join, resolve } from 'path';
+import { basename, isAbsolute, join, relative, resolve } from 'path';
 import { existsSync, mkdirSync, readdirSync, rmSync, statSync, writeFileSync } from 'fs';
 import { rm } from 'fs/promises';
 import * as yaml from 'js-yaml';
@@ -405,6 +405,21 @@ export interface WrapWorkspaceEntry {
   providerId: string;
 }
 
+/** Single path segment — rejects `..`, separators, and absolute paths. */
+function isSafeWorkingDirName(name: string): boolean {
+  if (!name || name === '.' || name === '..') return false;
+  if (name.includes('/') || name.includes('\\')) return false;
+  return !isAbsolute(name);
+}
+
+function isPathInside(parentDir: string, candidatePath: string): boolean {
+  const parent = resolve(parentDir);
+  const candidate = resolve(candidatePath);
+  const rel = relative(parent, candidate);
+  if (rel === '') return false;
+  return !rel.startsWith('..') && !isAbsolute(rel);
+}
+
 /**
  * Active wrap shadow workspaces whose marker points at `realProjectPath`.
  */
@@ -428,7 +443,9 @@ export async function listWrapWorkspacesForProject(
       if (!data?.realProjectPath || !data.providerId) continue;
       if (!pathsEqual(data.realProjectPath, real)) continue;
       const workName = data.workingDir ?? workingDirName(data.realProjectPath);
-      const workspacePath = join(cachePath, workName);
+      if (!isSafeWorkingDirName(workName)) continue;
+      const workspacePath = resolve(cachePath, workName);
+      if (!isPathInside(cachePath, workspacePath)) continue;
       if (!existsSync(workspacePath)) continue;
       entries.push({
         cachePath,

--- a/src/cli/utils/wrap/workspace.ts
+++ b/src/cli/utils/wrap/workspace.ts
@@ -399,6 +399,50 @@ export async function pruneWorkspaces(): Promise<number> {
   return removed;
 }
 
+export interface WrapWorkspaceEntry {
+  cachePath: string;
+  workspacePath: string;
+  providerId: string;
+}
+
+/**
+ * Active wrap shadow workspaces whose marker points at `realProjectPath`.
+ */
+export async function listWrapWorkspacesForProject(
+  realProjectPath: string,
+): Promise<WrapWorkspaceEntry[]> {
+  await ensureCapaDir();
+  const dir = getWorkspacesDir();
+  if (!existsSync(dir)) return [];
+
+  const real = resolve(realProjectPath);
+  const entries: WrapWorkspaceEntry[] = [];
+
+  for (const name of readdirSync(dir)) {
+    const cachePath = join(dir, name);
+    try {
+      if (!statSync(cachePath).isDirectory()) continue;
+      const markerPath = join(cachePath, WORKSPACE_MARKER);
+      if (!existsSync(markerPath)) continue;
+      const data = (await Bun.file(markerPath).json()) as WorkspaceMarker;
+      if (!data?.realProjectPath || !data.providerId) continue;
+      if (!pathsEqual(data.realProjectPath, real)) continue;
+      const workName = data.workingDir ?? workingDirName(data.realProjectPath);
+      const workspacePath = join(cachePath, workName);
+      if (!existsSync(workspacePath)) continue;
+      entries.push({
+        cachePath,
+        workspacePath,
+        providerId: data.providerId,
+      });
+    } catch {
+      // skip invalid cache dirs
+    }
+  }
+
+  return entries;
+}
+
 /**
  * Remove wrap cache dirs whose marker realProjectPath matches `realProjectPath`.
  */

--- a/src/server/__tests__/configure-routes.test.ts
+++ b/src/server/__tests__/configure-routes.test.ts
@@ -7,6 +7,7 @@ import type { Capabilities } from "../../types/capabilities";
 import { afterWrite, type CapabilitiesRouteDeps } from "../capabilities-route-helpers";
 import type { CapabilitiesFileWatcher } from "../capabilities-watcher";
 import {
+	applyProjectCapabilitiesOnly,
 	handleProjectConfigure,
 	type ConfigureRouteDeps,
 } from "../configure-routes";
@@ -61,6 +62,7 @@ describe("handleProjectConfigure", () => {
 				}
 				return [];
 			},
+			disconnectNonEnabledServers: async () => {},
 		} as unknown as CapaMCPServer;
 		deps = {
 			db,
@@ -116,6 +118,50 @@ describe("handleProjectConfigure", () => {
 		expect(res.status).toBe(200);
 		expect(validatedCmds).toEqual(["echo"]);
 		expect(validatedCmds).not.toContain("touch");
+	});
+
+	it("enables on-disk servers after configure", async () => {
+		const mcpServerState = new McpServerStateManager();
+		deps.mcpServerState = mcpServerState;
+		deps.syncProjectMcpClients = async () => {};
+
+		const res = await handleProjectConfigure(
+			deps,
+			"proj-1",
+			new Request("http://127.0.0.1/api/projects/proj-1/configure", {
+				method: "POST",
+				headers: { "Content-Type": "application/json" },
+				body: JSON.stringify({
+					providers: [],
+					skills: [],
+					tools: [],
+					servers: [],
+				}),
+			}),
+		);
+		expect(res.status).toBe(200);
+		expect(mcpServerState.isEnabled("proj-1", "safe")).toBe(true);
+	});
+
+	it("enables on-disk servers after light capability refresh (UI writes)", async () => {
+		const mcpServerState = new McpServerStateManager();
+		deps.mcpServerState = mcpServerState;
+
+		const caps: Capabilities = {
+			providers: [],
+			skills: [],
+			tools: [],
+			servers: [
+				{
+					id: "safe",
+					type: "mcp",
+					def: { cmd: "echo", args: ["ok"] },
+				},
+			],
+		};
+
+		await applyProjectCapabilitiesOnly(deps, "proj-1", caps);
+		expect(mcpServerState.isEnabled("proj-1", "safe")).toBe(true);
 	});
 
 	it("overlays non-empty providers from the request onto on-disk caps", async () => {

--- a/src/server/__tests__/mcp-server-state.test.ts
+++ b/src/server/__tests__/mcp-server-state.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'bun:test';
-import { McpServerStateManager } from '../mcp-server-state';
+import { McpServerStateManager, syncProjectServerEnablement } from '../mcp-server-state';
 
 describe('McpServerStateManager', () => {
   it('defaults servers to disabled', () => {
@@ -20,5 +20,20 @@ describe('McpServerStateManager', () => {
     const mgr = new McpServerStateManager();
     mgr.setEnabled('proj', '@slack', true);
     expect(mgr.getEnabledServers('proj').has('slack')).toBe(true);
+  });
+});
+
+describe('syncProjectServerEnablement', () => {
+  it('enables current servers and disables removed ones', () => {
+    const mgr = new McpServerStateManager();
+    mgr.setEnabled('proj', 'old', true);
+    syncProjectServerEnablement(
+      mgr,
+      'proj',
+      [{ id: 'brave', type: 'mcp', def: { cmd: 'npx' } }],
+      [{ id: 'old', type: 'mcp', def: { cmd: 'x' } }],
+    );
+    expect(mgr.isEnabled('proj', 'brave')).toBe(true);
+    expect(mgr.isEnabled('proj', 'old')).toBe(false);
   });
 });

--- a/src/server/__tests__/sync-project-artifacts.test.ts
+++ b/src/server/__tests__/sync-project-artifacts.test.ts
@@ -81,7 +81,9 @@ hooks: []
 			db,
 			sessionManager,
 			oauth2Manager: {} as OAuth2Manager,
-			capsWatcher: { watchProject: async () => {} } as CapabilitiesFileWatcher,
+			capsWatcher: {
+				watchProject: async () => {},
+			} as unknown as CapabilitiesFileWatcher,
 			effectiveCapsCache: new Map(),
 			getOrCreateMCPServer: () =>
 				({ disconnectNonEnabledServers: async () => {} }) as unknown as CapaMCPServer,
@@ -190,6 +192,8 @@ hooks: []
 				{
 					id: "reviewer",
 					description: "Reviews code changes",
+					skills: [],
+					tools: [],
 				},
 			],
 		};
@@ -206,22 +210,32 @@ describe("syncProjectManagedArtifacts wrap shadow path", () => {
 	let realDir: string;
 	let shadowDir: string;
 	let db: CapaDatabase;
+	let dbPath: string;
+	let prevHome: string | undefined;
 	const projectId = "proj-wrap-shadow";
 
 	beforeEach(() => {
+		prevHome = process.env.HOME;
+		const home = mkdtempSync(join(tmpdir(), "capa-wrap-sync-home-"));
+		process.env.HOME = home;
+		process.env.USERPROFILE = home;
+
 		realDir = mkdtempSync(join(tmpdir(), "capa-wrap-hooks-real-"));
 		shadowDir = mkdtempSync(join(tmpdir(), "capa-wrap-hooks-shadow-"));
 		mkdirSync(join(shadowDir, ".cursor"), { recursive: true });
 		writeFileSync(join(realDir, "capabilities.yaml"), "providers: [cursor]\n");
-		db = new CapaDatabase(":memory:");
+		dbPath = join(realDir, "test.db");
+		db = new CapaDatabase(dbPath);
 		db.upsertProject({ id: projectId, path: realDir });
 		db.setProjectProviders(projectId, ["cursor"]);
 	});
 
 	afterEach(() => {
+		db.close();
 		rmSync(realDir, { recursive: true, force: true });
 		rmSync(shadowDir, { recursive: true, force: true });
-		db.close();
+		if (prevHome === undefined) delete process.env.HOME;
+		else process.env.HOME = prevHome;
 	});
 
 	it("writes cursor hooks.json under the shadow workspace projectPath", async () => {
@@ -295,5 +309,48 @@ describe("syncProjectManagedArtifacts wrap shadow path", () => {
 		expect(readFileSync(join(realDir, "AGENTS.md"), "utf-8")).toBe(
 			"# User-owned\n",
 		);
+	});
+
+	it("warns and continues when a wrap shadow marker references an unknown provider", async () => {
+		const cachePath = join(getWorkspacesDir(), `bad-provider-${Date.now()}`);
+		const workspacePath = join(cachePath, "project");
+		mkdirSync(workspacePath, { recursive: true });
+		writeFileSync(
+			join(cachePath, WORKSPACE_MARKER),
+			JSON.stringify({
+				realProjectPath: realDir,
+				providerId: "not-a-real-provider",
+				workingDir: "project",
+			}),
+			"utf-8",
+		);
+
+		const result = await syncProjectManagedArtifactsAndWrapShadows({
+			projectPath: realDir,
+			projectId,
+			capabilitiesFilePath: join(realDir, "capabilities.yaml"),
+			capabilities: {
+				providers: ["cursor"],
+				skills: [],
+				tools: [],
+				servers: [],
+				hooks: [
+					{
+						id: "wrap-hook",
+						on: "sessionStart",
+						type: "command",
+						command: "echo wrap",
+					},
+				],
+			},
+			db,
+			serverOrigin: "http://127.0.0.1:5912",
+		});
+
+		expect(result.hooks.warnings.some((w) => w.includes("unknown provider"))).toBe(
+			true,
+		);
+		expect(result.skipped).toBe(true);
+		rmSync(cachePath, { recursive: true, force: true });
 	});
 });

--- a/src/server/__tests__/sync-project-artifacts.test.ts
+++ b/src/server/__tests__/sync-project-artifacts.test.ts
@@ -1,0 +1,299 @@
+import { afterEach, beforeEach, describe, expect, it } from "bun:test";
+import {
+	existsSync,
+	mkdtempSync,
+	mkdirSync,
+	readFileSync,
+	rmSync,
+	writeFileSync,
+} from "fs";
+import { tmpdir } from "os";
+import { join } from "path";
+import { CapaDatabase } from "../../db/database";
+import type { Capabilities } from "../../types/capabilities";
+import type { CapabilitiesFileWatcher } from "../capabilities-watcher";
+import {
+	applyProjectCapabilitiesOnly,
+	type ConfigureRouteDeps,
+} from "../configure-routes";
+import type { CapaMCPServer } from "../mcp-handler";
+import type { OAuth2Manager } from "../oauth-manager";
+import { SessionManager } from "../session-manager";
+import {
+	syncProjectManagedArtifacts,
+	syncProjectManagedArtifactsAndWrapShadows,
+} from "../sync-project-artifacts";
+import { getWorkspacesDir, WORKSPACE_MARKER } from "../../shared/workspaces/paths";
+
+function registerWrapShadow(
+	realProjectPath: string,
+	providerId: string,
+): string {
+	const cachePath = join(
+		getWorkspacesDir(),
+		`test-${Date.now()}-${Math.random().toString(36).slice(2)}`,
+	);
+	const workspacePath = join(cachePath, "project");
+	mkdirSync(join(workspacePath, ".cursor"), { recursive: true });
+	writeFileSync(
+		join(cachePath, WORKSPACE_MARKER),
+		JSON.stringify({
+			realProjectPath,
+			providerId,
+			workingDir: "project",
+		}),
+		"utf-8",
+	);
+	return workspacePath;
+}
+
+describe("applyProjectCapabilitiesOnly artifact sync", () => {
+	let dir: string;
+	let db: CapaDatabase;
+	let sessionManager: SessionManager;
+	let deps: ConfigureRouteDeps;
+	const projectId = "proj-hooks-ui";
+	let prevHome: string | undefined;
+
+	beforeEach(() => {
+		dir = mkdtempSync(join(tmpdir(), "capa-ui-hooks-"));
+		prevHome = process.env.HOME;
+		const home = mkdtempSync(join(tmpdir(), "capa-ui-home-"));
+		process.env.HOME = home;
+		process.env.USERPROFILE = home;
+
+		writeFileSync(
+			join(dir, "capabilities.yaml"),
+			`providers: [claude-code]
+hooks: []
+`,
+		);
+		writeFileSync(
+			join(dir, "AGENTS.md"),
+			"# User-owned instructions\nDo not overwrite.\n",
+			"utf-8",
+		);
+		db = new CapaDatabase(join(dir, "test.db"));
+		db.upsertProject({ id: projectId, path: dir });
+		db.setProjectProviders(projectId, ["claude-code"]);
+		sessionManager = new SessionManager(db);
+		deps = {
+			db,
+			sessionManager,
+			oauth2Manager: {} as OAuth2Manager,
+			capsWatcher: { watchProject: async () => {} } as CapabilitiesFileWatcher,
+			effectiveCapsCache: new Map(),
+			getOrCreateMCPServer: () =>
+				({ disconnectNonEnabledServers: async () => {} }) as unknown as CapaMCPServer,
+			uiOrigin: () => "http://127.0.0.1:5912",
+		};
+	});
+
+	afterEach(() => {
+		sessionManager.dispose();
+		db.close();
+		rmSync(dir, { recursive: true, force: true });
+		if (prevHome === undefined) delete process.env.HOME;
+		else process.env.HOME = prevHome;
+	});
+
+	it("does not write hooks or agent files to the source project on UI refresh", async () => {
+		const caps: Capabilities = {
+			providers: ["claude-code"],
+			skills: [],
+			tools: [],
+			servers: [],
+			hooks: [
+				{
+					id: "audit-bash",
+					on: "beforeShell",
+					type: "command",
+					command: "echo running",
+				},
+			],
+			agents: {
+				additional: [
+					{
+						id: "team-style",
+						type: "inline",
+						content: "Always write tests first.",
+					},
+				],
+			},
+		};
+
+		await applyProjectCapabilitiesOnly(deps, projectId, caps);
+
+		expect(existsSync(join(dir, ".claude", "settings.json"))).toBe(false);
+		expect(readFileSync(join(dir, "AGENTS.md"), "utf-8")).toBe(
+			"# User-owned instructions\nDo not overwrite.\n",
+		);
+	});
+
+	it("writes hooks and agent snippets to an active wrap shadow on UI refresh", async () => {
+		const workspacePath = registerWrapShadow(dir, "cursor");
+
+		db.setProjectProviders(projectId, ["cursor"]);
+		writeFileSync(
+			join(dir, "capabilities.yaml"),
+			`providers: [cursor]
+hooks: []
+`,
+		);
+
+		const caps: Capabilities = {
+			providers: ["cursor"],
+			skills: [],
+			tools: [],
+			servers: [],
+			hooks: [
+				{
+					id: "wrap-hook",
+					on: "sessionStart",
+					type: "command",
+					command: "echo wrap",
+				},
+			],
+			agents: {
+				additional: [
+					{
+						id: "team-style",
+						type: "inline",
+						content: "Always write tests first.",
+					},
+				],
+			},
+		};
+
+		await applyProjectCapabilitiesOnly(deps, projectId, caps);
+
+		expect(existsSync(join(dir, ".cursor", "hooks.json"))).toBe(false);
+		expect(readFileSync(join(dir, "AGENTS.md"), "utf-8")).toContain(
+			"User-owned instructions",
+		);
+
+		const hooksPath = join(workspacePath, ".cursor", "hooks.json");
+		expect(existsSync(hooksPath)).toBe(true);
+		const agentsPath = join(workspacePath, "AGENTS.md");
+		expect(existsSync(agentsPath)).toBe(true);
+		expect(readFileSync(agentsPath, "utf-8")).toContain("team-style");
+	});
+
+	it("does not install sub-agents on the source project on UI refresh", async () => {
+		db.setProjectProviders(projectId, ["cursor"]);
+		const caps: Capabilities = {
+			providers: ["cursor"],
+			skills: [],
+			tools: [],
+			servers: [],
+			subagents: [
+				{
+					id: "reviewer",
+					description: "Reviews code changes",
+				},
+			],
+		};
+
+		await applyProjectCapabilitiesOnly(deps, projectId, caps);
+
+		expect(existsSync(join(dir, ".cursor", "agents", "reviewer.md"))).toBe(
+			false,
+		);
+	});
+});
+
+describe("syncProjectManagedArtifacts wrap shadow path", () => {
+	let realDir: string;
+	let shadowDir: string;
+	let db: CapaDatabase;
+	const projectId = "proj-wrap-shadow";
+
+	beforeEach(() => {
+		realDir = mkdtempSync(join(tmpdir(), "capa-wrap-hooks-real-"));
+		shadowDir = mkdtempSync(join(tmpdir(), "capa-wrap-hooks-shadow-"));
+		mkdirSync(join(shadowDir, ".cursor"), { recursive: true });
+		writeFileSync(join(realDir, "capabilities.yaml"), "providers: [cursor]\n");
+		db = new CapaDatabase(":memory:");
+		db.upsertProject({ id: projectId, path: realDir });
+		db.setProjectProviders(projectId, ["cursor"]);
+	});
+
+	afterEach(() => {
+		rmSync(realDir, { recursive: true, force: true });
+		rmSync(shadowDir, { recursive: true, force: true });
+		db.close();
+	});
+
+	it("writes cursor hooks.json under the shadow workspace projectPath", async () => {
+		await syncProjectManagedArtifacts({
+			projectPath: shadowDir,
+			projectId,
+			capabilitiesFilePath: join(realDir, "capabilities.yaml"),
+			capabilities: {
+				providers: ["cursor"],
+				skills: [],
+				tools: [],
+				servers: [],
+				hooks: [
+					{
+						id: "wrap-hook",
+						on: "sessionStart",
+						type: "command",
+						command: "echo wrap",
+					},
+				],
+			},
+			db,
+			serverOrigin: "http://127.0.0.1:5912",
+			providers: ["cursor"],
+			pruneOptions: {
+				onlyDesiredProviders: true,
+				mutateRoot: shadowDir,
+			},
+			materializeShadow: true,
+		});
+
+		const hooksPath = join(shadowDir, ".cursor", "hooks.json");
+		expect(existsSync(hooksPath)).toBe(true);
+		const parsed = JSON.parse(readFileSync(hooksPath, "utf-8")) as {
+			hooks?: { sessionStart?: unknown[] };
+		};
+		expect(parsed.hooks?.sessionStart?.length).toBeGreaterThan(0);
+	});
+
+	it("syncProjectManagedArtifactsAndWrapShadows skips the source project tree", async () => {
+		writeFileSync(
+			join(realDir, "AGENTS.md"),
+			"# User-owned\n",
+			"utf-8",
+		);
+
+		const result = await syncProjectManagedArtifactsAndWrapShadows({
+			projectPath: realDir,
+			projectId,
+			capabilitiesFilePath: join(realDir, "capabilities.yaml"),
+			capabilities: {
+				providers: ["cursor"],
+				skills: [],
+				tools: [],
+				servers: [],
+				agents: {
+					additional: [
+						{
+							id: "x",
+							type: "inline",
+							content: "hello",
+						},
+					],
+				},
+			},
+			db,
+			serverOrigin: "http://127.0.0.1:5912",
+		});
+
+		expect(result.skipped).toBe(true);
+		expect(readFileSync(join(realDir, "AGENTS.md"), "utf-8")).toBe(
+			"# User-owned\n",
+		);
+	});
+});

--- a/src/server/configure-routes.ts
+++ b/src/server/configure-routes.ts
@@ -13,7 +13,10 @@ import type { OAuth2Config } from "../types/oauth";
 import type { CapabilitiesFileWatcher } from "./capabilities-watcher";
 import { matchRoute } from "./match-route";
 import type { CapaMCPServer, ValidationProgressEvent } from "./mcp-handler";
-import type { McpServerStateManager } from "./mcp-server-state";
+import {
+	type McpServerStateManager,
+	syncProjectServerEnablement,
+} from "./mcp-server-state";
 import { OAuth2Manager } from "./oauth-manager";
 import {
 	type OAuth2ServerEntry,
@@ -78,9 +81,28 @@ export async function applyProjectCapabilitiesOnly(
 		deps.effectiveCapsCache.delete(projectId);
 	}
 
+	const previousCapabilities =
+		deps.sessionManager.getProjectCapabilities(projectId);
 	deps.sessionManager.setProjectCapabilities(projectId, capabilitiesToUse);
 	if (project) {
 		void deps.capsWatcher.watchProject(projectId, project.path);
+	}
+
+	// UI capability writes (add/remove servers) use this light path instead of
+	// full configure — still auto-enable servers present in capabilities.
+	if (deps.mcpServerState) {
+		syncProjectServerEnablement(
+			deps.mcpServerState,
+			projectId,
+			capabilitiesToUse.servers,
+			previousCapabilities?.servers,
+		);
+		const mcpServer = deps.getOrCreateMCPServer(projectId);
+		if (mcpServer) {
+			await mcpServer.disconnectNonEnabledServers((serverId) =>
+				deps.mcpServerState!.isEnabled(projectId, serverId),
+			);
+		}
 	}
 
 	apiLogger.success(
@@ -290,9 +312,15 @@ export async function runProjectConfigure(
 		apiLogger.failure(`Tool validation error: ${error.message}`);
 	}
 
-	// Install validation connects servers temporarily; drop connections for
-	// servers the user has not explicitly enabled in the UI.
+	// Install / UI / wrap configure: enable every server in capabilities and
+	// drop connections for servers removed from the project.
 	if (deps.mcpServerState) {
+		syncProjectServerEnablement(
+			deps.mcpServerState,
+			projectId,
+			capabilitiesToUse.servers,
+			previousCapabilities?.servers,
+		);
 		const mcpServer = deps.getOrCreateMCPServer(projectId);
 		if (mcpServer) {
 			await mcpServer.disconnectNonEnabledServers((serverId) =>

--- a/src/server/configure-routes.ts
+++ b/src/server/configure-routes.ts
@@ -28,6 +28,7 @@ import {
 	loadEffectiveCapabilities,
 } from "./resolve-effective-capabilities";
 import type { SessionManager } from "./session-manager";
+import { syncProjectManagedArtifactsAndWrapShadows } from "./sync-project-artifacts";
 
 const JSON_HEADERS = { "Content-Type": "application/json" };
 
@@ -46,6 +47,80 @@ export interface ConfigureRouteDeps {
 		previousServers?: Capabilities["servers"],
 	) => void | Promise<void>;
 	mcpServerState?: McpServerStateManager;
+	/** Notify live UI clients after server enablement changes. */
+	notifyProjectChanged?: (projectId: string) => void;
+}
+
+async function applyProjectServerEnablement(
+	deps: ConfigureRouteDeps,
+	projectId: string,
+	servers: Capabilities["servers"],
+	previousServers: Capabilities["servers"] | undefined,
+): Promise<void> {
+	if (!deps.mcpServerState) return;
+	syncProjectServerEnablement(
+		deps.mcpServerState,
+		projectId,
+		servers,
+		previousServers,
+	);
+	const mcpServer = deps.getOrCreateMCPServer(projectId);
+	if (mcpServer) {
+		await mcpServer.disconnectNonEnabledServers((serverId) =>
+			deps.mcpServerState!.isEnabled(projectId, serverId),
+		);
+	}
+	deps.notifyProjectChanged?.(projectId);
+}
+
+async function syncManagedArtifactsForProject(
+	deps: ConfigureRouteDeps,
+	projectId: string,
+	capabilitiesToUse: Capabilities,
+): Promise<void> {
+	const apiLogger = logger.child("CapaServer").child("API");
+	const project = deps.db.getProject(projectId);
+	if (!project) return;
+
+	const file = await detectCapabilitiesFile(project.path);
+	if (!file) return;
+
+	const artifacts = await syncProjectManagedArtifactsAndWrapShadows({
+		projectPath: project.path,
+		projectId,
+		capabilitiesFilePath: file.path,
+		capabilities: capabilitiesToUse,
+		db: deps.db,
+		serverOrigin: deps.uiOrigin(),
+	});
+	for (const w of [
+		...artifacts.hooks.warnings,
+		...artifacts.rules.warnings,
+		...artifacts.agents.warnings,
+		...artifacts.subagents.warnings,
+	]) {
+		apiLogger.warn(w);
+	}
+	if (artifacts.hooks.installed > 0 || artifacts.hooks.removed > 0) {
+		apiLogger.info(
+			`Hooks synced (installed=${artifacts.hooks.installed}, removed=${artifacts.hooks.removed})`,
+		);
+	}
+	if (artifacts.rules.installed > 0 || artifacts.rules.removed > 0) {
+		apiLogger.info(
+			`Rules synced (installed=${artifacts.rules.installed}, removed=${artifacts.rules.removed})`,
+		);
+	}
+	if (artifacts.agents.installed > 0 || artifacts.agents.removed > 0) {
+		apiLogger.info(
+			`Agent instructions synced (installed=${artifacts.agents.installed}, removed=${artifacts.agents.removed})`,
+		);
+	}
+	if (artifacts.subagents.installed > 0 || artifacts.subagents.removed > 0) {
+		apiLogger.info(
+			`Sub-agents synced (installed=${artifacts.subagents.installed}, removed=${artifacts.subagents.removed})`,
+		);
+	}
 }
 
 /**
@@ -90,19 +165,15 @@ export async function applyProjectCapabilitiesOnly(
 
 	// UI capability writes (add/remove servers) use this light path instead of
 	// full configure — still auto-enable servers present in capabilities.
-	if (deps.mcpServerState) {
-		syncProjectServerEnablement(
-			deps.mcpServerState,
-			projectId,
-			capabilitiesToUse.servers,
-			previousCapabilities?.servers,
-		);
-		const mcpServer = deps.getOrCreateMCPServer(projectId);
-		if (mcpServer) {
-			await mcpServer.disconnectNonEnabledServers((serverId) =>
-				deps.mcpServerState!.isEnabled(projectId, serverId),
-			);
-		}
+	await applyProjectServerEnablement(
+		deps,
+		projectId,
+		capabilitiesToUse.servers,
+		previousCapabilities?.servers,
+	);
+
+	if (project) {
+		await syncManagedArtifactsForProject(deps, projectId, capabilitiesToUse);
 	}
 
 	apiLogger.success(
@@ -314,19 +385,15 @@ export async function runProjectConfigure(
 
 	// Install / UI / wrap configure: enable every server in capabilities and
 	// drop connections for servers removed from the project.
-	if (deps.mcpServerState) {
-		syncProjectServerEnablement(
-			deps.mcpServerState,
-			projectId,
-			capabilitiesToUse.servers,
-			previousCapabilities?.servers,
-		);
-		const mcpServer = deps.getOrCreateMCPServer(projectId);
-		if (mcpServer) {
-			await mcpServer.disconnectNonEnabledServers((serverId) =>
-				deps.mcpServerState!.isEnabled(projectId, serverId),
-			);
-		}
+	await applyProjectServerEnablement(
+		deps,
+		projectId,
+		capabilitiesToUse.servers,
+		previousCapabilities?.servers,
+	);
+
+	if (project) {
+		await syncManagedArtifactsForProject(deps, projectId, capabilitiesToUse);
 	}
 
 	if (missingVars.length > 0 || needsOAuth2Connection) {

--- a/src/server/index.ts
+++ b/src/server/index.ts
@@ -106,6 +106,7 @@ class CapaServer {
 			syncProjectMcpClients: (projectId, servers, previousServers) =>
 				this.syncProjectMcpClients(projectId, servers, previousServers),
 			mcpServerState: this.mcpServerStateManager,
+			notifyProjectChanged: (projectId) => this.notifyProjectChanged(projectId),
 		};
 	}
 

--- a/src/server/mcp-server-state.ts
+++ b/src/server/mcp-server-state.ts
@@ -1,3 +1,5 @@
+import type { MCPServer } from "../types/capabilities";
+
 /**
  * In-memory per-project MCP server on/off state.
  * Resets when the capa HTTP server restarts (not persisted).
@@ -29,5 +31,25 @@ export class McpServerStateManager {
 
 	getEnabledServers(projectId: string): ReadonlySet<string> {
 		return this.enabledByProject.get(projectId) ?? new Set();
+	}
+}
+
+/** Turn on every server in capabilities; turn off servers removed since last configure. */
+export function syncProjectServerEnablement(
+	mcpServerState: McpServerStateManager,
+	projectId: string,
+	servers: MCPServer[] | undefined,
+	previousServers?: MCPServer[],
+): void {
+	const current = servers ?? [];
+	const currentIds = new Set(current.map((s) => s.id.replace(/^@/, "")));
+	for (const server of current) {
+		mcpServerState.setEnabled(projectId, server.id, true);
+	}
+	for (const prev of previousServers ?? []) {
+		const id = prev.id.replace(/^@/, "");
+		if (!currentIds.has(id)) {
+			mcpServerState.setEnabled(projectId, prev.id, false);
+		}
 	}
 }

--- a/src/server/sync-project-artifacts.ts
+++ b/src/server/sync-project-artifacts.ts
@@ -1,0 +1,428 @@
+import { getRepoSnapshot } from "../cli/commands/install-tasks/helpers/repo-snapshot";
+import { resolveRuleBody } from "../cli/commands/install-tasks/install-rules";
+import { installAgentsFile, cleanAgentInstructionSnippets } from "../cli/utils/agents-file/index";
+import {
+	installHooks,
+	pruneOrphanHooks,
+	type PruneOrphanHooksOptions,
+} from "../cli/utils/hooks";
+import { installRules, pruneRules } from "../cli/utils/rules-installer";
+import { listWrapWorkspacesForProject } from "../cli/utils/wrap/workspace";
+import type { CapaDatabase } from "../db/database";
+import { syncSystemActivityHooks } from "../shared/agent-activity-sync";
+import {
+	buildSystemActivityHooks,
+	isAgentActivityEnabled,
+} from "../shared/agent-activity";
+import { createAuthenticatedFetch } from "../shared/authenticated-fetch";
+import { validateHooks } from "../shared/hooks-validate";
+import { validateProvider } from "../shared/providers/resolve";
+import {
+	syncProjectSubagents,
+	type SyncSectionResult,
+} from "../shared/sync-project-subagents";
+import {
+	checkBlockedPhrases,
+	getAllowedCharacters,
+	isBlockedPhrasesEnabled,
+	isCharacterSanitizationEnabled,
+	loadBlockedPhrases,
+	sanitizeContent,
+} from "../shared/skill-security";
+import type { Capabilities } from "../types/capabilities";
+import type { Rule } from "../types/rules";
+import { resolveProvidersForServer } from "./resolve-effective-capabilities";
+
+export type { SyncSectionResult };
+
+export interface SyncProjectArtifactsResult {
+	hooks: SyncSectionResult;
+	rules: SyncSectionResult;
+	agents: SyncSectionResult;
+	subagents: SyncSectionResult;
+	skipped: boolean;
+}
+
+/**
+ * Materialize managed artifacts for one project tree (typically a wrap shadow).
+ * The real project source tree is updated only by `capa install`, not UI sync.
+ */
+export async function syncProjectManagedArtifacts(opts: {
+	projectPath: string;
+	projectId: string;
+	capabilitiesFilePath: string;
+	capabilities: Capabilities;
+	db: CapaDatabase;
+	serverOrigin: string;
+	providers?: string[];
+	pruneOptions?: PruneOrphanHooksOptions;
+	/** True when writing into a wrap shadow workspace (always re-render). */
+	materializeShadow?: boolean;
+}): Promise<SyncProjectArtifactsResult> {
+	const empty: SyncSectionResult = { installed: 0, removed: 0, warnings: [] };
+	const providers =
+		opts.providers ??
+		resolveProvidersForServer(opts.capabilities, opts.db, opts.projectId);
+	if (!providers || providers.length === 0) {
+		return {
+			hooks: {
+				...empty,
+				warnings: ["No providers configured — skipped hook install"],
+			},
+			rules: {
+				...empty,
+				warnings: ["No providers configured — skipped rule install"],
+			},
+			agents: {
+				...empty,
+				warnings: ["No providers configured — skipped agent instructions"],
+			},
+			subagents: {
+				...empty,
+				warnings: ["No providers configured — skipped sub-agent install"],
+			},
+			skipped: true,
+		};
+	}
+
+	const hooks = await syncProjectHooks({
+		...opts,
+		providers,
+		pruneOptions: opts.pruneOptions,
+	});
+	const rules = await syncProjectRules({
+		...opts,
+		providers,
+	});
+	const agents = await syncProjectAgentInstructions({
+		...opts,
+		providers,
+		materializeShadow: opts.materializeShadow === true,
+	});
+	const subagents = await syncProjectSubagents({
+		projectPath: opts.projectPath,
+		projectId: opts.projectId,
+		capabilities: opts.capabilities,
+		providers,
+		db: opts.db,
+		serverOrigin: opts.serverOrigin,
+	});
+
+	return { hooks, rules, agents, subagents, skipped: false };
+}
+
+function mergeSyncSections(
+	a: SyncSectionResult,
+	b: SyncSectionResult,
+): SyncSectionResult {
+	return {
+		installed: a.installed + b.installed,
+		removed: a.removed + b.removed,
+		warnings: [...a.warnings, ...b.warnings],
+	};
+}
+
+/**
+ * Re-render managed artifacts in active wrap shadow workspaces when capabilities
+ * change (Web UI / configure). The source project directory is never mutated here —
+ * run `capa install` for that.
+ */
+export async function syncProjectManagedArtifactsAndWrapShadows(opts: {
+	projectPath: string;
+	projectId: string;
+	capabilitiesFilePath: string;
+	capabilities: Capabilities;
+	db: CapaDatabase;
+	serverOrigin: string;
+}): Promise<SyncProjectArtifactsResult> {
+	const empty: SyncSectionResult = { installed: 0, removed: 0, warnings: [] };
+	let hooks: SyncSectionResult = { ...empty };
+	let rules: SyncSectionResult = { ...empty };
+	let agents: SyncSectionResult = { ...empty };
+	let subagents: SyncSectionResult = { ...empty };
+	let skipped = true;
+
+	const shadows = await listWrapWorkspacesForProject(opts.projectPath);
+	for (const shadow of shadows) {
+		const shadowResult = await syncProjectManagedArtifacts({
+			...opts,
+			projectPath: shadow.workspacePath,
+			providers: [validateProvider(shadow.providerId)],
+			pruneOptions: {
+				onlyDesiredProviders: true,
+				mutateRoot: shadow.workspacePath,
+			},
+			materializeShadow: true,
+		});
+		hooks = mergeSyncSections(hooks, shadowResult.hooks);
+		rules = mergeSyncSections(rules, shadowResult.rules);
+		agents = mergeSyncSections(agents, shadowResult.agents);
+		subagents = mergeSyncSections(subagents, shadowResult.subagents);
+		if (!shadowResult.skipped) skipped = false;
+	}
+
+	return { hooks, rules, agents, subagents, skipped };
+}
+
+async function syncProjectHooks(opts: {
+	projectPath: string;
+	projectId: string;
+	capabilitiesFilePath: string;
+	capabilities: Capabilities;
+	db: CapaDatabase;
+	providers: string[];
+	pruneOptions?: PruneOrphanHooksOptions;
+}): Promise<SyncSectionResult> {
+	const warnings: string[] = [];
+	const rawHooks = opts.capabilities.hooks ?? [];
+	const { valid: userHooks, issues } = validateHooks(rawHooks as unknown[]);
+	for (const issue of issues) {
+		const prefix = issue.hookId ? `Hook "${issue.hookId}": ` : "Hook: ";
+		warnings.push(`${prefix}${issue.message} (skipped)`);
+	}
+
+	const systemHooks = isAgentActivityEnabled(opts.capabilities.options)
+		? buildSystemActivityHooks(opts.projectId)
+		: [];
+	const desiredHooks = [...userHooks, ...systemHooks];
+
+	let removed = 0;
+	try {
+		const prune = pruneOrphanHooks(
+			opts.projectPath,
+			opts.projectId,
+			desiredHooks,
+			opts.providers,
+			opts.db,
+			opts.pruneOptions ?? {},
+		);
+		removed += prune.removed;
+		warnings.push(...prune.warnings);
+	} catch (err: unknown) {
+		warnings.push(
+			`Failed to prune orphan hooks: ${err instanceof Error ? err.message : String(err)}`,
+		);
+	}
+
+	let installed = 0;
+	if (userHooks.length > 0) {
+		try {
+			const authFetch = createAuthenticatedFetch(opts.db);
+			const result = await installHooks({
+				projectPath: opts.projectPath,
+				projectId: opts.projectId,
+				capabilitiesFilePath: opts.capabilitiesFilePath,
+				hooks: userHooks,
+				providers: opts.providers,
+				db: opts.db,
+				authFetch,
+				getRepoSnapshot: (platform, repoPath, auth, snapOpts) =>
+					getRepoSnapshot(platform, repoPath, auth, snapOpts),
+				quiet: true,
+			});
+			installed += result.installed;
+			warnings.push(...result.warnings);
+		} catch (err: unknown) {
+			warnings.push(
+				`Failed to install hooks: ${err instanceof Error ? err.message : String(err)}`,
+			);
+		}
+	}
+
+	try {
+		const activity = await syncSystemActivityHooks({
+			projectPath: opts.projectPath,
+			projectId: opts.projectId,
+			capabilitiesFilePath: opts.capabilitiesFilePath,
+			capabilities: opts.capabilities,
+			providers: opts.providers,
+			db: opts.db,
+			quiet: true,
+			pruneOptions: opts.pruneOptions,
+		});
+		installed += activity.installed;
+		removed += activity.removed;
+		warnings.push(...activity.warnings);
+	} catch (err: unknown) {
+		warnings.push(
+			`Failed to sync agent activity hooks: ${err instanceof Error ? err.message : String(err)}`,
+		);
+	}
+
+	return { installed, removed, warnings };
+}
+
+async function syncProjectRules(opts: {
+	projectPath: string;
+	projectId: string;
+	capabilitiesFilePath: string;
+	capabilities: Capabilities;
+	db: CapaDatabase;
+	providers: string[];
+}): Promise<SyncSectionResult> {
+	const warnings: string[] = [];
+	const currentRules = opts.capabilities.rules ?? [];
+	let removed = 0;
+	let installed = 0;
+
+	try {
+		const previouslyManaged = opts.db.getManagedFiles(opts.projectId);
+		const { removedFiles, removedMarkers } = pruneRules(
+			opts.projectPath,
+			opts.providers,
+			currentRules,
+			previouslyManaged,
+		);
+		for (const file of removedFiles) {
+			opts.db.removeManagedFile(opts.projectId, file);
+		}
+		removed += removedFiles.length + removedMarkers.length;
+	} catch (err: unknown) {
+		warnings.push(
+			`Failed to prune orphan rules: ${err instanceof Error ? err.message : String(err)}`,
+		);
+	}
+
+	if (currentRules.length === 0) {
+		return { installed, removed, warnings };
+	}
+
+	const authFetch = createAuthenticatedFetch(opts.db);
+	const ruleBodies = new Map<string, string>();
+	const installedRules: Rule[] = [];
+	const security = opts.capabilities.options?.security;
+
+	for (const rule of currentRules) {
+		try {
+			let body = await resolveRuleBody(rule, {
+				capabilitiesFilePath: opts.capabilitiesFilePath,
+				authFetch,
+				getRepoSnapshot: (platform, repoPath, auth, snapOpts) =>
+					getRepoSnapshot(platform, repoPath, auth, snapOpts),
+			});
+			if (isBlockedPhrasesEnabled(security)) {
+				const blockedPhrases = loadBlockedPhrases(
+					security,
+					opts.capabilitiesFilePath,
+				);
+				const check = checkBlockedPhrases(body, blockedPhrases);
+				if (check.blocked) {
+					warnings.push(
+						`Rule "${rule.id}" blocked phrase "${check.phrase}" (skipped)`,
+					);
+					continue;
+				}
+			}
+			if (isCharacterSanitizationEnabled(security)) {
+				const allowedChars = getAllowedCharacters(security);
+				if (allowedChars !== null) {
+					body = sanitizeContent(body, allowedChars);
+				}
+			}
+			ruleBodies.set(rule.id, body);
+			installedRules.push(rule);
+		} catch (err: unknown) {
+			warnings.push(
+				`Rule "${rule.id}" failed: ${err instanceof Error ? err.message : String(err)}`,
+			);
+		}
+	}
+
+	if (installedRules.length > 0) {
+		try {
+			installRules(
+				opts.projectPath,
+				installedRules,
+				opts.providers,
+				ruleBodies,
+				{ quiet: true },
+			);
+			installed += installedRules.length;
+		} catch (err: unknown) {
+			warnings.push(
+				`Failed to install rules: ${err instanceof Error ? err.message : String(err)}`,
+			);
+		}
+	}
+
+	return { installed, removed, warnings };
+}
+
+async function syncProjectAgentInstructions(opts: {
+	projectPath: string;
+	capabilitiesFilePath: string;
+	capabilities: Capabilities;
+	db: CapaDatabase;
+	providers: string[];
+	materializeShadow?: boolean;
+}): Promise<SyncSectionResult> {
+	const warnings: string[] = [];
+	const config = opts.capabilities.agents;
+
+	if (!config) {
+		try {
+			const removed = cleanAgentInstructionSnippets(
+				opts.projectPath,
+				opts.providers,
+			);
+			return { installed: 0, removed, warnings };
+		} catch (err: unknown) {
+			warnings.push(
+				`Failed to clear agent instructions: ${err instanceof Error ? err.message : String(err)}`,
+			);
+		}
+		return { installed: 0, removed: 0, warnings };
+	}
+
+	const hasContent =
+		!!config.base || (config.additional?.length ?? 0) > 0;
+	if (!hasContent) {
+		try {
+			const removed = cleanAgentInstructionSnippets(
+				opts.projectPath,
+				opts.providers,
+			);
+			return { installed: 0, removed, warnings };
+		} catch (err: unknown) {
+			warnings.push(
+				`Failed to clear agent instructions: ${err instanceof Error ? err.message : String(err)}`,
+			);
+		}
+		return { installed: 0, removed: 0, warnings };
+	}
+
+	try {
+		const authFetch = createAuthenticatedFetch(opts.db);
+		await installAgentsFile(
+			opts.projectPath,
+			config,
+			opts.providers,
+			opts.capabilities.options?.security,
+			opts.capabilitiesFilePath,
+			{
+				authFetch,
+				getRepoSnapshot: (platform, repoPath, auth, snapOpts) =>
+					getRepoSnapshot(platform, repoPath, auth, snapOpts),
+				quiet: true,
+				forceMaterialize: opts.materializeShadow === true,
+				onBlockedPhrase: (sourceLabel, phrase) => {
+					throw new Error(
+						`blocked phrase "${phrase}" in ${sourceLabel}`,
+					);
+				},
+			},
+		);
+		const snippetCount =
+			(config.additional?.length ?? 0) + (config.base ? 1 : 0);
+		return {
+			installed: snippetCount > 0 ? snippetCount : 1,
+			removed: 0,
+			warnings,
+		};
+	} catch (err: unknown) {
+		warnings.push(
+			`Failed to install agent instructions: ${err instanceof Error ? err.message : String(err)}`,
+		);
+		return { installed: 0, removed: 0, warnings };
+	}
+}

--- a/src/server/sync-project-artifacts.ts
+++ b/src/server/sync-project-artifacts.ts
@@ -16,7 +16,7 @@ import {
 } from "../shared/agent-activity";
 import { createAuthenticatedFetch } from "../shared/authenticated-fetch";
 import { validateHooks } from "../shared/hooks-validate";
-import { validateProvider } from "../shared/providers/resolve";
+import { getProvider } from "../shared/providers";
 import {
 	syncProjectSubagents,
 	type SyncSectionResult,
@@ -143,22 +143,45 @@ export async function syncProjectManagedArtifactsAndWrapShadows(opts: {
 	let skipped = true;
 
 	const shadows = await listWrapWorkspacesForProject(opts.projectPath);
+	const shadowWarnings: string[] = [];
 	for (const shadow of shadows) {
-		const shadowResult = await syncProjectManagedArtifacts({
-			...opts,
-			projectPath: shadow.workspacePath,
-			providers: [validateProvider(shadow.providerId)],
-			pruneOptions: {
-				onlyDesiredProviders: true,
-				mutateRoot: shadow.workspacePath,
-			},
-			materializeShadow: true,
-		});
-		hooks = mergeSyncSections(hooks, shadowResult.hooks);
-		rules = mergeSyncSections(rules, shadowResult.rules);
-		agents = mergeSyncSections(agents, shadowResult.agents);
-		subagents = mergeSyncSections(subagents, shadowResult.subagents);
-		if (!shadowResult.skipped) skipped = false;
+		const provider = getProvider(shadow.providerId);
+		if (!provider) {
+			shadowWarnings.push(
+				`Skipped wrap shadow at ${shadow.cachePath}: unknown provider "${shadow.providerId}"`,
+			);
+			continue;
+		}
+		try {
+			const shadowResult = await syncProjectManagedArtifacts({
+				...opts,
+				projectPath: shadow.workspacePath,
+				providers: [provider.id],
+				pruneOptions: {
+					onlyDesiredProviders: true,
+					mutateRoot: shadow.workspacePath,
+				},
+				materializeShadow: true,
+			});
+			hooks = mergeSyncSections(hooks, shadowResult.hooks);
+			rules = mergeSyncSections(rules, shadowResult.rules);
+			agents = mergeSyncSections(agents, shadowResult.agents);
+			subagents = mergeSyncSections(subagents, shadowResult.subagents);
+			if (!shadowResult.skipped) skipped = false;
+		} catch (err: unknown) {
+			shadowWarnings.push(
+				`Failed to sync wrap shadow at ${shadow.cachePath}: ${
+					err instanceof Error ? err.message : String(err)
+				}`,
+			);
+		}
+	}
+
+	if (shadowWarnings.length > 0) {
+		hooks = {
+			...hooks,
+			warnings: [...hooks.warnings, ...shadowWarnings],
+		};
 	}
 
 	return { hooks, rules, agents, subagents, skipped };

--- a/src/shared/agent-activity-sync.ts
+++ b/src/shared/agent-activity-sync.ts
@@ -14,6 +14,7 @@ import { validateHooks } from "./hooks-validate";
 import {
 	installHooks,
 	pruneOrphanHooks,
+	type PruneOrphanHooksOptions,
 } from "../cli/utils/hooks";
 
 export interface SyncSystemActivityHooksResult {
@@ -32,12 +33,8 @@ export async function syncSystemActivityHooks(opts: {
 	db: CapaDatabase;
 	/** Suppress CLI-style install logs (server / API callers). */
 	quiet?: boolean;
-	/**
-	 * When true, skip orphan prune and only install/update activity hooks for
-	 * `providers`. Used by wrap shadow installs so shared project identity
-	 * (e.g. Cursor hooks) is never cleaned up.
-	 */
-	skipPrune?: boolean;
+	/** Optional scoped prune (wrap shadow installs). */
+	pruneOptions?: PruneOrphanHooksOptions;
 }): Promise<SyncSystemActivityHooksResult> {
 	const warnings: string[] = [];
 	const enabled = isAgentActivityEnabled(opts.capabilities.options);
@@ -50,23 +47,20 @@ export async function syncSystemActivityHooks(opts: {
 	}
 
 	let removed = 0;
-	if (!opts.skipPrune) {
-		const systemHooks = enabled
-			? // Ids only for prune desired-set (command text is per-provider below).
-				buildSystemActivityHooks(opts.projectId)
-			: [];
-		const desiredHooks = [...userHooks, ...systemHooks];
-
-		const prune = pruneOrphanHooks(
-			opts.projectPath,
-			opts.projectId,
-			desiredHooks,
-			opts.providers,
-			opts.db,
-		);
-		warnings.push(...prune.warnings);
-		removed = prune.removed;
-	}
+	const systemHooks = enabled
+		? buildSystemActivityHooks(opts.projectId)
+		: [];
+	const desiredHooks = [...userHooks, ...systemHooks];
+	const prune = pruneOrphanHooks(
+		opts.projectPath,
+		opts.projectId,
+		desiredHooks,
+		opts.providers,
+		opts.db,
+		opts.pruneOptions ?? {},
+	);
+	warnings.push(...prune.warnings);
+	removed = prune.removed;
 
 	let installed = 0;
 	if (enabled && opts.providers.length > 0) {

--- a/src/shared/providers/handlers.ts
+++ b/src/shared/providers/handlers.ts
@@ -154,10 +154,10 @@ function renderSkillsBlock(
 	opts: { backtick: boolean },
 ): string[] {
 	const header = opts.backtick ? "**Skills:**" : "Skills:";
-	if (subAgent.skills.length === 0) {
+	if ((subAgent.skills ?? []).length === 0) {
 		return [header, "- (none)"];
 	}
-	const bullets = subAgent.skills.map((skillId) => {
+	const bullets = (subAgent.skills ?? []).map((skillId) => {
 		const desc = skillDescriptions.get(skillId);
 		const name = opts.backtick ? `\`${skillId}\`` : skillId;
 		return desc ? `- ${name} — ${desc}` : `- ${name}`;
@@ -171,10 +171,10 @@ function renderToolsBlock(
 	opts: { backtick: boolean },
 ): string[] {
 	const header = opts.backtick ? "**Tools:**" : "Tools:";
-	if (subAgent.tools.length === 0) {
+	if ((subAgent.tools ?? []).length === 0) {
 		return [header, "- (none)"];
 	}
-	const bullets = subAgent.tools.map((toolId) => {
+	const bullets = (subAgent.tools ?? []).map((toolId) => {
 		const { qualified, capaSh, description } = resolveTool(
 			toolId,
 			capabilities,

--- a/src/shared/sync-project-subagents.ts
+++ b/src/shared/sync-project-subagents.ts
@@ -1,0 +1,135 @@
+import { buildSkillDescriptions } from "../cli/commands/install-tasks/install-subagents";
+import {
+	installSubAgentInstructions,
+	removeSubAgentInstructions,
+} from "../cli/utils/agents-file/index";
+import {
+	purgeCursorSubAgentMCPEntries,
+	registerSubAgentMCPServer,
+	unregisterSubAgentMCPServer,
+} from "../cli/utils/mcp-client-manager";
+import type { CapaDatabase } from "../db/database";
+import { getProvider } from "./providers";
+import type { Capabilities } from "../types/capabilities";
+
+export interface SyncSectionResult {
+	installed: number;
+	removed: number;
+	warnings: string[];
+}
+
+/**
+ * Materialize sub-agent files and MCP entries after a capabilities write.
+ * Mirrors `installSubagentsTask` without CLI task scaffolding.
+ */
+export async function syncProjectSubagents(opts: {
+	projectPath: string;
+	projectId: string;
+	capabilities: Capabilities;
+	providers: string[];
+	db: CapaDatabase;
+	serverOrigin: string;
+}): Promise<SyncSectionResult> {
+	const warnings: string[] = [];
+	const toolExposure = opts.capabilities.options?.toolExposure;
+	const skipMcpWrites = toolExposure === "none";
+	const installedAgents = opts.db.getSubAgents(opts.projectId);
+	const currentSubagents = opts.capabilities.subagents ?? [];
+	const currentAgentIds = new Set(currentSubagents.map((a) => a.id));
+	const removedAgents = installedAgents.filter(
+		({ agent_id }) => !currentAgentIds.has(agent_id),
+	);
+
+	const agentsNeedingMcpCleanup = skipMcpWrites
+		? installedAgents.map(({ agent_id }) => agent_id)
+		: removedAgents.map(({ agent_id }) => agent_id);
+
+	const needsPurge = opts.providers.some((id) => {
+		const provider = getProvider(id);
+		return (
+			provider &&
+			(provider.mcp?.supportsSubAgentEntries === false ||
+				provider.purgeStaleSubAgentMcp === true)
+		);
+	});
+
+	const skillDescriptions = buildSkillDescriptions(
+		opts.projectPath,
+		opts.capabilities,
+		opts.providers,
+	);
+
+	let removed = 0;
+	let installed = 0;
+
+	if (needsPurge) {
+		try {
+			await purgeCursorSubAgentMCPEntries(opts.projectPath);
+		} catch (err: unknown) {
+			warnings.push(
+				`Failed to purge stale sub-agent MCP entries: ${err instanceof Error ? err.message : String(err)}`,
+			);
+		}
+	}
+
+	const cleanupSet = new Set(agentsNeedingMcpCleanup);
+	for (const { agent_id } of removedAgents) {
+		try {
+			await unregisterSubAgentMCPServer(
+				opts.projectPath,
+				agent_id,
+				opts.providers,
+			);
+			removeSubAgentInstructions(opts.projectPath, agent_id, opts.providers);
+			opts.db.removeSubAgent(opts.projectId, agent_id);
+			removed++;
+			cleanupSet.delete(agent_id);
+		} catch (err: unknown) {
+			warnings.push(
+				`Failed to remove sub-agent "${agent_id}": ${err instanceof Error ? err.message : String(err)}`,
+			);
+		}
+	}
+	for (const agent_id of cleanupSet) {
+		try {
+			await unregisterSubAgentMCPServer(
+				opts.projectPath,
+				agent_id,
+				opts.providers,
+			);
+		} catch (err: unknown) {
+			warnings.push(
+				`Failed to unregister MCP for sub-agent "${agent_id}": ${err instanceof Error ? err.message : String(err)}`,
+			);
+		}
+	}
+
+	for (const subAgent of currentSubagents) {
+		try {
+			if (!skipMcpWrites) {
+				const agentMcpUrl = `${opts.serverOrigin}/${opts.projectId}/agents/${subAgent.id}/mcp`;
+				await registerSubAgentMCPServer(
+					opts.projectPath,
+					subAgent.id,
+					agentMcpUrl,
+					opts.providers,
+				);
+			}
+			installSubAgentInstructions(
+				opts.projectPath,
+				subAgent,
+				opts.capabilities,
+				opts.providers,
+				skillDescriptions,
+			);
+			opts.db.upsertSubAgent(opts.projectId, subAgent.id);
+			installed++;
+		} catch (err: unknown) {
+			warnings.push(
+				`Failed to install sub-agent "${subAgent.id}": ${err instanceof Error ? err.message : String(err)}`,
+			);
+		}
+	}
+
+	return { installed, removed, warnings };
+}


### PR DESCRIPTION
## Summary
- Auto-enable MCP servers present in capabilities on configure and light UI refresh, and disconnect removed servers.
- Materialize hooks, rules, agent instructions, and subagents on capability changes in **wrap shadow workspaces only**; the source project tree is updated by `capa install`.
- Harden agent instruction generation: idempotent full re-render of managed blocks, strip capa markers from source bodies, reject `agents.base` paths that resolve to managed instruction files, and skip user-owned `AGENTS.md` / `CLAUDE.md` files without capa markers.
- Scope wrap install orphan prune/cleanup to the shadow provider and workspace path so shared project identity state is not touched.

## Test plan
- [x] `bun test src/cli/utils/__tests__/agents-file.test.ts`
- [x] `bun test src/server/__tests__/sync-project-artifacts.test.ts`
- [x] `bun test src/cli/commands/install-tasks/helpers/__tests__/wrap-prune-rules.test.ts`
- [x] `bun test src/server/__tests__/configure-routes.test.ts`
- [x] `bun test src/server/__tests__/mcp-server-state.test.ts`
- [x] Manual: UI capability change updates wrap shadow `hooks.json` / `AGENTS.md` without modifying source project files
- [ ] Manual: `capa install` still materializes artifacts on the source project
- [ ] Manual: existing user-owned `AGENTS.md` is left untouched until capa markers are present or the file is missing


Made with [Cursor](https://cursor.com)