### PR TITLE
fix: restore OAuth endpoint aliases for MCP token refresh

### DIFF
--- a/src/server/__tests__/configure-routes.test.ts
+++ b/src/server/__tests__/configure-routes.test.ts
@@ -14,7 +14,7 @@ import {
 import type { CapaMCPServer } from "../mcp-handler";
 import { handleGetServerTools } from "../mcp-meta-routes";
 import { McpServerStateManager } from "../mcp-server-state";
-import type { OAuth2Manager } from "../oauth-manager";
+import { OAuth2DetectionStatus, type OAuth2Manager } from "../oauth-manager";
 import { SessionManager } from "../session-manager";
 
 const DISK_CAPS = `providers: []
@@ -68,7 +68,9 @@ describe("handleProjectConfigure", () => {
 			db,
 			sessionManager,
 			oauth2Manager: {
-				detectOAuth2Requirement: async () => ({ status: "not_required" }),
+				detectOAuth2Requirement: async () => ({
+					status: OAuth2DetectionStatus.NOT_REQUIRED,
+				}),
 				isServerConnected: () => false,
 				getAccessToken: async () => null,
 			} as unknown as OAuth2Manager,

--- a/src/server/__tests__/configure-routes.test.ts
+++ b/src/server/__tests__/configure-routes.test.ts
@@ -68,7 +68,7 @@ describe("handleProjectConfigure", () => {
 			db,
 			sessionManager,
 			oauth2Manager: {
-				detectOAuth2Requirement: async () => null,
+				detectOAuth2Requirement: async () => ({ status: "not_required" }),
 				isServerConnected: () => false,
 				getAccessToken: async () => null,
 			} as unknown as OAuth2Manager,

--- a/src/server/__tests__/oauth-discovery.test.ts
+++ b/src/server/__tests__/oauth-discovery.test.ts
@@ -2,6 +2,7 @@ import { afterEach, describe, expect, it } from "bun:test";
 import {
 	buildOAuthAuthorizationServerMetadataUrl,
 	detectOAuth2Requirement,
+	OAuth2DetectionStatus,
 	resolveOAuthScope,
 	sanitizeOAuthScope,
 } from "../oauth-discovery";
@@ -146,8 +147,8 @@ describe("detectOAuth2Requirement", () => {
 		const result = await detectOAuth2Requirement(
 			"https://mcp-gateway.example.test/mcp",
 		);
-		expect(result.status).toBe("required");
-		if (result.status !== "required") return;
+		expect(result.status).toBe(OAuth2DetectionStatus.REQUIRED);
+		if (result.status !== OAuth2DetectionStatus.REQUIRED) return;
 		expect(result.config.authorizationEndpoint).toBe(
 			"https://mcp-auth.example.test/realms/tenant/protocol/openid-connect/auth",
 		);
@@ -167,7 +168,7 @@ describe("detectOAuth2Requirement", () => {
 		const result = await detectOAuth2Requirement(
 			"https://unreachable.example.test/mcp",
 		);
-		expect(result.status).toBe("inconclusive");
+		expect(result.status).toBe(OAuth2DetectionStatus.INCONCLUSIVE);
 	});
 
 	it("returns not_required on a successful unauthenticated initialize", async () => {
@@ -177,6 +178,6 @@ describe("detectOAuth2Requirement", () => {
 		const result = await detectOAuth2Requirement(
 			"https://open.example.test/mcp",
 		);
-		expect(result.status).toBe("not_required");
+		expect(result.status).toBe(OAuth2DetectionStatus.NOT_REQUIRED);
 	});
 });

--- a/src/server/__tests__/oauth-discovery.test.ts
+++ b/src/server/__tests__/oauth-discovery.test.ts
@@ -146,15 +146,37 @@ describe("detectOAuth2Requirement", () => {
 		const result = await detectOAuth2Requirement(
 			"https://mcp-gateway.example.test/mcp",
 		);
-		expect(result).not.toBeNull();
-		expect(result?.authorizationEndpoint).toBe(
+		expect(result.status).toBe("required");
+		if (result.status !== "required") return;
+		expect(result.config.authorizationEndpoint).toBe(
 			"https://mcp-auth.example.test/realms/tenant/protocol/openid-connect/auth",
 		);
-		expect(result?.tokenEndpoint).toBe(
+		expect(result.config.tokenEndpoint).toBe(
 			"https://mcp-auth.example.test/realms/tenant/protocol/openid-connect/token",
 		);
-		expect(result?.scope).toBe(
+		expect(result.config.scope).toBe(
 			"openid email profile offline_access api.read",
 		);
+	});
+
+	it("returns inconclusive when the MCP server is unreachable", async () => {
+		globalThis.fetch = (async () => {
+			throw new DOMException("The operation was aborted.", "AbortError");
+		}) as unknown as typeof fetch;
+
+		const result = await detectOAuth2Requirement(
+			"https://unreachable.example.test/mcp",
+		);
+		expect(result.status).toBe("inconclusive");
+	});
+
+	it("returns not_required on a successful unauthenticated initialize", async () => {
+		globalThis.fetch = (async () =>
+			new Response("", { status: 200 })) as unknown as typeof fetch;
+
+		const result = await detectOAuth2Requirement(
+			"https://open.example.test/mcp",
+		);
+		expect(result.status).toBe("not_required");
 	});
 });

--- a/src/server/__tests__/oauth-endpoint-resolve.test.ts
+++ b/src/server/__tests__/oauth-endpoint-resolve.test.ts
@@ -1,0 +1,53 @@
+import { describe, expect, it } from "bun:test";
+import {
+	resolveAuthorizationEndpoint,
+	resolveTokenEndpoint,
+} from "../oauth-endpoint-resolve";
+
+describe("resolveTokenEndpoint", () => {
+	it("prefers canonical tokenEndpoint", () => {
+		expect(
+			resolveTokenEndpoint({
+				tokenEndpoint: "https://auth.example/token",
+				tokenUrl: "https://legacy.example/token",
+			} as never),
+		).toBe("https://auth.example/token");
+	});
+
+	it("falls back to tokenUrl / snake_case aliases", () => {
+		expect(
+			resolveTokenEndpoint({
+				tokenUrl: "https://auth.example/token",
+			} as never),
+		).toBe("https://auth.example/token");
+		expect(
+			resolveTokenEndpoint({
+				token_url: "https://auth.example/token",
+			} as never),
+		).toBe("https://auth.example/token");
+		expect(
+			resolveTokenEndpoint({
+				token_endpoint: "https://auth.example/token",
+			} as never),
+		).toBe("https://auth.example/token");
+	});
+
+	it("returns undefined when no endpoint is present", () => {
+		expect(resolveTokenEndpoint({} as never)).toBeUndefined();
+	});
+});
+
+describe("resolveAuthorizationEndpoint", () => {
+	it("falls back to authorizationUrl aliases", () => {
+		expect(
+			resolveAuthorizationEndpoint({
+				authorizationUrl: "https://auth.example/authorize",
+			} as never),
+		).toBe("https://auth.example/authorize");
+		expect(
+			resolveAuthorizationEndpoint({
+				authorization_url: "https://auth.example/authorize",
+			} as never),
+		).toBe("https://auth.example/authorize");
+	});
+});

--- a/src/server/__tests__/oauth-endpoint-resolve.test.ts
+++ b/src/server/__tests__/oauth-endpoint-resolve.test.ts
@@ -2,38 +2,39 @@ import { describe, expect, it } from "bun:test";
 import {
 	resolveAuthorizationEndpoint,
 	resolveTokenEndpoint,
+	type OAuthEndpointResolvable,
 } from "../oauth-endpoint-resolve";
 
 describe("resolveTokenEndpoint", () => {
 	it("prefers canonical tokenEndpoint", () => {
-		expect(
-			resolveTokenEndpoint({
-				tokenEndpoint: "https://auth.example/token",
-				tokenUrl: "https://legacy.example/token",
-			} as never),
-		).toBe("https://auth.example/token");
+		const cfg: OAuthEndpointResolvable = {
+			tokenEndpoint: "https://auth.example/token",
+			tokenUrl: "https://legacy.example/token",
+		};
+		expect(resolveTokenEndpoint(cfg)).toBe("https://auth.example/token");
 	});
 
 	it("falls back to tokenUrl / snake_case aliases", () => {
 		expect(
 			resolveTokenEndpoint({
 				tokenUrl: "https://auth.example/token",
-			} as never),
+			}),
 		).toBe("https://auth.example/token");
 		expect(
 			resolveTokenEndpoint({
 				token_url: "https://auth.example/token",
-			} as never),
+			}),
 		).toBe("https://auth.example/token");
 		expect(
 			resolveTokenEndpoint({
 				token_endpoint: "https://auth.example/token",
-			} as never),
+			}),
 		).toBe("https://auth.example/token");
 	});
 
 	it("returns undefined when no endpoint is present", () => {
-		expect(resolveTokenEndpoint({} as never)).toBeUndefined();
+		expect(resolveTokenEndpoint({})).toBeUndefined();
+		expect(resolveTokenEndpoint(null)).toBeUndefined();
 	});
 });
 
@@ -42,12 +43,12 @@ describe("resolveAuthorizationEndpoint", () => {
 		expect(
 			resolveAuthorizationEndpoint({
 				authorizationUrl: "https://auth.example/authorize",
-			} as never),
+			}),
 		).toBe("https://auth.example/authorize");
 		expect(
 			resolveAuthorizationEndpoint({
 				authorization_url: "https://auth.example/authorize",
-			} as never),
+			}),
 		).toBe("https://auth.example/authorize");
 	});
 });

--- a/src/server/__tests__/oauth-manager.test.ts
+++ b/src/server/__tests__/oauth-manager.test.ts
@@ -53,7 +53,15 @@ describe('OAuth2Manager', () => {
       expect(isPermanentRefreshFailure(undefined, res403, 'invalid_token')).toBe(true);
     });
 
-    it('treats 500 responses as transient', () => {
+    it('keeps tokens on bare 4xx without an explicit invalid/expired marker', () => {
+      const res401 = new Response('', { status: 401 });
+      expect(isPermanentRefreshFailure(undefined, res401, 'rate limited')).toBe(false);
+
+      const res403 = new Response('', { status: 403 });
+      expect(isPermanentRefreshFailure(undefined, res403, 'forbidden')).toBe(false);
+    });
+
+    it('treats 500 responses as transient even with invalid_grant in the body', () => {
       const res500 = new Response('', { status: 500 });
       expect(isPermanentRefreshFailure(undefined, res500, 'invalid_grant')).toBe(false);
     });

--- a/src/server/__tests__/oauth-manager.test.ts
+++ b/src/server/__tests__/oauth-manager.test.ts
@@ -45,17 +45,12 @@ describe('OAuth2Manager', () => {
   });
 
 	describe('isPermanentRefreshFailure', () => {
-    it('classifies only HTTP 403 as permanent', () => {
-      const res403 = new Response('', { status: 403 });
-      expect(isPermanentRefreshFailure(undefined, res403, 'anything')).toBe(true);
-    });
-
-    it('treats 401/400 with invalid_grant as transient (keep tokens)', () => {
+    it('classifies 401/403 with invalid_grant as permanent', () => {
       const res401 = new Response('', { status: 401 });
-      expect(isPermanentRefreshFailure(undefined, res401, '{"error":"invalid_grant"}')).toBe(false);
+      expect(isPermanentRefreshFailure(undefined, res401, '{"error":"invalid_grant"}')).toBe(true);
 
-      const res400 = new Response('', { status: 400 });
-      expect(isPermanentRefreshFailure(undefined, res400, 'invalid_token')).toBe(false);
+      const res403 = new Response('', { status: 403 });
+      expect(isPermanentRefreshFailure(undefined, res403, 'invalid_token')).toBe(true);
     });
 
     it('treats 500 responses as transient', () => {

--- a/src/server/__tests__/oauth-manager.test.ts
+++ b/src/server/__tests__/oauth-manager.test.ts
@@ -44,13 +44,18 @@ describe('OAuth2Manager', () => {
     ).not.toThrow();
   });
 
-  describe('isPermanentRefreshFailure', () => {
-    it('classifies 401/403 with invalid_grant as permanent', () => {
-      const res401 = new Response('', { status: 401 });
-      expect(isPermanentRefreshFailure(undefined, res401, '{"error":"invalid_grant"}')).toBe(true);
-
+	describe('isPermanentRefreshFailure', () => {
+    it('classifies only HTTP 403 as permanent', () => {
       const res403 = new Response('', { status: 403 });
-      expect(isPermanentRefreshFailure(undefined, res403, 'invalid_token')).toBe(true);
+      expect(isPermanentRefreshFailure(undefined, res403, 'anything')).toBe(true);
+    });
+
+    it('treats 401/400 with invalid_grant as transient (keep tokens)', () => {
+      const res401 = new Response('', { status: 401 });
+      expect(isPermanentRefreshFailure(undefined, res401, '{"error":"invalid_grant"}')).toBe(false);
+
+      const res400 = new Response('', { status: 400 });
+      expect(isPermanentRefreshFailure(undefined, res400, 'invalid_token')).toBe(false);
     });
 
     it('treats 500 responses as transient', () => {
@@ -70,7 +75,7 @@ describe('OAuth2Manager', () => {
       globalThis.fetch = originalFetch;
     });
 
-    it('returns null (does not throw) when the server is unreachable', async () => {
+    it('returns inconclusive (does not throw) when the server is unreachable', async () => {
       // Simulate a connection-refused / aborted fetch — the same class of error
       // that an unreachable MCP server produces at the network layer.
       globalThis.fetch = (async () => {
@@ -79,15 +84,15 @@ describe('OAuth2Manager', () => {
 
       const manager = new OAuth2Manager(makeMockDb());
       const result = await manager.detectOAuth2Requirement('http://192.0.2.1:9999/mcp');
-      expect(result).toBeNull();
+      expect(result.status).toBe('inconclusive');
     });
 
-    it('returns null when the MCP server returns a non-401 status', async () => {
+    it('returns not_required when the MCP server returns a non-401 status', async () => {
       globalThis.fetch = (async () => new Response('', { status: 200 })) as unknown as typeof fetch;
 
       const manager = new OAuth2Manager(makeMockDb());
       const result = await manager.detectOAuth2Requirement('http://localhost:9999/mcp');
-      expect(result).toBeNull();
+      expect(result.status).toBe('not_required');
     });
   });
 

--- a/src/server/__tests__/oauth-manager.test.ts
+++ b/src/server/__tests__/oauth-manager.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, beforeEach, afterEach } from 'bun:test';
-import { OAuth2Manager, isPermanentRefreshFailure } from '../oauth-manager';
+import { OAuth2Manager, isPermanentRefreshFailure, OAuth2DetectionStatus } from '../oauth-manager';
 import { shouldSkipTlsVerify } from '../../shared/tls-skip-verify';
 import type { CapaDatabase } from '../../db/database';
 
@@ -87,7 +87,7 @@ describe('OAuth2Manager', () => {
 
       const manager = new OAuth2Manager(makeMockDb());
       const result = await manager.detectOAuth2Requirement('http://192.0.2.1:9999/mcp');
-      expect(result.status).toBe('inconclusive');
+      expect(result.status).toBe(OAuth2DetectionStatus.INCONCLUSIVE);
     });
 
     it('returns not_required when the MCP server returns a non-401 status', async () => {
@@ -95,7 +95,7 @@ describe('OAuth2Manager', () => {
 
       const manager = new OAuth2Manager(makeMockDb());
       const result = await manager.detectOAuth2Requirement('http://localhost:9999/mcp');
-      expect(result.status).toBe('not_required');
+      expect(result.status).toBe(OAuth2DetectionStatus.NOT_REQUIRED);
     });
   });
 

--- a/src/server/__tests__/oauth-server-sync.test.ts
+++ b/src/server/__tests__/oauth-server-sync.test.ts
@@ -187,7 +187,7 @@ describe("mergePluginEmbeddedOAuth", () => {
 });
 
 describe("syncServerOAuth2Requirement", () => {
-	it("clears stale OAuth config when the live URL no longer requires auth", async () => {
+	it("clears stale OAuth config when the live URL no longer requires auth, without deleting tokens", async () => {
 		const server = mcpServer(
 			"server-a",
 			"https://new.example/mcp",
@@ -195,7 +195,7 @@ describe("syncServerOAuth2Requirement", () => {
 		);
 		const disconnects: string[] = [];
 		const oauth2Manager = {
-			detectOAuth2Requirement: async () => null,
+			detectOAuth2Requirement: async () => ({ status: "not_required" }),
 			isServerConnected: () => true,
 			getAccessToken: async () => "token",
 			disconnect: (_projectId: string, serverId: string) => {
@@ -212,6 +212,38 @@ describe("syncServerOAuth2Requirement", () => {
 		expect(result.changed).toBe(true);
 		expect(result.entry).toBeNull();
 		expect(server.def.oauth2).toBeUndefined();
-		expect(disconnects).toEqual(["server-a"]);
+		expect(disconnects).toEqual([]);
+	});
+
+	it("keeps OAuth config and tokens when the probe is inconclusive (unreachable)", async () => {
+		const server = mcpServer(
+			"server-a",
+			"https://unreachable.example/mcp",
+			DETECTED_OAUTH,
+		);
+		const disconnects: string[] = [];
+		const oauth2Manager = {
+			detectOAuth2Requirement: async () => ({
+				status: "inconclusive",
+				reason: "network failure",
+			}),
+			isServerConnected: () => true,
+			getAccessToken: async () => "token",
+			disconnect: (_projectId: string, serverId: string) => {
+				disconnects.push(serverId);
+			},
+		} as unknown as OAuth2Manager;
+
+		const result = await syncServerOAuth2Requirement(
+			"proj-1",
+			server,
+			oauth2Manager,
+		);
+
+		expect(result.changed).toBe(false);
+		expect(result.entry?.serverId).toBe("server-a");
+		expect(result.entry?.isConnected).toBe(true);
+		expect(server.def.oauth2).toEqual(DETECTED_OAUTH);
+		expect(disconnects).toEqual([]);
 	});
 });

--- a/src/server/__tests__/oauth-server-sync.test.ts
+++ b/src/server/__tests__/oauth-server-sync.test.ts
@@ -1,7 +1,7 @@
 import { describe, expect, it } from "bun:test";
 import type { Capabilities, MCPServer } from "../../types/capabilities";
 import type { OAuth2Config } from "../../types/oauth";
-import type { OAuth2Manager } from "../oauth-manager";
+import { OAuth2DetectionStatus, type OAuth2Manager } from "../oauth-manager";
 import {
 	mergeDetectedOAuth2,
 	mergeEmbeddedOAuthFields,
@@ -195,7 +195,9 @@ describe("syncServerOAuth2Requirement", () => {
 		);
 		const disconnects: string[] = [];
 		const oauth2Manager = {
-			detectOAuth2Requirement: async () => ({ status: "not_required" }),
+			detectOAuth2Requirement: async () => ({
+				status: OAuth2DetectionStatus.NOT_REQUIRED,
+			}),
 			isServerConnected: () => true,
 			getAccessToken: async () => "token",
 			disconnect: (_projectId: string, serverId: string) => {
@@ -224,7 +226,7 @@ describe("syncServerOAuth2Requirement", () => {
 		const disconnects: string[] = [];
 		const oauth2Manager = {
 			detectOAuth2Requirement: async () => ({
-				status: "inconclusive",
+				status: OAuth2DetectionStatus.INCONCLUSIVE,
 				reason: "network failure",
 			}),
 			isServerConnected: () => true,

--- a/src/server/__tests__/oauth-server-sync.test.ts
+++ b/src/server/__tests__/oauth-server-sync.test.ts
@@ -71,6 +71,34 @@ describe("preserveDiscoveredOAuth2", () => {
 		);
 	});
 
+	it("copies legacy tokenUrl / authorizationUrl aliases as canonical fields", () => {
+		const previous: Capabilities = {
+			providers: [],
+			skills: [],
+			tools: [],
+			servers: [
+				mcpServer("legacy", "https://mcp.example/mcp", {
+					authorizationUrl: "https://auth.example/authorize",
+					tokenUrl: "https://auth.example/token",
+				} as Capabilities["servers"][number]["def"]["oauth2"]),
+			],
+		};
+		const fresh: Capabilities = {
+			providers: [],
+			skills: [],
+			tools: [],
+			servers: [mcpServer("legacy", "https://mcp.example/mcp")],
+		};
+
+		const result = preserveDiscoveredOAuth2(fresh, previous);
+		expect(result.servers[0].def.oauth2?.authorizationEndpoint).toBe(
+			"https://auth.example/authorize",
+		);
+		expect(result.servers[0].def.oauth2?.tokenEndpoint).toBe(
+			"https://auth.example/token",
+		);
+	});
+
 	it("keeps plugin-embedded clientId when copying discovered endpoints", () => {
 		const previous: Capabilities = {
 			providers: [],

--- a/src/server/__tests__/oauth-token-refresh.test.ts
+++ b/src/server/__tests__/oauth-token-refresh.test.ts
@@ -109,4 +109,29 @@ describe("refreshAccessToken", () => {
 		expect(ok).toBe(true);
 		expect(new URLSearchParams(body).get("client_id")).toBe("test-app-id");
 	});
+
+	it("refreshes when oauth2 config only has legacy tokenUrl alias", async () => {
+		let postedUrl = "";
+		globalThis.fetch = (async (input: RequestInfo | URL) => {
+			postedUrl = String(input);
+			return new Response(
+				JSON.stringify({
+					access_token: "new-access",
+					refresh_token: "new-refresh",
+					expires_in: 3600,
+				}),
+				{ status: 200, headers: { "Content-Type": "application/json" } },
+			);
+		}) as unknown as typeof fetch;
+
+		const ok = await refreshAccessToken(db, "p1", "mcp-server", {
+			authorizationUrl: "https://example.com/authorize",
+			tokenUrl: "https://example.com/token",
+			resourceServer: "https://example.com",
+			clientId: "test-app-id",
+		} as never);
+
+		expect(ok).toBe(true);
+		expect(postedUrl).toBe("https://example.com/token");
+	});
 });

--- a/src/server/__tests__/oauth-token-refresh.test.ts
+++ b/src/server/__tests__/oauth-token-refresh.test.ts
@@ -67,9 +67,9 @@ describe("refreshAccessToken", () => {
 		rmSync(tempDir, { recursive: true, force: true });
 	});
 
-	it("keeps the token when the provider returns 200 without access_token", async () => {
+	it("keeps the token when a 200 payload fails without an explicit invalid/expired marker", async () => {
 		globalThis.fetch = (async () =>
-			new Response(JSON.stringify({ ok: false, error: "invalid_refresh_token" }), {
+			new Response(JSON.stringify({ ok: false, error: "temporarily_unavailable" }), {
 				status: 200,
 				headers: { "Content-Type": "application/json" },
 			})) as unknown as typeof fetch;
@@ -87,11 +87,49 @@ describe("refreshAccessToken", () => {
 		);
 	});
 
-	it("deletes the token only on a clear HTTP 403 from the token endpoint", async () => {
+	it("keeps the token on bare 403 without an explicit invalid/expired marker", async () => {
 		globalThis.fetch = (async () =>
 			new Response("forbidden", {
 				status: 403,
 				headers: { "Content-Type": "text/plain" },
+			})) as unknown as typeof fetch;
+
+		const ok = await refreshAccessToken(db, "p1", "mcp-server", {
+			authorizationEndpoint: "https://example.com/authorize",
+			tokenEndpoint: "https://example.com/token",
+			resourceServer: "https://example.com",
+			clientId: "test-app-id",
+		});
+
+		expect(ok).toBe(false);
+		expect(db.getOAuthToken("p1", "mcp-server")?.refresh_token).toBe(
+			"old-refresh",
+		);
+	});
+
+	it("deletes the token when the AS explicitly reports invalid_grant", async () => {
+		globalThis.fetch = (async () =>
+			new Response(JSON.stringify({ error: "invalid_grant" }), {
+				status: 400,
+				headers: { "Content-Type": "application/json" },
+			})) as unknown as typeof fetch;
+
+		const ok = await refreshAccessToken(db, "p1", "mcp-server", {
+			authorizationEndpoint: "https://example.com/authorize",
+			tokenEndpoint: "https://example.com/token",
+			resourceServer: "https://example.com",
+			clientId: "test-app-id",
+		});
+
+		expect(ok).toBe(false);
+		expect(db.getOAuthToken("p1", "mcp-server")).toBeNull();
+	});
+
+	it("deletes the token when a 200 error payload explicitly says invalid_refresh", async () => {
+		globalThis.fetch = (async () =>
+			new Response(JSON.stringify({ ok: false, error: "invalid_refresh_token" }), {
+				status: 200,
+				headers: { "Content-Type": "application/json" },
 			})) as unknown as typeof fetch;
 
 		const ok = await refreshAccessToken(db, "p1", "mcp-server", {

--- a/src/server/__tests__/oauth-token-refresh.test.ts
+++ b/src/server/__tests__/oauth-token-refresh.test.ts
@@ -67,11 +67,31 @@ describe("refreshAccessToken", () => {
 		rmSync(tempDir, { recursive: true, force: true });
 	});
 
-	it("does not throw when the provider returns 200 without access_token", async () => {
+	it("keeps the token when the provider returns 200 without access_token", async () => {
 		globalThis.fetch = (async () =>
 			new Response(JSON.stringify({ ok: false, error: "invalid_refresh_token" }), {
 				status: 200,
 				headers: { "Content-Type": "application/json" },
+			})) as unknown as typeof fetch;
+
+		const ok = await refreshAccessToken(db, "p1", "mcp-server", {
+			authorizationEndpoint: "https://example.com/authorize",
+			tokenEndpoint: "https://example.com/token",
+			resourceServer: "https://example.com",
+			clientId: "test-app-id",
+		});
+
+		expect(ok).toBe(false);
+		expect(db.getOAuthToken("p1", "mcp-server")?.refresh_token).toBe(
+			"old-refresh",
+		);
+	});
+
+	it("deletes the token only on a clear HTTP 403 from the token endpoint", async () => {
+		globalThis.fetch = (async () =>
+			new Response("forbidden", {
+				status: 403,
+				headers: { "Content-Type": "text/plain" },
 			})) as unknown as typeof fetch;
 
 		const ok = await refreshAccessToken(db, "p1", "mcp-server", {
@@ -129,7 +149,7 @@ describe("refreshAccessToken", () => {
 			tokenUrl: "https://example.com/token",
 			resourceServer: "https://example.com",
 			clientId: "test-app-id",
-		} as never);
+		});
 
 		expect(ok).toBe(true);
 		expect(postedUrl).toBe("https://example.com/token");

--- a/src/server/oauth-discovery.ts
+++ b/src/server/oauth-discovery.ts
@@ -122,6 +122,19 @@ export function resolveOAuthScope(options: {
 }
 
 /**
+ * Result of probing whether an MCP server requires OAuth2.
+ *
+ * - `required`: clear 401 + discoverable auth-server metadata
+ * - `not_required`: reachable server answered without requiring OAuth
+ * - `inconclusive`: network/timeout/5xx/401-without-metadata — callers must
+ *   not treat this as "OAuth went away" or delete stored tokens
+ */
+export type OAuth2DetectionResult =
+	| { status: "required"; config: OAuth2Config }
+	| { status: "not_required" }
+	| { status: "inconclusive"; reason: string };
+
+/**
  * Detect if an MCP server requires OAuth2 authentication.
  * Per MCP spec: Make unauthenticated request, check for 401 + WWW-Authenticate header.
  */
@@ -129,7 +142,7 @@ export async function detectOAuth2Requirement(
 	serverUrl: string,
 	options?: { tlsSkipVerify?: boolean },
 	log = logger.child("OAuth2Discovery"),
-): Promise<OAuth2Config | null> {
+): Promise<OAuth2DetectionResult> {
 	const tlsSkipVerify = shouldSkipTlsVerify(
 		!!options?.tlsSkipVerify,
 		`OAuth2 detection (${serverUrl})`,
@@ -156,9 +169,17 @@ export async function detectOAuth2Requirement(
 			...tlsFetchOptions(tlsSkipVerify),
 		} as RequestInit);
 
+		// 5xx / other ambiguous statuses: server is reachable but we cannot
+		// conclude that OAuth is no longer required.
+		if (response.status >= 500) {
+			const reason = `MCP probe returned ${response.status}`;
+			log.warn(reason);
+			return { status: "inconclusive", reason };
+		}
+
 		if (response.status !== 401) {
 			log.debug(`No OAuth2 required (status: ${response.status})`);
-			return null;
+			return { status: "not_required" };
 		}
 
 		const serverUrlObj = new URL(serverUrl);
@@ -226,8 +247,9 @@ export async function detectOAuth2Requirement(
 		}
 
 		if (!authMetadata) {
-			log.warn("Failed to fetch auth server metadata");
-			return null;
+			const reason = "401 received but auth server metadata unavailable";
+			log.warn(reason);
+			return { status: "inconclusive", reason };
 		}
 
 		const grantTypes = authMetadata.grant_types_supported;
@@ -236,12 +258,12 @@ export async function detectOAuth2Requirement(
 			!grantTypes.includes("authorization_code")
 		) {
 			log.debug("Auth server does not support authorization_code grant");
-			return null;
+			return { status: "not_required" };
 		}
 		const responseTypes = authMetadata.response_types_supported;
 		if (Array.isArray(responseTypes) && !responseTypes.includes("code")) {
 			log.debug("Auth server does not support response_type=code");
-			return null;
+			return { status: "not_required" };
 		}
 
 		const scope = resolveOAuthScope({
@@ -259,9 +281,10 @@ export async function detectOAuth2Requirement(
 		};
 
 		log.success("OAuth2 detected");
-		return config;
+		return { status: "required", config };
 	} catch (error: any) {
-		log.failure(`Error detecting OAuth2: ${error.message}`);
-		return null;
+		const reason = error?.message ?? "OAuth2 detection failed";
+		log.failure(`Error detecting OAuth2: ${reason}`);
+		return { status: "inconclusive", reason };
 	}
 }

--- a/src/server/oauth-discovery.ts
+++ b/src/server/oauth-discovery.ts
@@ -122,17 +122,26 @@ export function resolveOAuthScope(options: {
 }
 
 /**
- * Result of probing whether an MCP server requires OAuth2.
+ * Probe outcome for whether an MCP server requires OAuth2.
  *
- * - `required`: clear 401 + discoverable auth-server metadata
- * - `not_required`: reachable server answered without requiring OAuth
- * - `inconclusive`: network/timeout/5xx/401-without-metadata — callers must
+ * - REQUIRED: clear 401 + discoverable auth-server metadata
+ * - NOT_REQUIRED: reachable server answered without requiring OAuth
+ * - INCONCLUSIVE: network/timeout/5xx/401-without-metadata — callers must
  *   not treat this as "OAuth went away" or delete stored tokens
  */
+export const OAuth2DetectionStatus = {
+	REQUIRED: "required",
+	NOT_REQUIRED: "not_required",
+	INCONCLUSIVE: "inconclusive",
+} as const;
+
+export type OAuth2DetectionStatus =
+	(typeof OAuth2DetectionStatus)[keyof typeof OAuth2DetectionStatus];
+
 export type OAuth2DetectionResult =
-	| { status: "required"; config: OAuth2Config }
-	| { status: "not_required" }
-	| { status: "inconclusive"; reason: string };
+	| { status: typeof OAuth2DetectionStatus.REQUIRED; config: OAuth2Config }
+	| { status: typeof OAuth2DetectionStatus.NOT_REQUIRED }
+	| { status: typeof OAuth2DetectionStatus.INCONCLUSIVE; reason: string };
 
 /**
  * Detect if an MCP server requires OAuth2 authentication.
@@ -174,12 +183,12 @@ export async function detectOAuth2Requirement(
 		if (response.status >= 500) {
 			const reason = `MCP probe returned ${response.status}`;
 			log.warn(reason);
-			return { status: "inconclusive", reason };
+			return { status: OAuth2DetectionStatus.INCONCLUSIVE, reason };
 		}
 
 		if (response.status !== 401) {
 			log.debug(`No OAuth2 required (status: ${response.status})`);
-			return { status: "not_required" };
+			return { status: OAuth2DetectionStatus.NOT_REQUIRED };
 		}
 
 		const serverUrlObj = new URL(serverUrl);
@@ -249,7 +258,7 @@ export async function detectOAuth2Requirement(
 		if (!authMetadata) {
 			const reason = "401 received but auth server metadata unavailable";
 			log.warn(reason);
-			return { status: "inconclusive", reason };
+			return { status: OAuth2DetectionStatus.INCONCLUSIVE, reason };
 		}
 
 		const grantTypes = authMetadata.grant_types_supported;
@@ -258,12 +267,12 @@ export async function detectOAuth2Requirement(
 			!grantTypes.includes("authorization_code")
 		) {
 			log.debug("Auth server does not support authorization_code grant");
-			return { status: "not_required" };
+			return { status: OAuth2DetectionStatus.NOT_REQUIRED };
 		}
 		const responseTypes = authMetadata.response_types_supported;
 		if (Array.isArray(responseTypes) && !responseTypes.includes("code")) {
 			log.debug("Auth server does not support response_type=code");
-			return { status: "not_required" };
+			return { status: OAuth2DetectionStatus.NOT_REQUIRED };
 		}
 
 		const scope = resolveOAuthScope({
@@ -281,10 +290,10 @@ export async function detectOAuth2Requirement(
 		};
 
 		log.success("OAuth2 detected");
-		return { status: "required", config };
+		return { status: OAuth2DetectionStatus.REQUIRED, config };
 	} catch (error: any) {
 		const reason = error?.message ?? "OAuth2 detection failed";
 		log.failure(`Error detecting OAuth2: ${reason}`);
-		return { status: "inconclusive", reason };
+		return { status: OAuth2DetectionStatus.INCONCLUSIVE, reason };
 	}
 }

--- a/src/server/oauth-endpoint-resolve.ts
+++ b/src/server/oauth-endpoint-resolve.ts
@@ -1,12 +1,13 @@
-import type { OAuth2Config } from "../types/oauth";
-
 /**
  * Resolve auth/token endpoints from canonical camelCase fields, with legacy
  * alias fallbacks for session/DB oauth2 blocks that predate ingest normalization
  * (`tokenUrl` / `authorizationUrl`, snake_case, etc.).
+ *
+ * Accepts any oauth2-shaped object (capabilities config, discovery result, or
+ * legacy session JSON) — callers may pass optional or required endpoint fields.
  */
 export function resolveAuthorizationEndpoint(
-	oauth2Config: OAuth2Config | Record<string, unknown>,
+	oauth2Config: object,
 ): string | undefined {
 	const cfg = oauth2Config as Record<string, unknown>;
 	return firstNonEmptyString(
@@ -17,9 +18,7 @@ export function resolveAuthorizationEndpoint(
 	);
 }
 
-export function resolveTokenEndpoint(
-	oauth2Config: OAuth2Config | Record<string, unknown>,
-): string | undefined {
+export function resolveTokenEndpoint(oauth2Config: object): string | undefined {
 	const cfg = oauth2Config as Record<string, unknown>;
 	return firstNonEmptyString(
 		cfg.tokenEndpoint,

--- a/src/server/oauth-endpoint-resolve.ts
+++ b/src/server/oauth-endpoint-resolve.ts
@@ -1,14 +1,37 @@
 import type { OAuth2Config } from "../types/oauth";
 
-/** Canonical camelCase fields only — aliases are stripped at ingest. */
+/**
+ * Resolve auth/token endpoints from canonical camelCase fields, with legacy
+ * alias fallbacks for session/DB oauth2 blocks that predate ingest normalization
+ * (`tokenUrl` / `authorizationUrl`, snake_case, etc.).
+ */
 export function resolveAuthorizationEndpoint(
-	oauth2Config: OAuth2Config,
+	oauth2Config: OAuth2Config | Record<string, unknown>,
 ): string | undefined {
-	return oauth2Config.authorizationEndpoint;
+	const cfg = oauth2Config as Record<string, unknown>;
+	return firstNonEmptyString(
+		cfg.authorizationEndpoint,
+		cfg.authorizationUrl,
+		cfg.authorization_endpoint,
+		cfg.authorization_url,
+	);
 }
 
 export function resolveTokenEndpoint(
-	oauth2Config: OAuth2Config,
+	oauth2Config: OAuth2Config | Record<string, unknown>,
 ): string | undefined {
-	return oauth2Config.tokenEndpoint;
+	const cfg = oauth2Config as Record<string, unknown>;
+	return firstNonEmptyString(
+		cfg.tokenEndpoint,
+		cfg.tokenUrl,
+		cfg.token_endpoint,
+		cfg.token_url,
+	);
+}
+
+function firstNonEmptyString(...values: unknown[]): string | undefined {
+	for (const value of values) {
+		if (typeof value === "string" && value.length > 0) return value;
+	}
+	return undefined;
 }

--- a/src/server/oauth-endpoint-resolve.ts
+++ b/src/server/oauth-endpoint-resolve.ts
@@ -15,7 +15,6 @@ export type OAuthEndpointResolvable = {
 	token_endpoint?: string;
 	authorization_url?: string;
 	token_url?: string;
-	[key: string]: unknown;
 };
 
 export function resolveAuthorizationEndpoint(

--- a/src/server/oauth-endpoint-resolve.ts
+++ b/src/server/oauth-endpoint-resolve.ts
@@ -3,28 +3,46 @@
  * alias fallbacks for session/DB oauth2 blocks that predate ingest normalization
  * (`tokenUrl` / `authorizationUrl`, snake_case, etc.).
  *
- * Accepts any oauth2-shaped object (capabilities config, discovery result, or
+ * Accepts oauth2-shaped objects (capabilities config, discovery result, or
  * legacy session JSON) — callers may pass optional or required endpoint fields.
  */
+export type OAuthEndpointResolvable = {
+	authorizationEndpoint?: string;
+	tokenEndpoint?: string;
+	authorizationUrl?: string;
+	tokenUrl?: string;
+	authorization_endpoint?: string;
+	token_endpoint?: string;
+	authorization_url?: string;
+	token_url?: string;
+	[key: string]: unknown;
+};
+
 export function resolveAuthorizationEndpoint(
-	oauth2Config: object,
+	oauth2Config: OAuthEndpointResolvable | null | undefined,
 ): string | undefined {
-	const cfg = oauth2Config as Record<string, unknown>;
+	if (oauth2Config == null || typeof oauth2Config !== "object") {
+		return undefined;
+	}
 	return firstNonEmptyString(
-		cfg.authorizationEndpoint,
-		cfg.authorizationUrl,
-		cfg.authorization_endpoint,
-		cfg.authorization_url,
+		oauth2Config.authorizationEndpoint,
+		oauth2Config.authorizationUrl,
+		oauth2Config.authorization_endpoint,
+		oauth2Config.authorization_url,
 	);
 }
 
-export function resolveTokenEndpoint(oauth2Config: object): string | undefined {
-	const cfg = oauth2Config as Record<string, unknown>;
+export function resolveTokenEndpoint(
+	oauth2Config: OAuthEndpointResolvable | null | undefined,
+): string | undefined {
+	if (oauth2Config == null || typeof oauth2Config !== "object") {
+		return undefined;
+	}
 	return firstNonEmptyString(
-		cfg.tokenEndpoint,
-		cfg.tokenUrl,
-		cfg.token_endpoint,
-		cfg.token_url,
+		oauth2Config.tokenEndpoint,
+		oauth2Config.tokenUrl,
+		oauth2Config.token_endpoint,
+		oauth2Config.token_url,
 	);
 }
 

--- a/src/server/oauth-manager.ts
+++ b/src/server/oauth-manager.ts
@@ -6,7 +6,10 @@ import type { CapaDatabase } from "../db/database";
 import { logger } from "../shared/logger";
 import { isPermanentRefreshFailure } from "../shared/oauth-refresh";
 import type { OAuth2Config } from "../types/oauth";
-import { detectOAuth2Requirement } from "./oauth-discovery";
+import {
+	detectOAuth2Requirement,
+	type OAuth2DetectionResult,
+} from "./oauth-discovery";
 import { generateAuthorizationUrl, handleCallback } from "./oauth-pkce-flow";
 import {
 	disconnect,
@@ -17,6 +20,7 @@ import {
 
 // Re-exported for backwards compatibility with existing import sites.
 export { isPermanentRefreshFailure };
+export type { OAuth2DetectionResult };
 
 export class OAuth2Manager {
 	private db: CapaDatabase;
@@ -36,17 +40,19 @@ export class OAuth2Manager {
 	}
 
 	/**
-	 * Detect if an MCP server requires OAuth2 authentication
+	 * Detect if an MCP server requires OAuth2 authentication.
+	 * Returns required / not_required / inconclusive — never collapses
+	 * network failures into "OAuth no longer required".
 	 */
 	async detectOAuth2Requirement(
 		serverUrl: string,
 		options?: { tlsSkipVerify?: boolean },
-	): Promise<OAuth2Config | null> {
-		const config = await detectOAuth2Requirement(serverUrl, options, this.log);
-		if (config) {
-			this.oauth2ConfigCache.set(serverUrl, config);
+	): Promise<OAuth2DetectionResult> {
+		const result = await detectOAuth2Requirement(serverUrl, options, this.log);
+		if (result.status === "required") {
+			this.oauth2ConfigCache.set(serverUrl, result.config);
 		}
-		return config;
+		return result;
 	}
 
 	/**

--- a/src/server/oauth-manager.ts
+++ b/src/server/oauth-manager.ts
@@ -8,6 +8,7 @@ import { isPermanentRefreshFailure } from "../shared/oauth-refresh";
 import type { OAuth2Config } from "../types/oauth";
 import {
 	detectOAuth2Requirement,
+	OAuth2DetectionStatus,
 	type OAuth2DetectionResult,
 } from "./oauth-discovery";
 import { generateAuthorizationUrl, handleCallback } from "./oauth-pkce-flow";
@@ -19,7 +20,7 @@ import {
 } from "./oauth-token-store";
 
 // Re-exported for backwards compatibility with existing import sites.
-export { isPermanentRefreshFailure };
+export { isPermanentRefreshFailure, OAuth2DetectionStatus };
 export type { OAuth2DetectionResult };
 
 export class OAuth2Manager {
@@ -49,7 +50,7 @@ export class OAuth2Manager {
 		options?: { tlsSkipVerify?: boolean },
 	): Promise<OAuth2DetectionResult> {
 		const result = await detectOAuth2Requirement(serverUrl, options, this.log);
-		if (result.status === "required") {
+		if (result.status === OAuth2DetectionStatus.REQUIRED) {
 			this.oauth2ConfigCache.set(serverUrl, result.config);
 		}
 		return result;

--- a/src/server/oauth-routes.ts
+++ b/src/server/oauth-routes.ts
@@ -7,7 +7,7 @@ import { projectUiUrl } from "../shared/ui-urls";
 import type { MCPServer } from "../types/capabilities";
 import type { OAuth2Config } from "../types/oauth";
 import { matchRoute } from "./match-route";
-import type { OAuth2Manager } from "./oauth-manager";
+import { OAuth2DetectionStatus, type OAuth2Manager } from "./oauth-manager";
 import { syncAllServersOAuth2Requirements } from "./oauth-server-sync";
 import {
 	type EffectiveCapsCacheEntry,
@@ -380,7 +380,7 @@ export async function handleOAuth2Start(
 					tlsSkipVerify: server.def.tlsSkipVerify,
 				},
 			);
-			if (detected.status === "not_required") {
+			if (detected.status === OAuth2DetectionStatus.NOT_REQUIRED) {
 				// Clear stale oauth2 config only — never delete tokens from a probe.
 				delete server.def.oauth2;
 				deps.sessionManager.setProjectCapabilities(projectId, capabilities);
@@ -392,7 +392,7 @@ export async function handleOAuth2Start(
 					{ status: 409, headers: JSON_HEADERS },
 				);
 			}
-			if (detected.status === "required") {
+			if (detected.status === OAuth2DetectionStatus.REQUIRED) {
 				configForFlow = {
 					...configForFlow,
 					...detected.config,

--- a/src/server/oauth-routes.ts
+++ b/src/server/oauth-routes.ts
@@ -380,9 +380,9 @@ export async function handleOAuth2Start(
 					tlsSkipVerify: server.def.tlsSkipVerify,
 				},
 			);
-			if (!detected) {
+			if (detected.status === "not_required") {
+				// Clear stale oauth2 config only — never delete tokens from a probe.
 				delete server.def.oauth2;
-				deps.oauth2Manager.disconnect(projectId, serverId);
 				deps.sessionManager.setProjectCapabilities(projectId, capabilities);
 				return new Response(
 					JSON.stringify({
@@ -392,21 +392,26 @@ export async function handleOAuth2Start(
 					{ status: 409, headers: JSON_HEADERS },
 				);
 			}
-			configForFlow = {
-				...configForFlow,
-				...detected,
-				authorizationEndpoint:
-					configForFlow.authorizationEndpoint || detected.authorizationEndpoint,
-				tokenEndpoint: configForFlow.tokenEndpoint || detected.tokenEndpoint,
-				resourceServer:
-					configForFlow.resourceServer ||
-					detected.resourceServer ||
-					server.def.url,
-				scope: detected.scope ?? configForFlow.scope,
-				...(effectiveClientId ? { clientId: effectiveClientId } : {}),
-			};
-			server.def.oauth2 = configForFlow;
-			deps.sessionManager.setProjectCapabilities(projectId, capabilities);
+			if (detected.status === "required") {
+				configForFlow = {
+					...configForFlow,
+					...detected.config,
+					authorizationEndpoint:
+						configForFlow.authorizationEndpoint ||
+						detected.config.authorizationEndpoint,
+					tokenEndpoint:
+						configForFlow.tokenEndpoint || detected.config.tokenEndpoint,
+					resourceServer:
+						configForFlow.resourceServer ||
+						detected.config.resourceServer ||
+						server.def.url,
+					scope: detected.config.scope ?? configForFlow.scope,
+					...(effectiveClientId ? { clientId: effectiveClientId } : {}),
+				};
+				server.def.oauth2 = configForFlow;
+				deps.sessionManager.setProjectCapabilities(projectId, capabilities);
+			}
+			// inconclusive: keep existing oauth2 endpoints and continue the flow
 		}
 
 		const { url: authUrl, state } =

--- a/src/server/oauth-server-sync.ts
+++ b/src/server/oauth-server-sync.ts
@@ -3,7 +3,7 @@ import type {
 	OAuth2Config as CapabilitiesOAuth2Config,
 } from "../types/capabilities";
 import type { OAuth2Config } from "../types/oauth";
-import type { OAuth2Manager } from "./oauth-manager";
+import { OAuth2DetectionStatus, type OAuth2Manager } from "./oauth-manager";
 
 function readEmbeddedClientId(
 	oauth: CapabilitiesOAuth2Config | undefined,
@@ -121,7 +121,7 @@ export async function syncServerOAuth2Requirement(
 		tlsSkipVerify: server.def.tlsSkipVerify,
 	});
 
-	if (detected.status === "required") {
+	if (detected.status === OAuth2DetectionStatus.REQUIRED) {
 		const merged = mergeDetectedOAuth2(existingOAuth, detected.config);
 		const changed =
 			!existingOAuth ||
@@ -143,7 +143,7 @@ export async function syncServerOAuth2Requirement(
 		};
 	}
 
-	if (detected.status === "inconclusive") {
+	if (detected.status === OAuth2DetectionStatus.INCONCLUSIVE) {
 		// Unreachable / timed out / ambiguous probe — keep oauth2 + tokens.
 		if (!existingOAuth) return { changed: false, entry: null };
 		const isConnected = oauth2Manager.isServerConnected(projectId, server.id);
@@ -158,7 +158,7 @@ export async function syncServerOAuth2Requirement(
 		};
 	}
 
-	// not_required: drop stale oauth2 config, but never delete tokens.
+	// NOT_REQUIRED: drop stale oauth2 config, but never delete tokens.
 	if (existingOAuth) {
 		delete server.def.oauth2;
 		return { changed: true, entry: null };

--- a/src/server/oauth-server-sync.ts
+++ b/src/server/oauth-server-sync.ts
@@ -92,7 +92,10 @@ export type SyncServerOAuth2Result = {
 
 /**
  * Probe the live MCP URL and align def.oauth2 with what the server actually needs.
- * Clears stale OAuth config when the URL no longer returns 401 + WWW-Authenticate.
+ *
+ * Clears stale oauth2 *config* when the URL clearly no longer requires OAuth.
+ * Never deletes stored tokens from sync — tokens are only removed on an
+ * explicit user disconnect or a clear HTTP 403 from the token endpoint.
  */
 export async function syncServerOAuth2Requirement(
 	projectId: string,
@@ -104,51 +107,44 @@ export async function syncServerOAuth2Requirement(
 	}
 
 	if (serverHasExplicitAuthHeader(server)) {
+		// Static Authorization header replaces OAuth config, but do not wipe
+		// stored tokens here — only a clear 403 (or explicit disconnect) may.
 		if (server.def.oauth2) {
 			delete server.def.oauth2;
-			oauth2Manager.disconnect(projectId, server.id);
 			return { changed: true, entry: null };
 		}
 		return { changed: false, entry: null };
 	}
 
 	const existingOAuth = server.def.oauth2;
-	try {
-		const detected = await oauth2Manager.detectOAuth2Requirement(server.def.url, {
-			tlsSkipVerify: server.def.tlsSkipVerify,
-		});
+	const detected = await oauth2Manager.detectOAuth2Requirement(server.def.url, {
+		tlsSkipVerify: server.def.tlsSkipVerify,
+	});
 
-		if (detected) {
-			const merged = mergeDetectedOAuth2(existingOAuth, detected);
-			const changed =
-				!existingOAuth ||
-				JSON.stringify(existingOAuth) !== JSON.stringify(merged);
-			server.def.oauth2 = merged;
+	if (detected.status === "required") {
+		const merged = mergeDetectedOAuth2(existingOAuth, detected.config);
+		const changed =
+			!existingOAuth ||
+			JSON.stringify(existingOAuth) !== JSON.stringify(merged);
+		server.def.oauth2 = merged;
 
-			let isConnected = oauth2Manager.isServerConnected(projectId, server.id);
-			// Token row presence is the source of truth for "authenticated" in the UI.
-			// Refresh may fail transiently without invalidating stored credentials.
+		const isConnected = oauth2Manager.isServerConnected(projectId, server.id);
+		// Token row presence is the source of truth for "authenticated" in the UI.
+		// Refresh may fail transiently without invalidating stored credentials.
 
-			return {
-				changed,
-				entry: {
-					serverId: server.id,
-					serverUrl: server.def.url,
-					displayName: server.displayName ?? server.id,
-					isConnected,
-				},
-			};
-		}
+		return {
+			changed,
+			entry: {
+				serverId: server.id,
+				serverUrl: server.def.url,
+				displayName: server.displayName ?? server.id,
+				isConnected,
+			},
+		};
+	}
 
-		if (existingOAuth) {
-			delete server.def.oauth2;
-			oauth2Manager.disconnect(projectId, server.id);
-			return { changed: true, entry: null };
-		}
-
-		return { changed: false, entry: null };
-	} catch {
-		// Transient probe failures should not strip a working OAuth config.
+	if (detected.status === "inconclusive") {
+		// Unreachable / timed out / ambiguous probe — keep oauth2 + tokens.
 		if (!existingOAuth) return { changed: false, entry: null };
 		const isConnected = oauth2Manager.isServerConnected(projectId, server.id);
 		return {
@@ -161,6 +157,14 @@ export async function syncServerOAuth2Requirement(
 			},
 		};
 	}
+
+	// not_required: drop stale oauth2 config, but never delete tokens.
+	if (existingOAuth) {
+		delete server.def.oauth2;
+		return { changed: true, entry: null };
+	}
+
+	return { changed: false, entry: null };
 }
 
 export type SyncAllServersOAuth2Result = {

--- a/src/server/oauth-token-store.ts
+++ b/src/server/oauth-token-store.ts
@@ -1,6 +1,6 @@
 import type { CapaDatabase } from "../db/database";
 import { logger } from "../shared/logger";
-import { isMcpOAuthTokenPermanentFailure } from "../shared/oauth-refresh";
+import { isPermanentRefreshFailure } from "../shared/oauth-refresh";
 import type { OAuth2Config } from "../types/oauth";
 import {
 	resolveTokenEndpoint,
@@ -135,7 +135,7 @@ export async function refreshAccessToken(
 			log.failure(
 				`Token refresh failed: ${response.status} ${response.statusText}`,
 			);
-			if (isMcpOAuthTokenPermanentFailure(undefined, response, body)) {
+			if (isPermanentRefreshFailure(undefined, response, body)) {
 				db.deleteOAuthToken(projectId, serverId);
 				log.info(`Deleted invalid token for ${serverId}`);
 			} else {
@@ -148,8 +148,8 @@ export async function refreshAccessToken(
 		if (parsed.error || !parsed.accessToken) {
 			const message = parsed.error || "Token response did not include access_token";
 			log.failure(`Token refresh failed: ${message}`);
-			// Only a clear HTTP 403 may delete stored MCP tokens automatically.
-			if (isMcpOAuthTokenPermanentFailure(undefined, response, message)) {
+			// Only wipe when the AS explicitly marks the token invalid/expired.
+			if (isPermanentRefreshFailure(undefined, response, message)) {
 				db.deleteOAuthToken(projectId, serverId);
 				log.info(`Deleted invalid token for ${serverId}`);
 			} else {
@@ -175,7 +175,7 @@ export async function refreshAccessToken(
 		return true;
 	} catch (error: any) {
 		log.failure(`Token refresh error: ${error.message}`);
-		if (isMcpOAuthTokenPermanentFailure(error)) {
+		if (isPermanentRefreshFailure(error)) {
 			db.deleteOAuthToken(projectId, serverId);
 			log.info(`Deleted failed token for ${serverId}`);
 		} else {

--- a/src/server/oauth-token-store.ts
+++ b/src/server/oauth-token-store.ts
@@ -2,7 +2,10 @@ import type { CapaDatabase } from "../db/database";
 import { logger } from "../shared/logger";
 import { isPermanentRefreshFailure } from "../shared/oauth-refresh";
 import type { OAuth2Config } from "../types/oauth";
-import { resolveTokenEndpoint } from "./oauth-endpoint-resolve";
+import {
+	resolveTokenEndpoint,
+	type OAuthEndpointResolvable,
+} from "./oauth-endpoint-resolve";
 
 const tokenLogger = logger.child("OAuth2TokenStore");
 
@@ -76,7 +79,7 @@ export async function refreshAccessToken(
 	db: CapaDatabase,
 	projectId: string,
 	serverId: string,
-	oauth2Config: OAuth2Config,
+	oauth2Config: OAuth2Config | OAuthEndpointResolvable,
 	log = tokenLogger,
 ): Promise<boolean> {
 	try {
@@ -95,7 +98,7 @@ export async function refreshAccessToken(
 		const clientId = resolveStoredClientId(
 			projectId,
 			serverId,
-			oauth2Config,
+			oauth2Config as OAuth2Config,
 			db,
 		);
 		const clientSecret = db.getVariable(
@@ -145,10 +148,8 @@ export async function refreshAccessToken(
 		if (parsed.error || !parsed.accessToken) {
 			const message = parsed.error || "Token response did not include access_token";
 			log.failure(`Token refresh failed: ${message}`);
-			if (
-				isPermanentRefreshFailure(undefined, response, message) ||
-				/invalid|expired|revoked|not_found|unauthorized/i.test(message)
-			) {
+			// Only a clear HTTP 403 may delete stored tokens automatically.
+			if (isPermanentRefreshFailure(undefined, response, message)) {
 				db.deleteOAuthToken(projectId, serverId);
 				log.info(`Deleted invalid token for ${serverId}`);
 			} else {

--- a/src/server/oauth-token-store.ts
+++ b/src/server/oauth-token-store.ts
@@ -1,6 +1,6 @@
 import type { CapaDatabase } from "../db/database";
 import { logger } from "../shared/logger";
-import { isPermanentRefreshFailure } from "../shared/oauth-refresh";
+import { isMcpOAuthTokenPermanentFailure } from "../shared/oauth-refresh";
 import type { OAuth2Config } from "../types/oauth";
 import {
 	resolveTokenEndpoint,
@@ -135,7 +135,7 @@ export async function refreshAccessToken(
 			log.failure(
 				`Token refresh failed: ${response.status} ${response.statusText}`,
 			);
-			if (isPermanentRefreshFailure(undefined, response, body)) {
+			if (isMcpOAuthTokenPermanentFailure(undefined, response, body)) {
 				db.deleteOAuthToken(projectId, serverId);
 				log.info(`Deleted invalid token for ${serverId}`);
 			} else {
@@ -148,8 +148,8 @@ export async function refreshAccessToken(
 		if (parsed.error || !parsed.accessToken) {
 			const message = parsed.error || "Token response did not include access_token";
 			log.failure(`Token refresh failed: ${message}`);
-			// Only a clear HTTP 403 may delete stored tokens automatically.
-			if (isPermanentRefreshFailure(undefined, response, message)) {
+			// Only a clear HTTP 403 may delete stored MCP tokens automatically.
+			if (isMcpOAuthTokenPermanentFailure(undefined, response, message)) {
 				db.deleteOAuthToken(projectId, serverId);
 				log.info(`Deleted invalid token for ${serverId}`);
 			} else {
@@ -175,7 +175,7 @@ export async function refreshAccessToken(
 		return true;
 	} catch (error: any) {
 		log.failure(`Token refresh error: ${error.message}`);
-		if (isPermanentRefreshFailure(error)) {
+		if (isMcpOAuthTokenPermanentFailure(error)) {
 			db.deleteOAuthToken(projectId, serverId);
 			log.info(`Deleted failed token for ${serverId}`);
 		} else {

--- a/src/server/resolve-effective-capabilities.ts
+++ b/src/server/resolve-effective-capabilities.ts
@@ -7,6 +7,10 @@ import { LockfileBuilder, loadLockfile } from "../shared/lockfile";
 import { logger } from "../shared/logger";
 import { validateProvider } from "../shared/providers/resolve";
 import type { Capabilities } from "../types/capabilities";
+import {
+	resolveAuthorizationEndpoint,
+	resolveTokenEndpoint,
+} from "./oauth-endpoint-resolve";
 import { mergeEmbeddedOAuthFields, mergePluginEmbeddedOAuth } from "./oauth-server-sync";
 
 const log = logger.child("plugin-resolve");
@@ -222,8 +226,10 @@ export function preserveDiscoveredOAuth2(
 		// URL changes invalidate previously discovered OAuth metadata.
 		if (prev?.def?.url !== server.def?.url) continue;
 
-		const prevAuth = prevOAuth.authorizationEndpoint;
-		const prevToken = prevOAuth.tokenEndpoint;
+		// Prefer canonical fields; fall back to legacy aliases still present in
+		// pre-normalize session/DB oauth2 blocks (tokenUrl / authorizationUrl).
+		const prevAuth = resolveAuthorizationEndpoint(prevOAuth);
+		const prevToken = resolveTokenEndpoint(prevOAuth);
 		if (
 			!prevAuth &&
 			!prevToken &&

--- a/src/shared/oauth-refresh.ts
+++ b/src/shared/oauth-refresh.ts
@@ -1,16 +1,53 @@
 /**
- * Shared OAuth refresh-failure classifier.
+ * Shared OAuth refresh-failure classifier (Git integrations + generic callers).
  *
  * A refresh call can fail for many reasons. Most of them are transient
  * (network blip, proxy 5xx, rate limit, DNS hiccup, laptop sleep/resume)
  * and the stored refresh_token is still good — retrying later will succeed.
  *
- * Tokens are only treated as permanently invalid when the token endpoint
- * returns a clear HTTP 403. Other 4xx responses (including 400/401 with
- * `invalid_grant`) and all network/5xx failures are treated as transient so
- * we never wipe stored credentials on an ambiguous failure.
+ * Only a small set of failures indicate the refresh_token itself is no
+ * longer usable and the user must re-authenticate:
+ *   - HTTP 400 / 401 / 403, AND
+ *   - The response body mentions `invalid_grant`, `invalid_token`, or
+ *     `expired` (per RFC 6749 §5.2 + common provider conventions).
+ *
+ * Anything else (5xx, timeouts, thrown errors) is treated as transient so
+ * we don't delete a perfectly valid stored token on a temporary outage.
+ *
+ * MCP server OAuth tokens use a stricter rule — see
+ * `isMcpOAuthTokenPermanentFailure`.
  */
+const PERMANENT_REFRESH_FAILURE_MARKERS = [
+	"invalid_grant",
+	"invalid_token",
+	"expired",
+];
+
 export function isPermanentRefreshFailure(
+	error?: unknown,
+	response?: Response,
+	responseBody?: string,
+): boolean {
+	if (response) {
+		const status = response.status;
+		if (status === 400 || status === 401 || status === 403) {
+			const body = (responseBody ?? "").toLowerCase();
+			return PERMANENT_REFRESH_FAILURE_MARKERS.some((marker) =>
+				body.includes(marker),
+			);
+		}
+		return false;
+	}
+	return false;
+}
+
+/**
+ * MCP OAuth token wipe policy: only a clear HTTP 403 from the token
+ * endpoint may delete stored credentials automatically. Probe failures,
+ * network errors, and other 4xx responses keep the token so users are not
+ * forced to re-auth after a temporary outage.
+ */
+export function isMcpOAuthTokenPermanentFailure(
 	error?: unknown,
 	response?: Response,
 	_responseBody?: string,

--- a/src/shared/oauth-refresh.ts
+++ b/src/shared/oauth-refresh.ts
@@ -5,35 +5,18 @@
  * (network blip, proxy 5xx, rate limit, DNS hiccup, laptop sleep/resume)
  * and the stored refresh_token is still good — retrying later will succeed.
  *
- * Only a small set of failures indicate the refresh_token itself is no
- * longer usable and the user must re-authenticate:
- *   - HTTP 400 / 401 / 403, AND
- *   - The response body mentions `invalid_grant`, `invalid_token`, or
- *     `expired` (per RFC 6749 §5.2 + common provider conventions).
- *
- * Anything else (5xx, timeouts, thrown errors) is treated as transient so
- * we don't delete a perfectly valid stored token on a temporary outage.
+ * Tokens are only treated as permanently invalid when the token endpoint
+ * returns a clear HTTP 403. Other 4xx responses (including 400/401 with
+ * `invalid_grant`) and all network/5xx failures are treated as transient so
+ * we never wipe stored credentials on an ambiguous failure.
  */
-const PERMANENT_REFRESH_FAILURE_MARKERS = [
-	"invalid_grant",
-	"invalid_token",
-	"expired",
-];
-
 export function isPermanentRefreshFailure(
 	error?: unknown,
 	response?: Response,
-	responseBody?: string,
+	_responseBody?: string,
 ): boolean {
 	if (response) {
-		const status = response.status;
-		if (status === 400 || status === 401 || status === 403) {
-			const body = (responseBody ?? "").toLowerCase();
-			return PERMANENT_REFRESH_FAILURE_MARKERS.some((marker) =>
-				body.includes(marker),
-			);
-		}
-		return false;
+		return response.status === 403;
 	}
 	return false;
 }

--- a/src/shared/oauth-refresh.ts
+++ b/src/shared/oauth-refresh.ts
@@ -1,26 +1,25 @@
 /**
- * Shared OAuth refresh-failure classifier (Git integrations + generic callers).
+ * Shared OAuth refresh-failure classifier.
  *
  * A refresh call can fail for many reasons. Most of them are transient
  * (network blip, proxy 5xx, rate limit, DNS hiccup, laptop sleep/resume)
  * and the stored refresh_token is still good — retrying later will succeed.
  *
- * Only a small set of failures indicate the refresh_token itself is no
- * longer usable and the user must re-authenticate:
- *   - HTTP 400 / 401 / 403, AND
- *   - The response body mentions `invalid_grant`, `invalid_token`, or
- *     `expired` (per RFC 6749 §5.2 + common provider conventions).
+ * Tokens are deleted only when the authorization server explicitly says the
+ * credential is dead or expired (RFC 6749 §5.2 + common provider conventions):
+ *   - HTTP 200 / 400 / 401 / 403 (not 5xx), AND
+ *   - The response body mentions a permanent marker such as `invalid_grant`,
+ *     `invalid_token`, `invalid_refresh`, `expired`, or `revoked`.
  *
- * Anything else (5xx, timeouts, thrown errors) is treated as transient so
- * we don't delete a perfectly valid stored token on a temporary outage.
- *
- * MCP server OAuth tokens use a stricter rule — see
- * `isMcpOAuthTokenPermanentFailure`.
+ * Bare status codes without those markers (and all network/thrown errors) are
+ * treated as transient so we never wipe credentials prematurely.
  */
 const PERMANENT_REFRESH_FAILURE_MARKERS = [
 	"invalid_grant",
 	"invalid_token",
+	"invalid_refresh",
 	"expired",
+	"revoked",
 ];
 
 export function isPermanentRefreshFailure(
@@ -28,32 +27,18 @@ export function isPermanentRefreshFailure(
 	response?: Response,
 	responseBody?: string,
 ): boolean {
-	if (response) {
-		const status = response.status;
-		if (status === 400 || status === 401 || status === 403) {
-			const body = (responseBody ?? "").toLowerCase();
-			return PERMANENT_REFRESH_FAILURE_MARKERS.some((marker) =>
-				body.includes(marker),
-			);
-		}
+	if (!response) {
+		// Network / thrown errors: keep the token.
 		return false;
 	}
-	return false;
-}
-
-/**
- * MCP OAuth token wipe policy: only a clear HTTP 403 from the token
- * endpoint may delete stored credentials automatically. Probe failures,
- * network errors, and other 4xx responses keep the token so users are not
- * forced to re-auth after a temporary outage.
- */
-export function isMcpOAuthTokenPermanentFailure(
-	error?: unknown,
-	response?: Response,
-	_responseBody?: string,
-): boolean {
-	if (response) {
-		return response.status === 403;
+	const status = response.status;
+	// Never wipe on 5xx — even if the body text looks fatal.
+	if (status >= 500) return false;
+	if (status !== 200 && status !== 400 && status !== 401 && status !== 403) {
+		return false;
 	}
-	return false;
+	const body = (responseBody ?? "").toLowerCase();
+	return PERMANENT_REFRESH_FAILURE_MARKERS.some((marker) =>
+		body.includes(marker),
+	);
 }

--- a/web-ui/src/features/projects/components/tools/ServerDialog.tsx
+++ b/web-ui/src/features/projects/components/tools/ServerDialog.tsx
@@ -144,8 +144,8 @@ export function ServerDialog({
       const oauth2: Record<string, unknown> = {};
       if (oauthClientId.trim()) oauth2.clientId = oauthClientId.trim();
       if (oauthClientSecret.trim()) oauth2.clientSecret = oauthClientSecret.trim();
-      if (oauthAuthUrl.trim()) oauth2.authorizationUrl = oauthAuthUrl.trim();
-      if (oauthTokenUrl.trim()) oauth2.tokenUrl = oauthTokenUrl.trim();
+      if (oauthAuthUrl.trim()) oauth2.authorizationEndpoint = oauthAuthUrl.trim();
+      if (oauthTokenUrl.trim()) oauth2.tokenEndpoint = oauthTokenUrl.trim();
       if (scopes.length) oauth2.scopes = scopes;
       if (oauthRedirectUri.trim()) oauth2.redirectUri = oauthRedirectUri.trim();
       if (oauthPkce) oauth2.pkce = true;


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Restores MCP OAuth2 token refresh after v2.1.0, and stops capa from deleting stored tokens prematurely.

### Endpoint alias fix
- Resolve `tokenEndpoint` / `authorizationEndpoint` with legacy aliases (`tokenUrl`, `authorizationUrl`, snake_case)
- Preserve discovered endpoints across capability reloads via alias-aware resolvers
- Server dialog writes canonical field names
- Typed as `OAuthEndpointResolvable` (Qodo review)

### Token retention
- OAuth probe returns `required` | `not_required` | `inconclusive`
- Unreachable / timeout / 5xx / 401-without-metadata → **inconclusive** — keep `def.oauth2` and tokens
- Sync and OAuth start no longer call `disconnect()` on probe failures
- Auto-delete stored tokens **only** when the authorization server explicitly reports the credential is dead/expired (`invalid_grant`, `invalid_token`, `invalid_refresh`, `expired`, `revoked`) — not on bare 4xx, 5xx, or network errors
- Explicit user disconnect still works

## Test plan
- [x] Unit tests for alias resolution + legacy refresh
- [x] Unit tests for inconclusive/unreachable sync (tokens kept)
- [x] Unit tests for explicit-invalid wipe vs bare 4xx keep
- [x] CI green on this branch

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-01a0338d-5f99-7d9f-8e7a-f3ec9021f338?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-01a0338d-5f99-7d9f-8e7a-f3ec9021f338&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

