### PR TITLE
fix(web-ui): remove unsupported MCP server display name form

### DIFF
--- a/web-ui/src/features/projects/components/tools/ServerDialog.tsx
+++ b/web-ui/src/features/projects/components/tools/ServerDialog.tsx
@@ -14,7 +14,6 @@ import {
 
 function serverHasAdvanced(server: Server): boolean {
   return !!(
-    server.displayName ||
     server.description ||
     (server.headers && Object.keys(server.headers).length > 0) ||
     (server.env && Object.keys(server.env).length > 0) ||
@@ -42,7 +41,6 @@ export function ServerDialog({
   const [url, setUrl] = useState('');
   const [cmd, setCmd] = useState('');
   const [args, setArgs] = useState('');
-  const [displayName, setDisplayName] = useState('');
   const [description, setDescription] = useState('');
   const [headers, setHeaders] = useState<SecretValuePair[]>([]);
   const [env, setEnv] = useState<SecretValuePair[]>([]);
@@ -67,7 +65,6 @@ export function ServerDialog({
     setUrl('');
     setCmd('');
     setArgs('');
-    setDisplayName('');
     setDescription('');
     setHeaders([]);
     setEnv([]);
@@ -91,7 +88,6 @@ export function ServerDialog({
     setUrl(s.url || '');
     setCmd(s.cmd || '');
     setArgs((s.args || []).join(' '));
-    setDisplayName(s.displayName || '');
     setDescription(s.description || '');
     setHeaders(recordToSecretPairs(s.headers));
     setEnv(recordToSecretPairs(s.env));
@@ -160,7 +156,6 @@ export function ServerDialog({
       id: id.trim(),
       type: 'mcp',
       def,
-      displayName: displayName.trim() || null,
       description: description.trim() || null,
     };
     return entry;
@@ -290,14 +285,6 @@ export function ServerDialog({
                 </button>
                 {advancedOpen && (
                   <div className="ui-panel-enter space-y-3 border-t border-border-tertiary px-2.5 py-3">
-                    <label className="block text-xs text-text-secondary">
-                      {t('actions.serverDisplayName')}
-                      <input
-                        value={displayName}
-                        onChange={(e) => setDisplayName(e.target.value)}
-                        className="mt-1 w-full rounded-sm border border-border-tertiary bg-bg-tertiary px-2.5 py-2 text-sm text-text-primary"
-                      />
-                    </label>
                     <label className="block text-xs text-text-secondary">
                       {t('actions.serverDescription')}
                       <textarea

--- a/web-ui/src/locales/en/projects.json
+++ b/web-ui/src/locales/en/projects.json
@@ -185,7 +185,6 @@
     "idInvalidChars": "ID may only contain letters, numbers, hyphens, and underscores",
     "serverId": "Server ID",
     "serverIdRequired": "Server ID is required",
-    "serverDisplayName": "Display name",
     "serverDescription": "Description",
     "serverAdvanced": "Advanced",
     "serverHeaders": "HTTP headers",


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
The MCP server add/edit dialog offered a “Display name” field that is not a user-authored `capabilities.yaml` setting (`displayName` is for plugin-derived labels). Remove that form control so users cannot write an unsupported field.

## What changed
- Remove display name input from `ServerDialog`
- Stop including `displayName` in dialog save payloads
- Drop unused `serverDisplayName` locale string

## Test plan
- [ ] Open Add/Edit MCP server → Advanced: confirm Display name is gone; Description and other advanced fields remain
- [ ] Save a server edit and confirm no `displayName` is written to `capabilities.yaml`

## Checklist
- [ ] Tests added or updated
- [ ] `bunx tsc --noEmit` passes
- [ ] `bun run smells` clean vs base (or CI Qlty Smells job green)
- [ ] Docs updated (if user-facing)

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-01a0338d-5f99-7d9f-8e7a-f3ec9021f338?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-01a0338d-5f99-7d9f-8e7a-f3ec9021f338&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

