### PR TITLE
feat(web-ui): clickable capa skill chips and installed browse marks

### DIFF
--- a/web-ui/src/features/projects/components/activity/ActivityRunDialog.tsx
+++ b/web-ui/src/features/projects/components/activity/ActivityRunDialog.tsx
@@ -26,6 +26,7 @@ import { filterActivityCalls, filterRunsBySearch } from './filterActivityCalls';
 import { ActivityProcessDiagram } from './ActivityProcessDiagram';
 import type { ActivityRunRightView } from './ActivityRunViewTabs';
 import { useProjectActivityGeneration } from '../../activityHooks';
+import { useProject } from '../../hooks';
 import {
   aggregateDurationMs,
   runsEvents,
@@ -68,6 +69,8 @@ export function ActivityRunDialog({
   emptyLabel,
 }: ActivityRunDialogProps) {
   const { t } = useTranslation('projects');
+  const { data: project } = useProject(projectId);
+  const managedSkills = project?.capabilities?.skills ?? [];
   const multiMode = (runs?.length ?? 0) > 0;
   const generationQuery = useProjectActivityGeneration(
     projectId,
@@ -419,6 +422,8 @@ export function ActivityRunDialog({
                       <ActivityRunSkillsPanel
                         events={displayEvents}
                         projectPath={projectPath}
+                        projectId={projectId}
+                        managedSkills={managedSkills}
                       />
                     </div>
                   </div>

--- a/web-ui/src/features/projects/components/activity/ActivityRunDialog.tsx
+++ b/web-ui/src/features/projects/components/activity/ActivityRunDialog.tsx
@@ -69,7 +69,7 @@ export function ActivityRunDialog({
   emptyLabel,
 }: ActivityRunDialogProps) {
   const { t } = useTranslation('projects');
-  const { data: project } = useProject(projectId);
+  const { data: project } = useProject(open ? projectId : null);
   const managedSkills = project?.capabilities?.skills ?? [];
   const multiMode = (runs?.length ?? 0) > 0;
   const generationQuery = useProjectActivityGeneration(

--- a/web-ui/src/features/projects/components/activity/ActivityRunSkillsPanel.test.ts
+++ b/web-ui/src/features/projects/components/activity/ActivityRunSkillsPanel.test.ts
@@ -1,0 +1,31 @@
+import { describe, expect, it } from 'bun:test';
+import type { Skill } from '../../../../types/api';
+import { findManagedSkillForFolder } from './ActivityRunSkillsPanel';
+
+function skill(partial: Partial<Skill> & { id: string }): Skill {
+  return {
+    type: 'local',
+    description: null,
+    requires: [],
+    sourcePlugin: null,
+    ...partial,
+  };
+}
+
+describe('findManagedSkillForFolder', () => {
+  it('matches capa-managed skills by id', () => {
+    const managed = [skill({ id: 'debug' }), skill({ id: 'standup' })];
+    expect(findManagedSkillForFolder('debug', managed)?.id).toBe('debug');
+    expect(findManagedSkillForFolder('missing', managed)).toBeNull();
+  });
+
+  it('matches local skill path basenames', () => {
+    const managed = [skill({ id: 'my-debug', path: 'skills/debug' })];
+    expect(findManagedSkillForFolder('debug', managed)?.id).toBe('my-debug');
+  });
+
+  it('returns null for provider-built-in folders with no capa skill', () => {
+    expect(findManagedSkillForFolder('create-rule', [])).toBeNull();
+    expect(findManagedSkillForFolder('create-rule', undefined)).toBeNull();
+  });
+});

--- a/web-ui/src/features/projects/components/activity/ActivityRunSkillsPanel.tsx
+++ b/web-ui/src/features/projects/components/activity/ActivityRunSkillsPanel.tsx
@@ -1,19 +1,49 @@
-import { useMemo } from 'react';
+import { useMemo, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import { Sparkles } from 'lucide-react';
-import type { ToolCallRecord } from '../../../../types/api';
+import type { Skill, ToolCallRecord } from '../../../../types/api';
+import { SkillDetailDialog } from '../SkillDetailDialog';
 import { collectRunSkillFolders } from './buildRunFileTree';
 
 interface ActivityRunSkillsPanelProps {
   events: ToolCallRecord[];
   projectPath: string | null;
+  projectId?: string | null;
+  /** Skills managed by capa for this project — used to make chips clickable. */
+  managedSkills?: Skill[];
+}
+
+/** Match a detected skill folder to a capa-managed skill id when possible. */
+export function findManagedSkillForFolder(
+  folder: string,
+  managedSkills: Skill[] | undefined,
+): Skill | null {
+  if (!managedSkills?.length) return null;
+  const exact = managedSkills.find((s) => s.id === folder);
+  if (exact) return exact;
+
+  const lower = folder.toLowerCase();
+  const byIdIgnoreCase = managedSkills.find((s) => s.id.toLowerCase() === lower);
+  if (byIdIgnoreCase) return byIdIgnoreCase;
+
+  // Local skills may use a path whose basename matches the folder.
+  for (const skill of managedSkills) {
+    const path = skill.path?.replace(/\\/g, '/').replace(/\/+$/, '');
+    if (!path) continue;
+    const base = path.split('/').filter(Boolean).pop();
+    if (base === folder || base?.toLowerCase() === lower) return skill;
+  }
+  return null;
 }
 
 export function ActivityRunSkillsPanel({
   events,
   projectPath,
+  projectId = null,
+  managedSkills = [],
 }: ActivityRunSkillsPanelProps) {
   const { t } = useTranslation('projects');
+  const [selectedSkill, setSelectedSkill] = useState<Skill | null>(null);
 
   const skills = useMemo(
     () => collectRunSkillFolders(events, { realProjectPath: projectPath }),
@@ -42,20 +72,44 @@ export function ActivityRunSkillsPanel({
           </p>
         ) : (
           <ul className="flex flex-wrap gap-1.5">
-            {skills.map((skill) => (
-              <li key={skill}>
-                <span
-                  className="inline-flex max-w-full items-center gap-1 rounded-full border border-accent-primary/25 bg-accent-primary/10 px-2 py-0.5 text-[11px] font-medium leading-none text-accent-primary"
-                  title={skill}
-                >
-                  <Sparkles size={10} className="shrink-0 opacity-80" aria-hidden />
-                  <span className="truncate">{skill}</span>
-                </span>
-              </li>
-            ))}
+            {skills.map((skillFolder) => {
+              const managed = findManagedSkillForFolder(skillFolder, managedSkills);
+              const chipClass =
+                'inline-flex max-w-full items-center gap-1 rounded-full border border-accent-primary/25 bg-accent-primary/10 px-2 py-0.5 text-[11px] font-medium leading-none text-accent-primary';
+              return (
+                <li key={skillFolder}>
+                  {managed && projectId ? (
+                    <button
+                      type="button"
+                      className={`${chipClass} cursor-pointer transition-colors hover:border-accent-primary/50 hover:bg-accent-primary/20`}
+                      title={t('activity.runSkills.openSkill', { id: managed.id })}
+                      onClick={() => setSelectedSkill(managed)}
+                    >
+                      <Sparkles size={10} className="shrink-0 opacity-80" aria-hidden />
+                      <span className="truncate">{skillFolder}</span>
+                    </button>
+                  ) : (
+                    <span className={chipClass} title={skillFolder}>
+                      <Sparkles size={10} className="shrink-0 opacity-80" aria-hidden />
+                      <span className="truncate">{skillFolder}</span>
+                    </span>
+                  )}
+                </li>
+              );
+            })}
           </ul>
         )}
       </div>
+      {projectId && (
+        <SkillDetailDialog
+          skill={selectedSkill}
+          projectId={projectId}
+          open={!!selectedSkill}
+          onOpenChange={(next) => {
+            if (!next) setSelectedSkill(null);
+          }}
+        />
+      )}
     </aside>
   );
 }

--- a/web-ui/src/features/projects/components/registry-browse/DetailPanel.tsx
+++ b/web-ui/src/features/projects/components/registry-browse/DetailPanel.tsx
@@ -1,5 +1,5 @@
+import { Check, Loader2 } from 'lucide-react';
 import { useMemo } from 'react';
-import { Loader2 } from 'lucide-react';
 import { useTranslation } from 'react-i18next';
 import type { RegistryItemDetail } from '../../../registries/api';
 import { Spinner } from '../../../../components/common/Spinner';
@@ -12,10 +12,19 @@ interface DetailPanelProps {
   detail: RegistryItemDetail | null;
   detailLoading: boolean;
   busy: boolean;
+  /** True when this registry item is already in the project's capabilities. */
+  installed?: boolean;
   onAdd: () => void;
 }
 
-export function DetailPanel({ selected, detail, detailLoading, busy, onAdd }: DetailPanelProps) {
+export function DetailPanel({
+  selected,
+  detail,
+  detailLoading,
+  busy,
+  installed = false,
+  onAdd,
+}: DetailPanelProps) {
   const { t } = useTranslation('projects');
 
   const previewHtml = useMemo(
@@ -47,15 +56,25 @@ export function DetailPanel({ selected, detail, detailLoading, busy, onAdd }: De
                 {detail.version ? ` · ${detail.version}` : ''}
               </p>
             </div>
-            <button
-              type="button"
-              disabled={busy}
-              onClick={onAdd}
-              className="inline-flex shrink-0 items-center gap-2 rounded-sm bg-accent-primary px-3 py-2 text-xs font-medium text-white cursor-pointer disabled:opacity-50"
-            >
-              {busy && <Loader2 size={14} className="animate-spin" />}
-              {t('actions.add')}
-            </button>
+            {installed ? (
+              <span
+                className="inline-flex shrink-0 items-center gap-1.5 rounded-sm border border-success-border/40 bg-success-bg/40 px-3 py-2 text-xs font-medium text-success-text"
+                title={t('actions.alreadyInstalled')}
+              >
+                <Check size={14} aria-hidden />
+                {t('actions.installed')}
+              </span>
+            ) : (
+              <button
+                type="button"
+                disabled={busy}
+                onClick={onAdd}
+                className="inline-flex shrink-0 items-center gap-2 rounded-sm bg-accent-primary px-3 py-2 text-xs font-medium text-white cursor-pointer disabled:opacity-50"
+              >
+                {busy && <Loader2 size={14} className="animate-spin" />}
+                {t('actions.add')}
+              </button>
+            )}
           </div>
           <div className="min-h-0 flex-1 overflow-y-auto px-4 py-4">
             {detail.files && detail.files.length > 0 && (

--- a/web-ui/src/features/projects/components/registry-browse/RegistryBrowseDialog.tsx
+++ b/web-ui/src/features/projects/components/registry-browse/RegistryBrowseDialog.tsx
@@ -35,7 +35,7 @@ export function RegistryBrowseDialog({
 }: RegistryBrowseDialogProps) {
   const { t } = useTranslation('projects');
   const { data: registries } = useRegistries();
-  const { data: project } = useProject(projectId);
+  const { data: project } = useProject(open ? projectId : null);
   const addMutation = useAddFromRegistry(projectId);
   const appendMutation = useAppendCapability(projectId);
 
@@ -78,7 +78,11 @@ export function RegistryBrowseDialog({
   }, [capability, project?.capabilities]);
 
   const selectedInstalled = selected
-    ? isRegistryItemInstalled(selected.id, installedIds)
+    ? isRegistryItemInstalled(
+        selected.id,
+        installedIds,
+        detail?.installSnippet ?? selected.installSnippet,
+      )
     : false;
 
   const selectedRegistry = useMemo(() => {

--- a/web-ui/src/features/projects/components/registry-browse/RegistryBrowseDialog.tsx
+++ b/web-ui/src/features/projects/components/registry-browse/RegistryBrowseDialog.tsx
@@ -4,12 +4,12 @@ import { ChevronDown, Loader2, Search, X } from 'lucide-react';
 import { useTranslation } from 'react-i18next';
 import { useRegistries } from '../../../registries/hooks';
 import { registriesApi, type RegistryItemDetail } from '../../../registries/api';
-import { useAddFromRegistry, useAppendCapability } from '../../hooks';
+import { useAddFromRegistry, useAppendCapability, useProject } from '../../hooks';
 import { capaIdErrorMessage, sanitizeCapaIdInput } from '../../../../lib/ids';
 import { LocalPathPicker } from '../LocalPathPicker';
 import { ResultList } from './ResultList';
 import { DetailPanel } from './DetailPanel';
-import type { ResultRow } from './types';
+import { isRegistryItemInstalled, type ResultRow } from './types';
 
 
 const ALL = '__all__';
@@ -35,6 +35,7 @@ export function RegistryBrowseDialog({
 }: RegistryBrowseDialogProps) {
   const { t } = useTranslation('projects');
   const { data: registries } = useRegistries();
+  const { data: project } = useProject(projectId);
   const addMutation = useAddFromRegistry(projectId);
   const appendMutation = useAppendCapability(projectId);
 
@@ -60,6 +61,25 @@ export function RegistryBrowseDialog({
     () => (registries ?? []).filter((r) => r.capabilities?.includes(capability)),
     [registries, capability],
   );
+
+  const installedIds = useMemo(() => {
+    const caps = project?.capabilities;
+    const ids = new Set<string>();
+    if (capability === 'skills') {
+      for (const skill of caps?.skills ?? []) {
+        if (skill.id) ids.add(skill.id);
+      }
+    } else {
+      for (const plugin of caps?.plugins ?? []) {
+        if (plugin.id) ids.add(plugin.id);
+      }
+    }
+    return ids;
+  }, [capability, project?.capabilities]);
+
+  const selectedInstalled = selected
+    ? isRegistryItemInstalled(selected.id, installedIds)
+    : false;
 
   const selectedRegistry = useMemo(() => {
     if (registryId === ALL) return null;
@@ -457,6 +477,7 @@ export function RegistryBrowseDialog({
                   results={results}
                   selected={selected}
                   showRegistry={registryId === ALL}
+                  installedIds={installedIds}
                   onSelect={setSelected}
                 />
                 <DetailPanel
@@ -464,6 +485,7 @@ export function RegistryBrowseDialog({
                   detail={detail}
                   detailLoading={detailLoading}
                   busy={busy}
+                  installed={selectedInstalled}
                   onAdd={() => void handleAdd()}
                 />
               </div>

--- a/web-ui/src/features/projects/components/registry-browse/ResultList.tsx
+++ b/web-ui/src/features/projects/components/registry-browse/ResultList.tsx
@@ -1,16 +1,25 @@
 import { useTranslation } from 'react-i18next';
+import { Check } from 'lucide-react';
 import { Spinner } from '../../../../components/common/Spinner';
-import type { ResultRow } from './types';
+import { isRegistryItemInstalled, type ResultRow } from './types';
 
 interface ResultListProps {
   searching: boolean;
   results: ResultRow[];
   selected: ResultRow | null;
   showRegistry: boolean;
+  installedIds?: ReadonlySet<string>;
   onSelect: (item: ResultRow) => void;
 }
 
-export function ResultList({ searching, results, selected, showRegistry, onSelect }: ResultListProps) {
+export function ResultList({
+  searching,
+  results,
+  selected,
+  showRegistry,
+  installedIds,
+  onSelect,
+}: ResultListProps) {
   const { t } = useTranslation('projects');
 
   return (
@@ -25,6 +34,9 @@ export function ResultList({ searching, results, selected, showRegistry, onSelec
         results.map((item) => {
           const active =
             selected?.id === item.id && selected?.registryId === item.registryId;
+          const installed = installedIds
+            ? isRegistryItemInstalled(item.id, installedIds)
+            : false;
           return (
             <button
               key={`${item.registryId}:${item.id}`}
@@ -44,9 +56,16 @@ export function ResultList({ searching, results, selected, showRegistry, onSelec
                     className="h-4 w-4 shrink-0 rounded-sm object-contain opacity-70"
                   />
                 ) : null}
-                <span className="truncate font-mono text-xs font-medium text-text-primary">
+                <span className="min-w-0 flex-1 truncate font-mono text-xs font-medium text-text-primary">
                   {item.title || item.id}
                 </span>
+                {installed && (
+                  <Check
+                    size={14}
+                    className="shrink-0 text-success-text"
+                    aria-label={t('actions.installed')}
+                  />
+                )}
               </div>
               {item.description && (
                 <span className="mt-1 line-clamp-2 text-[11px] text-text-secondary">

--- a/web-ui/src/features/projects/components/registry-browse/ResultList.tsx
+++ b/web-ui/src/features/projects/components/registry-browse/ResultList.tsx
@@ -35,7 +35,7 @@ export function ResultList({
           const active =
             selected?.id === item.id && selected?.registryId === item.registryId;
           const installed = installedIds
-            ? isRegistryItemInstalled(item.id, installedIds)
+            ? isRegistryItemInstalled(item.id, installedIds, item.installSnippet)
             : false;
           return (
             <button

--- a/web-ui/src/features/projects/components/registry-browse/types.test.ts
+++ b/web-ui/src/features/projects/components/registry-browse/types.test.ts
@@ -6,6 +6,12 @@ describe('registryInstallId', () => {
     expect(registryInstallId('owner/repo/skill-name')).toBe('skill-name');
     expect(registryInstallId('skill-name')).toBe('skill-name');
   });
+
+  it('prefers installSnippet.id when present', () => {
+    expect(
+      registryInstallId('owner/repo/display-name', { id: 'canonical-id' }),
+    ).toBe('canonical-id');
+  });
 });
 
 describe('isRegistryItemInstalled', () => {
@@ -14,5 +20,17 @@ describe('isRegistryItemInstalled', () => {
     expect(isRegistryItemInstalled('skill-name', installed)).toBe(true);
     expect(isRegistryItemInstalled('owner/repo/skill-name', installed)).toBe(true);
     expect(isRegistryItemInstalled('owner/repo/missing', installed)).toBe(false);
+  });
+
+  it('matches installSnippet.id when it differs from itemId/leaf', () => {
+    const installed = new Set(['canonical-id']);
+    expect(
+      isRegistryItemInstalled('owner/repo/display-name', installed, {
+        id: 'canonical-id',
+      }),
+    ).toBe(true);
+    expect(
+      isRegistryItemInstalled('owner/repo/display-name', installed),
+    ).toBe(false);
   });
 });

--- a/web-ui/src/features/projects/components/registry-browse/types.test.ts
+++ b/web-ui/src/features/projects/components/registry-browse/types.test.ts
@@ -1,0 +1,18 @@
+import { describe, expect, it } from 'bun:test';
+import { isRegistryItemInstalled, registryInstallId } from './types';
+
+describe('registryInstallId', () => {
+  it('uses the leaf path segment', () => {
+    expect(registryInstallId('owner/repo/skill-name')).toBe('skill-name');
+    expect(registryInstallId('skill-name')).toBe('skill-name');
+  });
+});
+
+describe('isRegistryItemInstalled', () => {
+  it('matches full id or install leaf id', () => {
+    const installed = new Set(['skill-name', 'other']);
+    expect(isRegistryItemInstalled('skill-name', installed)).toBe(true);
+    expect(isRegistryItemInstalled('owner/repo/skill-name', installed)).toBe(true);
+    expect(isRegistryItemInstalled('owner/repo/missing', installed)).toBe(false);
+  });
+});

--- a/web-ui/src/features/projects/components/registry-browse/types.ts
+++ b/web-ui/src/features/projects/components/registry-browse/types.ts
@@ -5,3 +5,22 @@ export type ResultRow = RegistryItemSummary & {
   registryName: string;
   registryIcon?: string;
 };
+
+/**
+ * Resolve the capa capability id a registry item would install as
+ * (matches server-side handleFromRegistry naming).
+ */
+export function registryInstallId(itemId: string): string {
+  const leaf = itemId.split('/').pop();
+  return leaf && leaf.length > 0 ? leaf : itemId;
+}
+
+/** True when a registry browse row is already present in the project. */
+export function isRegistryItemInstalled(
+  itemId: string,
+  installedIds: ReadonlySet<string>,
+): boolean {
+  if (installedIds.has(itemId)) return true;
+  const leaf = registryInstallId(itemId);
+  return leaf !== itemId && installedIds.has(leaf);
+}

--- a/web-ui/src/features/projects/components/registry-browse/types.ts
+++ b/web-ui/src/features/projects/components/registry-browse/types.ts
@@ -6,11 +6,23 @@ export type ResultRow = RegistryItemSummary & {
   registryIcon?: string;
 };
 
+function snippetIdOf(
+  installSnippet?: Record<string, unknown> | null,
+): string | undefined {
+  const id = installSnippet?.id;
+  return typeof id === 'string' && id.length > 0 ? id : undefined;
+}
+
 /**
  * Resolve the capa capability id a registry item would install as
- * (matches server-side handleFromRegistry naming).
+ * (matches server-side handleFromRegistry: `installSnippet.id ?? leaf(itemId)`).
  */
-export function registryInstallId(itemId: string): string {
+export function registryInstallId(
+  itemId: string,
+  installSnippet?: Record<string, unknown> | null,
+): string {
+  const fromSnippet = snippetIdOf(installSnippet);
+  if (fromSnippet) return fromSnippet;
   const leaf = itemId.split('/').pop();
   return leaf && leaf.length > 0 ? leaf : itemId;
 }
@@ -19,8 +31,13 @@ export function registryInstallId(itemId: string): string {
 export function isRegistryItemInstalled(
   itemId: string,
   installedIds: ReadonlySet<string>,
+  installSnippet?: Record<string, unknown> | null,
 ): boolean {
   if (installedIds.has(itemId)) return true;
-  const leaf = registryInstallId(itemId);
-  return leaf !== itemId && installedIds.has(leaf);
+  const installId = registryInstallId(itemId, installSnippet);
+  if (installedIds.has(installId)) return true;
+  // Also accept leaf(itemId) when snippet id differs, in case older installs
+  // used the leaf path before snippet ids were honored.
+  const leaf = itemId.split('/').pop();
+  return !!(leaf && leaf !== itemId && leaf !== installId && installedIds.has(leaf));
 }

--- a/web-ui/src/locales/en/projects.json
+++ b/web-ui/src/locales/en/projects.json
@@ -71,6 +71,8 @@
   },
   "actions": {
     "add": "Add",
+    "installed": "Installed",
+    "alreadyInstalled": "Already installed in this project",
     "save": "Save",
     "edit": "Edit",
     "cancel": "Cancel",
@@ -338,7 +340,8 @@
       "empty": "No skills detected from file activity.",
       "emptyHint": "Skills appear when the agent reads or edits a SKILL.md file.",
       "count": "{{count}} skill",
-      "count_other": "{{count}} skills"
+      "count_other": "{{count}} skills",
+      "openSkill": "Open skill {{id}}"
     },
     "runCommands": {
       "aria": "Shell commands in this run",


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

UX polish for capa-managed skills in activity traces and the registry browser.

- Activity skill chips open Skill Detail when they match a capa-managed project skill
- Registry browse list/detail show an Installed checkmark for already-added skills/plugins

### Qodo follow-ups
- Installed detection now mirrors server install ids: `installSnippet.id ?? leaf(itemId)`
- `useProject` is gated on dialog `open` so closed browse/run dialogs do not fetch project data

## Test plan
- [x] Unit tests for managed-skill matching
- [x] Unit tests for registry install id / installSnippet matching
- [ ] CI green on this branch

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-01a0338d-5f99-7d9f-8e7a-f3ec9021f338?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-01a0338d-5f99-7d9f-8e7a-f3ec9021f338&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

