### PR TITLE
Update dependencies and fix OAuth handling

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -153,7 +153,7 @@ jobs:
           cat SHA256SUMS.txt
 
       - name: Attest build provenance
-        uses: actions/attest-build-provenance@v3
+        uses: actions/attest-build-provenance@v4
         with:
           subject-path: |
             SHA256SUMS.txt

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -29,13 +29,13 @@ jobs:
         uses: actions/checkout@v7
 
       - name: Initialize CodeQL
-        uses: github/codeql-action/init@v4.37.6
+        uses: github/codeql-action/init@v4.37.7
         with:
           languages: ${{ matrix.language }}
           queries: security-extended
 
       - name: Perform CodeQL Analysis
-        uses: github/codeql-action/analyze@v4.37.6
+        uses: github/codeql-action/analyze@v4.37.7
         with:
           category: /language:${{ matrix.language }}
 

--- a/src/server/__tests__/configure-routes.test.ts
+++ b/src/server/__tests__/configure-routes.test.ts
@@ -14,7 +14,7 @@ import {
 import type { CapaMCPServer } from "../mcp-handler";
 import { handleGetServerTools } from "../mcp-meta-routes";
 import { McpServerStateManager } from "../mcp-server-state";
-import type { OAuth2Manager } from "../oauth-manager";
+import { OAuth2DetectionStatus, type OAuth2Manager } from "../oauth-manager";
 import { SessionManager } from "../session-manager";
 
 const DISK_CAPS = `providers: []
@@ -68,7 +68,9 @@ describe("handleProjectConfigure", () => {
 			db,
 			sessionManager,
 			oauth2Manager: {
-				detectOAuth2Requirement: async () => ({ status: "not_required" }),
+				detectOAuth2Requirement: async () => ({
+					status: OAuth2DetectionStatus.NOT_REQUIRED,
+				}),
 				isServerConnected: () => false,
 				getAccessToken: async () => null,
 			} as unknown as OAuth2Manager,

--- a/src/server/__tests__/configure-routes.test.ts
+++ b/src/server/__tests__/configure-routes.test.ts
@@ -68,7 +68,7 @@ describe("handleProjectConfigure", () => {
 			db,
 			sessionManager,
 			oauth2Manager: {
-				detectOAuth2Requirement: async () => null,
+				detectOAuth2Requirement: async () => ({ status: "not_required" }),
 				isServerConnected: () => false,
 				getAccessToken: async () => null,
 			} as unknown as OAuth2Manager,

--- a/src/server/__tests__/oauth-discovery.test.ts
+++ b/src/server/__tests__/oauth-discovery.test.ts
@@ -180,4 +180,51 @@ describe("detectOAuth2Requirement", () => {
 		);
 		expect(result.status).toBe(OAuth2DetectionStatus.NOT_REQUIRED);
 	});
+
+	it("returns inconclusive for ambiguous client errors that are not 401", async () => {
+		for (const status of [400, 403, 404]) {
+			globalThis.fetch = (async () =>
+				new Response("", { status })) as unknown as typeof fetch;
+
+			const result = await detectOAuth2Requirement(
+				"https://ambiguous.example.test/mcp",
+			);
+			expect(result.status).toBe(OAuth2DetectionStatus.INCONCLUSIVE);
+			if (result.status === OAuth2DetectionStatus.INCONCLUSIVE) {
+				expect(result.reason).toContain(String(status));
+			}
+		}
+	});
+
+	it("returns inconclusive when metadata lacks authorization_code support", async () => {
+		globalThis.fetch = (async (input: RequestInfo | URL, init?: RequestInit) => {
+			const url = String(input);
+			if (url === "https://mcp.example.test/mcp" && init?.method === "POST") {
+				return new Response("", {
+					status: 401,
+					headers: { "WWW-Authenticate": 'Bearer realm="mcp"' },
+				});
+			}
+			if (
+				url ===
+				"https://mcp.example.test/.well-known/oauth-authorization-server"
+			) {
+				return Response.json({
+					authorization_endpoint: "https://auth.example.test/authorize",
+					token_endpoint: "https://auth.example.test/token",
+					grant_types_supported: ["client_credentials"],
+					response_types_supported: ["token"],
+				});
+			}
+			return new Response("", { status: 404 });
+		}) as unknown as typeof fetch;
+
+		const result = await detectOAuth2Requirement(
+			"https://mcp.example.test/mcp",
+		);
+		expect(result.status).toBe(OAuth2DetectionStatus.INCONCLUSIVE);
+		if (result.status === OAuth2DetectionStatus.INCONCLUSIVE) {
+			expect(result.reason).toContain("authorization_code");
+		}
+	});
 });

--- a/src/server/__tests__/oauth-discovery.test.ts
+++ b/src/server/__tests__/oauth-discovery.test.ts
@@ -2,6 +2,7 @@ import { afterEach, describe, expect, it } from "bun:test";
 import {
 	buildOAuthAuthorizationServerMetadataUrl,
 	detectOAuth2Requirement,
+	OAuth2DetectionStatus,
 	resolveOAuthScope,
 	sanitizeOAuthScope,
 } from "../oauth-discovery";
@@ -146,8 +147,8 @@ describe("detectOAuth2Requirement", () => {
 		const result = await detectOAuth2Requirement(
 			"https://mcp-gateway.example.test/mcp",
 		);
-		expect(result.status).toBe("required");
-		if (result.status !== "required") return;
+		expect(result.status).toBe(OAuth2DetectionStatus.REQUIRED);
+		if (result.status !== OAuth2DetectionStatus.REQUIRED) return;
 		expect(result.config.authorizationEndpoint).toBe(
 			"https://mcp-auth.example.test/realms/tenant/protocol/openid-connect/auth",
 		);
@@ -167,7 +168,7 @@ describe("detectOAuth2Requirement", () => {
 		const result = await detectOAuth2Requirement(
 			"https://unreachable.example.test/mcp",
 		);
-		expect(result.status).toBe("inconclusive");
+		expect(result.status).toBe(OAuth2DetectionStatus.INCONCLUSIVE);
 	});
 
 	it("returns not_required on a successful unauthenticated initialize", async () => {
@@ -177,6 +178,6 @@ describe("detectOAuth2Requirement", () => {
 		const result = await detectOAuth2Requirement(
 			"https://open.example.test/mcp",
 		);
-		expect(result.status).toBe("not_required");
+		expect(result.status).toBe(OAuth2DetectionStatus.NOT_REQUIRED);
 	});
 });

--- a/src/server/__tests__/oauth-discovery.test.ts
+++ b/src/server/__tests__/oauth-discovery.test.ts
@@ -146,15 +146,37 @@ describe("detectOAuth2Requirement", () => {
 		const result = await detectOAuth2Requirement(
 			"https://mcp-gateway.example.test/mcp",
 		);
-		expect(result).not.toBeNull();
-		expect(result?.authorizationEndpoint).toBe(
+		expect(result.status).toBe("required");
+		if (result.status !== "required") return;
+		expect(result.config.authorizationEndpoint).toBe(
 			"https://mcp-auth.example.test/realms/tenant/protocol/openid-connect/auth",
 		);
-		expect(result?.tokenEndpoint).toBe(
+		expect(result.config.tokenEndpoint).toBe(
 			"https://mcp-auth.example.test/realms/tenant/protocol/openid-connect/token",
 		);
-		expect(result?.scope).toBe(
+		expect(result.config.scope).toBe(
 			"openid email profile offline_access api.read",
 		);
+	});
+
+	it("returns inconclusive when the MCP server is unreachable", async () => {
+		globalThis.fetch = (async () => {
+			throw new DOMException("The operation was aborted.", "AbortError");
+		}) as unknown as typeof fetch;
+
+		const result = await detectOAuth2Requirement(
+			"https://unreachable.example.test/mcp",
+		);
+		expect(result.status).toBe("inconclusive");
+	});
+
+	it("returns not_required on a successful unauthenticated initialize", async () => {
+		globalThis.fetch = (async () =>
+			new Response("", { status: 200 })) as unknown as typeof fetch;
+
+		const result = await detectOAuth2Requirement(
+			"https://open.example.test/mcp",
+		);
+		expect(result.status).toBe("not_required");
 	});
 });

--- a/src/server/__tests__/oauth-endpoint-resolve.test.ts
+++ b/src/server/__tests__/oauth-endpoint-resolve.test.ts
@@ -1,0 +1,53 @@
+import { describe, expect, it } from "bun:test";
+import {
+	resolveAuthorizationEndpoint,
+	resolveTokenEndpoint,
+} from "../oauth-endpoint-resolve";
+
+describe("resolveTokenEndpoint", () => {
+	it("prefers canonical tokenEndpoint", () => {
+		expect(
+			resolveTokenEndpoint({
+				tokenEndpoint: "https://auth.example/token",
+				tokenUrl: "https://legacy.example/token",
+			} as never),
+		).toBe("https://auth.example/token");
+	});
+
+	it("falls back to tokenUrl / snake_case aliases", () => {
+		expect(
+			resolveTokenEndpoint({
+				tokenUrl: "https://auth.example/token",
+			} as never),
+		).toBe("https://auth.example/token");
+		expect(
+			resolveTokenEndpoint({
+				token_url: "https://auth.example/token",
+			} as never),
+		).toBe("https://auth.example/token");
+		expect(
+			resolveTokenEndpoint({
+				token_endpoint: "https://auth.example/token",
+			} as never),
+		).toBe("https://auth.example/token");
+	});
+
+	it("returns undefined when no endpoint is present", () => {
+		expect(resolveTokenEndpoint({} as never)).toBeUndefined();
+	});
+});
+
+describe("resolveAuthorizationEndpoint", () => {
+	it("falls back to authorizationUrl aliases", () => {
+		expect(
+			resolveAuthorizationEndpoint({
+				authorizationUrl: "https://auth.example/authorize",
+			} as never),
+		).toBe("https://auth.example/authorize");
+		expect(
+			resolveAuthorizationEndpoint({
+				authorization_url: "https://auth.example/authorize",
+			} as never),
+		).toBe("https://auth.example/authorize");
+	});
+});

--- a/src/server/__tests__/oauth-endpoint-resolve.test.ts
+++ b/src/server/__tests__/oauth-endpoint-resolve.test.ts
@@ -2,38 +2,39 @@ import { describe, expect, it } from "bun:test";
 import {
 	resolveAuthorizationEndpoint,
 	resolveTokenEndpoint,
+	type OAuthEndpointResolvable,
 } from "../oauth-endpoint-resolve";
 
 describe("resolveTokenEndpoint", () => {
 	it("prefers canonical tokenEndpoint", () => {
-		expect(
-			resolveTokenEndpoint({
-				tokenEndpoint: "https://auth.example/token",
-				tokenUrl: "https://legacy.example/token",
-			} as never),
-		).toBe("https://auth.example/token");
+		const cfg: OAuthEndpointResolvable = {
+			tokenEndpoint: "https://auth.example/token",
+			tokenUrl: "https://legacy.example/token",
+		};
+		expect(resolveTokenEndpoint(cfg)).toBe("https://auth.example/token");
 	});
 
 	it("falls back to tokenUrl / snake_case aliases", () => {
 		expect(
 			resolveTokenEndpoint({
 				tokenUrl: "https://auth.example/token",
-			} as never),
+			}),
 		).toBe("https://auth.example/token");
 		expect(
 			resolveTokenEndpoint({
 				token_url: "https://auth.example/token",
-			} as never),
+			}),
 		).toBe("https://auth.example/token");
 		expect(
 			resolveTokenEndpoint({
 				token_endpoint: "https://auth.example/token",
-			} as never),
+			}),
 		).toBe("https://auth.example/token");
 	});
 
 	it("returns undefined when no endpoint is present", () => {
-		expect(resolveTokenEndpoint({} as never)).toBeUndefined();
+		expect(resolveTokenEndpoint({})).toBeUndefined();
+		expect(resolveTokenEndpoint(null)).toBeUndefined();
 	});
 });
 
@@ -42,12 +43,12 @@ describe("resolveAuthorizationEndpoint", () => {
 		expect(
 			resolveAuthorizationEndpoint({
 				authorizationUrl: "https://auth.example/authorize",
-			} as never),
+			}),
 		).toBe("https://auth.example/authorize");
 		expect(
 			resolveAuthorizationEndpoint({
 				authorization_url: "https://auth.example/authorize",
-			} as never),
+			}),
 		).toBe("https://auth.example/authorize");
 	});
 });

--- a/src/server/__tests__/oauth-manager.test.ts
+++ b/src/server/__tests__/oauth-manager.test.ts
@@ -90,12 +90,20 @@ describe('OAuth2Manager', () => {
       expect(result.status).toBe(OAuth2DetectionStatus.INCONCLUSIVE);
     });
 
-    it('returns not_required when the MCP server returns a non-401 status', async () => {
+    it('returns not_required when unauthenticated initialize succeeds', async () => {
       globalThis.fetch = (async () => new Response('', { status: 200 })) as unknown as typeof fetch;
 
       const manager = new OAuth2Manager(makeMockDb());
       const result = await manager.detectOAuth2Requirement('http://localhost:9999/mcp');
       expect(result.status).toBe(OAuth2DetectionStatus.NOT_REQUIRED);
+    });
+
+    it('returns inconclusive for non-401 client errors', async () => {
+      globalThis.fetch = (async () => new Response('', { status: 403 })) as unknown as typeof fetch;
+
+      const manager = new OAuth2Manager(makeMockDb());
+      const result = await manager.detectOAuth2Requirement('http://localhost:9999/mcp');
+      expect(result.status).toBe(OAuth2DetectionStatus.INCONCLUSIVE);
     });
   });
 

--- a/src/server/__tests__/oauth-manager.test.ts
+++ b/src/server/__tests__/oauth-manager.test.ts
@@ -53,7 +53,15 @@ describe('OAuth2Manager', () => {
       expect(isPermanentRefreshFailure(undefined, res403, 'invalid_token')).toBe(true);
     });
 
-    it('treats 500 responses as transient', () => {
+    it('keeps tokens on bare 4xx without an explicit invalid/expired marker', () => {
+      const res401 = new Response('', { status: 401 });
+      expect(isPermanentRefreshFailure(undefined, res401, 'rate limited')).toBe(false);
+
+      const res403 = new Response('', { status: 403 });
+      expect(isPermanentRefreshFailure(undefined, res403, 'forbidden')).toBe(false);
+    });
+
+    it('treats 500 responses as transient even with invalid_grant in the body', () => {
       const res500 = new Response('', { status: 500 });
       expect(isPermanentRefreshFailure(undefined, res500, 'invalid_grant')).toBe(false);
     });

--- a/src/server/__tests__/oauth-manager.test.ts
+++ b/src/server/__tests__/oauth-manager.test.ts
@@ -45,17 +45,12 @@ describe('OAuth2Manager', () => {
   });
 
 	describe('isPermanentRefreshFailure', () => {
-    it('classifies only HTTP 403 as permanent', () => {
-      const res403 = new Response('', { status: 403 });
-      expect(isPermanentRefreshFailure(undefined, res403, 'anything')).toBe(true);
-    });
-
-    it('treats 401/400 with invalid_grant as transient (keep tokens)', () => {
+    it('classifies 401/403 with invalid_grant as permanent', () => {
       const res401 = new Response('', { status: 401 });
-      expect(isPermanentRefreshFailure(undefined, res401, '{"error":"invalid_grant"}')).toBe(false);
+      expect(isPermanentRefreshFailure(undefined, res401, '{"error":"invalid_grant"}')).toBe(true);
 
-      const res400 = new Response('', { status: 400 });
-      expect(isPermanentRefreshFailure(undefined, res400, 'invalid_token')).toBe(false);
+      const res403 = new Response('', { status: 403 });
+      expect(isPermanentRefreshFailure(undefined, res403, 'invalid_token')).toBe(true);
     });
 
     it('treats 500 responses as transient', () => {

--- a/src/server/__tests__/oauth-manager.test.ts
+++ b/src/server/__tests__/oauth-manager.test.ts
@@ -44,13 +44,18 @@ describe('OAuth2Manager', () => {
     ).not.toThrow();
   });
 
-  describe('isPermanentRefreshFailure', () => {
-    it('classifies 401/403 with invalid_grant as permanent', () => {
-      const res401 = new Response('', { status: 401 });
-      expect(isPermanentRefreshFailure(undefined, res401, '{"error":"invalid_grant"}')).toBe(true);
-
+	describe('isPermanentRefreshFailure', () => {
+    it('classifies only HTTP 403 as permanent', () => {
       const res403 = new Response('', { status: 403 });
-      expect(isPermanentRefreshFailure(undefined, res403, 'invalid_token')).toBe(true);
+      expect(isPermanentRefreshFailure(undefined, res403, 'anything')).toBe(true);
+    });
+
+    it('treats 401/400 with invalid_grant as transient (keep tokens)', () => {
+      const res401 = new Response('', { status: 401 });
+      expect(isPermanentRefreshFailure(undefined, res401, '{"error":"invalid_grant"}')).toBe(false);
+
+      const res400 = new Response('', { status: 400 });
+      expect(isPermanentRefreshFailure(undefined, res400, 'invalid_token')).toBe(false);
     });
 
     it('treats 500 responses as transient', () => {
@@ -70,7 +75,7 @@ describe('OAuth2Manager', () => {
       globalThis.fetch = originalFetch;
     });
 
-    it('returns null (does not throw) when the server is unreachable', async () => {
+    it('returns inconclusive (does not throw) when the server is unreachable', async () => {
       // Simulate a connection-refused / aborted fetch — the same class of error
       // that an unreachable MCP server produces at the network layer.
       globalThis.fetch = (async () => {
@@ -79,15 +84,15 @@ describe('OAuth2Manager', () => {
 
       const manager = new OAuth2Manager(makeMockDb());
       const result = await manager.detectOAuth2Requirement('http://192.0.2.1:9999/mcp');
-      expect(result).toBeNull();
+      expect(result.status).toBe('inconclusive');
     });
 
-    it('returns null when the MCP server returns a non-401 status', async () => {
+    it('returns not_required when the MCP server returns a non-401 status', async () => {
       globalThis.fetch = (async () => new Response('', { status: 200 })) as unknown as typeof fetch;
 
       const manager = new OAuth2Manager(makeMockDb());
       const result = await manager.detectOAuth2Requirement('http://localhost:9999/mcp');
-      expect(result).toBeNull();
+      expect(result.status).toBe('not_required');
     });
   });
 

--- a/src/server/__tests__/oauth-manager.test.ts
+++ b/src/server/__tests__/oauth-manager.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, beforeEach, afterEach } from 'bun:test';
-import { OAuth2Manager, isPermanentRefreshFailure } from '../oauth-manager';
+import { OAuth2Manager, isPermanentRefreshFailure, OAuth2DetectionStatus } from '../oauth-manager';
 import { shouldSkipTlsVerify } from '../../shared/tls-skip-verify';
 import type { CapaDatabase } from '../../db/database';
 
@@ -87,7 +87,7 @@ describe('OAuth2Manager', () => {
 
       const manager = new OAuth2Manager(makeMockDb());
       const result = await manager.detectOAuth2Requirement('http://192.0.2.1:9999/mcp');
-      expect(result.status).toBe('inconclusive');
+      expect(result.status).toBe(OAuth2DetectionStatus.INCONCLUSIVE);
     });
 
     it('returns not_required when the MCP server returns a non-401 status', async () => {
@@ -95,7 +95,7 @@ describe('OAuth2Manager', () => {
 
       const manager = new OAuth2Manager(makeMockDb());
       const result = await manager.detectOAuth2Requirement('http://localhost:9999/mcp');
-      expect(result.status).toBe('not_required');
+      expect(result.status).toBe(OAuth2DetectionStatus.NOT_REQUIRED);
     });
   });
 

--- a/src/server/__tests__/oauth-server-sync.test.ts
+++ b/src/server/__tests__/oauth-server-sync.test.ts
@@ -187,7 +187,7 @@ describe("mergePluginEmbeddedOAuth", () => {
 });
 
 describe("syncServerOAuth2Requirement", () => {
-	it("clears stale OAuth config when the live URL no longer requires auth", async () => {
+	it("clears stale OAuth config when the live URL no longer requires auth, without deleting tokens", async () => {
 		const server = mcpServer(
 			"server-a",
 			"https://new.example/mcp",
@@ -195,7 +195,7 @@ describe("syncServerOAuth2Requirement", () => {
 		);
 		const disconnects: string[] = [];
 		const oauth2Manager = {
-			detectOAuth2Requirement: async () => null,
+			detectOAuth2Requirement: async () => ({ status: "not_required" }),
 			isServerConnected: () => true,
 			getAccessToken: async () => "token",
 			disconnect: (_projectId: string, serverId: string) => {
@@ -212,6 +212,38 @@ describe("syncServerOAuth2Requirement", () => {
 		expect(result.changed).toBe(true);
 		expect(result.entry).toBeNull();
 		expect(server.def.oauth2).toBeUndefined();
-		expect(disconnects).toEqual(["server-a"]);
+		expect(disconnects).toEqual([]);
+	});
+
+	it("keeps OAuth config and tokens when the probe is inconclusive (unreachable)", async () => {
+		const server = mcpServer(
+			"server-a",
+			"https://unreachable.example/mcp",
+			DETECTED_OAUTH,
+		);
+		const disconnects: string[] = [];
+		const oauth2Manager = {
+			detectOAuth2Requirement: async () => ({
+				status: "inconclusive",
+				reason: "network failure",
+			}),
+			isServerConnected: () => true,
+			getAccessToken: async () => "token",
+			disconnect: (_projectId: string, serverId: string) => {
+				disconnects.push(serverId);
+			},
+		} as unknown as OAuth2Manager;
+
+		const result = await syncServerOAuth2Requirement(
+			"proj-1",
+			server,
+			oauth2Manager,
+		);
+
+		expect(result.changed).toBe(false);
+		expect(result.entry?.serverId).toBe("server-a");
+		expect(result.entry?.isConnected).toBe(true);
+		expect(server.def.oauth2).toEqual(DETECTED_OAUTH);
+		expect(disconnects).toEqual([]);
 	});
 });

--- a/src/server/__tests__/oauth-server-sync.test.ts
+++ b/src/server/__tests__/oauth-server-sync.test.ts
@@ -1,7 +1,7 @@
 import { describe, expect, it } from "bun:test";
 import type { Capabilities, MCPServer } from "../../types/capabilities";
 import type { OAuth2Config } from "../../types/oauth";
-import type { OAuth2Manager } from "../oauth-manager";
+import { OAuth2DetectionStatus, type OAuth2Manager } from "../oauth-manager";
 import {
 	mergeDetectedOAuth2,
 	mergeEmbeddedOAuthFields,
@@ -195,7 +195,9 @@ describe("syncServerOAuth2Requirement", () => {
 		);
 		const disconnects: string[] = [];
 		const oauth2Manager = {
-			detectOAuth2Requirement: async () => ({ status: "not_required" }),
+			detectOAuth2Requirement: async () => ({
+				status: OAuth2DetectionStatus.NOT_REQUIRED,
+			}),
 			isServerConnected: () => true,
 			getAccessToken: async () => "token",
 			disconnect: (_projectId: string, serverId: string) => {
@@ -224,7 +226,7 @@ describe("syncServerOAuth2Requirement", () => {
 		const disconnects: string[] = [];
 		const oauth2Manager = {
 			detectOAuth2Requirement: async () => ({
-				status: "inconclusive",
+				status: OAuth2DetectionStatus.INCONCLUSIVE,
 				reason: "network failure",
 			}),
 			isServerConnected: () => true,

--- a/src/server/__tests__/oauth-server-sync.test.ts
+++ b/src/server/__tests__/oauth-server-sync.test.ts
@@ -71,6 +71,34 @@ describe("preserveDiscoveredOAuth2", () => {
 		);
 	});
 
+	it("copies legacy tokenUrl / authorizationUrl aliases as canonical fields", () => {
+		const previous: Capabilities = {
+			providers: [],
+			skills: [],
+			tools: [],
+			servers: [
+				mcpServer("legacy", "https://mcp.example/mcp", {
+					authorizationUrl: "https://auth.example/authorize",
+					tokenUrl: "https://auth.example/token",
+				} as Capabilities["servers"][number]["def"]["oauth2"]),
+			],
+		};
+		const fresh: Capabilities = {
+			providers: [],
+			skills: [],
+			tools: [],
+			servers: [mcpServer("legacy", "https://mcp.example/mcp")],
+		};
+
+		const result = preserveDiscoveredOAuth2(fresh, previous);
+		expect(result.servers[0].def.oauth2?.authorizationEndpoint).toBe(
+			"https://auth.example/authorize",
+		);
+		expect(result.servers[0].def.oauth2?.tokenEndpoint).toBe(
+			"https://auth.example/token",
+		);
+	});
+
 	it("keeps plugin-embedded clientId when copying discovered endpoints", () => {
 		const previous: Capabilities = {
 			providers: [],

--- a/src/server/__tests__/oauth-token-refresh.test.ts
+++ b/src/server/__tests__/oauth-token-refresh.test.ts
@@ -109,4 +109,29 @@ describe("refreshAccessToken", () => {
 		expect(ok).toBe(true);
 		expect(new URLSearchParams(body).get("client_id")).toBe("test-app-id");
 	});
+
+	it("refreshes when oauth2 config only has legacy tokenUrl alias", async () => {
+		let postedUrl = "";
+		globalThis.fetch = (async (input: RequestInfo | URL) => {
+			postedUrl = String(input);
+			return new Response(
+				JSON.stringify({
+					access_token: "new-access",
+					refresh_token: "new-refresh",
+					expires_in: 3600,
+				}),
+				{ status: 200, headers: { "Content-Type": "application/json" } },
+			);
+		}) as unknown as typeof fetch;
+
+		const ok = await refreshAccessToken(db, "p1", "mcp-server", {
+			authorizationUrl: "https://example.com/authorize",
+			tokenUrl: "https://example.com/token",
+			resourceServer: "https://example.com",
+			clientId: "test-app-id",
+		} as never);
+
+		expect(ok).toBe(true);
+		expect(postedUrl).toBe("https://example.com/token");
+	});
 });

--- a/src/server/__tests__/oauth-token-refresh.test.ts
+++ b/src/server/__tests__/oauth-token-refresh.test.ts
@@ -67,9 +67,9 @@ describe("refreshAccessToken", () => {
 		rmSync(tempDir, { recursive: true, force: true });
 	});
 
-	it("keeps the token when the provider returns 200 without access_token", async () => {
+	it("keeps the token when a 200 payload fails without an explicit invalid/expired marker", async () => {
 		globalThis.fetch = (async () =>
-			new Response(JSON.stringify({ ok: false, error: "invalid_refresh_token" }), {
+			new Response(JSON.stringify({ ok: false, error: "temporarily_unavailable" }), {
 				status: 200,
 				headers: { "Content-Type": "application/json" },
 			})) as unknown as typeof fetch;
@@ -87,11 +87,49 @@ describe("refreshAccessToken", () => {
 		);
 	});
 
-	it("deletes the token only on a clear HTTP 403 from the token endpoint", async () => {
+	it("keeps the token on bare 403 without an explicit invalid/expired marker", async () => {
 		globalThis.fetch = (async () =>
 			new Response("forbidden", {
 				status: 403,
 				headers: { "Content-Type": "text/plain" },
+			})) as unknown as typeof fetch;
+
+		const ok = await refreshAccessToken(db, "p1", "mcp-server", {
+			authorizationEndpoint: "https://example.com/authorize",
+			tokenEndpoint: "https://example.com/token",
+			resourceServer: "https://example.com",
+			clientId: "test-app-id",
+		});
+
+		expect(ok).toBe(false);
+		expect(db.getOAuthToken("p1", "mcp-server")?.refresh_token).toBe(
+			"old-refresh",
+		);
+	});
+
+	it("deletes the token when the AS explicitly reports invalid_grant", async () => {
+		globalThis.fetch = (async () =>
+			new Response(JSON.stringify({ error: "invalid_grant" }), {
+				status: 400,
+				headers: { "Content-Type": "application/json" },
+			})) as unknown as typeof fetch;
+
+		const ok = await refreshAccessToken(db, "p1", "mcp-server", {
+			authorizationEndpoint: "https://example.com/authorize",
+			tokenEndpoint: "https://example.com/token",
+			resourceServer: "https://example.com",
+			clientId: "test-app-id",
+		});
+
+		expect(ok).toBe(false);
+		expect(db.getOAuthToken("p1", "mcp-server")).toBeNull();
+	});
+
+	it("deletes the token when a 200 error payload explicitly says invalid_refresh", async () => {
+		globalThis.fetch = (async () =>
+			new Response(JSON.stringify({ ok: false, error: "invalid_refresh_token" }), {
+				status: 200,
+				headers: { "Content-Type": "application/json" },
 			})) as unknown as typeof fetch;
 
 		const ok = await refreshAccessToken(db, "p1", "mcp-server", {

--- a/src/server/__tests__/oauth-token-refresh.test.ts
+++ b/src/server/__tests__/oauth-token-refresh.test.ts
@@ -67,11 +67,31 @@ describe("refreshAccessToken", () => {
 		rmSync(tempDir, { recursive: true, force: true });
 	});
 
-	it("does not throw when the provider returns 200 without access_token", async () => {
+	it("keeps the token when the provider returns 200 without access_token", async () => {
 		globalThis.fetch = (async () =>
 			new Response(JSON.stringify({ ok: false, error: "invalid_refresh_token" }), {
 				status: 200,
 				headers: { "Content-Type": "application/json" },
+			})) as unknown as typeof fetch;
+
+		const ok = await refreshAccessToken(db, "p1", "mcp-server", {
+			authorizationEndpoint: "https://example.com/authorize",
+			tokenEndpoint: "https://example.com/token",
+			resourceServer: "https://example.com",
+			clientId: "test-app-id",
+		});
+
+		expect(ok).toBe(false);
+		expect(db.getOAuthToken("p1", "mcp-server")?.refresh_token).toBe(
+			"old-refresh",
+		);
+	});
+
+	it("deletes the token only on a clear HTTP 403 from the token endpoint", async () => {
+		globalThis.fetch = (async () =>
+			new Response("forbidden", {
+				status: 403,
+				headers: { "Content-Type": "text/plain" },
 			})) as unknown as typeof fetch;
 
 		const ok = await refreshAccessToken(db, "p1", "mcp-server", {
@@ -129,7 +149,7 @@ describe("refreshAccessToken", () => {
 			tokenUrl: "https://example.com/token",
 			resourceServer: "https://example.com",
 			clientId: "test-app-id",
-		} as never);
+		});
 
 		expect(ok).toBe(true);
 		expect(postedUrl).toBe("https://example.com/token");

--- a/src/server/__tests__/secret-redaction.test.ts
+++ b/src/server/__tests__/secret-redaction.test.ts
@@ -76,24 +76,47 @@ describe("mergeServerDef", () => {
 		);
 	});
 
-	it("preserves secret source objects in env and headers", () => {
+	it("clears oauth2 when the patch sets oauth2 to null", () => {
 		const merged = mergeServerDef(
 			{
-				env: { A: { fromEnv: "OLD" } },
-				headers: { Authorization: { fromCommand: "op read old" } },
+				url: "https://mcp.example/mcp",
+				oauth2: {
+					clientId: "id",
+					authorizationEndpoint: "https://auth.example/authorize",
+				},
+			},
+			{ url: "https://mcp.example/mcp", oauth2: null },
+		);
+		expect(merged.oauth2).toBeUndefined();
+	});
+
+	it("clears canonical and legacy endpoint aliases when the patch sends empty values", () => {
+		const merged = mergeServerDef(
+			{
+				url: "https://mcp.example/mcp",
+				oauth2: {
+					clientId: "id",
+					authorizationEndpoint: "https://auth.example/authorize",
+					authorizationUrl: "https://legacy.example/authorize",
+					tokenEndpoint: "https://auth.example/token",
+					tokenUrl: "https://legacy.example/token",
+				},
 			},
 			{
-				env: { A: { fromEnv: "NEW" }, B: { fromFile: "./b" } },
-				headers: { Authorization: { fromCommand: "op read new" } },
+				url: "https://mcp.example/mcp",
+				oauth2: {
+					clientId: "id",
+					authorizationEndpoint: "",
+					tokenEndpoint: null,
+				},
 			},
 		);
-		expect(merged.env).toEqual({
-			A: { fromEnv: "NEW" },
-			B: { fromFile: "./b" },
-		});
-		expect(merged.headers).toEqual({
-			Authorization: { fromCommand: "op read new" },
-		});
+		const oauth2 = merged.oauth2 as Record<string, unknown>;
+		expect(oauth2.clientId).toBe("id");
+		expect(oauth2.authorizationEndpoint).toBeUndefined();
+		expect(oauth2.authorizationUrl).toBeUndefined();
+		expect(oauth2.tokenEndpoint).toBeUndefined();
+		expect(oauth2.tokenUrl).toBeUndefined();
 	});
 });
 

--- a/src/server/oauth-discovery.ts
+++ b/src/server/oauth-discovery.ts
@@ -122,6 +122,19 @@ export function resolveOAuthScope(options: {
 }
 
 /**
+ * Result of probing whether an MCP server requires OAuth2.
+ *
+ * - `required`: clear 401 + discoverable auth-server metadata
+ * - `not_required`: reachable server answered without requiring OAuth
+ * - `inconclusive`: network/timeout/5xx/401-without-metadata — callers must
+ *   not treat this as "OAuth went away" or delete stored tokens
+ */
+export type OAuth2DetectionResult =
+	| { status: "required"; config: OAuth2Config }
+	| { status: "not_required" }
+	| { status: "inconclusive"; reason: string };
+
+/**
  * Detect if an MCP server requires OAuth2 authentication.
  * Per MCP spec: Make unauthenticated request, check for 401 + WWW-Authenticate header.
  */
@@ -129,7 +142,7 @@ export async function detectOAuth2Requirement(
 	serverUrl: string,
 	options?: { tlsSkipVerify?: boolean },
 	log = logger.child("OAuth2Discovery"),
-): Promise<OAuth2Config | null> {
+): Promise<OAuth2DetectionResult> {
 	const tlsSkipVerify = shouldSkipTlsVerify(
 		!!options?.tlsSkipVerify,
 		`OAuth2 detection (${serverUrl})`,
@@ -156,9 +169,17 @@ export async function detectOAuth2Requirement(
 			...tlsFetchOptions(tlsSkipVerify),
 		} as RequestInit);
 
+		// 5xx / other ambiguous statuses: server is reachable but we cannot
+		// conclude that OAuth is no longer required.
+		if (response.status >= 500) {
+			const reason = `MCP probe returned ${response.status}`;
+			log.warn(reason);
+			return { status: "inconclusive", reason };
+		}
+
 		if (response.status !== 401) {
 			log.debug(`No OAuth2 required (status: ${response.status})`);
-			return null;
+			return { status: "not_required" };
 		}
 
 		const serverUrlObj = new URL(serverUrl);
@@ -226,8 +247,9 @@ export async function detectOAuth2Requirement(
 		}
 
 		if (!authMetadata) {
-			log.warn("Failed to fetch auth server metadata");
-			return null;
+			const reason = "401 received but auth server metadata unavailable";
+			log.warn(reason);
+			return { status: "inconclusive", reason };
 		}
 
 		const grantTypes = authMetadata.grant_types_supported;
@@ -236,12 +258,12 @@ export async function detectOAuth2Requirement(
 			!grantTypes.includes("authorization_code")
 		) {
 			log.debug("Auth server does not support authorization_code grant");
-			return null;
+			return { status: "not_required" };
 		}
 		const responseTypes = authMetadata.response_types_supported;
 		if (Array.isArray(responseTypes) && !responseTypes.includes("code")) {
 			log.debug("Auth server does not support response_type=code");
-			return null;
+			return { status: "not_required" };
 		}
 
 		const scope = resolveOAuthScope({
@@ -259,9 +281,10 @@ export async function detectOAuth2Requirement(
 		};
 
 		log.success("OAuth2 detected");
-		return config;
+		return { status: "required", config };
 	} catch (error: any) {
-		log.failure(`Error detecting OAuth2: ${error.message}`);
-		return null;
+		const reason = error?.message ?? "OAuth2 detection failed";
+		log.failure(`Error detecting OAuth2: ${reason}`);
+		return { status: "inconclusive", reason };
 	}
 }

--- a/src/server/oauth-discovery.ts
+++ b/src/server/oauth-discovery.ts
@@ -122,17 +122,26 @@ export function resolveOAuthScope(options: {
 }
 
 /**
- * Result of probing whether an MCP server requires OAuth2.
+ * Probe outcome for whether an MCP server requires OAuth2.
  *
- * - `required`: clear 401 + discoverable auth-server metadata
- * - `not_required`: reachable server answered without requiring OAuth
- * - `inconclusive`: network/timeout/5xx/401-without-metadata — callers must
+ * - REQUIRED: clear 401 + discoverable auth-server metadata
+ * - NOT_REQUIRED: reachable server answered without requiring OAuth
+ * - INCONCLUSIVE: network/timeout/5xx/401-without-metadata — callers must
  *   not treat this as "OAuth went away" or delete stored tokens
  */
+export const OAuth2DetectionStatus = {
+	REQUIRED: "required",
+	NOT_REQUIRED: "not_required",
+	INCONCLUSIVE: "inconclusive",
+} as const;
+
+export type OAuth2DetectionStatus =
+	(typeof OAuth2DetectionStatus)[keyof typeof OAuth2DetectionStatus];
+
 export type OAuth2DetectionResult =
-	| { status: "required"; config: OAuth2Config }
-	| { status: "not_required" }
-	| { status: "inconclusive"; reason: string };
+	| { status: typeof OAuth2DetectionStatus.REQUIRED; config: OAuth2Config }
+	| { status: typeof OAuth2DetectionStatus.NOT_REQUIRED }
+	| { status: typeof OAuth2DetectionStatus.INCONCLUSIVE; reason: string };
 
 /**
  * Detect if an MCP server requires OAuth2 authentication.
@@ -174,12 +183,12 @@ export async function detectOAuth2Requirement(
 		if (response.status >= 500) {
 			const reason = `MCP probe returned ${response.status}`;
 			log.warn(reason);
-			return { status: "inconclusive", reason };
+			return { status: OAuth2DetectionStatus.INCONCLUSIVE, reason };
 		}
 
 		if (response.status !== 401) {
 			log.debug(`No OAuth2 required (status: ${response.status})`);
-			return { status: "not_required" };
+			return { status: OAuth2DetectionStatus.NOT_REQUIRED };
 		}
 
 		const serverUrlObj = new URL(serverUrl);
@@ -249,7 +258,7 @@ export async function detectOAuth2Requirement(
 		if (!authMetadata) {
 			const reason = "401 received but auth server metadata unavailable";
 			log.warn(reason);
-			return { status: "inconclusive", reason };
+			return { status: OAuth2DetectionStatus.INCONCLUSIVE, reason };
 		}
 
 		const grantTypes = authMetadata.grant_types_supported;
@@ -258,12 +267,12 @@ export async function detectOAuth2Requirement(
 			!grantTypes.includes("authorization_code")
 		) {
 			log.debug("Auth server does not support authorization_code grant");
-			return { status: "not_required" };
+			return { status: OAuth2DetectionStatus.NOT_REQUIRED };
 		}
 		const responseTypes = authMetadata.response_types_supported;
 		if (Array.isArray(responseTypes) && !responseTypes.includes("code")) {
 			log.debug("Auth server does not support response_type=code");
-			return { status: "not_required" };
+			return { status: OAuth2DetectionStatus.NOT_REQUIRED };
 		}
 
 		const scope = resolveOAuthScope({
@@ -281,10 +290,10 @@ export async function detectOAuth2Requirement(
 		};
 
 		log.success("OAuth2 detected");
-		return { status: "required", config };
+		return { status: OAuth2DetectionStatus.REQUIRED, config };
 	} catch (error: any) {
 		const reason = error?.message ?? "OAuth2 detection failed";
 		log.failure(`Error detecting OAuth2: ${reason}`);
-		return { status: "inconclusive", reason };
+		return { status: OAuth2DetectionStatus.INCONCLUSIVE, reason };
 	}
 }

--- a/src/server/oauth-discovery.ts
+++ b/src/server/oauth-discovery.ts
@@ -125,9 +125,10 @@ export function resolveOAuthScope(options: {
  * Probe outcome for whether an MCP server requires OAuth2.
  *
  * - REQUIRED: clear 401 + discoverable auth-server metadata
- * - NOT_REQUIRED: reachable server answered without requiring OAuth
- * - INCONCLUSIVE: network/timeout/5xx/401-without-metadata — callers must
- *   not treat this as "OAuth went away" or delete stored tokens
+ * - NOT_REQUIRED: unauthenticated MCP initialize succeeded (2xx)
+ * - INCONCLUSIVE: network/timeout/non-2xx-except-401/401-without-metadata/
+ *   unsupported grant — callers must not treat this as "OAuth went away"
+ *   or delete stored tokens
  */
 export const OAuth2DetectionStatus = {
 	REQUIRED: "required",
@@ -178,17 +179,17 @@ export async function detectOAuth2Requirement(
 			...tlsFetchOptions(tlsSkipVerify),
 		} as RequestInit);
 
-		// 5xx / other ambiguous statuses: server is reachable but we cannot
-		// conclude that OAuth is no longer required.
-		if (response.status >= 500) {
+		// Only a successful unauthenticated initialize proves OAuth is absent.
+		// 401 continues discovery. Other 4xx/3xx/5xx are protocol, gateway, or
+		// auth-adjacent failures and must not erase stored OAuth configuration.
+		if (response.status !== 401) {
+			if (response.ok) {
+				log.debug(`No OAuth2 required (status: ${response.status})`);
+				return { status: OAuth2DetectionStatus.NOT_REQUIRED };
+			}
 			const reason = `MCP probe returned ${response.status}`;
 			log.warn(reason);
 			return { status: OAuth2DetectionStatus.INCONCLUSIVE, reason };
-		}
-
-		if (response.status !== 401) {
-			log.debug(`No OAuth2 required (status: ${response.status})`);
-			return { status: OAuth2DetectionStatus.NOT_REQUIRED };
 		}
 
 		const serverUrlObj = new URL(serverUrl);
@@ -266,13 +267,15 @@ export async function detectOAuth2Requirement(
 			Array.isArray(grantTypes) &&
 			!grantTypes.includes("authorization_code")
 		) {
-			log.debug("Auth server does not support authorization_code grant");
-			return { status: OAuth2DetectionStatus.NOT_REQUIRED };
+			const reason = "Auth server does not support authorization_code grant";
+			log.warn(reason);
+			return { status: OAuth2DetectionStatus.INCONCLUSIVE, reason };
 		}
 		const responseTypes = authMetadata.response_types_supported;
 		if (Array.isArray(responseTypes) && !responseTypes.includes("code")) {
-			log.debug("Auth server does not support response_type=code");
-			return { status: OAuth2DetectionStatus.NOT_REQUIRED };
+			const reason = "Auth server does not support response_type=code";
+			log.warn(reason);
+			return { status: OAuth2DetectionStatus.INCONCLUSIVE, reason };
 		}
 
 		const scope = resolveOAuthScope({

--- a/src/server/oauth-endpoint-resolve.ts
+++ b/src/server/oauth-endpoint-resolve.ts
@@ -1,12 +1,13 @@
-import type { OAuth2Config } from "../types/oauth";
-
 /**
  * Resolve auth/token endpoints from canonical camelCase fields, with legacy
  * alias fallbacks for session/DB oauth2 blocks that predate ingest normalization
  * (`tokenUrl` / `authorizationUrl`, snake_case, etc.).
+ *
+ * Accepts any oauth2-shaped object (capabilities config, discovery result, or
+ * legacy session JSON) — callers may pass optional or required endpoint fields.
  */
 export function resolveAuthorizationEndpoint(
-	oauth2Config: OAuth2Config | Record<string, unknown>,
+	oauth2Config: object,
 ): string | undefined {
 	const cfg = oauth2Config as Record<string, unknown>;
 	return firstNonEmptyString(
@@ -17,9 +18,7 @@ export function resolveAuthorizationEndpoint(
 	);
 }
 
-export function resolveTokenEndpoint(
-	oauth2Config: OAuth2Config | Record<string, unknown>,
-): string | undefined {
+export function resolveTokenEndpoint(oauth2Config: object): string | undefined {
 	const cfg = oauth2Config as Record<string, unknown>;
 	return firstNonEmptyString(
 		cfg.tokenEndpoint,

--- a/src/server/oauth-endpoint-resolve.ts
+++ b/src/server/oauth-endpoint-resolve.ts
@@ -1,14 +1,37 @@
 import type { OAuth2Config } from "../types/oauth";
 
-/** Canonical camelCase fields only — aliases are stripped at ingest. */
+/**
+ * Resolve auth/token endpoints from canonical camelCase fields, with legacy
+ * alias fallbacks for session/DB oauth2 blocks that predate ingest normalization
+ * (`tokenUrl` / `authorizationUrl`, snake_case, etc.).
+ */
 export function resolveAuthorizationEndpoint(
-	oauth2Config: OAuth2Config,
+	oauth2Config: OAuth2Config | Record<string, unknown>,
 ): string | undefined {
-	return oauth2Config.authorizationEndpoint;
+	const cfg = oauth2Config as Record<string, unknown>;
+	return firstNonEmptyString(
+		cfg.authorizationEndpoint,
+		cfg.authorizationUrl,
+		cfg.authorization_endpoint,
+		cfg.authorization_url,
+	);
 }
 
 export function resolveTokenEndpoint(
-	oauth2Config: OAuth2Config,
+	oauth2Config: OAuth2Config | Record<string, unknown>,
 ): string | undefined {
-	return oauth2Config.tokenEndpoint;
+	const cfg = oauth2Config as Record<string, unknown>;
+	return firstNonEmptyString(
+		cfg.tokenEndpoint,
+		cfg.tokenUrl,
+		cfg.token_endpoint,
+		cfg.token_url,
+	);
+}
+
+function firstNonEmptyString(...values: unknown[]): string | undefined {
+	for (const value of values) {
+		if (typeof value === "string" && value.length > 0) return value;
+	}
+	return undefined;
 }

--- a/src/server/oauth-endpoint-resolve.ts
+++ b/src/server/oauth-endpoint-resolve.ts
@@ -15,7 +15,6 @@ export type OAuthEndpointResolvable = {
 	token_endpoint?: string;
 	authorization_url?: string;
 	token_url?: string;
-	[key: string]: unknown;
 };
 
 export function resolveAuthorizationEndpoint(

--- a/src/server/oauth-endpoint-resolve.ts
+++ b/src/server/oauth-endpoint-resolve.ts
@@ -3,28 +3,46 @@
  * alias fallbacks for session/DB oauth2 blocks that predate ingest normalization
  * (`tokenUrl` / `authorizationUrl`, snake_case, etc.).
  *
- * Accepts any oauth2-shaped object (capabilities config, discovery result, or
+ * Accepts oauth2-shaped objects (capabilities config, discovery result, or
  * legacy session JSON) — callers may pass optional or required endpoint fields.
  */
+export type OAuthEndpointResolvable = {
+	authorizationEndpoint?: string;
+	tokenEndpoint?: string;
+	authorizationUrl?: string;
+	tokenUrl?: string;
+	authorization_endpoint?: string;
+	token_endpoint?: string;
+	authorization_url?: string;
+	token_url?: string;
+	[key: string]: unknown;
+};
+
 export function resolveAuthorizationEndpoint(
-	oauth2Config: object,
+	oauth2Config: OAuthEndpointResolvable | null | undefined,
 ): string | undefined {
-	const cfg = oauth2Config as Record<string, unknown>;
+	if (oauth2Config == null || typeof oauth2Config !== "object") {
+		return undefined;
+	}
 	return firstNonEmptyString(
-		cfg.authorizationEndpoint,
-		cfg.authorizationUrl,
-		cfg.authorization_endpoint,
-		cfg.authorization_url,
+		oauth2Config.authorizationEndpoint,
+		oauth2Config.authorizationUrl,
+		oauth2Config.authorization_endpoint,
+		oauth2Config.authorization_url,
 	);
 }
 
-export function resolveTokenEndpoint(oauth2Config: object): string | undefined {
-	const cfg = oauth2Config as Record<string, unknown>;
+export function resolveTokenEndpoint(
+	oauth2Config: OAuthEndpointResolvable | null | undefined,
+): string | undefined {
+	if (oauth2Config == null || typeof oauth2Config !== "object") {
+		return undefined;
+	}
 	return firstNonEmptyString(
-		cfg.tokenEndpoint,
-		cfg.tokenUrl,
-		cfg.token_endpoint,
-		cfg.token_url,
+		oauth2Config.tokenEndpoint,
+		oauth2Config.tokenUrl,
+		oauth2Config.token_endpoint,
+		oauth2Config.token_url,
 	);
 }
 

--- a/src/server/oauth-manager.ts
+++ b/src/server/oauth-manager.ts
@@ -6,7 +6,10 @@ import type { CapaDatabase } from "../db/database";
 import { logger } from "../shared/logger";
 import { isPermanentRefreshFailure } from "../shared/oauth-refresh";
 import type { OAuth2Config } from "../types/oauth";
-import { detectOAuth2Requirement } from "./oauth-discovery";
+import {
+	detectOAuth2Requirement,
+	type OAuth2DetectionResult,
+} from "./oauth-discovery";
 import { generateAuthorizationUrl, handleCallback } from "./oauth-pkce-flow";
 import {
 	disconnect,
@@ -17,6 +20,7 @@ import {
 
 // Re-exported for backwards compatibility with existing import sites.
 export { isPermanentRefreshFailure };
+export type { OAuth2DetectionResult };
 
 export class OAuth2Manager {
 	private db: CapaDatabase;
@@ -36,17 +40,19 @@ export class OAuth2Manager {
 	}
 
 	/**
-	 * Detect if an MCP server requires OAuth2 authentication
+	 * Detect if an MCP server requires OAuth2 authentication.
+	 * Returns required / not_required / inconclusive — never collapses
+	 * network failures into "OAuth no longer required".
 	 */
 	async detectOAuth2Requirement(
 		serverUrl: string,
 		options?: { tlsSkipVerify?: boolean },
-	): Promise<OAuth2Config | null> {
-		const config = await detectOAuth2Requirement(serverUrl, options, this.log);
-		if (config) {
-			this.oauth2ConfigCache.set(serverUrl, config);
+	): Promise<OAuth2DetectionResult> {
+		const result = await detectOAuth2Requirement(serverUrl, options, this.log);
+		if (result.status === "required") {
+			this.oauth2ConfigCache.set(serverUrl, result.config);
 		}
-		return config;
+		return result;
 	}
 
 	/**

--- a/src/server/oauth-manager.ts
+++ b/src/server/oauth-manager.ts
@@ -8,6 +8,7 @@ import { isPermanentRefreshFailure } from "../shared/oauth-refresh";
 import type { OAuth2Config } from "../types/oauth";
 import {
 	detectOAuth2Requirement,
+	OAuth2DetectionStatus,
 	type OAuth2DetectionResult,
 } from "./oauth-discovery";
 import { generateAuthorizationUrl, handleCallback } from "./oauth-pkce-flow";
@@ -19,7 +20,7 @@ import {
 } from "./oauth-token-store";
 
 // Re-exported for backwards compatibility with existing import sites.
-export { isPermanentRefreshFailure };
+export { isPermanentRefreshFailure, OAuth2DetectionStatus };
 export type { OAuth2DetectionResult };
 
 export class OAuth2Manager {
@@ -49,7 +50,7 @@ export class OAuth2Manager {
 		options?: { tlsSkipVerify?: boolean },
 	): Promise<OAuth2DetectionResult> {
 		const result = await detectOAuth2Requirement(serverUrl, options, this.log);
-		if (result.status === "required") {
+		if (result.status === OAuth2DetectionStatus.REQUIRED) {
 			this.oauth2ConfigCache.set(serverUrl, result.config);
 		}
 		return result;

--- a/src/server/oauth-routes.ts
+++ b/src/server/oauth-routes.ts
@@ -7,7 +7,7 @@ import { projectUiUrl } from "../shared/ui-urls";
 import type { MCPServer } from "../types/capabilities";
 import type { OAuth2Config } from "../types/oauth";
 import { matchRoute } from "./match-route";
-import type { OAuth2Manager } from "./oauth-manager";
+import { OAuth2DetectionStatus, type OAuth2Manager } from "./oauth-manager";
 import { syncAllServersOAuth2Requirements } from "./oauth-server-sync";
 import {
 	type EffectiveCapsCacheEntry,
@@ -380,7 +380,7 @@ export async function handleOAuth2Start(
 					tlsSkipVerify: server.def.tlsSkipVerify,
 				},
 			);
-			if (detected.status === "not_required") {
+			if (detected.status === OAuth2DetectionStatus.NOT_REQUIRED) {
 				// Clear stale oauth2 config only — never delete tokens from a probe.
 				delete server.def.oauth2;
 				deps.sessionManager.setProjectCapabilities(projectId, capabilities);
@@ -392,7 +392,7 @@ export async function handleOAuth2Start(
 					{ status: 409, headers: JSON_HEADERS },
 				);
 			}
-			if (detected.status === "required") {
+			if (detected.status === OAuth2DetectionStatus.REQUIRED) {
 				configForFlow = {
 					...configForFlow,
 					...detected.config,

--- a/src/server/oauth-routes.ts
+++ b/src/server/oauth-routes.ts
@@ -410,8 +410,24 @@ export async function handleOAuth2Start(
 				};
 				server.def.oauth2 = configForFlow;
 				deps.sessionManager.setProjectCapabilities(projectId, capabilities);
+			} else if (detected.status === OAuth2DetectionStatus.INCONCLUSIVE) {
+				// Ambiguous probe or unsupported grant/response type: keep oauth2.
+				// Do not start a flow we cannot complete when metadata is present
+				// but authorization_code/code is missing.
+				const reason = detected.reason;
+				if (
+					reason.includes("authorization_code") ||
+					reason.includes("response_type=code")
+				) {
+					return new Response(
+						JSON.stringify({
+							error: `This server requires OAuth, but its authorization server does not support the authorization-code flow. ${reason}`,
+						}),
+						{ status: 409, headers: JSON_HEADERS },
+					);
+				}
+				// Other inconclusive outcomes: keep existing endpoints and continue.
 			}
-			// inconclusive: keep existing oauth2 endpoints and continue the flow
 		}
 
 		const { url: authUrl, state } =

--- a/src/server/oauth-routes.ts
+++ b/src/server/oauth-routes.ts
@@ -380,9 +380,9 @@ export async function handleOAuth2Start(
 					tlsSkipVerify: server.def.tlsSkipVerify,
 				},
 			);
-			if (!detected) {
+			if (detected.status === "not_required") {
+				// Clear stale oauth2 config only — never delete tokens from a probe.
 				delete server.def.oauth2;
-				deps.oauth2Manager.disconnect(projectId, serverId);
 				deps.sessionManager.setProjectCapabilities(projectId, capabilities);
 				return new Response(
 					JSON.stringify({
@@ -392,21 +392,26 @@ export async function handleOAuth2Start(
 					{ status: 409, headers: JSON_HEADERS },
 				);
 			}
-			configForFlow = {
-				...configForFlow,
-				...detected,
-				authorizationEndpoint:
-					configForFlow.authorizationEndpoint || detected.authorizationEndpoint,
-				tokenEndpoint: configForFlow.tokenEndpoint || detected.tokenEndpoint,
-				resourceServer:
-					configForFlow.resourceServer ||
-					detected.resourceServer ||
-					server.def.url,
-				scope: detected.scope ?? configForFlow.scope,
-				...(effectiveClientId ? { clientId: effectiveClientId } : {}),
-			};
-			server.def.oauth2 = configForFlow;
-			deps.sessionManager.setProjectCapabilities(projectId, capabilities);
+			if (detected.status === "required") {
+				configForFlow = {
+					...configForFlow,
+					...detected.config,
+					authorizationEndpoint:
+						configForFlow.authorizationEndpoint ||
+						detected.config.authorizationEndpoint,
+					tokenEndpoint:
+						configForFlow.tokenEndpoint || detected.config.tokenEndpoint,
+					resourceServer:
+						configForFlow.resourceServer ||
+						detected.config.resourceServer ||
+						server.def.url,
+					scope: detected.config.scope ?? configForFlow.scope,
+					...(effectiveClientId ? { clientId: effectiveClientId } : {}),
+				};
+				server.def.oauth2 = configForFlow;
+				deps.sessionManager.setProjectCapabilities(projectId, capabilities);
+			}
+			// inconclusive: keep existing oauth2 endpoints and continue the flow
 		}
 
 		const { url: authUrl, state } =

--- a/src/server/oauth-server-sync.ts
+++ b/src/server/oauth-server-sync.ts
@@ -3,7 +3,7 @@ import type {
 	OAuth2Config as CapabilitiesOAuth2Config,
 } from "../types/capabilities";
 import type { OAuth2Config } from "../types/oauth";
-import type { OAuth2Manager } from "./oauth-manager";
+import { OAuth2DetectionStatus, type OAuth2Manager } from "./oauth-manager";
 
 function readEmbeddedClientId(
 	oauth: CapabilitiesOAuth2Config | undefined,
@@ -121,7 +121,7 @@ export async function syncServerOAuth2Requirement(
 		tlsSkipVerify: server.def.tlsSkipVerify,
 	});
 
-	if (detected.status === "required") {
+	if (detected.status === OAuth2DetectionStatus.REQUIRED) {
 		const merged = mergeDetectedOAuth2(existingOAuth, detected.config);
 		const changed =
 			!existingOAuth ||
@@ -143,7 +143,7 @@ export async function syncServerOAuth2Requirement(
 		};
 	}
 
-	if (detected.status === "inconclusive") {
+	if (detected.status === OAuth2DetectionStatus.INCONCLUSIVE) {
 		// Unreachable / timed out / ambiguous probe — keep oauth2 + tokens.
 		if (!existingOAuth) return { changed: false, entry: null };
 		const isConnected = oauth2Manager.isServerConnected(projectId, server.id);
@@ -158,7 +158,7 @@ export async function syncServerOAuth2Requirement(
 		};
 	}
 
-	// not_required: drop stale oauth2 config, but never delete tokens.
+	// NOT_REQUIRED: drop stale oauth2 config, but never delete tokens.
 	if (existingOAuth) {
 		delete server.def.oauth2;
 		return { changed: true, entry: null };

--- a/src/server/oauth-server-sync.ts
+++ b/src/server/oauth-server-sync.ts
@@ -92,7 +92,10 @@ export type SyncServerOAuth2Result = {
 
 /**
  * Probe the live MCP URL and align def.oauth2 with what the server actually needs.
- * Clears stale OAuth config when the URL no longer returns 401 + WWW-Authenticate.
+ *
+ * Clears stale oauth2 *config* when the URL clearly no longer requires OAuth.
+ * Never deletes stored tokens from sync — tokens are only removed on an
+ * explicit user disconnect or a clear HTTP 403 from the token endpoint.
  */
 export async function syncServerOAuth2Requirement(
 	projectId: string,
@@ -104,51 +107,44 @@ export async function syncServerOAuth2Requirement(
 	}
 
 	if (serverHasExplicitAuthHeader(server)) {
+		// Static Authorization header replaces OAuth config, but do not wipe
+		// stored tokens here — only a clear 403 (or explicit disconnect) may.
 		if (server.def.oauth2) {
 			delete server.def.oauth2;
-			oauth2Manager.disconnect(projectId, server.id);
 			return { changed: true, entry: null };
 		}
 		return { changed: false, entry: null };
 	}
 
 	const existingOAuth = server.def.oauth2;
-	try {
-		const detected = await oauth2Manager.detectOAuth2Requirement(server.def.url, {
-			tlsSkipVerify: server.def.tlsSkipVerify,
-		});
+	const detected = await oauth2Manager.detectOAuth2Requirement(server.def.url, {
+		tlsSkipVerify: server.def.tlsSkipVerify,
+	});
 
-		if (detected) {
-			const merged = mergeDetectedOAuth2(existingOAuth, detected);
-			const changed =
-				!existingOAuth ||
-				JSON.stringify(existingOAuth) !== JSON.stringify(merged);
-			server.def.oauth2 = merged;
+	if (detected.status === "required") {
+		const merged = mergeDetectedOAuth2(existingOAuth, detected.config);
+		const changed =
+			!existingOAuth ||
+			JSON.stringify(existingOAuth) !== JSON.stringify(merged);
+		server.def.oauth2 = merged;
 
-			let isConnected = oauth2Manager.isServerConnected(projectId, server.id);
-			// Token row presence is the source of truth for "authenticated" in the UI.
-			// Refresh may fail transiently without invalidating stored credentials.
+		const isConnected = oauth2Manager.isServerConnected(projectId, server.id);
+		// Token row presence is the source of truth for "authenticated" in the UI.
+		// Refresh may fail transiently without invalidating stored credentials.
 
-			return {
-				changed,
-				entry: {
-					serverId: server.id,
-					serverUrl: server.def.url,
-					displayName: server.displayName ?? server.id,
-					isConnected,
-				},
-			};
-		}
+		return {
+			changed,
+			entry: {
+				serverId: server.id,
+				serverUrl: server.def.url,
+				displayName: server.displayName ?? server.id,
+				isConnected,
+			},
+		};
+	}
 
-		if (existingOAuth) {
-			delete server.def.oauth2;
-			oauth2Manager.disconnect(projectId, server.id);
-			return { changed: true, entry: null };
-		}
-
-		return { changed: false, entry: null };
-	} catch {
-		// Transient probe failures should not strip a working OAuth config.
+	if (detected.status === "inconclusive") {
+		// Unreachable / timed out / ambiguous probe — keep oauth2 + tokens.
 		if (!existingOAuth) return { changed: false, entry: null };
 		const isConnected = oauth2Manager.isServerConnected(projectId, server.id);
 		return {
@@ -161,6 +157,14 @@ export async function syncServerOAuth2Requirement(
 			},
 		};
 	}
+
+	// not_required: drop stale oauth2 config, but never delete tokens.
+	if (existingOAuth) {
+		delete server.def.oauth2;
+		return { changed: true, entry: null };
+	}
+
+	return { changed: false, entry: null };
 }
 
 export type SyncAllServersOAuth2Result = {

--- a/src/server/oauth-token-store.ts
+++ b/src/server/oauth-token-store.ts
@@ -1,6 +1,6 @@
 import type { CapaDatabase } from "../db/database";
 import { logger } from "../shared/logger";
-import { isMcpOAuthTokenPermanentFailure } from "../shared/oauth-refresh";
+import { isPermanentRefreshFailure } from "../shared/oauth-refresh";
 import type { OAuth2Config } from "../types/oauth";
 import {
 	resolveTokenEndpoint,
@@ -135,7 +135,7 @@ export async function refreshAccessToken(
 			log.failure(
 				`Token refresh failed: ${response.status} ${response.statusText}`,
 			);
-			if (isMcpOAuthTokenPermanentFailure(undefined, response, body)) {
+			if (isPermanentRefreshFailure(undefined, response, body)) {
 				db.deleteOAuthToken(projectId, serverId);
 				log.info(`Deleted invalid token for ${serverId}`);
 			} else {
@@ -148,8 +148,8 @@ export async function refreshAccessToken(
 		if (parsed.error || !parsed.accessToken) {
 			const message = parsed.error || "Token response did not include access_token";
 			log.failure(`Token refresh failed: ${message}`);
-			// Only a clear HTTP 403 may delete stored MCP tokens automatically.
-			if (isMcpOAuthTokenPermanentFailure(undefined, response, message)) {
+			// Only wipe when the AS explicitly marks the token invalid/expired.
+			if (isPermanentRefreshFailure(undefined, response, message)) {
 				db.deleteOAuthToken(projectId, serverId);
 				log.info(`Deleted invalid token for ${serverId}`);
 			} else {
@@ -175,7 +175,7 @@ export async function refreshAccessToken(
 		return true;
 	} catch (error: any) {
 		log.failure(`Token refresh error: ${error.message}`);
-		if (isMcpOAuthTokenPermanentFailure(error)) {
+		if (isPermanentRefreshFailure(error)) {
 			db.deleteOAuthToken(projectId, serverId);
 			log.info(`Deleted failed token for ${serverId}`);
 		} else {

--- a/src/server/oauth-token-store.ts
+++ b/src/server/oauth-token-store.ts
@@ -2,7 +2,10 @@ import type { CapaDatabase } from "../db/database";
 import { logger } from "../shared/logger";
 import { isPermanentRefreshFailure } from "../shared/oauth-refresh";
 import type { OAuth2Config } from "../types/oauth";
-import { resolveTokenEndpoint } from "./oauth-endpoint-resolve";
+import {
+	resolveTokenEndpoint,
+	type OAuthEndpointResolvable,
+} from "./oauth-endpoint-resolve";
 
 const tokenLogger = logger.child("OAuth2TokenStore");
 
@@ -76,7 +79,7 @@ export async function refreshAccessToken(
 	db: CapaDatabase,
 	projectId: string,
 	serverId: string,
-	oauth2Config: OAuth2Config,
+	oauth2Config: OAuth2Config | OAuthEndpointResolvable,
 	log = tokenLogger,
 ): Promise<boolean> {
 	try {
@@ -95,7 +98,7 @@ export async function refreshAccessToken(
 		const clientId = resolveStoredClientId(
 			projectId,
 			serverId,
-			oauth2Config,
+			oauth2Config as OAuth2Config,
 			db,
 		);
 		const clientSecret = db.getVariable(
@@ -145,10 +148,8 @@ export async function refreshAccessToken(
 		if (parsed.error || !parsed.accessToken) {
 			const message = parsed.error || "Token response did not include access_token";
 			log.failure(`Token refresh failed: ${message}`);
-			if (
-				isPermanentRefreshFailure(undefined, response, message) ||
-				/invalid|expired|revoked|not_found|unauthorized/i.test(message)
-			) {
+			// Only a clear HTTP 403 may delete stored tokens automatically.
+			if (isPermanentRefreshFailure(undefined, response, message)) {
 				db.deleteOAuthToken(projectId, serverId);
 				log.info(`Deleted invalid token for ${serverId}`);
 			} else {

--- a/src/server/oauth-token-store.ts
+++ b/src/server/oauth-token-store.ts
@@ -1,6 +1,6 @@
 import type { CapaDatabase } from "../db/database";
 import { logger } from "../shared/logger";
-import { isPermanentRefreshFailure } from "../shared/oauth-refresh";
+import { isMcpOAuthTokenPermanentFailure } from "../shared/oauth-refresh";
 import type { OAuth2Config } from "../types/oauth";
 import {
 	resolveTokenEndpoint,
@@ -135,7 +135,7 @@ export async function refreshAccessToken(
 			log.failure(
 				`Token refresh failed: ${response.status} ${response.statusText}`,
 			);
-			if (isPermanentRefreshFailure(undefined, response, body)) {
+			if (isMcpOAuthTokenPermanentFailure(undefined, response, body)) {
 				db.deleteOAuthToken(projectId, serverId);
 				log.info(`Deleted invalid token for ${serverId}`);
 			} else {
@@ -148,8 +148,8 @@ export async function refreshAccessToken(
 		if (parsed.error || !parsed.accessToken) {
 			const message = parsed.error || "Token response did not include access_token";
 			log.failure(`Token refresh failed: ${message}`);
-			// Only a clear HTTP 403 may delete stored tokens automatically.
-			if (isPermanentRefreshFailure(undefined, response, message)) {
+			// Only a clear HTTP 403 may delete stored MCP tokens automatically.
+			if (isMcpOAuthTokenPermanentFailure(undefined, response, message)) {
 				db.deleteOAuthToken(projectId, serverId);
 				log.info(`Deleted invalid token for ${serverId}`);
 			} else {
@@ -175,7 +175,7 @@ export async function refreshAccessToken(
 		return true;
 	} catch (error: any) {
 		log.failure(`Token refresh error: ${error.message}`);
-		if (isPermanentRefreshFailure(error)) {
+		if (isMcpOAuthTokenPermanentFailure(error)) {
 			db.deleteOAuthToken(projectId, serverId);
 			log.info(`Deleted failed token for ${serverId}`);
 		} else {

--- a/src/server/project-routes.ts
+++ b/src/server/project-routes.ts
@@ -13,6 +13,10 @@ import { clientErrorMessage } from "./http-error";
 import { matchRoute } from "./match-route";
 import type { CapaMCPServer } from "./mcp-handler";
 import type { McpServerStateManager } from "./mcp-server-state";
+import {
+	resolveAuthorizationEndpoint,
+	resolveTokenEndpoint,
+} from "./oauth-endpoint-resolve";
 import { OAuth2Manager } from "./oauth-manager";
 import { listProjectFs, writeProjectImport } from "./project-fs";
 import {
@@ -188,6 +192,12 @@ export async function handleGetProject(
 								? deps.oauth2Manager.isServerConnected(projectId, s.id)
 								: null;
 							const enabled = deps.mcpServerState.isEnabled(projectId, s.id);
+							const authorizationEndpoint = s.def?.oauth2
+								? (resolveAuthorizationEndpoint(s.def.oauth2) ?? null)
+								: null;
+							const tokenEndpoint = s.def?.oauth2
+								? (resolveTokenEndpoint(s.def.oauth2) ?? null)
+								: null;
 							return redactServerForApi({
 								id: s.id,
 								type: s.type,
@@ -202,9 +212,10 @@ export async function handleGetProject(
 									? {
 											clientId: s.def.oauth2.clientId ?? null,
 											clientSecret: s.def.oauth2.clientSecret ?? null,
-											authorizationUrl:
-												s.def.oauth2.authorizationEndpoint ?? null,
-											tokenUrl: s.def.oauth2.tokenEndpoint ?? null,
+											authorizationUrl: authorizationEndpoint,
+											tokenUrl: tokenEndpoint,
+											authorizationEndpoint,
+											tokenEndpoint,
 											scopes:
 												s.def.oauth2.scopes ??
 												(s.def.oauth2.scope ? [s.def.oauth2.scope] : null),

--- a/src/server/resolve-effective-capabilities.ts
+++ b/src/server/resolve-effective-capabilities.ts
@@ -7,6 +7,10 @@ import { LockfileBuilder, loadLockfile } from "../shared/lockfile";
 import { logger } from "../shared/logger";
 import { validateProvider } from "../shared/providers/resolve";
 import type { Capabilities } from "../types/capabilities";
+import {
+	resolveAuthorizationEndpoint,
+	resolveTokenEndpoint,
+} from "./oauth-endpoint-resolve";
 import { mergeEmbeddedOAuthFields, mergePluginEmbeddedOAuth } from "./oauth-server-sync";
 
 const log = logger.child("plugin-resolve");
@@ -222,8 +226,10 @@ export function preserveDiscoveredOAuth2(
 		// URL changes invalidate previously discovered OAuth metadata.
 		if (prev?.def?.url !== server.def?.url) continue;
 
-		const prevAuth = prevOAuth.authorizationEndpoint;
-		const prevToken = prevOAuth.tokenEndpoint;
+		// Prefer canonical fields; fall back to legacy aliases still present in
+		// pre-normalize session/DB oauth2 blocks (tokenUrl / authorizationUrl).
+		const prevAuth = resolveAuthorizationEndpoint(prevOAuth);
+		const prevToken = resolveTokenEndpoint(prevOAuth);
 		if (
 			!prevAuth &&
 			!prevToken &&

--- a/src/server/secret-redaction.ts
+++ b/src/server/secret-redaction.ts
@@ -22,6 +22,24 @@ function asObj(value: unknown): Record<string, unknown> | null {
 	return value as Record<string, unknown>;
 }
 
+function isClearedOauthField(value: unknown): boolean {
+	return value === "" || value === null;
+}
+
+/** Drop canonical + alias endpoint keys when the patch explicitly clears them. */
+function clearEmptyOAuthEndpoint(
+	oauth2: Record<string, unknown>,
+	incoming: Record<string, unknown>,
+	canonical: string,
+	aliases: string[],
+): void {
+	if (!(canonical in incoming) || !isClearedOauthField(incoming[canonical])) {
+		return;
+	}
+	delete oauth2[canonical];
+	for (const alias of aliases) delete oauth2[alias];
+}
+
 export function isSensitiveHeaderName(name: string): boolean {
 	return SENSITIVE_HEADER.test(name);
 }
@@ -119,7 +137,9 @@ export function mergeServerDef(
 
 	const prevOauth = asObj(prev.oauth2);
 	const nextOauth = asObj(incoming.oauth2);
-	if (nextOauth) {
+	if (incoming.oauth2 === null) {
+		delete merged.oauth2;
+	} else if (nextOauth) {
 		const oauth2: Record<string, unknown> = { ...prevOauth, ...nextOauth };
 		const incomingSecret = nextOauth.clientSecret;
 		if (
@@ -130,6 +150,16 @@ export function mergeServerDef(
 		) {
 			oauth2.clientSecret = prevOauth.clientSecret;
 		}
+		clearEmptyOAuthEndpoint(oauth2, nextOauth, "authorizationEndpoint", [
+			"authorizationUrl",
+			"authorization_endpoint",
+			"authorization_url",
+		]);
+		clearEmptyOAuthEndpoint(oauth2, nextOauth, "tokenEndpoint", [
+			"tokenUrl",
+			"token_endpoint",
+			"token_url",
+		]);
 		merged.oauth2 = oauth2;
 	}
 

--- a/src/shared/oauth-refresh.ts
+++ b/src/shared/oauth-refresh.ts
@@ -1,16 +1,53 @@
 /**
- * Shared OAuth refresh-failure classifier.
+ * Shared OAuth refresh-failure classifier (Git integrations + generic callers).
  *
  * A refresh call can fail for many reasons. Most of them are transient
  * (network blip, proxy 5xx, rate limit, DNS hiccup, laptop sleep/resume)
  * and the stored refresh_token is still good — retrying later will succeed.
  *
- * Tokens are only treated as permanently invalid when the token endpoint
- * returns a clear HTTP 403. Other 4xx responses (including 400/401 with
- * `invalid_grant`) and all network/5xx failures are treated as transient so
- * we never wipe stored credentials on an ambiguous failure.
+ * Only a small set of failures indicate the refresh_token itself is no
+ * longer usable and the user must re-authenticate:
+ *   - HTTP 400 / 401 / 403, AND
+ *   - The response body mentions `invalid_grant`, `invalid_token`, or
+ *     `expired` (per RFC 6749 §5.2 + common provider conventions).
+ *
+ * Anything else (5xx, timeouts, thrown errors) is treated as transient so
+ * we don't delete a perfectly valid stored token on a temporary outage.
+ *
+ * MCP server OAuth tokens use a stricter rule — see
+ * `isMcpOAuthTokenPermanentFailure`.
  */
+const PERMANENT_REFRESH_FAILURE_MARKERS = [
+	"invalid_grant",
+	"invalid_token",
+	"expired",
+];
+
 export function isPermanentRefreshFailure(
+	error?: unknown,
+	response?: Response,
+	responseBody?: string,
+): boolean {
+	if (response) {
+		const status = response.status;
+		if (status === 400 || status === 401 || status === 403) {
+			const body = (responseBody ?? "").toLowerCase();
+			return PERMANENT_REFRESH_FAILURE_MARKERS.some((marker) =>
+				body.includes(marker),
+			);
+		}
+		return false;
+	}
+	return false;
+}
+
+/**
+ * MCP OAuth token wipe policy: only a clear HTTP 403 from the token
+ * endpoint may delete stored credentials automatically. Probe failures,
+ * network errors, and other 4xx responses keep the token so users are not
+ * forced to re-auth after a temporary outage.
+ */
+export function isMcpOAuthTokenPermanentFailure(
 	error?: unknown,
 	response?: Response,
 	_responseBody?: string,

--- a/src/shared/oauth-refresh.ts
+++ b/src/shared/oauth-refresh.ts
@@ -5,35 +5,18 @@
  * (network blip, proxy 5xx, rate limit, DNS hiccup, laptop sleep/resume)
  * and the stored refresh_token is still good — retrying later will succeed.
  *
- * Only a small set of failures indicate the refresh_token itself is no
- * longer usable and the user must re-authenticate:
- *   - HTTP 400 / 401 / 403, AND
- *   - The response body mentions `invalid_grant`, `invalid_token`, or
- *     `expired` (per RFC 6749 §5.2 + common provider conventions).
- *
- * Anything else (5xx, timeouts, thrown errors) is treated as transient so
- * we don't delete a perfectly valid stored token on a temporary outage.
+ * Tokens are only treated as permanently invalid when the token endpoint
+ * returns a clear HTTP 403. Other 4xx responses (including 400/401 with
+ * `invalid_grant`) and all network/5xx failures are treated as transient so
+ * we never wipe stored credentials on an ambiguous failure.
  */
-const PERMANENT_REFRESH_FAILURE_MARKERS = [
-	"invalid_grant",
-	"invalid_token",
-	"expired",
-];
-
 export function isPermanentRefreshFailure(
 	error?: unknown,
 	response?: Response,
-	responseBody?: string,
+	_responseBody?: string,
 ): boolean {
 	if (response) {
-		const status = response.status;
-		if (status === 400 || status === 401 || status === 403) {
-			const body = (responseBody ?? "").toLowerCase();
-			return PERMANENT_REFRESH_FAILURE_MARKERS.some((marker) =>
-				body.includes(marker),
-			);
-		}
-		return false;
+		return response.status === 403;
 	}
 	return false;
 }

--- a/src/shared/oauth-refresh.ts
+++ b/src/shared/oauth-refresh.ts
@@ -1,26 +1,25 @@
 /**
- * Shared OAuth refresh-failure classifier (Git integrations + generic callers).
+ * Shared OAuth refresh-failure classifier.
  *
  * A refresh call can fail for many reasons. Most of them are transient
  * (network blip, proxy 5xx, rate limit, DNS hiccup, laptop sleep/resume)
  * and the stored refresh_token is still good — retrying later will succeed.
  *
- * Only a small set of failures indicate the refresh_token itself is no
- * longer usable and the user must re-authenticate:
- *   - HTTP 400 / 401 / 403, AND
- *   - The response body mentions `invalid_grant`, `invalid_token`, or
- *     `expired` (per RFC 6749 §5.2 + common provider conventions).
+ * Tokens are deleted only when the authorization server explicitly says the
+ * credential is dead or expired (RFC 6749 §5.2 + common provider conventions):
+ *   - HTTP 200 / 400 / 401 / 403 (not 5xx), AND
+ *   - The response body mentions a permanent marker such as `invalid_grant`,
+ *     `invalid_token`, `invalid_refresh`, `expired`, or `revoked`.
  *
- * Anything else (5xx, timeouts, thrown errors) is treated as transient so
- * we don't delete a perfectly valid stored token on a temporary outage.
- *
- * MCP server OAuth tokens use a stricter rule — see
- * `isMcpOAuthTokenPermanentFailure`.
+ * Bare status codes without those markers (and all network/thrown errors) are
+ * treated as transient so we never wipe credentials prematurely.
  */
 const PERMANENT_REFRESH_FAILURE_MARKERS = [
 	"invalid_grant",
 	"invalid_token",
+	"invalid_refresh",
 	"expired",
+	"revoked",
 ];
 
 export function isPermanentRefreshFailure(
@@ -28,32 +27,18 @@ export function isPermanentRefreshFailure(
 	response?: Response,
 	responseBody?: string,
 ): boolean {
-	if (response) {
-		const status = response.status;
-		if (status === 400 || status === 401 || status === 403) {
-			const body = (responseBody ?? "").toLowerCase();
-			return PERMANENT_REFRESH_FAILURE_MARKERS.some((marker) =>
-				body.includes(marker),
-			);
-		}
+	if (!response) {
+		// Network / thrown errors: keep the token.
 		return false;
 	}
-	return false;
-}
-
-/**
- * MCP OAuth token wipe policy: only a clear HTTP 403 from the token
- * endpoint may delete stored credentials automatically. Probe failures,
- * network errors, and other 4xx responses keep the token so users are not
- * forced to re-auth after a temporary outage.
- */
-export function isMcpOAuthTokenPermanentFailure(
-	error?: unknown,
-	response?: Response,
-	_responseBody?: string,
-): boolean {
-	if (response) {
-		return response.status === 403;
+	const status = response.status;
+	// Never wipe on 5xx — even if the body text looks fatal.
+	if (status >= 500) return false;
+	if (status !== 200 && status !== 400 && status !== 401 && status !== 403) {
+		return false;
 	}
-	return false;
+	const body = (responseBody ?? "").toLowerCase();
+	return PERMANENT_REFRESH_FAILURE_MARKERS.some((marker) =>
+		body.includes(marker),
+	);
 }

--- a/web-ui/src/features/projects/components/activity/ActivityRunDialog.tsx
+++ b/web-ui/src/features/projects/components/activity/ActivityRunDialog.tsx
@@ -26,6 +26,7 @@ import { filterActivityCalls, filterRunsBySearch } from './filterActivityCalls';
 import { ActivityProcessDiagram } from './ActivityProcessDiagram';
 import type { ActivityRunRightView } from './ActivityRunViewTabs';
 import { useProjectActivityGeneration } from '../../activityHooks';
+import { useProject } from '../../hooks';
 import {
   aggregateDurationMs,
   runsEvents,
@@ -68,6 +69,8 @@ export function ActivityRunDialog({
   emptyLabel,
 }: ActivityRunDialogProps) {
   const { t } = useTranslation('projects');
+  const { data: project } = useProject(projectId);
+  const managedSkills = project?.capabilities?.skills ?? [];
   const multiMode = (runs?.length ?? 0) > 0;
   const generationQuery = useProjectActivityGeneration(
     projectId,
@@ -419,6 +422,8 @@ export function ActivityRunDialog({
                       <ActivityRunSkillsPanel
                         events={displayEvents}
                         projectPath={projectPath}
+                        projectId={projectId}
+                        managedSkills={managedSkills}
                       />
                     </div>
                   </div>

--- a/web-ui/src/features/projects/components/activity/ActivityRunDialog.tsx
+++ b/web-ui/src/features/projects/components/activity/ActivityRunDialog.tsx
@@ -69,7 +69,7 @@ export function ActivityRunDialog({
   emptyLabel,
 }: ActivityRunDialogProps) {
   const { t } = useTranslation('projects');
-  const { data: project } = useProject(projectId);
+  const { data: project } = useProject(open ? projectId : null);
   const managedSkills = project?.capabilities?.skills ?? [];
   const multiMode = (runs?.length ?? 0) > 0;
   const generationQuery = useProjectActivityGeneration(

--- a/web-ui/src/features/projects/components/activity/ActivityRunSkillsPanel.test.ts
+++ b/web-ui/src/features/projects/components/activity/ActivityRunSkillsPanel.test.ts
@@ -1,0 +1,31 @@
+import { describe, expect, it } from 'bun:test';
+import type { Skill } from '../../../../types/api';
+import { findManagedSkillForFolder } from './ActivityRunSkillsPanel';
+
+function skill(partial: Partial<Skill> & { id: string }): Skill {
+  return {
+    type: 'local',
+    description: null,
+    requires: [],
+    sourcePlugin: null,
+    ...partial,
+  };
+}
+
+describe('findManagedSkillForFolder', () => {
+  it('matches capa-managed skills by id', () => {
+    const managed = [skill({ id: 'debug' }), skill({ id: 'standup' })];
+    expect(findManagedSkillForFolder('debug', managed)?.id).toBe('debug');
+    expect(findManagedSkillForFolder('missing', managed)).toBeNull();
+  });
+
+  it('matches local skill path basenames', () => {
+    const managed = [skill({ id: 'my-debug', path: 'skills/debug' })];
+    expect(findManagedSkillForFolder('debug', managed)?.id).toBe('my-debug');
+  });
+
+  it('returns null for provider-built-in folders with no capa skill', () => {
+    expect(findManagedSkillForFolder('create-rule', [])).toBeNull();
+    expect(findManagedSkillForFolder('create-rule', undefined)).toBeNull();
+  });
+});

--- a/web-ui/src/features/projects/components/activity/ActivityRunSkillsPanel.tsx
+++ b/web-ui/src/features/projects/components/activity/ActivityRunSkillsPanel.tsx
@@ -1,19 +1,49 @@
-import { useMemo } from 'react';
+import { useMemo, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import { Sparkles } from 'lucide-react';
-import type { ToolCallRecord } from '../../../../types/api';
+import type { Skill, ToolCallRecord } from '../../../../types/api';
+import { SkillDetailDialog } from '../SkillDetailDialog';
 import { collectRunSkillFolders } from './buildRunFileTree';
 
 interface ActivityRunSkillsPanelProps {
   events: ToolCallRecord[];
   projectPath: string | null;
+  projectId?: string | null;
+  /** Skills managed by capa for this project — used to make chips clickable. */
+  managedSkills?: Skill[];
+}
+
+/** Match a detected skill folder to a capa-managed skill id when possible. */
+export function findManagedSkillForFolder(
+  folder: string,
+  managedSkills: Skill[] | undefined,
+): Skill | null {
+  if (!managedSkills?.length) return null;
+  const exact = managedSkills.find((s) => s.id === folder);
+  if (exact) return exact;
+
+  const lower = folder.toLowerCase();
+  const byIdIgnoreCase = managedSkills.find((s) => s.id.toLowerCase() === lower);
+  if (byIdIgnoreCase) return byIdIgnoreCase;
+
+  // Local skills may use a path whose basename matches the folder.
+  for (const skill of managedSkills) {
+    const path = skill.path?.replace(/\\/g, '/').replace(/\/+$/, '');
+    if (!path) continue;
+    const base = path.split('/').filter(Boolean).pop();
+    if (base === folder || base?.toLowerCase() === lower) return skill;
+  }
+  return null;
 }
 
 export function ActivityRunSkillsPanel({
   events,
   projectPath,
+  projectId = null,
+  managedSkills = [],
 }: ActivityRunSkillsPanelProps) {
   const { t } = useTranslation('projects');
+  const [selectedSkill, setSelectedSkill] = useState<Skill | null>(null);
 
   const skills = useMemo(
     () => collectRunSkillFolders(events, { realProjectPath: projectPath }),
@@ -42,20 +72,44 @@ export function ActivityRunSkillsPanel({
           </p>
         ) : (
           <ul className="flex flex-wrap gap-1.5">
-            {skills.map((skill) => (
-              <li key={skill}>
-                <span
-                  className="inline-flex max-w-full items-center gap-1 rounded-full border border-accent-primary/25 bg-accent-primary/10 px-2 py-0.5 text-[11px] font-medium leading-none text-accent-primary"
-                  title={skill}
-                >
-                  <Sparkles size={10} className="shrink-0 opacity-80" aria-hidden />
-                  <span className="truncate">{skill}</span>
-                </span>
-              </li>
-            ))}
+            {skills.map((skillFolder) => {
+              const managed = findManagedSkillForFolder(skillFolder, managedSkills);
+              const chipClass =
+                'inline-flex max-w-full items-center gap-1 rounded-full border border-accent-primary/25 bg-accent-primary/10 px-2 py-0.5 text-[11px] font-medium leading-none text-accent-primary';
+              return (
+                <li key={skillFolder}>
+                  {managed && projectId ? (
+                    <button
+                      type="button"
+                      className={`${chipClass} cursor-pointer transition-colors hover:border-accent-primary/50 hover:bg-accent-primary/20`}
+                      title={t('activity.runSkills.openSkill', { id: managed.id })}
+                      onClick={() => setSelectedSkill(managed)}
+                    >
+                      <Sparkles size={10} className="shrink-0 opacity-80" aria-hidden />
+                      <span className="truncate">{skillFolder}</span>
+                    </button>
+                  ) : (
+                    <span className={chipClass} title={skillFolder}>
+                      <Sparkles size={10} className="shrink-0 opacity-80" aria-hidden />
+                      <span className="truncate">{skillFolder}</span>
+                    </span>
+                  )}
+                </li>
+              );
+            })}
           </ul>
         )}
       </div>
+      {projectId && (
+        <SkillDetailDialog
+          skill={selectedSkill}
+          projectId={projectId}
+          open={!!selectedSkill}
+          onOpenChange={(next) => {
+            if (!next) setSelectedSkill(null);
+          }}
+        />
+      )}
     </aside>
   );
 }

--- a/web-ui/src/features/projects/components/registry-browse/DetailPanel.tsx
+++ b/web-ui/src/features/projects/components/registry-browse/DetailPanel.tsx
@@ -1,5 +1,5 @@
+import { Check, Loader2 } from 'lucide-react';
 import { useMemo } from 'react';
-import { Loader2 } from 'lucide-react';
 import { useTranslation } from 'react-i18next';
 import type { RegistryItemDetail } from '../../../registries/api';
 import { Spinner } from '../../../../components/common/Spinner';
@@ -12,10 +12,19 @@ interface DetailPanelProps {
   detail: RegistryItemDetail | null;
   detailLoading: boolean;
   busy: boolean;
+  /** True when this registry item is already in the project's capabilities. */
+  installed?: boolean;
   onAdd: () => void;
 }
 
-export function DetailPanel({ selected, detail, detailLoading, busy, onAdd }: DetailPanelProps) {
+export function DetailPanel({
+  selected,
+  detail,
+  detailLoading,
+  busy,
+  installed = false,
+  onAdd,
+}: DetailPanelProps) {
   const { t } = useTranslation('projects');
 
   const previewHtml = useMemo(
@@ -47,15 +56,25 @@ export function DetailPanel({ selected, detail, detailLoading, busy, onAdd }: De
                 {detail.version ? ` · ${detail.version}` : ''}
               </p>
             </div>
-            <button
-              type="button"
-              disabled={busy}
-              onClick={onAdd}
-              className="inline-flex shrink-0 items-center gap-2 rounded-sm bg-accent-primary px-3 py-2 text-xs font-medium text-white cursor-pointer disabled:opacity-50"
-            >
-              {busy && <Loader2 size={14} className="animate-spin" />}
-              {t('actions.add')}
-            </button>
+            {installed ? (
+              <span
+                className="inline-flex shrink-0 items-center gap-1.5 rounded-sm border border-success-border/40 bg-success-bg/40 px-3 py-2 text-xs font-medium text-success-text"
+                title={t('actions.alreadyInstalled')}
+              >
+                <Check size={14} aria-hidden />
+                {t('actions.installed')}
+              </span>
+            ) : (
+              <button
+                type="button"
+                disabled={busy}
+                onClick={onAdd}
+                className="inline-flex shrink-0 items-center gap-2 rounded-sm bg-accent-primary px-3 py-2 text-xs font-medium text-white cursor-pointer disabled:opacity-50"
+              >
+                {busy && <Loader2 size={14} className="animate-spin" />}
+                {t('actions.add')}
+              </button>
+            )}
           </div>
           <div className="min-h-0 flex-1 overflow-y-auto px-4 py-4">
             {detail.files && detail.files.length > 0 && (

--- a/web-ui/src/features/projects/components/registry-browse/RegistryBrowseDialog.tsx
+++ b/web-ui/src/features/projects/components/registry-browse/RegistryBrowseDialog.tsx
@@ -35,7 +35,7 @@ export function RegistryBrowseDialog({
 }: RegistryBrowseDialogProps) {
   const { t } = useTranslation('projects');
   const { data: registries } = useRegistries();
-  const { data: project } = useProject(projectId);
+  const { data: project } = useProject(open ? projectId : null);
   const addMutation = useAddFromRegistry(projectId);
   const appendMutation = useAppendCapability(projectId);
 
@@ -78,7 +78,11 @@ export function RegistryBrowseDialog({
   }, [capability, project?.capabilities]);
 
   const selectedInstalled = selected
-    ? isRegistryItemInstalled(selected.id, installedIds)
+    ? isRegistryItemInstalled(
+        selected.id,
+        installedIds,
+        detail?.installSnippet ?? selected.installSnippet,
+      )
     : false;
 
   const selectedRegistry = useMemo(() => {

--- a/web-ui/src/features/projects/components/registry-browse/RegistryBrowseDialog.tsx
+++ b/web-ui/src/features/projects/components/registry-browse/RegistryBrowseDialog.tsx
@@ -4,12 +4,12 @@ import { ChevronDown, Loader2, Search, X } from 'lucide-react';
 import { useTranslation } from 'react-i18next';
 import { useRegistries } from '../../../registries/hooks';
 import { registriesApi, type RegistryItemDetail } from '../../../registries/api';
-import { useAddFromRegistry, useAppendCapability } from '../../hooks';
+import { useAddFromRegistry, useAppendCapability, useProject } from '../../hooks';
 import { capaIdErrorMessage, sanitizeCapaIdInput } from '../../../../lib/ids';
 import { LocalPathPicker } from '../LocalPathPicker';
 import { ResultList } from './ResultList';
 import { DetailPanel } from './DetailPanel';
-import type { ResultRow } from './types';
+import { isRegistryItemInstalled, type ResultRow } from './types';
 
 
 const ALL = '__all__';
@@ -35,6 +35,7 @@ export function RegistryBrowseDialog({
 }: RegistryBrowseDialogProps) {
   const { t } = useTranslation('projects');
   const { data: registries } = useRegistries();
+  const { data: project } = useProject(projectId);
   const addMutation = useAddFromRegistry(projectId);
   const appendMutation = useAppendCapability(projectId);
 
@@ -60,6 +61,25 @@ export function RegistryBrowseDialog({
     () => (registries ?? []).filter((r) => r.capabilities?.includes(capability)),
     [registries, capability],
   );
+
+  const installedIds = useMemo(() => {
+    const caps = project?.capabilities;
+    const ids = new Set<string>();
+    if (capability === 'skills') {
+      for (const skill of caps?.skills ?? []) {
+        if (skill.id) ids.add(skill.id);
+      }
+    } else {
+      for (const plugin of caps?.plugins ?? []) {
+        if (plugin.id) ids.add(plugin.id);
+      }
+    }
+    return ids;
+  }, [capability, project?.capabilities]);
+
+  const selectedInstalled = selected
+    ? isRegistryItemInstalled(selected.id, installedIds)
+    : false;
 
   const selectedRegistry = useMemo(() => {
     if (registryId === ALL) return null;
@@ -457,6 +477,7 @@ export function RegistryBrowseDialog({
                   results={results}
                   selected={selected}
                   showRegistry={registryId === ALL}
+                  installedIds={installedIds}
                   onSelect={setSelected}
                 />
                 <DetailPanel
@@ -464,6 +485,7 @@ export function RegistryBrowseDialog({
                   detail={detail}
                   detailLoading={detailLoading}
                   busy={busy}
+                  installed={selectedInstalled}
                   onAdd={() => void handleAdd()}
                 />
               </div>

--- a/web-ui/src/features/projects/components/registry-browse/ResultList.tsx
+++ b/web-ui/src/features/projects/components/registry-browse/ResultList.tsx
@@ -1,16 +1,25 @@
 import { useTranslation } from 'react-i18next';
+import { Check } from 'lucide-react';
 import { Spinner } from '../../../../components/common/Spinner';
-import type { ResultRow } from './types';
+import { isRegistryItemInstalled, type ResultRow } from './types';
 
 interface ResultListProps {
   searching: boolean;
   results: ResultRow[];
   selected: ResultRow | null;
   showRegistry: boolean;
+  installedIds?: ReadonlySet<string>;
   onSelect: (item: ResultRow) => void;
 }
 
-export function ResultList({ searching, results, selected, showRegistry, onSelect }: ResultListProps) {
+export function ResultList({
+  searching,
+  results,
+  selected,
+  showRegistry,
+  installedIds,
+  onSelect,
+}: ResultListProps) {
   const { t } = useTranslation('projects');
 
   return (
@@ -25,6 +34,9 @@ export function ResultList({ searching, results, selected, showRegistry, onSelec
         results.map((item) => {
           const active =
             selected?.id === item.id && selected?.registryId === item.registryId;
+          const installed = installedIds
+            ? isRegistryItemInstalled(item.id, installedIds)
+            : false;
           return (
             <button
               key={`${item.registryId}:${item.id}`}
@@ -44,9 +56,16 @@ export function ResultList({ searching, results, selected, showRegistry, onSelec
                     className="h-4 w-4 shrink-0 rounded-sm object-contain opacity-70"
                   />
                 ) : null}
-                <span className="truncate font-mono text-xs font-medium text-text-primary">
+                <span className="min-w-0 flex-1 truncate font-mono text-xs font-medium text-text-primary">
                   {item.title || item.id}
                 </span>
+                {installed && (
+                  <Check
+                    size={14}
+                    className="shrink-0 text-success-text"
+                    aria-label={t('actions.installed')}
+                  />
+                )}
               </div>
               {item.description && (
                 <span className="mt-1 line-clamp-2 text-[11px] text-text-secondary">

--- a/web-ui/src/features/projects/components/registry-browse/ResultList.tsx
+++ b/web-ui/src/features/projects/components/registry-browse/ResultList.tsx
@@ -35,7 +35,7 @@ export function ResultList({
           const active =
             selected?.id === item.id && selected?.registryId === item.registryId;
           const installed = installedIds
-            ? isRegistryItemInstalled(item.id, installedIds)
+            ? isRegistryItemInstalled(item.id, installedIds, item.installSnippet)
             : false;
           return (
             <button

--- a/web-ui/src/features/projects/components/registry-browse/types.test.ts
+++ b/web-ui/src/features/projects/components/registry-browse/types.test.ts
@@ -33,4 +33,13 @@ describe('isRegistryItemInstalled', () => {
       isRegistryItemInstalled('owner/repo/display-name', installed),
     ).toBe(false);
   });
+
+  it('does not treat a catalog id as installed when the snippet id differs', () => {
+    const installed = new Set(['owner/repo/display-name']);
+    expect(
+      isRegistryItemInstalled('owner/repo/display-name', installed, {
+        id: 'canonical-id',
+      }),
+    ).toBe(false);
+  });
 });

--- a/web-ui/src/features/projects/components/registry-browse/types.test.ts
+++ b/web-ui/src/features/projects/components/registry-browse/types.test.ts
@@ -6,6 +6,12 @@ describe('registryInstallId', () => {
     expect(registryInstallId('owner/repo/skill-name')).toBe('skill-name');
     expect(registryInstallId('skill-name')).toBe('skill-name');
   });
+
+  it('prefers installSnippet.id when present', () => {
+    expect(
+      registryInstallId('owner/repo/display-name', { id: 'canonical-id' }),
+    ).toBe('canonical-id');
+  });
 });
 
 describe('isRegistryItemInstalled', () => {
@@ -14,5 +20,17 @@ describe('isRegistryItemInstalled', () => {
     expect(isRegistryItemInstalled('skill-name', installed)).toBe(true);
     expect(isRegistryItemInstalled('owner/repo/skill-name', installed)).toBe(true);
     expect(isRegistryItemInstalled('owner/repo/missing', installed)).toBe(false);
+  });
+
+  it('matches installSnippet.id when it differs from itemId/leaf', () => {
+    const installed = new Set(['canonical-id']);
+    expect(
+      isRegistryItemInstalled('owner/repo/display-name', installed, {
+        id: 'canonical-id',
+      }),
+    ).toBe(true);
+    expect(
+      isRegistryItemInstalled('owner/repo/display-name', installed),
+    ).toBe(false);
   });
 });

--- a/web-ui/src/features/projects/components/registry-browse/types.test.ts
+++ b/web-ui/src/features/projects/components/registry-browse/types.test.ts
@@ -1,0 +1,18 @@
+import { describe, expect, it } from 'bun:test';
+import { isRegistryItemInstalled, registryInstallId } from './types';
+
+describe('registryInstallId', () => {
+  it('uses the leaf path segment', () => {
+    expect(registryInstallId('owner/repo/skill-name')).toBe('skill-name');
+    expect(registryInstallId('skill-name')).toBe('skill-name');
+  });
+});
+
+describe('isRegistryItemInstalled', () => {
+  it('matches full id or install leaf id', () => {
+    const installed = new Set(['skill-name', 'other']);
+    expect(isRegistryItemInstalled('skill-name', installed)).toBe(true);
+    expect(isRegistryItemInstalled('owner/repo/skill-name', installed)).toBe(true);
+    expect(isRegistryItemInstalled('owner/repo/missing', installed)).toBe(false);
+  });
+});

--- a/web-ui/src/features/projects/components/registry-browse/types.ts
+++ b/web-ui/src/features/projects/components/registry-browse/types.ts
@@ -5,3 +5,22 @@ export type ResultRow = RegistryItemSummary & {
   registryName: string;
   registryIcon?: string;
 };
+
+/**
+ * Resolve the capa capability id a registry item would install as
+ * (matches server-side handleFromRegistry naming).
+ */
+export function registryInstallId(itemId: string): string {
+  const leaf = itemId.split('/').pop();
+  return leaf && leaf.length > 0 ? leaf : itemId;
+}
+
+/** True when a registry browse row is already present in the project. */
+export function isRegistryItemInstalled(
+  itemId: string,
+  installedIds: ReadonlySet<string>,
+): boolean {
+  if (installedIds.has(itemId)) return true;
+  const leaf = registryInstallId(itemId);
+  return leaf !== itemId && installedIds.has(leaf);
+}

--- a/web-ui/src/features/projects/components/registry-browse/types.ts
+++ b/web-ui/src/features/projects/components/registry-browse/types.ts
@@ -6,11 +6,23 @@ export type ResultRow = RegistryItemSummary & {
   registryIcon?: string;
 };
 
+function snippetIdOf(
+  installSnippet?: Record<string, unknown> | null,
+): string | undefined {
+  const id = installSnippet?.id;
+  return typeof id === 'string' && id.length > 0 ? id : undefined;
+}
+
 /**
  * Resolve the capa capability id a registry item would install as
- * (matches server-side handleFromRegistry naming).
+ * (matches server-side handleFromRegistry: `installSnippet.id ?? leaf(itemId)`).
  */
-export function registryInstallId(itemId: string): string {
+export function registryInstallId(
+  itemId: string,
+  installSnippet?: Record<string, unknown> | null,
+): string {
+  const fromSnippet = snippetIdOf(installSnippet);
+  if (fromSnippet) return fromSnippet;
   const leaf = itemId.split('/').pop();
   return leaf && leaf.length > 0 ? leaf : itemId;
 }
@@ -19,8 +31,13 @@ export function registryInstallId(itemId: string): string {
 export function isRegistryItemInstalled(
   itemId: string,
   installedIds: ReadonlySet<string>,
+  installSnippet?: Record<string, unknown> | null,
 ): boolean {
   if (installedIds.has(itemId)) return true;
-  const leaf = registryInstallId(itemId);
-  return leaf !== itemId && installedIds.has(leaf);
+  const installId = registryInstallId(itemId, installSnippet);
+  if (installedIds.has(installId)) return true;
+  // Also accept leaf(itemId) when snippet id differs, in case older installs
+  // used the leaf path before snippet ids were honored.
+  const leaf = itemId.split('/').pop();
+  return !!(leaf && leaf !== itemId && leaf !== installId && installedIds.has(leaf));
 }

--- a/web-ui/src/features/projects/components/registry-browse/types.ts
+++ b/web-ui/src/features/projects/components/registry-browse/types.ts
@@ -33,11 +33,9 @@ export function isRegistryItemInstalled(
   installedIds: ReadonlySet<string>,
   installSnippet?: Record<string, unknown> | null,
 ): boolean {
-  if (installedIds.has(itemId)) return true;
   const installId = registryInstallId(itemId, installSnippet);
   if (installedIds.has(installId)) return true;
-  // Also accept leaf(itemId) when snippet id differs, in case older installs
-  // used the leaf path before snippet ids were honored.
+  // Legacy installs used the leaf path before snippet ids were honored.
   const leaf = itemId.split('/').pop();
-  return !!(leaf && leaf !== itemId && leaf !== installId && installedIds.has(leaf));
+  return !!(leaf && leaf !== installId && installedIds.has(leaf));
 }

--- a/web-ui/src/features/projects/components/tools/ServerDialog.tsx
+++ b/web-ui/src/features/projects/components/tools/ServerDialog.tsx
@@ -14,7 +14,6 @@ import {
 
 function serverHasAdvanced(server: Server): boolean {
   return !!(
-    server.displayName ||
     server.description ||
     (server.headers && Object.keys(server.headers).length > 0) ||
     (server.env && Object.keys(server.env).length > 0) ||
@@ -42,7 +41,6 @@ export function ServerDialog({
   const [url, setUrl] = useState('');
   const [cmd, setCmd] = useState('');
   const [args, setArgs] = useState('');
-  const [displayName, setDisplayName] = useState('');
   const [description, setDescription] = useState('');
   const [headers, setHeaders] = useState<SecretValuePair[]>([]);
   const [env, setEnv] = useState<SecretValuePair[]>([]);
@@ -67,7 +65,6 @@ export function ServerDialog({
     setUrl('');
     setCmd('');
     setArgs('');
-    setDisplayName('');
     setDescription('');
     setHeaders([]);
     setEnv([]);
@@ -91,7 +88,6 @@ export function ServerDialog({
     setUrl(s.url || '');
     setCmd(s.cmd || '');
     setArgs((s.args || []).join(' '));
-    setDisplayName(s.displayName || '');
     setDescription(s.description || '');
     setHeaders(recordToSecretPairs(s.headers));
     setEnv(recordToSecretPairs(s.env));
@@ -160,7 +156,6 @@ export function ServerDialog({
       id: id.trim(),
       type: 'mcp',
       def,
-      displayName: displayName.trim() || null,
       description: description.trim() || null,
     };
     return entry;
@@ -290,14 +285,6 @@ export function ServerDialog({
                 </button>
                 {advancedOpen && (
                   <div className="ui-panel-enter space-y-3 border-t border-border-tertiary px-2.5 py-3">
-                    <label className="block text-xs text-text-secondary">
-                      {t('actions.serverDisplayName')}
-                      <input
-                        value={displayName}
-                        onChange={(e) => setDisplayName(e.target.value)}
-                        className="mt-1 w-full rounded-sm border border-border-tertiary bg-bg-tertiary px-2.5 py-2 text-sm text-text-primary"
-                      />
-                    </label>
                     <label className="block text-xs text-text-secondary">
                       {t('actions.serverDescription')}
                       <textarea

--- a/web-ui/src/features/projects/components/tools/ServerDialog.tsx
+++ b/web-ui/src/features/projects/components/tools/ServerDialog.tsx
@@ -95,8 +95,10 @@ export function ServerDialog({
     setTlsSkipVerify(!!s.tlsSkipVerify);
     setOauthClientId(s.oauth2?.clientId || '');
     setOauthClientSecret(s.oauth2?.clientSecret || '');
-    setOauthAuthUrl(s.oauth2?.authorizationUrl || '');
-    setOauthTokenUrl(s.oauth2?.tokenUrl || '');
+    setOauthAuthUrl(
+      s.oauth2?.authorizationEndpoint || s.oauth2?.authorizationUrl || '',
+    );
+    setOauthTokenUrl(s.oauth2?.tokenEndpoint || s.oauth2?.tokenUrl || '');
     setOauthScopes((s.oauth2?.scopes || []).join(' '));
     setOauthRedirectUri(s.oauth2?.redirectUri || '');
     setOauthPkce(!!s.oauth2?.pkce);
@@ -140,12 +142,22 @@ export function ServerDialog({
       const oauth2: Record<string, unknown> = {};
       if (oauthClientId.trim()) oauth2.clientId = oauthClientId.trim();
       if (oauthClientSecret.trim()) oauth2.clientSecret = oauthClientSecret.trim();
-      if (oauthAuthUrl.trim()) oauth2.authorizationEndpoint = oauthAuthUrl.trim();
-      if (oauthTokenUrl.trim()) oauth2.tokenEndpoint = oauthTokenUrl.trim();
       if (scopes.length) oauth2.scopes = scopes;
       if (oauthRedirectUri.trim()) oauth2.redirectUri = oauthRedirectUri.trim();
       if (oauthPkce) oauth2.pkce = true;
-      if (Object.keys(oauth2).length > 0) def.oauth2 = oauth2;
+      const authEndpoint = oauthAuthUrl.trim();
+      const tokenEndpoint = oauthTokenUrl.trim();
+      const hasOauthValues =
+        Object.keys(oauth2).length > 0 || !!authEndpoint || !!tokenEndpoint;
+      if (hasOauthValues) {
+        // Always send canonical endpoint fields so an empty input can clear
+        // persisted values through mergeServerDef (omitted keys are kept).
+        oauth2.authorizationEndpoint = authEndpoint || null;
+        oauth2.tokenEndpoint = tokenEndpoint || null;
+        def.oauth2 = oauth2;
+      } else if (isEdit) {
+        def.oauth2 = null;
+      }
     } else {
       const envMap = secretPairsToRecord(env);
       if (envMap) def.env = envMap;

--- a/web-ui/src/features/projects/components/tools/ServerDialog.tsx
+++ b/web-ui/src/features/projects/components/tools/ServerDialog.tsx
@@ -144,8 +144,8 @@ export function ServerDialog({
       const oauth2: Record<string, unknown> = {};
       if (oauthClientId.trim()) oauth2.clientId = oauthClientId.trim();
       if (oauthClientSecret.trim()) oauth2.clientSecret = oauthClientSecret.trim();
-      if (oauthAuthUrl.trim()) oauth2.authorizationUrl = oauthAuthUrl.trim();
-      if (oauthTokenUrl.trim()) oauth2.tokenUrl = oauthTokenUrl.trim();
+      if (oauthAuthUrl.trim()) oauth2.authorizationEndpoint = oauthAuthUrl.trim();
+      if (oauthTokenUrl.trim()) oauth2.tokenEndpoint = oauthTokenUrl.trim();
       if (scopes.length) oauth2.scopes = scopes;
       if (oauthRedirectUri.trim()) oauth2.redirectUri = oauthRedirectUri.trim();
       if (oauthPkce) oauth2.pkce = true;

--- a/web-ui/src/locales/en/projects.json
+++ b/web-ui/src/locales/en/projects.json
@@ -71,6 +71,8 @@
   },
   "actions": {
     "add": "Add",
+    "installed": "Installed",
+    "alreadyInstalled": "Already installed in this project",
     "save": "Save",
     "edit": "Edit",
     "cancel": "Cancel",
@@ -338,7 +340,8 @@
       "empty": "No skills detected from file activity.",
       "emptyHint": "Skills appear when the agent reads or edits a SKILL.md file.",
       "count": "{{count}} skill",
-      "count_other": "{{count}} skills"
+      "count_other": "{{count}} skills",
+      "openSkill": "Open skill {{id}}"
     },
     "runCommands": {
       "aria": "Shell commands in this run",

--- a/web-ui/src/locales/en/projects.json
+++ b/web-ui/src/locales/en/projects.json
@@ -185,7 +185,6 @@
     "idInvalidChars": "ID may only contain letters, numbers, hyphens, and underscores",
     "serverId": "Server ID",
     "serverIdRequired": "Server ID is required",
-    "serverDisplayName": "Display name",
     "serverDescription": "Description",
     "serverAdvanced": "Advanced",
     "serverHeaders": "HTTP headers",

--- a/web-ui/src/types/api.ts
+++ b/web-ui/src/types/api.ts
@@ -77,6 +77,8 @@ export interface ServerOAuth2Config {
   clientSecret?: string | null;
   authorizationUrl: string | null;
   tokenUrl: string | null;
+  authorizationEndpoint?: string | null;
+  tokenEndpoint?: string | null;
   scopes: string[] | null;
   redirectUri: string | null;
   pkce: boolean;


### PR DESCRIPTION
This pull request introduces important improvements to the detection and handling of OAuth2 requirements for MCP servers, with a focus on making OAuth2 detection outcomes more explicit and robust. The changes introduce a new `OAuth2DetectionStatus` enum to clarify the result of OAuth2 detection probes, update related tests and logic to use this new status, and improve compatibility with legacy OAuth2 field names. There are also updates to CI/CD workflows.

**OAuth2 Detection and Handling Improvements:**

* Introduced a new `OAuth2DetectionStatus` enum and `OAuth2DetectionResult` type in `oauth-discovery.ts` to explicitly distinguish between "required", "not_required", and "inconclusive" outcomes when probing MCP servers for OAuth2 requirements. The detection logic now returns structured results instead of `null` or `OAuth2Config`. [[1]](diffhunk://#diff-c50626d95dc44decc1de5638be2b5b4dd5f6fd957312cdd7268abd4b3ea07053R124-R145) [[2]](diffhunk://#diff-c50626d95dc44decc1de5638be2b5b4dd5f6fd957312cdd7268abd4b3ea07053L132-R154)
* Updated the `detectOAuth2Requirement` function and all related test cases to use the new detection result format, ensuring that ambiguous or network-failure cases are handled as "inconclusive" and do not cause tokens to be deleted. [[1]](diffhunk://#diff-c50626d95dc44decc1de5638be2b5b4dd5f6fd957312cdd7268abd4b3ea07053R181-R191) [[2]](diffhunk://#diff-c50626d95dc44decc1de5638be2b5b4dd5f6fd957312cdd7268abd4b3ea07053L229-R261) [[3]](diffhunk://#diff-c50626d95dc44decc1de5638be2b5b4dd5f6fd957312cdd7268abd4b3ea07053L239-R275) [[4]](diffhunk://#diff-c50626d95dc44decc1de5638be2b5b4dd5f6fd957312cdd7268abd4b3ea07053L262-R297) [[5]](diffhunk://#diff-ba92947e997f0eabf3653c1c0e97e336856dfb62471bd985b4f50ffa5c80c572L149-R182) [[6]](diffhunk://#diff-c0a2c21cd6d465c6c837b53c146cfafa64eaf79211ef54b1eeb257868582d8c3L73-R81) [[7]](diffhunk://#diff-c0a2c21cd6d465c6c837b53c146cfafa64eaf79211ef54b1eeb257868582d8c3L82-R98) [[8]](diffhunk://#diff-2256817773003a0ff1555daf1a73c12adb18c6a44d3bc37cfcc4f2905603a188L162-R200) [[9]](diffhunk://#diff-2256817773003a0ff1555daf1a73c12adb18c6a44d3bc37cfcc4f2905603a188L187-R249) [[10]](diffhunk://#diff-e8adf60f8f1270049057f54c75e7b650a27e34c1e24639e41cf9a84382abda68L71-R73)
* Refactored all usages and mocks of `detectOAuth2Requirement` in tests and supporting code to use the new status/result format, improving clarity and correctness throughout the codebase. [[1]](diffhunk://#diff-e8adf60f8f1270049057f54c75e7b650a27e34c1e24639e41cf9a84382abda68L17-R17) [[2]](diffhunk://#diff-c0a2c21cd6d465c6c837b53c146cfafa64eaf79211ef54b1eeb257868582d8c3L2-R2) [[3]](diffhunk://#diff-ba92947e997f0eabf3653c1c0e97e336856dfb62471bd985b4f50ffa5c80c572R5) [[4]](diffhunk://#diff-2256817773003a0ff1555daf1a73c12adb18c6a44d3bc37cfcc4f2905603a188L4-R4)

**OAuth2 Legacy Field Compatibility:**

* Added logic and tests to support legacy OAuth2 field names (`tokenUrl`, `authorizationUrl`) as canonical fields, ensuring backward compatibility when copying or merging OAuth2 configs. [[1]](diffhunk://#diff-2256817773003a0ff1555daf1a73c12adb18c6a44d3bc37cfcc4f2905603a188R74-R101) [[2]](diffhunk://#diff-121ed2ccc8206e8f727e22489cd8e4328b0c6fe38d12d60f304cf5db4a145927R1-R54) [[3]](diffhunk://#diff-e72302ff9dcfea28a91c161a3a85848b0011b22834ca56e8ab1124b6cdc21e18R170-R194)

**OAuth2 Token Refresh Robustness:**

* Improved token refresh logic and tests to ensure tokens are only deleted when an explicit invalid/expired marker is present, and not on ambiguous or transient errors (e.g., 4xx without marker, 200 without `access_token`).

**CI/CD Workflow Updates:**

* Updated GitHub Actions workflow versions for build provenance attestation and CodeQL analysis to their latest releases for improved security and reliability. (`.github/workflows/release.yml`, `.github/workflows/security.yml`) [[1]](diffhunk://#diff-87db21a973eed4fef5f32b267aa60fcee5cbdf03c67fafdc2a9b553bb0b15f34L156-R156) [[2]](diffhunk://#diff-6102d4f2cddb56c446459bde9bf8e8044b87ce3f98a24c2bba99debfd62461dcL32-R38)

These changes collectively make OAuth2 detection more explicit, robust against network/transient errors, and easier to maintain, while improving compatibility and reliability across the codebase.