### PR TITLE
fix: serialize Cursor hook matcher as matcher, not pattern

### DIFF
--- a/docs/providers/cursor.md
+++ b/docs/providers/cursor.md
@@ -15,7 +15,7 @@ Source-of-truth definition: [`src/shared/providers/registry.ts → cursor`](../.
 | Instructions | `AGENTS.md` | — |
 | Rules | `.cursor/rules/<id>.mdc` | YAML frontmatter: `description`, `globs` (from capa's `appliesTo`), `alwaysApply`. |
 | Sub-agents | `.cursor/agents/<id>.md` | Markdown + frontmatter (`model`, `readonly`, `is_background`). |
-| Hooks | `.cursor/hooks.json` (standalone) | `{ version: 1, hooks: { <eventName>: [ { name: "capa:<id>", command, … } ] } }` envelope. Supports both command-based hooks (`command`) and prompt-based, LLM-evaluated hooks (`type: "prompt"` + `prompt`). Cursor lets a hook fail-close on a non-zero exit (`failClosed: true`). |
+| Hooks | `.cursor/hooks.json` (standalone) | `{ version: 1, hooks: { <eventName>: [ { name: "capa:<id>", command, matcher, … } ] } }` envelope. Supports both command-based hooks (`command`) and prompt-based, LLM-evaluated hooks (`type: "prompt"` + `prompt`). A declared capa `matcher` is serialised as Cursor's native `matcher` field (not `pattern`). Cursor lets a hook fail-close on a non-zero exit (`failClosed: true`). |
 | Plugin manifests | `.cursor-plugin/plugin.json` (`pluginProviderId: cursor`) | Parsed by `parseCursorManifest` — see [plugin docs](../README.md#plugin-discovery-and-unpack). |
 
 ## Hooks event mapping

--- a/skills/capabilities-manager/references/capabilities-schema.md
+++ b/skills/capabilities-manager/references/capabilities-schema.md
@@ -302,7 +302,7 @@ Lifecycle hooks installed into each provider's hook configuration. The schema is
   - **Provider-scoped events** (e.g. `cursor:beforeShellExecution`) target a single provider verbatim and are skipped for everyone else.
 - `type` (optional): `command` (default — shell command) or `prompt` (text injected into the model when supported).
 - `command` / `prompt` (one of, when no `source`): Inline body for command/prompt-type hooks.
-- `matcher` (optional): Provider-specific glob/pattern (e.g. Claude `Bash`, Cursor `rm -rf *`).
+- `matcher` (optional): Provider-specific tool/glob filter (e.g. Claude `Bash`, Cursor `Write|Edit` on `postToolUse`).
 - `timeout` (optional): Per-hook timeout in seconds; provider may clamp.
 - `failClosed` (optional): When true, hook failure aborts the action (Cursor only today).
 - `sequential` (optional): Run hooks one-at-a-time instead of in parallel.

--- a/src/cli/utils/__tests__/hooks-installer.test.ts
+++ b/src/cli/utils/__tests__/hooks-installer.test.ts
@@ -452,6 +452,98 @@ describe('hooks-installer (cursor standalone)', () => {
     const rows = db.getManagedHooks(projectId);
     expect(rows).toHaveLength(1);
   });
+
+  it('serializes matcher as matcher, never pattern, on postToolUse', async () => {
+    const result = await installHooks({
+      projectPath,
+      projectId,
+      capabilitiesFilePath: join(projectPath, 'capabilities.yaml'),
+      hooks: [
+        {
+          id: 'cursor-matcher-repro',
+          on: 'afterTool',
+          matcher: 'Write|Edit',
+          command: 'echo check-docs',
+          timeout: 10,
+          failClosed: false,
+        },
+      ],
+      providers: ['cursor'],
+      db,
+      authFetch: makeAuthFetch(),
+      getRepoSnapshot: stubGetRepoSnapshot,
+    });
+    expect(result.installed).toBe(1);
+    expect(result.warnings).toEqual([]);
+
+    const config = JSON.parse(
+      readFileSync(join(projectPath, '.cursor', 'hooks.json'), 'utf-8'),
+    ) as { hooks: { postToolUse: Array<Record<string, unknown>> } };
+    expect(config.hooks.postToolUse).toHaveLength(1);
+    const entry = config.hooks.postToolUse[0];
+    expect(entry.matcher).toBe('Write|Edit');
+    expect(entry.pattern).toBeUndefined();
+    expect(entry.command).toBe('echo check-docs');
+    expect(entry.timeout).toBe(10);
+    expect(entry.name).toBe('capa:cursor-matcher-repro');
+    expect(Object.keys(entry)).not.toContain('pattern');
+  });
+
+  it('cleanHooks removes only capa-owned cursor entries', async () => {
+    const hooksPath = join(projectPath, '.cursor', 'hooks.json');
+    require('fs').mkdirSync(join(projectPath, '.cursor'), { recursive: true });
+    writeFileSync(
+      hooksPath,
+      JSON.stringify(
+        {
+          version: 1,
+          hooks: {
+            postToolUse: [
+              { command: './user-hook.sh', matcher: 'Read', name: 'user-authored' },
+            ],
+          },
+        },
+        null,
+        2,
+      ),
+    );
+
+    await installHooks({
+      projectPath,
+      projectId,
+      capabilitiesFilePath: join(projectPath, 'capabilities.yaml'),
+      hooks: [
+        {
+          id: 'cursor-matcher-repro',
+          on: 'afterTool',
+          matcher: 'Write|Edit',
+          command: 'echo capa',
+        },
+      ],
+      providers: ['cursor'],
+      db,
+      authFetch: makeAuthFetch(),
+      getRepoSnapshot: stubGetRepoSnapshot,
+    });
+
+    const beforeClean = JSON.parse(readFileSync(hooksPath, 'utf-8')) as {
+      hooks: { postToolUse: Array<{ name?: string }> };
+    };
+    expect(beforeClean.hooks.postToolUse).toHaveLength(2);
+
+    const { removed } = cleanHooks(projectPath, projectId, db);
+    expect(removed).toBe(1);
+    expect(db.getManagedHooks(projectId)).toEqual([]);
+
+    const after = JSON.parse(readFileSync(hooksPath, 'utf-8')) as {
+      hooks: { postToolUse: Array<{ name?: string; command?: string; matcher?: string; pattern?: string }> };
+    };
+    expect(after.hooks.postToolUse).toHaveLength(1);
+    expect(after.hooks.postToolUse[0].name).toBe('user-authored');
+    expect(after.hooks.postToolUse[0].command).toBe('./user-hook.sh');
+    expect(after.hooks.postToolUse[0].matcher).toBe('Read');
+    expect(after.hooks.postToolUse[0].pattern).toBeUndefined();
+  });
 });
 
 describe('hooks-installer — pruneOrphanHooks / cleanHooks', () => {

--- a/src/cli/utils/hooks/plugin-hook-merge.ts
+++ b/src/cli/utils/hooks/plugin-hook-merge.ts
@@ -73,7 +73,7 @@ export function coalescePluginHook(
   if (providers.size > 1) {
     delete existing.providers;
     // Matcher from one provider (e.g. Claude SessionStart kinds) must not
-    // become a Cursor `pattern` filter on the unified hook.
+    // become a Cursor `matcher` filter on the unified hook.
     if ((existing.matcher ?? '') !== (candidate.matcher ?? '')) {
       delete existing.matcher;
     }

--- a/src/shared/providers/__tests__/hook-handlers.test.ts
+++ b/src/shared/providers/__tests__/hook-handlers.test.ts
@@ -58,7 +58,7 @@ describe('hook-handlers — buildHookEntry', () => {
     expect(out.entry.name).toBe('capa:lint');
   });
 
-  it('cursor shape stores entries as flat arrays with pattern + name', () => {
+  it('cursor shape stores entries as flat arrays with matcher + name', () => {
     const hook: Hook = { id: 'block-rm', on: 'beforeShell', command: 'echo blocked', matcher: 'rm -rf' };
     const out = buildHookEntry(cursorIntegration, {
       hook,
@@ -68,8 +68,30 @@ describe('hook-handlers — buildHookEntry', () => {
     expect(out.eventName).toBe('beforeShellExecution');
     expect(out.entry.command).toBe('echo blocked');
     expect(out.entry.type).toBeUndefined();
-    expect(out.entry.pattern).toBe('rm -rf');
+    expect(out.entry.matcher).toBe('rm -rf');
+    expect(out.entry.pattern).toBeUndefined();
     expect(out.entry.name).toBe('capa:block-rm');
+  });
+
+  it('cursor shape preserves matcher verbatim on postToolUse and never emits pattern', () => {
+    const hook: Hook = {
+      id: 'cursor-matcher-repro',
+      on: 'afterTool',
+      command: './.agent/hooks/check-stale-docs-cursor.sh',
+      matcher: 'Write|Edit',
+      timeout: 10,
+    };
+    const out = buildHookEntry(cursorIntegration, {
+      hook,
+      runReference: './.agent/hooks/check-stale-docs-cursor.sh',
+      mapping: { event: 'postToolUse' },
+    });
+    expect(out.eventName).toBe('postToolUse');
+    expect(out.entry.matcher).toBe('Write|Edit');
+    expect(out.entry.pattern).toBeUndefined();
+    expect(Object.keys(out.entry).sort()).toEqual(
+      ['command', 'matcher', 'name', 'timeout'].sort(),
+    );
   });
 
   it('cursor shape emits a prompt entry for type: prompt hooks', () => {
@@ -92,7 +114,8 @@ describe('hook-handlers — buildHookEntry', () => {
     expect(out.entry.type).toBe('prompt');
     expect(out.entry.prompt).toBe('Only allow read-only commands.');
     expect(out.entry.command).toBeUndefined();
-    expect(out.entry.pattern).toBe('rm -rf');
+    expect(out.entry.matcher).toBe('rm -rf');
+    expect(out.entry.pattern).toBeUndefined();
     expect(out.entry.timeout).toBe(10);
     expect(out.entry.name).toBe('capa:safe-shell');
   });

--- a/src/shared/providers/hook-handlers.ts
+++ b/src/shared/providers/hook-handlers.ts
@@ -59,6 +59,23 @@ export interface HookEntryOutput {
 
 const NAME_TAG_PREFIX = "capa:";
 
+/**
+ * Cursor-documented per-script keys, plus capa's `name` tag used for
+ * surgical install/clean. `pattern` is intentionally absent — Cursor
+ * filters with `matcher`, and emitting `pattern` is the bug in #202.
+ * Docs: https://cursor.com/docs/agent/hooks
+ */
+const CURSOR_HOOK_ENTRY_KEYS = new Set([
+	"command",
+	"type",
+	"prompt",
+	"matcher",
+	"timeout",
+	"failClosed",
+	"loop_limit",
+	"name",
+]);
+
 export function buildNameTag(
 	hookId: string,
 	prefix: string = NAME_TAG_PREFIX,
@@ -151,12 +168,13 @@ function buildCursorEntry(input: HookEntryInput): HookEntryOutput {
 		? { type: "prompt", prompt: runReference }
 		: { command: runReference };
 	const matcher = resolveMatcher(input);
-	if (matcher) entry.pattern = matcher;
+	if (matcher) entry.matcher = matcher;
 	if (hook.timeout !== undefined) entry.timeout = hook.timeout;
 	if (hook.failClosed) entry.failClosed = true;
 	const prefix = input.nameTagPrefix ?? NAME_TAG_PREFIX;
 	const nameTag = buildNameTag(hook.id, prefix);
 	entry.name = nameTag;
+	assertCursorHookEntrySchema(entry);
 	return {
 		eventName: mapping.event,
 		entry,
@@ -381,4 +399,23 @@ function ensureArray(obj: Record<string, unknown>, key: string): unknown[] {
 	const next: unknown[] = [];
 	obj[key] = next;
 	return next;
+}
+
+/**
+ * Refuse to serialise a Cursor entry with keys Cursor does not document.
+ * In particular, never emit `pattern` as a stand-in for `matcher`.
+ */
+function assertCursorHookEntrySchema(entry: Record<string, unknown>): void {
+	const keys = Object.keys(entry);
+	if (keys.includes("pattern")) {
+		throw new Error(
+			'Cursor hook entries must use "matcher", not the unsupported "pattern" field',
+		);
+	}
+	const unknown = keys.filter((k) => !CURSOR_HOOK_ENTRY_KEYS.has(k));
+	if (unknown.length > 0) {
+		throw new Error(
+			`Cursor hook entry has unsupported keys: ${unknown.sort().join(", ")}`,
+		);
+	}
 }

--- a/src/types/hooks.ts
+++ b/src/types/hooks.ts
@@ -120,7 +120,7 @@ export interface Hook {
   /** Inline prompt text. Required when `type` is `prompt` and `source` is unset. */
   prompt?: string;
 
-  /** Provider-specific tool/glob filter (e.g. Claude `matcher`, Cursor `pattern`). */
+  /** Provider-specific tool/glob filter (e.g. Claude `matcher`, Cursor `matcher`). */
   matcher?: string;
   /** Per-hook timeout in seconds. Provider may clamp or ignore. */
   timeout?: number;

--- a/src/types/providers.ts
+++ b/src/types/providers.ts
@@ -214,7 +214,7 @@ export interface HooksIntegration {
    * every provider that uses the matcher-grouped layout (Claude Code, Gemini
    * CLI, Codex, Windsurf, Antigravity); the variant labels exist only as
    * future-proofing in case a provider diverges (e.g. extra fields). The
-   * `cursor` shape is a flat array with `pattern`+`name` per entry.
+   * `cursor` shape is a flat array with `matcher`+`name` per entry.
    *
    * Codex serialises through the same `claude` shape; the storage format is
    * what makes it land as TOML rather than JSON.


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
Fixes [#202](https://github.com/infragate/capa/issues/202): Capa was writing a declared hook `matcher` onto Cursor's `.cursor/hooks.json` as `pattern`, which Cursor does not accept. Tool-scoped `postToolUse` hooks therefore ran for every tool (or never matched).

## What changed
- Cursor hook serialiser now emits the provider-native `matcher` field and copies the declared value verbatim.
- Generated Cursor entries are validated against the documented per-script keys (`command`, `type`, `prompt`, `matcher`, `timeout`, `failClosed`, `loop_limit`, `name`). Unknown keys, including `pattern`, fail serialisation instead of landing in the config.
- Install test asserts `afterTool` → `postToolUse` writes `matcher: "Write|Edit"` and never `pattern`.
- Clean test asserts `capa clean` removes only the `capa:<id>` entry and leaves user-authored Cursor hooks in place.
- Docs/comments updated so Cursor is described as using `matcher`, not `pattern`.

## Test plan
- [x] Unit tests for Cursor `buildHookEntry` (command + prompt) expect `matcher` and reject `pattern`
- [x] Install test for the #202 repro (`afterTool` + `Write|Edit`)
- [x] Clean test that user-authored Cursor entries survive `capa clean`
- [x] `bun test src/shared/providers/__tests__/hook-handlers.test.ts src/cli/utils/__tests__/hooks-installer.test.ts src/cli/utils/hooks/__tests__/plugin-hook-merge.test.ts` (40 pass)
- [x] `bunx tsc --noEmit`

## Checklist
- [x] Tests added or updated
- [x] `bunx tsc --noEmit` passes
- [x] `bun run smells` clean vs base (or CI Qlty Smells job green)
- [x] Docs updated (if user-facing)
<!-- CURSOR_AGENT_PR_BODY_END -->

[Slack Thread](https://infragateworkspace.slack.com/archives/C0BMLL7R336/p1787744037467249?thread_ts=1787744037.467249&cid=C0BMLL7R336)

<div><a href="https://cursor.com/agents/bc-5b38b576-4c6f-592a-816c-8889ba35fd52?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-5b38b576-4c6f-592a-816c-8889ba35fd52&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

