### PR TITLE
Fix serialization of Cursor hook matcher to use matcher field

### DIFF
--- a/docs/providers/cursor.md
+++ b/docs/providers/cursor.md
@@ -15,7 +15,7 @@ Source-of-truth definition: [`src/shared/providers/registry.ts → cursor`](../.
 | Instructions | `AGENTS.md` | — |
 | Rules | `.cursor/rules/<id>.mdc` | YAML frontmatter: `description`, `globs` (from capa's `appliesTo`), `alwaysApply`. |
 | Sub-agents | `.cursor/agents/<id>.md` | Markdown + frontmatter (`model`, `readonly`, `is_background`). |
-| Hooks | `.cursor/hooks.json` (standalone) | `{ version: 1, hooks: { <eventName>: [ { name: "capa:<id>", command, … } ] } }` envelope. Supports both command-based hooks (`command`) and prompt-based, LLM-evaluated hooks (`type: "prompt"` + `prompt`). Cursor lets a hook fail-close on a non-zero exit (`failClosed: true`). |
+| Hooks | `.cursor/hooks.json` (standalone) | `{ version: 1, hooks: { <eventName>: [ { name: "capa:<id>", command, matcher, … } ] } }` envelope. Supports both command-based hooks (`command`) and prompt-based, LLM-evaluated hooks (`type: "prompt"` + `prompt`). A declared capa `matcher` is serialised as Cursor's native `matcher` field (not `pattern`). Cursor lets a hook fail-close on a non-zero exit (`failClosed: true`). |
 | Plugin manifests | `.cursor-plugin/plugin.json` (`pluginProviderId: cursor`) | Parsed by `parseCursorManifest` — see [plugin docs](../README.md#plugin-discovery-and-unpack). |
 
 ## Hooks event mapping

--- a/skills/capabilities-manager/references/capabilities-schema.md
+++ b/skills/capabilities-manager/references/capabilities-schema.md
@@ -302,7 +302,7 @@ Lifecycle hooks installed into each provider's hook configuration. The schema is
   - **Provider-scoped events** (e.g. `cursor:beforeShellExecution`) target a single provider verbatim and are skipped for everyone else.
 - `type` (optional): `command` (default — shell command) or `prompt` (text injected into the model when supported).
 - `command` / `prompt` (one of, when no `source`): Inline body for command/prompt-type hooks.
-- `matcher` (optional): Provider-specific glob/pattern (e.g. Claude `Bash`, Cursor `rm -rf *`).
+- `matcher` (optional): Provider-specific tool/glob filter (e.g. Claude `Bash`, Cursor `Write|Edit` on `postToolUse`).
 - `timeout` (optional): Per-hook timeout in seconds; provider may clamp.
 - `failClosed` (optional): When true, hook failure aborts the action (Cursor only today).
 - `sequential` (optional): Run hooks one-at-a-time instead of in parallel.

--- a/src/cli/utils/__tests__/hooks-installer.test.ts
+++ b/src/cli/utils/__tests__/hooks-installer.test.ts
@@ -452,6 +452,98 @@ describe('hooks-installer (cursor standalone)', () => {
     const rows = db.getManagedHooks(projectId);
     expect(rows).toHaveLength(1);
   });
+
+  it('serializes matcher as matcher, never pattern, on postToolUse', async () => {
+    const result = await installHooks({
+      projectPath,
+      projectId,
+      capabilitiesFilePath: join(projectPath, 'capabilities.yaml'),
+      hooks: [
+        {
+          id: 'cursor-matcher-repro',
+          on: 'afterTool',
+          matcher: 'Write|Edit',
+          command: 'echo check-docs',
+          timeout: 10,
+          failClosed: false,
+        },
+      ],
+      providers: ['cursor'],
+      db,
+      authFetch: makeAuthFetch(),
+      getRepoSnapshot: stubGetRepoSnapshot,
+    });
+    expect(result.installed).toBe(1);
+    expect(result.warnings).toEqual([]);
+
+    const config = JSON.parse(
+      readFileSync(join(projectPath, '.cursor', 'hooks.json'), 'utf-8'),
+    ) as { hooks: { postToolUse: Array<Record<string, unknown>> } };
+    expect(config.hooks.postToolUse).toHaveLength(1);
+    const entry = config.hooks.postToolUse[0];
+    expect(entry.matcher).toBe('Write|Edit');
+    expect(entry.pattern).toBeUndefined();
+    expect(entry.command).toBe('echo check-docs');
+    expect(entry.timeout).toBe(10);
+    expect(entry.name).toBe('capa:cursor-matcher-repro');
+    expect(Object.keys(entry)).not.toContain('pattern');
+  });
+
+  it('cleanHooks removes only capa-owned cursor entries', async () => {
+    const hooksPath = join(projectPath, '.cursor', 'hooks.json');
+    require('fs').mkdirSync(join(projectPath, '.cursor'), { recursive: true });
+    writeFileSync(
+      hooksPath,
+      JSON.stringify(
+        {
+          version: 1,
+          hooks: {
+            postToolUse: [
+              { command: './user-hook.sh', matcher: 'Read', name: 'user-authored' },
+            ],
+          },
+        },
+        null,
+        2,
+      ),
+    );
+
+    await installHooks({
+      projectPath,
+      projectId,
+      capabilitiesFilePath: join(projectPath, 'capabilities.yaml'),
+      hooks: [
+        {
+          id: 'cursor-matcher-repro',
+          on: 'afterTool',
+          matcher: 'Write|Edit',
+          command: 'echo capa',
+        },
+      ],
+      providers: ['cursor'],
+      db,
+      authFetch: makeAuthFetch(),
+      getRepoSnapshot: stubGetRepoSnapshot,
+    });
+
+    const beforeClean = JSON.parse(readFileSync(hooksPath, 'utf-8')) as {
+      hooks: { postToolUse: Array<{ name?: string }> };
+    };
+    expect(beforeClean.hooks.postToolUse).toHaveLength(2);
+
+    const { removed } = cleanHooks(projectPath, projectId, db);
+    expect(removed).toBe(1);
+    expect(db.getManagedHooks(projectId)).toEqual([]);
+
+    const after = JSON.parse(readFileSync(hooksPath, 'utf-8')) as {
+      hooks: { postToolUse: Array<{ name?: string; command?: string; matcher?: string; pattern?: string }> };
+    };
+    expect(after.hooks.postToolUse).toHaveLength(1);
+    expect(after.hooks.postToolUse[0].name).toBe('user-authored');
+    expect(after.hooks.postToolUse[0].command).toBe('./user-hook.sh');
+    expect(after.hooks.postToolUse[0].matcher).toBe('Read');
+    expect(after.hooks.postToolUse[0].pattern).toBeUndefined();
+  });
 });
 
 describe('hooks-installer — pruneOrphanHooks / cleanHooks', () => {

--- a/src/cli/utils/hooks/plugin-hook-merge.ts
+++ b/src/cli/utils/hooks/plugin-hook-merge.ts
@@ -73,7 +73,7 @@ export function coalescePluginHook(
   if (providers.size > 1) {
     delete existing.providers;
     // Matcher from one provider (e.g. Claude SessionStart kinds) must not
-    // become a Cursor `pattern` filter on the unified hook.
+    // become a Cursor `matcher` filter on the unified hook.
     if ((existing.matcher ?? '') !== (candidate.matcher ?? '')) {
       delete existing.matcher;
     }

--- a/src/shared/providers/__tests__/hook-handlers.test.ts
+++ b/src/shared/providers/__tests__/hook-handlers.test.ts
@@ -58,7 +58,7 @@ describe('hook-handlers — buildHookEntry', () => {
     expect(out.entry.name).toBe('capa:lint');
   });
 
-  it('cursor shape stores entries as flat arrays with pattern + name', () => {
+  it('cursor shape stores entries as flat arrays with matcher + name', () => {
     const hook: Hook = { id: 'block-rm', on: 'beforeShell', command: 'echo blocked', matcher: 'rm -rf' };
     const out = buildHookEntry(cursorIntegration, {
       hook,
@@ -68,8 +68,30 @@ describe('hook-handlers — buildHookEntry', () => {
     expect(out.eventName).toBe('beforeShellExecution');
     expect(out.entry.command).toBe('echo blocked');
     expect(out.entry.type).toBeUndefined();
-    expect(out.entry.pattern).toBe('rm -rf');
+    expect(out.entry.matcher).toBe('rm -rf');
+    expect(out.entry.pattern).toBeUndefined();
     expect(out.entry.name).toBe('capa:block-rm');
+  });
+
+  it('cursor shape preserves matcher verbatim on postToolUse and never emits pattern', () => {
+    const hook: Hook = {
+      id: 'cursor-matcher-repro',
+      on: 'afterTool',
+      command: './.agent/hooks/check-stale-docs-cursor.sh',
+      matcher: 'Write|Edit',
+      timeout: 10,
+    };
+    const out = buildHookEntry(cursorIntegration, {
+      hook,
+      runReference: './.agent/hooks/check-stale-docs-cursor.sh',
+      mapping: { event: 'postToolUse' },
+    });
+    expect(out.eventName).toBe('postToolUse');
+    expect(out.entry.matcher).toBe('Write|Edit');
+    expect(out.entry.pattern).toBeUndefined();
+    expect(Object.keys(out.entry).sort()).toEqual(
+      ['command', 'matcher', 'name', 'timeout'].sort(),
+    );
   });
 
   it('cursor shape emits a prompt entry for type: prompt hooks', () => {
@@ -92,7 +114,8 @@ describe('hook-handlers — buildHookEntry', () => {
     expect(out.entry.type).toBe('prompt');
     expect(out.entry.prompt).toBe('Only allow read-only commands.');
     expect(out.entry.command).toBeUndefined();
-    expect(out.entry.pattern).toBe('rm -rf');
+    expect(out.entry.matcher).toBe('rm -rf');
+    expect(out.entry.pattern).toBeUndefined();
     expect(out.entry.timeout).toBe(10);
     expect(out.entry.name).toBe('capa:safe-shell');
   });

--- a/src/shared/providers/hook-handlers.ts
+++ b/src/shared/providers/hook-handlers.ts
@@ -59,6 +59,23 @@ export interface HookEntryOutput {
 
 const NAME_TAG_PREFIX = "capa:";
 
+/**
+ * Cursor-documented per-script keys, plus capa's `name` tag used for
+ * surgical install/clean. `pattern` is intentionally absent — Cursor
+ * filters with `matcher`, and emitting `pattern` is the bug in #202.
+ * Docs: https://cursor.com/docs/agent/hooks
+ */
+const CURSOR_HOOK_ENTRY_KEYS = new Set([
+	"command",
+	"type",
+	"prompt",
+	"matcher",
+	"timeout",
+	"failClosed",
+	"loop_limit",
+	"name",
+]);
+
 export function buildNameTag(
 	hookId: string,
 	prefix: string = NAME_TAG_PREFIX,
@@ -151,12 +168,13 @@ function buildCursorEntry(input: HookEntryInput): HookEntryOutput {
 		? { type: "prompt", prompt: runReference }
 		: { command: runReference };
 	const matcher = resolveMatcher(input);
-	if (matcher) entry.pattern = matcher;
+	if (matcher) entry.matcher = matcher;
 	if (hook.timeout !== undefined) entry.timeout = hook.timeout;
 	if (hook.failClosed) entry.failClosed = true;
 	const prefix = input.nameTagPrefix ?? NAME_TAG_PREFIX;
 	const nameTag = buildNameTag(hook.id, prefix);
 	entry.name = nameTag;
+	assertCursorHookEntrySchema(entry);
 	return {
 		eventName: mapping.event,
 		entry,
@@ -381,4 +399,23 @@ function ensureArray(obj: Record<string, unknown>, key: string): unknown[] {
 	const next: unknown[] = [];
 	obj[key] = next;
 	return next;
+}
+
+/**
+ * Refuse to serialise a Cursor entry with keys Cursor does not document.
+ * In particular, never emit `pattern` as a stand-in for `matcher`.
+ */
+function assertCursorHookEntrySchema(entry: Record<string, unknown>): void {
+	const keys = Object.keys(entry);
+	if (keys.includes("pattern")) {
+		throw new Error(
+			'Cursor hook entries must use "matcher", not the unsupported "pattern" field',
+		);
+	}
+	const unknown = keys.filter((k) => !CURSOR_HOOK_ENTRY_KEYS.has(k));
+	if (unknown.length > 0) {
+		throw new Error(
+			`Cursor hook entry has unsupported keys: ${unknown.sort().join(", ")}`,
+		);
+	}
 }

--- a/src/types/hooks.ts
+++ b/src/types/hooks.ts
@@ -120,7 +120,7 @@ export interface Hook {
   /** Inline prompt text. Required when `type` is `prompt` and `source` is unset. */
   prompt?: string;
 
-  /** Provider-specific tool/glob filter (e.g. Claude `matcher`, Cursor `pattern`). */
+  /** Provider-specific tool/glob filter (e.g. Claude `matcher`, Cursor `matcher`). */
   matcher?: string;
   /** Per-hook timeout in seconds. Provider may clamp or ignore. */
   timeout?: number;

--- a/src/types/providers.ts
+++ b/src/types/providers.ts
@@ -214,7 +214,7 @@ export interface HooksIntegration {
    * every provider that uses the matcher-grouped layout (Claude Code, Gemini
    * CLI, Codex, Windsurf, Antigravity); the variant labels exist only as
    * future-proofing in case a provider diverges (e.g. extra fields). The
-   * `cursor` shape is a flat array with `pattern`+`name` per entry.
+   * `cursor` shape is a flat array with `matcher`+`name` per entry.
    *
    * Codex serialises through the same `claude` shape; the storage format is
    * what makes it land as TOML rather than JSON.


### PR DESCRIPTION
This pull request fixes a long-standing bug where Cursor hooks were incorrectly serialized with a `pattern` field instead of the correct `matcher` field. The changes ensure that only Cursor's documented fields are emitted, preventing accidental use of unsupported keys like `pattern`. Comprehensive tests and documentation updates reinforce this behavior, and new schema assertions guarantee future correctness.

**Cursor hook serialization and schema enforcement:**

* Updated all hook serialization logic to emit `matcher` (never `pattern`) for Cursor hooks, preventing accidental schema violations and aligning with Cursor's documentation. [[1]](diffhunk://#diff-c4b141e8a2798fb8718cde7c12213c101e8d43ad94b17032a83a6ba77bdc097dL154-R177) [[2]](diffhunk://#diff-f0338bc44a82363d4b23a4cff7dad5df3a483a4a30a892c31f496fd72f27e842L18-R18) [[3]](diffhunk://#diff-16649e1d8d6d03c12a3fdbecae7692a87cc8f59fc69e21a71301aa19a5910de8L71-R96) [[4]](diffhunk://#diff-16649e1d8d6d03c12a3fdbecae7692a87cc8f59fc69e21a71301aa19a5910de8L95-R118) [[5]](diffhunk://#diff-d0128b8e49f26cb67dceec86ca31656bd4e8b762ef907391d5d4c16c95994489L123-R123) [[6]](diffhunk://#diff-dd72f298f0d578a2cae933f503dc2a46a1ed12987feeff2abb173b0b521cda7cL217-R217)
* Added a schema assertion (`assertCursorHookEntrySchema`) to refuse serialization of any unsupported fields (especially `pattern`) for Cursor hooks, ensuring only documented keys are present. [[1]](diffhunk://#diff-c4b141e8a2798fb8718cde7c12213c101e8d43ad94b17032a83a6ba77bdc097dR62-R78) [[2]](diffhunk://#diff-c4b141e8a2798fb8718cde7c12213c101e8d43ad94b17032a83a6ba77bdc097dR403-R421)

**Testing improvements:**

* Introduced new and updated test cases to verify that Cursor hook entries always use `matcher` and never emit `pattern`, including checks for correct field presence and removal of capa-owned hooks. [[1]](diffhunk://#diff-094d77a9ab069c2016cc91f10696f618ac3ea9dd1fbeceddc69ab0c960224fbdR455-R546) [[2]](diffhunk://#diff-16649e1d8d6d03c12a3fdbecae7692a87cc8f59fc69e21a71301aa19a5910de8L61-R61) [[3]](diffhunk://#diff-16649e1d8d6d03c12a3fdbecae7692a87cc8f59fc69e21a71301aa19a5910de8L71-R96) [[4]](diffhunk://#diff-16649e1d8d6d03c12a3fdbecae7692a87cc8f59fc69e21a71301aa19a5910de8L95-R118)

**Documentation updates:**

* Updated documentation and schema references to clarify that Cursor uses `matcher` (not `pattern`) for tool/glob filtering in hooks, and described the correct field usage in both markdown docs and schema references. [[1]](diffhunk://#diff-f0338bc44a82363d4b23a4cff7dad5df3a483a4a30a892c31f496fd72f27e842L18-R18) [[2]](diffhunk://#diff-d1c872a495b72a590b64f9584c4166aef46302f1387a83d929ada91d2a924e2bL305-R305) [[3]](diffhunk://#diff-dd72f298f0d578a2cae933f503dc2a46a1ed12987feeff2abb173b0b521cda7cL217-R217) [[4]](diffhunk://#diff-d0128b8e49f26cb67dceec86ca31656bd4e8b762ef907391d5d4c16c95994489L123-R123)

**Code comments and maintainability:**

* Improved comments and documentation within the codebase to clarify the distinction between `matcher` and `pattern`, and to explain the rationale behind the schema enforcement. [[1]](diffhunk://#diff-71151ff3cee58d2f1606461a6531040de28fee12706843fb53c97e5729bc01a9L76-R76) [[2]](diffhunk://#diff-c4b141e8a2798fb8718cde7c12213c101e8d43ad94b17032a83a6ba77bdc097dR62-R78)

These changes collectively ensure Cursor hooks are always serialized according to spec, prevent future regressions, and make the codebase easier to maintain and understand.