### PR TITLE
Point public docs and install URLs at capa.sh

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,13 +61,13 @@ The teammate who clones tomorrow gets the exact setup you have today.
 **macOS and Linux:**
 
 ```bash
-curl -LsSf https://capa.infragate.ai/install.sh | sh
+curl -LsSf https://capa.sh/install.sh | sh
 ```
 
 **Windows:**
 
 ```powershell
-powershell -ExecutionPolicy ByPass -c "irm https://capa.infragate.ai/install.ps1 | iex"
+powershell -ExecutionPolicy ByPass -c "irm https://capa.sh/install.ps1 | iex"
 ```
 
 ## Quick start
@@ -198,7 +198,7 @@ capabilities.yaml  ──►  capa install  ──►  provider files (.cursor/,
         │
         └──► Web UI editor ◄──► file watcher ◄──► disk
 
-Agent ──MCP──► capa gateway (:5912) ──proxy──► upstream MCP (stdio / HTTP / SSE)
+Agent ──MCP──► capa gateway (:5912)  ──proxy──► upstream MCP (stdio / HTTP / SSE)
                      │
                      ├── on-demand tools (setup_tools / call_tool)
                      ├── per-sub-agent filtered endpoints
@@ -226,6 +226,6 @@ capa upgrade [--yes]                   # pin GitHub release + verify installer c
 
 Guides, the full schema reference, and the registry catalog:
 
-**[https://capa.infragate.ai](https://capa.infragate.ai/getting-started/introduction/)**
+**[https://capa.sh](https://capa.sh/getting-started/introduction/)**
 
 Maintainer-oriented internals (install pipeline, provider matrix, lockfile semantics) live in [`docs/`](./docs/README.md).

--- a/docs/README.md
+++ b/docs/README.md
@@ -2,7 +2,7 @@
 
 This folder is for people working **on** capa, not people using it. End-user docs
 (getting started, the capabilities schema reference, the registry catalog) live
-in a separate repo and are published at <https://capa.infragate.ai/getting-started/introduction/>. Anything
+in a separate repo and are published at <https://capa.sh/getting-started/introduction/>. Anything
 that explains how capa is wired together internally — install pipeline ordering,
 per-provider quirks, lockfile semantics, the database schema, etc. — belongs
 here.

--- a/install.ps1
+++ b/install.ps1
@@ -61,7 +61,7 @@ USAGE:
     .\install.ps1 [OPTIONS]
     
     Or via web:
-    powershell -ExecutionPolicy ByPass -c "irm https://capa.infragate.ai/install.ps1 | iex"
+    powershell -ExecutionPolicy ByPass -c "irm https://capa.sh/install.ps1 | iex"
 
 OPTIONS:
     -InstallDir <DIR>
@@ -88,13 +88,13 @@ ENVIRONMENT VARIABLES:
 
 EXAMPLES:
     # Install with defaults
-    irm https://capa.infragate.ai/install.ps1 | iex
+    irm https://capa.sh/install.ps1 | iex
 
     # Install to custom directory
-    `$env:CAPA_INSTALL_DIR="C:\Tools"; irm https://capa.infragate.ai/install.ps1 | iex
+    `$env:CAPA_INSTALL_DIR="C:\Tools"; irm https://capa.sh/install.ps1 | iex
 
     # Install without modifying PATH
-    powershell -c "irm https://capa.infragate.ai/install.ps1 | iex" -NoModifyPath
+    powershell -c "irm https://capa.sh/install.ps1 | iex" -NoModifyPath
 "@
 }
 

--- a/install.sh
+++ b/install.sh
@@ -109,7 +109,7 @@ EXAMPLES:
     # verifies SHA256 against SHA256SUMS.txt, then runs the local file)
 
     # Convenience only — does not verify the installer script itself:
-    curl -LsSf https://capa.infragate.ai/install.sh | sh
+    curl -LsSf https://capa.sh/install.sh | sh
 EOF
 }
 

--- a/registries/claude-plugins/adapter.ts
+++ b/registries/claude-plugins/adapter.ts
@@ -115,7 +115,7 @@ const MAX_LISTING_PAGES = 50;
 const LIST_CACHE_TTL_MS = 10 * 60 * 1000;
 const SUMMARY_PREVIEW_CHARS = 600;
 const UA =
-  'Mozilla/5.0 (compatible; capa-registry-claude-plugins/1.0; +https://capa.infragate.ai)';
+  'Mozilla/5.0 (compatible; capa-registry-claude-plugins/1.0; +https://capa.sh)';
 
 // Anthropic's official plugin marketplace manifest — the source of truth
 // for `(repo, path, sha)` per plugin. We pin to `main` because that's

--- a/src/cli/commands/__tests__/upgrade-plan.test.ts
+++ b/src/cli/commands/__tests__/upgrade-plan.test.ts
@@ -10,8 +10,8 @@ import {
   upgradeConfirmationState,
 } from '../upgrade-plan';
 
-const VENDOR_INSTALL_SH = 'https://capa.infragate.ai/install.sh';
-const VENDOR_INSTALL_PS1 = 'https://capa.infragate.ai/install.ps1';
+const VENDOR_INSTALL_SH = 'https://capa.sh/install.sh';
+const VENDOR_INSTALL_PS1 = 'https://capa.sh/install.ps1';
 
 function sha256Hex(data: string | Uint8Array): string {
   return createHash('sha256').update(data).digest('hex');
@@ -38,7 +38,7 @@ describe('capa upgrade planning', () => {
       'https://github.com/infragate/capa/releases/download/v1.2.3/install.sh',
     );
     expect(url).not.toBe(VENDOR_INSTALL_SH);
-    expect(url).not.toContain('capa.infragate.ai');
+    expect(url).not.toContain('capa.sh');
 
     const ps1 = githubReleaseAssetUrl('1.2.3', 'install.ps1');
     expect(ps1).toBe(
@@ -71,7 +71,7 @@ describe('capa upgrade planning', () => {
       },
     });
 
-    expect(fetched.some((u) => u.includes('capa.infragate.ai'))).toBe(false);
+    expect(fetched.some((u) => u.includes('capa.sh'))).toBe(false);
     expect(plan.tag).toBe('v9.9.9');
     expect(plan.version).toBe('9.9.9');
     expect(plan.installerAsset).toBe('install.sh');

--- a/src/server/__tests__/mcp-handler.integration.test.ts
+++ b/src/server/__tests__/mcp-handler.integration.test.ts
@@ -693,7 +693,7 @@ describe('handleMessage > initialize (server icons)', () => {
     expect(resp.result.serverInfo.description).toBe(
       'An agentic skills and tools package manager',
     );
-    expect(resp.result.serverInfo.websiteUrl).toBe('https://capa.infragate.ai');
+    expect(resp.result.serverInfo.websiteUrl).toBe('https://capa.sh');
 
     const icons = resp.result.serverInfo.icons;
     expect(icons).toHaveLength(1);

--- a/src/server/mcp-handler.ts
+++ b/src/server/mcp-handler.ts
@@ -171,7 +171,7 @@ export class CapaMCPServer {
 				version: VERSION,
 				title: "capa",
 				description: "An agentic skills and tools package manager",
-				websiteUrl: "https://capa.infragate.ai",
+				websiteUrl: "https://capa.sh",
 				icons: CAPA_SERVER_ICONS,
 			},
 			{
@@ -1045,7 +1045,7 @@ export class CapaMCPServer {
 						title: "capa",
 						version: VERSION,
 						description: "An agentic skills and tools package manager",
-						websiteUrl: "https://capa.infragate.ai",
+						websiteUrl: "https://capa.sh",
 						icons: CAPA_SERVER_ICONS,
 					},
 				},

--- a/src/shared/__tests__/ui-urls.test.ts
+++ b/src/shared/__tests__/ui-urls.test.ts
@@ -3,7 +3,7 @@ import { CAPA_CLOUD_OAUTH_URL, CAPA_DOCS_URL, cloudOAuthDisclosure, projectUiPat
 
 describe('ui-urls', () => {
   it('CAPA_DOCS_URL points to capa docs site', () => {
-    expect(CAPA_DOCS_URL).toBe('https://capa.infragate.ai/getting-started/introduction/');
+    expect(CAPA_DOCS_URL).toBe('https://capa.sh/getting-started/introduction/');
   });
 
   it('CAPA_CLOUD_OAUTH_URL points to cloud OAuth endpoint', () => {

--- a/src/shared/registries/bundled.ts
+++ b/src/shared/registries/bundled.ts
@@ -19,7 +19,7 @@ export const BUNDLED_ADAPTER_PINS: Record<BundledAdapterSlug, string> = {
 	"skills-sh":
 		"4f6b1c7ad0f0ab5a13edb673397602faf073736b86030a9755ab1a0fc87b7a08",
 	"claude-plugins":
-		"075345f00a90ca325032dc9c6910f0d758cf4936e7abe40e160aae9190dbfc49",
+		"e963bb725eb6dfe6ea161d28ae7edbc29802e5c1bcade3ee80db1e0e9c9231f6",
 	"cursor-marketplace":
 		"93fb72fc4c66381f28e7893e9af6b54f270d1fdfdab318838121e802967c0dfd",
 };

--- a/src/shared/ui-urls.ts
+++ b/src/shared/ui-urls.ts
@@ -2,7 +2,7 @@
  * Web UI route helpers for the capa server SPA.
  */
 
-export const CAPA_DOCS_URL = "https://capa.infragate.ai/getting-started/introduction/";
+export const CAPA_DOCS_URL = "https://capa.sh/getting-started/introduction/";
 export const CAPA_CLOUD_OAUTH_URL = "https://capa.infragate.ai/auth";
 
 /** Shown before browser OAuth. Cloud host is pinned; not request-controlled. */

--- a/web-ui/src/components/layout/NavLinks.tsx
+++ b/web-ui/src/components/layout/NavLinks.tsx
@@ -25,7 +25,7 @@ export function NavLinks() {
         <span>{t('nav.integrations')}</span>
       </Link>
       <a
-        href="https://capa.infragate.ai/getting-started/introduction/"
+        href="https://capa.sh/getting-started/introduction/"
         target="_blank"
         rel="noopener noreferrer"
         className="flex items-center gap-2 rounded-sm px-3 py-2 text-[13px] text-text-secondary no-underline transition-colors hover:bg-hover-bg"


### PR DESCRIPTION
capa.sh is live. Update docs/install/website URLs. Keep cloud OAuth on capa.infragate.ai because GitHub/GitLab callbacks are registered there. Leave registry.capa.infragate.ai alone.