### PR TITLE
Keep marketplace fixture tests offline so main CI stays green

### DIFF
--- a/src/cli/commands/install-tasks/helpers/__tests__/install-one-skill-id.test.ts
+++ b/src/cli/commands/install-tasks/helpers/__tests__/install-one-skill-id.test.ts
@@ -25,7 +25,8 @@ describe('installOneSkill id hardening', () => {
 
   afterEach(() => {
     db.close();
-    rmSync(tempDir, { recursive: true, force: true });
+    // Windows can keep SQLite WAL/SHM locked briefly after close().
+    rmSync(tempDir, { recursive: true, force: true, maxRetries: 10, retryDelay: 50 });
   });
 
   it('rejects skill ids that leave the provider skills directory', async () => {

--- a/src/server/__tests__/registries-routes.test.ts
+++ b/src/server/__tests__/registries-routes.test.ts
@@ -2,6 +2,7 @@ import { describe, it, expect, beforeEach, afterEach, spyOn } from 'bun:test';
 import { mkdtempSync, rmSync, writeFileSync, mkdirSync, existsSync, readFileSync } from 'fs';
 import { join } from 'path';
 import { tmpdir } from 'os';
+import * as cache from '../../shared/cache';
 import * as config from '../../shared/config';
 import * as safeRemoteUrl from '../../shared/safe-remote-url';
 import { CapaDatabase } from '../../db/database';
@@ -539,50 +540,60 @@ describe('registries-routes', () => {
 
     it('installs a git-backed marketplace when materializing from a local snapshot fixture', async () => {
       // Simulate install by writing managed files directly then loading —
-      // full git clone is covered by unit source-mapping tests.
-      const { writeFileSync: write } = await import('fs');
-      const slug = 'dk-local';
-      const dir = join(managedDir, slug);
-      mkdirSync(dir, { recursive: true });
-      write(join(dir, 'marketplace.json'), MARKETPLACE_JSON);
-      write(
-        join(dir, 'marketplace.meta.json'),
-        JSON.stringify({
+      // full git clone is covered by unit source-mapping tests. Stub the
+      // snapshot helper because manager.view() otherwise clones the plugin
+      // repo via inspectPlugin and can exceed bun's 5s default timeout.
+      const snapshotSpy = spyOn(cache, 'getOrCreateSnapshot').mockRejectedValue(
+        new Error('git clone must not run during local marketplace fixture test'),
+      );
+      try {
+        const { writeFileSync: write } = await import('fs');
+        const slug = 'dk-local';
+        const dir = join(managedDir, slug);
+        mkdirSync(dir, { recursive: true });
+        write(join(dir, 'marketplace.json'), MARKETPLACE_JSON);
+        write(
+          join(dir, 'marketplace.meta.json'),
+          JSON.stringify({
+            source: 'giuseppe-trisciuoglio/developer-kit',
+            host: 'github',
+            ownerRepo: 'giuseppe-trisciuoglio/developer-kit',
+            marketplaceName: 'developer-kit',
+            pluginCount: 2,
+            fetchedAt: Date.now(),
+          }),
+        );
+        db.upsertRegistry({
+          slug,
+          type: 'claude-marketplace',
           source: 'giuseppe-trisciuoglio/developer-kit',
-          host: 'github',
-          ownerRepo: 'giuseppe-trisciuoglio/developer-kit',
-          marketplaceName: 'developer-kit',
-          pluginCount: 2,
-          fetchedAt: Date.now(),
-        }),
-      );
-      db.upsertRegistry({
-        slug,
-        type: 'claude-marketplace',
-        source: 'giuseppe-trisciuoglio/developer-kit',
-        status: 'installed',
-        enabled: true,
-      });
-      await manager.reload();
-      const detail = await manager.view(slug, {
-        capability: 'plugins',
-        id: 'developer-kit-typescript',
-      });
-      expect(detail.installSnippet).toMatchObject({
-        id: 'developer-kit-typescript',
-        type: 'github',
-        def: {
-          repo: 'giuseppe-trisciuoglio/developer-kit::plugins/developer-kit-typescript',
-        },
-      });
+          status: 'installed',
+          enabled: true,
+        });
+        await manager.reload();
+        const detail = await manager.view(slug, {
+          capability: 'plugins',
+          id: 'developer-kit-typescript',
+        });
+        expect(detail.installSnippet).toMatchObject({
+          id: 'developer-kit-typescript',
+          type: 'github',
+          def: {
+            repo: 'giuseppe-trisciuoglio/developer-kit::plugins/developer-kit-typescript',
+          },
+        });
 
-      const core = await manager.view(slug, {
-        capability: 'plugins',
-        id: 'developer-kit',
-      });
-      expect((core.installSnippet as any).def.repo).toBe(
-        'giuseppe-trisciuoglio/developer-kit::plugins/developer-kit-core',
-      );
+        const core = await manager.view(slug, {
+          capability: 'plugins',
+          id: 'developer-kit',
+        });
+        expect((core.installSnippet as any).def.repo).toBe(
+          'giuseppe-trisciuoglio/developer-kit::plugins/developer-kit-core',
+        );
+        expect(snapshotSpy).toHaveBeenCalled();
+      } finally {
+        snapshotSpy.mockRestore();
+      }
     });
   });
 });

--- a/src/server/__tests__/registries-routes.test.ts
+++ b/src/server/__tests__/registries-routes.test.ts
@@ -2,10 +2,10 @@ import { describe, it, expect, beforeEach, afterEach, spyOn } from 'bun:test';
 import { mkdtempSync, rmSync, writeFileSync, mkdirSync, existsSync, readFileSync } from 'fs';
 import { join } from 'path';
 import { tmpdir } from 'os';
-import * as cache from '../../shared/cache';
 import * as config from '../../shared/config';
 import * as safeRemoteUrl from '../../shared/safe-remote-url';
 import { CapaDatabase } from '../../db/database';
+import { loadClaudeMarketplaceAdapter } from '../../shared/registries/claude-marketplace';
 import { RegistryManager } from '../../shared/registries/manager';
 import {
   listRegistriesHandler,
@@ -540,60 +540,55 @@ describe('registries-routes', () => {
 
     it('installs a git-backed marketplace when materializing from a local snapshot fixture', async () => {
       // Simulate install by writing managed files directly then loading —
-      // full git clone is covered by unit source-mapping tests. Stub the
-      // snapshot helper because manager.view() otherwise clones the plugin
-      // repo via inspectPlugin and can exceed bun's 5s default timeout.
-      const snapshotSpy = spyOn(cache, 'getOrCreateSnapshot').mockRejectedValue(
-        new Error('git clone must not run during local marketplace fixture test'),
-      );
-      try {
-        const { writeFileSync: write } = await import('fs');
-        const slug = 'dk-local';
-        const dir = join(managedDir, slug);
-        mkdirSync(dir, { recursive: true });
-        write(join(dir, 'marketplace.json'), MARKETPLACE_JSON);
-        write(
-          join(dir, 'marketplace.meta.json'),
-          JSON.stringify({
-            source: 'giuseppe-trisciuoglio/developer-kit',
-            host: 'github',
-            ownerRepo: 'giuseppe-trisciuoglio/developer-kit',
-            marketplaceName: 'developer-kit',
-            pluginCount: 2,
-            fetchedAt: Date.now(),
-          }),
-        );
-        db.upsertRegistry({
-          slug,
-          type: 'claude-marketplace',
+      // full git clone is covered by unit source-mapping tests. View through
+      // loadClaudeMarketplaceAdapter without a db so inspectPlugin is not
+      // attached (manager.view() would clone the plugin repo).
+      const { writeFileSync: write } = await import('fs');
+      const slug = 'dk-local';
+      const dir = join(managedDir, slug);
+      mkdirSync(dir, { recursive: true });
+      write(join(dir, 'marketplace.json'), MARKETPLACE_JSON);
+      write(
+        join(dir, 'marketplace.meta.json'),
+        JSON.stringify({
           source: 'giuseppe-trisciuoglio/developer-kit',
-          status: 'installed',
-          enabled: true,
-        });
-        await manager.reload();
-        const detail = await manager.view(slug, {
-          capability: 'plugins',
-          id: 'developer-kit-typescript',
-        });
-        expect(detail.installSnippet).toMatchObject({
-          id: 'developer-kit-typescript',
-          type: 'github',
-          def: {
-            repo: 'giuseppe-trisciuoglio/developer-kit::plugins/developer-kit-typescript',
-          },
-        });
+          host: 'github',
+          ownerRepo: 'giuseppe-trisciuoglio/developer-kit',
+          marketplaceName: 'developer-kit',
+          pluginCount: 2,
+          fetchedAt: Date.now(),
+        }),
+      );
+      db.upsertRegistry({
+        slug,
+        type: 'claude-marketplace',
+        source: 'giuseppe-trisciuoglio/developer-kit',
+        status: 'installed',
+        enabled: true,
+      });
+      await manager.reload();
+      expect((await manager.list()).some((m) => m.id === slug)).toBe(true);
 
-        const core = await manager.view(slug, {
-          capability: 'plugins',
-          id: 'developer-kit',
-        });
-        expect((core.installSnippet as any).def.repo).toBe(
-          'giuseppe-trisciuoglio/developer-kit::plugins/developer-kit-core',
-        );
-        expect(snapshotSpy).toHaveBeenCalled();
-      } finally {
-        snapshotSpy.mockRestore();
-      }
+      const adapter = loadClaudeMarketplaceAdapter(slug);
+      const detail = await adapter.view({
+        capability: 'plugins',
+        id: 'developer-kit-typescript',
+      });
+      expect(detail.installSnippet).toMatchObject({
+        id: 'developer-kit-typescript',
+        type: 'github',
+        def: {
+          repo: 'giuseppe-trisciuoglio/developer-kit::plugins/developer-kit-typescript',
+        },
+      });
+
+      const core = await adapter.view({
+        capability: 'plugins',
+        id: 'developer-kit',
+      });
+      expect((core.installSnippet as any).def.repo).toBe(
+        'giuseppe-trisciuoglio/developer-kit::plugins/developer-kit-core',
+      );
     });
   });
 });


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
PR #205 merged with a red `Tests` run on `main`. The URL change itself was fine; `registries-routes` was cloning `giuseppe-trisciuoglio/developer-kit` during a “local snapshot” fixture, which often took ~4s and sometimes exceeded bun’s 5s default timeout.

## What changed
- Load the fixture through `loadClaudeMarketplaceAdapter` without a db so `inspectPlugin` is not attached (no GitHub clone, no process-wide snapshot spy).
- Retry SQLite temp-dir cleanup in the `installOneSkill` id-hardening tests (Windows `afterEach` hook timeout).

## Screenshots / logs
Local: marketplace fixture ~12ms. CI: all 9 checks green, including Windows Tests.

## Test plan
- [x] `bun test src/server/__tests__/registries-routes.test.ts src/cli/commands/install-tasks/helpers/__tests__/install-one-skill-id.test.ts` (31 pass)
- [x] `bunx tsc --noEmit`
- [x] CI Tests workflow green on this PR (Windows included)

## Checklist
- [x] Tests added or updated
- [x] `bunx tsc --noEmit` passes
- [x] `bun run smells` clean vs base (or CI Qlty Smells job green)
- [x] Docs updated (if user-facing)

<!-- CURSOR_AGENT_PR_BODY_END -->

[Slack Thread](https://infragateworkspace.slack.com/archives/D0BQ5AU95NX/p1787768488218039?thread_ts=1787768488.218039&cid=D0BQ5AU95NX)

<div><a href="https://cursor.com/agents/bc-7cd510ab-806d-565d-9b10-99f85d36d748?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-7cd510ab-806d-565d-9b10-99f85d36d748&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

