### PR TITLE
fix: honor provider targeting for subagents

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,13 +61,13 @@ The teammate who clones tomorrow gets the exact setup you have today.
 **macOS and Linux:**
 
 ```bash
-curl -LsSf https://capa.infragate.ai/install.sh | sh
+curl -LsSf https://capa.sh/install.sh | sh
 ```
 
 **Windows:**
 
 ```powershell
-powershell -ExecutionPolicy ByPass -c "irm https://capa.infragate.ai/install.ps1 | iex"
+powershell -ExecutionPolicy ByPass -c "irm https://capa.sh/install.ps1 | iex"
 ```
 
 ## Quick start
@@ -198,7 +198,7 @@ capabilities.yaml  ──►  capa install  ──►  provider files (.cursor/,
         │
         └──► Web UI editor ◄──► file watcher ◄──► disk
 
-Agent ──MCP──► capa gateway (:5912) ──proxy──► upstream MCP (stdio / HTTP / SSE)
+Agent ──MCP──► capa gateway (:5912)  ──proxy──► upstream MCP (stdio / HTTP / SSE)
                      │
                      ├── on-demand tools (setup_tools / call_tool)
                      ├── per-sub-agent filtered endpoints
@@ -226,6 +226,6 @@ capa upgrade [--yes]                   # pin GitHub release + verify installer c
 
 Guides, the full schema reference, and the registry catalog:
 
-**[https://capa.infragate.ai](https://capa.infragate.ai/getting-started/introduction/)**
+**[https://capa.sh](https://capa.sh/getting-started/introduction/)**
 
 Maintainer-oriented internals (install pipeline, provider matrix, lockfile semantics) live in [`docs/`](./docs/README.md).

--- a/docs/README.md
+++ b/docs/README.md
@@ -2,7 +2,7 @@
 
 This folder is for people working **on** capa, not people using it. End-user docs
 (getting started, the capabilities schema reference, the registry catalog) live
-in a separate repo and are published at <https://capa.infragate.ai/getting-started/introduction/>. Anything
+in a separate repo and are published at <https://capa.sh/getting-started/introduction/>. Anything
 that explains how capa is wired together internally — install pipeline ordering,
 per-provider quirks, lockfile semantics, the database schema, etc. — belongs
 here.

--- a/docs/providers/codex.md
+++ b/docs/providers/codex.md
@@ -16,6 +16,10 @@ Source-of-truth definition: [`src/shared/providers/registry.ts → codex`](../..
 | Rules | folded into `AGENTS.md` | No project-local rules directory; capa writes marker blocks into the instructions file. |
 | Sub-agents | `.codex/agents/<id>.toml` | TOML format; body goes into the `developer_instructions` field. |
 | Hooks | `.codex/config.toml` → `[hooks]` | Matcher-grouped Claude-style layout (`[[hooks.<Event>]]` + nested `[[hooks.<Event>.hooks]]`), serialised as TOML. Capa appends an opaque `name = "capa:<hookId>"` field on entries it owns; Codex's TOML deserialiser ignores unknown fields, so the tag round-trips cleanly and capa uses it for surgical updates without disturbing user-authored entries. |
+
+With `options.toolExposure: none`, generated custom-agent TOML omits
+`mcp_servers` so Codex inherits normal parent configuration without an invalid
+empty server URL.
 | Plugin manifests | — | Not declared; Codex consumes plugins via the same Claude/Cursor manifest paths handled elsewhere. |
 
 ## Hooks event mapping

--- a/install.ps1
+++ b/install.ps1
@@ -61,7 +61,7 @@ USAGE:
     .\install.ps1 [OPTIONS]
     
     Or via web:
-    powershell -ExecutionPolicy ByPass -c "irm https://capa.infragate.ai/install.ps1 | iex"
+    powershell -ExecutionPolicy ByPass -c "irm https://capa.sh/install.ps1 | iex"
 
 OPTIONS:
     -InstallDir <DIR>
@@ -88,13 +88,13 @@ ENVIRONMENT VARIABLES:
 
 EXAMPLES:
     # Install with defaults
-    irm https://capa.infragate.ai/install.ps1 | iex
+    irm https://capa.sh/install.ps1 | iex
 
     # Install to custom directory
-    `$env:CAPA_INSTALL_DIR="C:\Tools"; irm https://capa.infragate.ai/install.ps1 | iex
+    `$env:CAPA_INSTALL_DIR="C:\Tools"; irm https://capa.sh/install.ps1 | iex
 
     # Install without modifying PATH
-    powershell -c "irm https://capa.infragate.ai/install.ps1 | iex" -NoModifyPath
+    powershell -c "irm https://capa.sh/install.ps1 | iex" -NoModifyPath
 "@
 }
 

--- a/install.sh
+++ b/install.sh
@@ -109,7 +109,7 @@ EXAMPLES:
     # verifies SHA256 against SHA256SUMS.txt, then runs the local file)
 
     # Convenience only — does not verify the installer script itself:
-    curl -LsSf https://capa.infragate.ai/install.sh | sh
+    curl -LsSf https://capa.sh/install.sh | sh
 EOF
 }
 

--- a/registries/claude-plugins/adapter.ts
+++ b/registries/claude-plugins/adapter.ts
@@ -115,7 +115,7 @@ const MAX_LISTING_PAGES = 50;
 const LIST_CACHE_TTL_MS = 10 * 60 * 1000;
 const SUMMARY_PREVIEW_CHARS = 600;
 const UA =
-  'Mozilla/5.0 (compatible; capa-registry-claude-plugins/1.0; +https://capa.infragate.ai)';
+  'Mozilla/5.0 (compatible; capa-registry-claude-plugins/1.0; +https://capa.sh)';
 
 // Anthropic's official plugin marketplace manifest — the source of truth
 // for `(repo, path, sha)` per plugin. We pin to `main` because that's

--- a/skills/capabilities-manager/references/capabilities-schema.md
+++ b/skills/capabilities-manager/references/capabilities-schema.md
@@ -43,7 +43,7 @@ tools:
 #   - `owner/repo@plugin-name`        — recursive search by basename / manifest name
 #   - `owner/repo::path/inside/repo`  — exact subpath
 
-# subagents: [ { id, description?, skills, tools, instructions? } ]
+# subagents: [ { id, providers?, description?, skills, tools, instructions? } ]
 ```
 
 ## Skills Section (seven types)
@@ -192,6 +192,7 @@ The **filtered MCP endpoint** at `/{projectId}/agents/{id}/mcp` exposes only the
 subagents:
   - id: infra-agent
     description: AWS CDK and Terraform specialist. Use when working in backend-infra/ or user-infra/.
+    providers: [claude-code, cursor]
     skills:
       - my-iac-skill          # skill IDs from the top-level skills array
     tools:
@@ -214,6 +215,7 @@ subagents:
 
 **Fields:**
 - `id` (required): Unique identifier. Used as the MCP key (`capa-{id}`) and agent file name.
+- `providers` (optional): Provider allow-list for this subagent. Omit it or use `[]` to generate an adapter for every active top-level provider. Unknown provider IDs fail validation; known providers that are not active are ignored; active providers without a subagent integration produce a warning. Retargeting and clean remove only adapters and MCP entries that retain Capa's generated ownership signature, preserving same-name files or entries that were replaced manually.
 - `description` (optional): Role description. For Cursor this drives automatic delegation — be specific.
 - `skills` (required): List of skill IDs from the top-level `skills` array.
 - `tools` (required): List of tools the subagent may call. Each entry references a tool in the top-level `tools` array using any of three equivalent forms — `tool_id` (bare local id), `server.tool` (qualified), or `@server.tool` (same dialect `skills.requires` uses). All three resolve to the same tool; pick whichever reads best. Only the resolved tools are exposed on the filtered MCP endpoint.

--- a/src/cli/commands/__tests__/clean-project-subagents.test.ts
+++ b/src/cli/commands/__tests__/clean-project-subagents.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, beforeEach, afterEach } from 'bun:test';
-import { existsSync, mkdirSync, mkdtempSync, writeFileSync, rmSync } from 'fs';
+import { existsSync, mkdirSync, mkdtempSync, readFileSync, writeFileSync, rmSync } from 'fs';
 import { join } from 'path';
 import { tmpdir } from 'os';
 import { CapaDatabase } from '../../../db/database';
@@ -24,7 +24,11 @@ describe('cleanProject sub-agent files', () => {
   it('removes .cursor/agents files listed in capabilities even with no providers: and empty DB', async () => {
     const agentsDir = join(tempDir, '.cursor', 'agents');
     mkdirSync(agentsDir, { recursive: true });
-    writeFileSync(join(agentsDir, 'typescript-refactor-expert.md'), '---\nname: x\n---\n', 'utf-8');
+    writeFileSync(
+      join(agentsDir, 'typescript-refactor-expert.md'),
+      '**MCP server key:** `capa-typescript-refactor-expert`\n',
+      'utf-8',
+    );
     writeFileSync(join(agentsDir, 'unrelated-manual.md'), 'keep me', 'utf-8');
 
     const capabilities: Capabilities = {
@@ -50,7 +54,11 @@ describe('cleanProject sub-agent files', () => {
   it('removes DB-tracked sub-agents when capabilities omits the subagents block', async () => {
     const agentsDir = join(tempDir, '.cursor', 'agents');
     mkdirSync(agentsDir, { recursive: true });
-    writeFileSync(join(agentsDir, 'api-agent.md'), '---\nname: api-agent\n---\n', 'utf-8');
+    writeFileSync(
+      join(agentsDir, 'api-agent.md'),
+      '**MCP server key:** `capa-api-agent`\n',
+      'utf-8',
+    );
 
     const db = new CapaDatabase(dbPath);
     const projectId = 'capa-clean-subagents-0002';
@@ -67,5 +75,103 @@ describe('cleanProject sub-agent files', () => {
     db.close();
 
     expect(existsSync(join(agentsDir, 'api-agent.md'))).toBe(false);
+  });
+
+  it('preserves a same-name adapter owned by an excluded provider', async () => {
+    const cursorAgentsDir = join(tempDir, '.cursor', 'agents');
+    const claudeAgentsDir = join(tempDir, '.claude', 'agents');
+    mkdirSync(cursorAgentsDir, { recursive: true });
+    mkdirSync(claudeAgentsDir, { recursive: true });
+    writeFileSync(
+      join(cursorAgentsDir, 'reviewer.md'),
+      '**MCP server key:** `capa-reviewer`\n',
+      'utf-8',
+    );
+    writeFileSync(join(claudeAgentsDir, 'reviewer.md'), 'manual claude adapter', 'utf-8');
+
+    const capabilities: Capabilities = {
+      providers: ['claude-code', 'cursor'],
+      skills: [],
+      servers: [],
+      tools: [],
+      subagents: [
+        {
+          id: 'reviewer',
+          providers: ['cursor'],
+          skills: [],
+          tools: [],
+        },
+      ],
+    };
+    const db = new CapaDatabase(dbPath);
+    const projectId = 'capa-clean-subagents-0003';
+    db.upsertProject({ id: projectId, path: tempDir });
+    db.setProjectProviders(projectId, ['claude-code', 'cursor']);
+    db.upsertSubAgent(projectId, 'reviewer', {
+      installPath: tempDir,
+      providerIds: ['cursor'],
+      migrateLegacy: true,
+    });
+
+    await cleanProject({ projectPath: tempDir, projectId, db, capabilities });
+    db.close();
+
+    expect(existsSync(join(cursorAgentsDir, 'reviewer.md'))).toBe(false);
+    expect(readFileSync(join(claudeAgentsDir, 'reviewer.md'), 'utf-8')).toBe(
+      'manual claude adapter',
+    );
+  });
+
+  it('cleans every historical provider for a legacy unscoped agent', async () => {
+    const cursorAgent = join(tempDir, '.cursor', 'agents', 'reviewer.md');
+    const claudeAgent = join(tempDir, '.claude', 'agents', 'reviewer.md');
+    const cursorMcp = join(tempDir, '.cursor', 'mcp.json');
+    mkdirSync(join(tempDir, '.cursor', 'agents'), { recursive: true });
+    mkdirSync(join(tempDir, '.claude', 'agents'), { recursive: true });
+    for (const filePath of [cursorAgent, claudeAgent]) {
+      writeFileSync(filePath, '**MCP server key:** `capa-reviewer`\n', 'utf-8');
+    }
+    writeFileSync(
+      cursorMcp,
+      JSON.stringify({
+        mcpServers: {
+          'capa-reviewer': {
+            url: 'http://localhost:5912/capa-clean-subagents-legacy/agents/reviewer/mcp',
+          },
+        },
+      }),
+      'utf-8',
+    );
+
+    const db = new CapaDatabase(dbPath);
+    const projectId = 'capa-clean-subagents-legacy';
+    db.upsertProject({ id: projectId, path: tempDir });
+    db.setProjectProviders(projectId, ['claude-code', 'cursor']);
+    db.upsertSubAgent(projectId, 'reviewer');
+
+    await cleanProject({
+      projectPath: tempDir,
+      projectId,
+      db,
+      capabilities: {
+        providers: ['cursor'],
+        skills: [],
+        servers: [],
+        tools: [],
+        subagents: [
+          {
+            id: 'reviewer',
+            providers: ['cursor'],
+            skills: [],
+            tools: [],
+          },
+        ],
+      },
+    });
+    db.close();
+
+    expect(existsSync(cursorAgent)).toBe(false);
+    expect(existsSync(claudeAgent)).toBe(false);
+    expect(JSON.parse(readFileSync(cursorMcp, 'utf-8')).mcpServers).toEqual({});
   });
 });

--- a/src/cli/commands/__tests__/upgrade-plan.test.ts
+++ b/src/cli/commands/__tests__/upgrade-plan.test.ts
@@ -10,8 +10,8 @@ import {
   upgradeConfirmationState,
 } from '../upgrade-plan';
 
-const VENDOR_INSTALL_SH = 'https://capa.infragate.ai/install.sh';
-const VENDOR_INSTALL_PS1 = 'https://capa.infragate.ai/install.ps1';
+const VENDOR_INSTALL_SH = 'https://capa.sh/install.sh';
+const VENDOR_INSTALL_PS1 = 'https://capa.sh/install.ps1';
 
 function sha256Hex(data: string | Uint8Array): string {
   return createHash('sha256').update(data).digest('hex');
@@ -38,7 +38,7 @@ describe('capa upgrade planning', () => {
       'https://github.com/infragate/capa/releases/download/v1.2.3/install.sh',
     );
     expect(url).not.toBe(VENDOR_INSTALL_SH);
-    expect(url).not.toContain('capa.infragate.ai');
+    expect(url).not.toContain('capa.sh');
 
     const ps1 = githubReleaseAssetUrl('1.2.3', 'install.ps1');
     expect(ps1).toBe(
@@ -71,7 +71,7 @@ describe('capa upgrade planning', () => {
       },
     });
 
-    expect(fetched.some((u) => u.includes('capa.infragate.ai'))).toBe(false);
+    expect(fetched.some((u) => u.includes('capa.sh'))).toBe(false);
     expect(plan.tag).toBe('v9.9.9');
     expect(plan.version).toBe('9.9.9');
     expect(plan.installerAsset).toBe('install.sh');

--- a/src/cli/commands/clean-project.ts
+++ b/src/cli/commands/clean-project.ts
@@ -3,14 +3,22 @@ import { rm } from 'fs/promises';
 import { join, resolve } from 'path';
 import { isCapaOwnedInstallPath } from '../../shared/install-path-guard';
 import { isUnderWrapWorkspacesDir } from '../../shared/workspaces/paths';
-import { detectCapabilitiesFile } from '../../shared/paths';
+import { canonicalizePath, detectCapabilitiesFile } from '../../shared/paths';
 import { parseCapabilitiesFile } from '../../shared/capabilities';
 import { getLockfilePath } from '../../shared/lockfile';
 import { resolveProvidersForClean } from '../../shared/providers/resolve';
 import { getAllProviders, getProvider } from '../../shared/providers';
+import {
+  resolvePreviousSubAgentProviders,
+  resolveSubAgentProviders,
+} from '../../shared/subagent-providers';
 import type { CapaDatabase } from '../../db/database';
 import type { Capabilities } from '../../types/capabilities';
-import { unregisterMCPServer, unregisterSubAgentMCPServer } from '../utils/mcp-client-manager';
+import {
+  purgeCursorSubAgentMCPEntries,
+  unregisterMCPServer,
+  unregisterSubAgentMCPServer,
+} from '../utils/mcp-client-manager';
 import { cleanAgentsFile, removeSubAgentInstructions } from '../utils/agents-file/index';
 import { cleanRules } from '../utils/rules-installer';
 import { cleanHooks } from '../utils/hooks';
@@ -144,6 +152,7 @@ export async function cleanProject(opts: CleanProjectOptions): Promise<CleanProj
     db,
     projectId,
   });
+  const storedProviders = db.getProjectProviders(projectId);
   const providers = providersForOnDiskCleanup(resolvedProviders);
 
   const managedFiles = db.getManagedFiles(projectId);
@@ -209,16 +218,52 @@ export async function cleanProject(opts: CleanProjectOptions): Promise<CleanProj
   // not tracked as managed_files. Remove by id from the DB *and* from the
   // capabilities file so a clean still works when the DB row was already wiped
   // or capabilities.yaml omits `providers:`.
+  const installedAgents = db.getSubAgents(projectId);
+  const installedAgentsById = new Map(
+    installedAgents.map((agent) => [agent.agent_id, agent]),
+  );
+  const installPath = canonicalizePath(projectPath);
+  const configuredAgentsById = new Map(
+    (capabilities?.subagents ?? []).map((agent) => [agent.id, agent]),
+  );
   const agentIds = new Set<string>([
-    ...db.getSubAgents(projectId).map((row) => row.agent_id),
-    ...(capabilities?.subagents ?? []).map((a) => a.id),
+    ...installedAgentsById.keys(),
+    ...configuredAgentsById.keys(),
   ]);
 
   if (providers.length > 0 && agentIds.size > 0 && !wrapOnlyManagedArtifacts) {
+    try {
+      await purgeCursorSubAgentMCPEntries(projectPath, projectId);
+    } catch (err) {
+      warnings.push(
+        `Failed to purge stale sub-agent MCP entries: ${
+          err instanceof Error ? err.message : String(err)
+        }`,
+      );
+    }
     for (const agentId of agentIds) {
       try {
-        await unregisterSubAgentMCPServer(projectPath, agentId, providers);
-        removeSubAgentInstructions(projectPath, agentId, providers);
+        const installedAgent = installedAgentsById.get(agentId);
+        const configuredAgent = configuredAgentsById.get(agentId);
+        const agentProviders = installedAgent
+          ? resolvePreviousSubAgentProviders({
+              installedAgent,
+              installPath,
+              activeProviders: providers,
+              previousProjectProviders: storedProviders,
+              isWrapInstall: false,
+            })
+          : configuredAgent
+            ? resolveSubAgentProviders(configuredAgent, providers).supported
+            : providers;
+        if (agentProviders.length === 0) continue;
+        await unregisterSubAgentMCPServer(
+          projectPath,
+          agentId,
+          agentProviders,
+          projectId,
+        );
+        removeSubAgentInstructions(projectPath, agentId, agentProviders);
       } catch (err) {
         warnings.push(
           `Failed to unregister sub-agent ${agentId}: ${

--- a/src/cli/commands/install-tasks/context.ts
+++ b/src/cli/commands/install-tasks/context.ts
@@ -21,6 +21,8 @@ export interface InstallCtx {
   settings: Awaited<ReturnType<typeof loadSettings>>;
   serverStatus: { running: boolean; url: string };
   resolvedProviders: string[];
+  /** Provider selection stored before this install updates project ownership. */
+  previousProviders: string[];
   /**
    * Providers sent to POST /configure (identity / real project session).
    * For wrap installs this stays the authored capabilities.providers list so

--- a/src/cli/commands/install-tasks/helpers/__tests__/install-one-skill-id.test.ts
+++ b/src/cli/commands/install-tasks/helpers/__tests__/install-one-skill-id.test.ts
@@ -25,7 +25,8 @@ describe('installOneSkill id hardening', () => {
 
   afterEach(() => {
     db.close();
-    rmSync(tempDir, { recursive: true, force: true });
+    // Windows can keep SQLite WAL/SHM locked briefly after close().
+    rmSync(tempDir, { recursive: true, force: true, maxRetries: 10, retryDelay: 50 });
   });
 
   it('rejects skill ids that leave the provider skills directory', async () => {

--- a/src/cli/commands/install-tasks/install-subagents.ts
+++ b/src/cli/commands/install-tasks/install-subagents.ts
@@ -12,8 +12,24 @@ import {
 import { installSubAgentInstructions, removeSubAgentInstructions } from '../../utils/agents-file/index';
 import { parseSkillMd } from '../../../shared/skill-md';
 import type { Capabilities } from '../../../types/capabilities';
+import {
+  getSubAgentProviderWarnings,
+  resolvePreviousSubAgentProviders,
+  resolveSubAgentProviders,
+} from '../../../shared/subagent-providers';
+import { canonicalizePath } from '../../../shared/paths';
+import type { InstalledSubAgent } from '../../../db/sub-agents';
 import type { InstallCtx } from './context';
 import { materialInstallProviders } from './helpers/install-providers';
+
+function providersInstalledAt(
+  agent: InstalledSubAgent,
+  installPath: string,
+): string[] | undefined {
+  return agent.installations.find(
+    (installation) => installation.install_path === installPath,
+  )?.provider_ids;
+}
 
 /**
  * Strip a single pair of matching surrounding quotes (either `"` or `'`).
@@ -84,28 +100,47 @@ export function installSubagentsTask(): Task<InstallCtx> {
     title: 'Installing sub-agents',
     enabled: (ctx) => {
       const installedAgents = ctx.db.getSubAgents(ctx.projectId);
+      const installPath = canonicalizePath(ctx.projectPath);
       const currentSubagents = ctx.capabilitiesToUse.subagents ?? [];
       const currentAgentIds = new Set(currentSubagents.map((a) => a.id));
       const removedSubAgentIds = installedAgents
-        .filter(({ agent_id }) => !currentAgentIds.has(agent_id))
+        .filter(
+          (agent) =>
+            !currentAgentIds.has(agent.agent_id) &&
+            (agent.legacy_unscoped || providersInstalledAt(agent, installPath)),
+        )
         .map(({ agent_id }) => agent_id);
       return removedSubAgentIds.length > 0 || currentSubagents.length > 0;
     },
     task: async (ctx, task) => {
       const providers = materialInstallProviders(ctx);
+      const installPath = canonicalizePath(ctx.projectPath);
       const toolExposure = ctx.capabilitiesToUse.options?.toolExposure;
       const skipMcpWrites = toolExposure === 'none';
       const installedAgents = ctx.db.getSubAgents(ctx.projectId);
       const currentSubagents = ctx.capabilitiesToUse.subagents ?? [];
       const currentAgentIds = new Set(currentSubagents.map((a) => a.id));
-      const removedAgents = installedAgents.filter(({ agent_id }) => !currentAgentIds.has(agent_id));
-
-      // Under `toolExposure: 'none'` we also strip *previously-installed*
-      // sub-agent MCP entries — having a `capa-<id>` entry pointing at a
-      // capa endpoint we said we wouldn't expose is a footgun.
-      const agentsNeedingMcpCleanup = skipMcpWrites
-        ? installedAgents.map(({ agent_id }) => agent_id)
-        : removedAgents.map(({ agent_id }) => agent_id);
+      const removedAgents = installedAgents.filter(
+        (agent) =>
+          !currentAgentIds.has(agent.agent_id) &&
+          (agent.legacy_unscoped || providersInstalledAt(agent, installPath)),
+      );
+      const installedById = new Map(installedAgents.map((agent) => [agent.agent_id, agent]));
+      const lifecycleProviders = [
+        ...new Set([
+          ...providers,
+          ...installedAgents.flatMap(
+            (installedAgent) =>
+              resolvePreviousSubAgentProviders({
+                installedAgent,
+                installPath,
+                activeProviders: providers,
+                previousProjectProviders: ctx.previousProviders,
+                isWrapInstall: ctx.isWrapInstall,
+              }),
+          ),
+        ]),
+      ];
 
       // Purge stale sub-agent MCP entries for providers that need a sweep
       // (Cursor doesn't model per-sub-agent entries — its `capa-<id>` entries
@@ -115,7 +150,7 @@ export function installSubagentsTask(): Task<InstallCtx> {
       // contradicts the "no .mcp writes" contract. The per-sub-agent
       // unregister loop below is a no-op for those providers, so without
       // this purge their entries would linger forever.
-      const needsPurge = providers.some((id) => {
+      const needsPurge = lifecycleProviders.some((id) => {
         const provider = getProvider(id);
         return (
           provider &&
@@ -138,48 +173,106 @@ export function installSubagentsTask(): Task<InstallCtx> {
       if (needsPurge) {
         step++;
         task.output = `[${step}/${total}] purging stale sub-agent MCP entries`;
-        await purgeCursorSubAgentMCPEntries(ctx.projectPath);
+        await purgeCursorSubAgentMCPEntries(ctx.projectPath, ctx.projectId);
       }
 
-      // Drop MCP entries for any sub-agent that needs them gone — either
-      // because the agent itself was removed from the capabilities file, or
-      // because `toolExposure: 'none'` rescinds MCP wiring entirely.
-      const cleanupSet = new Set(agentsNeedingMcpCleanup);
-      for (const { agent_id } of removedAgents) {
+      for (const installedAgent of removedAgents) {
+        const { agent_id } = installedAgent;
+        const previousProviders = resolvePreviousSubAgentProviders({
+          installedAgent,
+          installPath,
+          activeProviders: providers,
+          previousProjectProviders: ctx.previousProviders,
+          isWrapInstall: ctx.isWrapInstall,
+        });
         step++;
         task.output = `[${step}/${total}] removing ${agent_id}`;
-        await unregisterSubAgentMCPServer(ctx.projectPath, agent_id, providers);
-        removeSubAgentInstructions(ctx.projectPath, agent_id, providers);
-        ctx.db.removeSubAgent(ctx.projectId, agent_id);
-        cleanupSet.delete(agent_id);
-      }
-      for (const agent_id of cleanupSet) {
-        await unregisterSubAgentMCPServer(ctx.projectPath, agent_id, providers);
+        await unregisterSubAgentMCPServer(
+          ctx.projectPath,
+          agent_id,
+          previousProviders,
+          ctx.projectId,
+        );
+        removeSubAgentInstructions(ctx.projectPath, agent_id, previousProviders);
+        ctx.db.removeSubAgentInstallation(
+          ctx.projectId,
+          agent_id,
+          {
+            installPath,
+            removeLegacy: !ctx.isWrapInstall,
+          },
+        );
       }
 
+      let installed = 0;
       for (const subAgent of currentSubagents) {
         step++;
         task.output = `[${step}/${total}] ${subAgent.id}`;
-        if (!skipMcpWrites) {
-          const agentMcpUrl = `${ctx.serverStatus.url}/${ctx.projectId}/agents/${subAgent.id}/mcp`;
-          await registerSubAgentMCPServer(ctx.projectPath, subAgent.id, agentMcpUrl, providers);
+        const targets = resolveSubAgentProviders(
+          subAgent,
+          providers,
+        );
+        const { supported } = targets;
+        ctx.warnings.push(...getSubAgentProviderWarnings(subAgent, targets));
+
+        const previous = installedById.get(subAgent.id);
+        const previousProviders = previous
+          ? resolvePreviousSubAgentProviders({
+              installedAgent: previous,
+              installPath,
+              activeProviders: providers,
+              previousProjectProviders: ctx.previousProviders,
+              isWrapInstall: ctx.isWrapInstall,
+            })
+          : [];
+        const staleProviders = previousProviders.filter(
+          (providerId) => !supported.includes(providerId),
+        );
+        if (staleProviders.length > 0) {
+          await unregisterSubAgentMCPServer(
+            ctx.projectPath,
+            subAgent.id,
+            staleProviders,
+            ctx.projectId,
+          );
+          removeSubAgentInstructions(ctx.projectPath, subAgent.id, staleProviders);
         }
-        // Instructions are still informative even without MCP wiring — they
-        // describe the agent's purpose. The agent file itself encodes the
-        // expected MCP server key, but missing entries simply mean those
-        // tools won't be available to that sub-agent (an explicit choice).
+
+        if (skipMcpWrites) {
+          await unregisterSubAgentMCPServer(
+            ctx.projectPath,
+            subAgent.id,
+            supported,
+            ctx.projectId,
+          );
+        } else {
+          const agentMcpUrl = `${ctx.serverStatus.url}/${ctx.projectId}/agents/${subAgent.id}/mcp`;
+          await registerSubAgentMCPServer(ctx.projectPath, subAgent.id, agentMcpUrl, supported);
+        }
         installSubAgentInstructions(
           ctx.projectPath,
           subAgent,
           ctx.capabilitiesToUse,
-          providers,
+          supported,
           skillDescriptions
         );
-        ctx.db.upsertSubAgent(ctx.projectId, subAgent.id);
-        ctx.added++;
+        ctx.db.upsertSubAgent(
+          ctx.projectId,
+          subAgent.id,
+          {
+            installPath,
+            providerIds: supported,
+            migrateLegacy: !ctx.isWrapInstall,
+          },
+        );
+        if (supported.length > 0) {
+          installed++;
+          ctx.added++;
+        } else {
+          ctx.skipped++;
+        }
       }
 
-      const installed = currentSubagents.length;
       if (skipMcpWrites && installed > 0) {
         task.title = `Installed ${installed} sub-agent${installed === 1 ? '' : 's'} (no MCP wiring — toolExposure: none)`;
       } else {

--- a/src/cli/commands/install.ts
+++ b/src/cli/commands/install.ts
@@ -206,10 +206,12 @@ async function installCommandBody(opts: {
 
   let resolvedProviders: string[];
   let configureProviders: string[];
+  let previousProviders: string[];
   let isWrapInstall = false;
   try {
     // Always store the real project path for MCP tool cwd / identity.
     db.upsertProject({ id: projectId, path: idPath });
+    previousProviders = db.getProjectProviders(projectId);
     const authoredProviders = [...(capabilities.providers ?? [])];
     resolvedProviders = await resolveProvidersForInstall({
       flagProvider,
@@ -270,6 +272,7 @@ async function installCommandBody(opts: {
     settings,
     serverStatus: { running: true, url: serverStatus.url },
     resolvedProviders,
+    previousProviders,
     configureProviders,
     isWrapInstall,
     lockBuilder,

--- a/src/cli/utils/__tests__/mcp-client-manager.test.ts
+++ b/src/cli/utils/__tests__/mcp-client-manager.test.ts
@@ -399,7 +399,10 @@ describe('mcp-client-manager', () => {
         JSON.stringify({
           mcpServers: {
             capa: { url: 'http://x/mcp' },
-            'capa-old-agent': { url: 'http://x/agent/mcp' },
+            'capa-old-agent': {
+              url: 'http://localhost:5912/project/agents/old-agent/mcp',
+            },
+            'capa-manual': { url: 'https://example.com/manual' },
           },
         }, null, 2),
         'utf-8'
@@ -410,6 +413,9 @@ describe('mcp-client-manager', () => {
       const config = JSON.parse(readFileSync(join(projectPath, '.cursor', 'mcp.json'), 'utf-8'));
       expect(config.mcpServers['capa']).toBeDefined();
       expect(config.mcpServers['capa-old-agent']).toBeUndefined();
+      expect(config.mcpServers['capa-manual']).toEqual({
+        url: 'https://example.com/manual',
+      });
     });
   });
 

--- a/src/cli/utils/__tests__/sub-agent-instructions.test.ts
+++ b/src/cli/utils/__tests__/sub-agent-instructions.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, beforeEach, afterEach } from 'bun:test';
-import { existsSync, mkdtempSync, readFileSync, rmSync } from 'fs';
+import { existsSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from 'fs';
 import { join } from 'path';
 import { tmpdir } from 'os';
 import { installSubAgentInstructions, removeSubAgentInstructions } from '../agents-file/index';
@@ -291,6 +291,21 @@ describe('removeSubAgentInstructions', () => {
 
     expect(existsSync(join(tempDir, '.claude', 'agents', 'infra-agent.md'))).toBe(false);
     expect(existsSync(join(tempDir, '.claude', 'agents', 'api-agent.md'))).toBe(true);
+  });
+
+  it('preserves a generated adapter that was replaced manually', () => {
+    const filePath = join(tempDir, '.claude', 'agents', 'infra-agent.md');
+    installSubAgentInstructions(
+      tempDir,
+      { id: 'infra-agent', description: 'infra', skills: [], tools: [] },
+      capabilities,
+      ['claude-code'],
+    );
+    writeFileSync(filePath, 'manual replacement\n', 'utf8');
+
+    removeSubAgentInstructions(tempDir, 'infra-agent', ['claude-code']);
+
+    expect(readFileSync(filePath, 'utf8')).toBe('manual replacement\n');
   });
 
   it('removes .cursor/agents/{id}.md for cursor', () => {

--- a/src/cli/utils/__tests__/sub-agent-mcp.test.ts
+++ b/src/cli/utils/__tests__/sub-agent-mcp.test.ts
@@ -99,6 +99,25 @@ describe('sub-agent MCP client registration', () => {
     expect(existsSync(join(tempDir, '.mcp.json'))).toBe(false);
   });
 
+  it('preserves a generated MCP key that was replaced manually', async () => {
+    await registerSubAgentMCPServer(
+      tempDir,
+      'infra-agent',
+      'http://localhost:5912/proj-1/agents/infra-agent/mcp',
+      ['claude-code'],
+    );
+    const configPath = join(tempDir, '.mcp.json');
+    const config = readConfig(configPath);
+    config.mcpServers['capa-infra-agent'] = { url: 'https://example.com/manual' };
+    writeFileSync(configPath, JSON.stringify(config, null, 2), 'utf8');
+
+    await unregisterSubAgentMCPServer(tempDir, 'infra-agent', ['claude-code']);
+
+    expect(readConfig(configPath).mcpServers['capa-infra-agent']).toEqual({
+      url: 'https://example.com/manual',
+    });
+  });
+
   it('registers sub-agent MCP only for claude-code when both providers given', async () => {
     await registerSubAgentMCPServer(
       tempDir,

--- a/src/cli/utils/agents-file/subagents.ts
+++ b/src/cli/utils/agents-file/subagents.ts
@@ -1,4 +1,4 @@
-import { existsSync, mkdirSync, writeFileSync, unlinkSync } from 'fs';
+import { existsSync, mkdirSync, readFileSync, writeFileSync, unlinkSync } from 'fs';
 import { join } from 'path';
 import type { SubAgent, Capabilities } from '../../../types/capabilities';
 import { getProvider } from '../../../shared/providers';
@@ -124,6 +124,19 @@ function removeSubAgentFile(projectPath: string, providerId: string, agentId: st
   }
   if (existsSync(filePath)) {
     assertCapaOwnedInstallPath(projectPath, filePath);
+    const content = readFileSync(filePath, 'utf8');
+    // Generated adapters carry one of these provider-format-specific lines.
+    // Its absence means the same-name file may have been replaced by the user.
+    const signatures = [
+      `MCP server key: capa-${agentId}`,
+      `**MCP server key:** \`capa-${agentId}\``,
+    ];
+    if (!signatures.some((signature) => content.includes(signature))) {
+      taskLog(
+        `  - Preserved ${sa.dir}/${agentId}${sa.extension} (not recognizably Capa-owned)`,
+      );
+      return;
+    }
     unlinkSync(filePath);
     taskLog(`  ✓ Removed ${sa.dir}/${agentId}${sa.extension}`);
   }

--- a/src/cli/utils/mcp-client-manager.ts
+++ b/src/cli/utils/mcp-client-manager.ts
@@ -35,6 +35,32 @@ function getServerMap(config: McpJsonConfig, serversKey: string): Record<string,
   return config[serversKey] as Record<string, McpServerEntry>;
 }
 
+function isCapaSubAgentMcpEntry(
+  entry: unknown,
+  mcp: McpIntegration,
+  agentId: string,
+  projectId?: string,
+): boolean {
+  if (!isPlainObject(entry)) return false;
+  const rawUrl = entry[mcp.entryUrlKey];
+  if (typeof rawUrl !== 'string') return false;
+
+  try {
+    const url = new URL(rawUrl);
+    const segments = url.pathname.split('/').filter(Boolean).map(decodeURIComponent);
+    return (
+      (url.protocol === 'http:' || url.protocol === 'https:') &&
+      segments.length === 4 &&
+      (!projectId || segments[0] === projectId) &&
+      segments.at(-3) === 'agents' &&
+      segments.at(-2) === agentId &&
+      segments.at(-1) === 'mcp'
+    );
+  } catch {
+    return false;
+  }
+}
+
 /**
  * Apply the provider's optional sub-agent scope-fence at the top level of
  * the MCP config. For OpenCode this writes
@@ -163,7 +189,8 @@ export async function registerSubAgentMCPServer(
 export async function unregisterSubAgentMCPServer(
   projectPath: string,
   agentId: string,
-  clients: string[]
+  clients: string[],
+  projectId?: string,
 ): Promise<void> {
   for (const clientName of clients) {
     const provider = getProvider(clientName);
@@ -182,10 +209,29 @@ export async function unregisterSubAgentMCPServer(
         if (config === null) continue;
         const servers = config[mcp.serversKey];
         if (!isPlainObject(servers) || !(serverKey in servers)) continue;
+        if (!isCapaSubAgentMcpEntry(servers[serverKey], mcp, agentId, projectId)) {
+          taskLog(
+            `  - Preserved ${provider.displayName} MCP entry "${serverKey}" ` +
+              '(not recognizably Capa-owned)',
+          );
+          continue;
+        }
         delete (servers as Record<string, McpServerEntry>)[serverKey];
         writeFileSync(configPath, JSON.stringify(config, null, 2), 'utf-8');
       } else if (mcp.format === 'toml') {
         const config = readTomlFile(configPath);
+        const servers = config[mcp.serversKey];
+        const entry = isPlainObject(servers) ? servers[serverKey] : undefined;
+        if (
+          entry !== undefined &&
+          !isCapaSubAgentMcpEntry(entry, mcp, agentId, projectId)
+        ) {
+          taskLog(
+            `  - Preserved ${provider.displayName} MCP entry "${serverKey}" ` +
+              '(not recognizably Capa-owned)',
+          );
+          continue;
+        }
         if (!deleteNestedKey(config, [mcp.serversKey, serverKey])) continue;
         writeTomlFile(configPath, config);
       }
@@ -201,7 +247,10 @@ export async function unregisterSubAgentMCPServer(
  * Remove stale capa-{agentId} sub-agent entries from MCP configs for providers
  * that opt in via `purgeStaleSubAgentMcp`.
  */
-export async function purgeCursorSubAgentMCPEntries(projectPath: string): Promise<void> {
+export async function purgeCursorSubAgentMCPEntries(
+  projectPath: string,
+  projectId?: string,
+): Promise<void> {
   for (const provider of getAllProviders()) {
     if (!provider.purgeStaleSubAgentMcp || !provider.mcp) continue;
 
@@ -215,8 +264,12 @@ export async function purgeCursorSubAgentMCPEntries(projectPath: string): Promis
     const serversObj = config[provider.mcp.serversKey];
     if (!isPlainObject(serversObj)) continue;
 
+    const mcp = provider.mcp;
     const servers = serversObj as Record<string, McpServerEntry>;
-    const staleKeys = Object.keys(servers).filter((k) => k.startsWith('capa-'));
+    const staleKeys = Object.keys(servers).filter((key) => {
+      if (!key.startsWith('capa-')) return false;
+      return isCapaSubAgentMcpEntry(servers[key], mcp, key.slice(5), projectId);
+    });
     if (staleKeys.length === 0) continue;
 
     for (const key of staleKeys) {

--- a/src/cli/utils/passthrough/install-plugin.ts
+++ b/src/cli/utils/passthrough/install-plugin.ts
@@ -10,6 +10,10 @@ import { expandSecretRecord, emptyCapabilities } from './env';
 import { installRules } from '../rules-installer';
 import { installHooks } from '../hooks';
 import { installSubAgentInstructions } from '../agents-file/index';
+import {
+  getSubAgentProviderWarnings,
+  resolveSubAgentProviders,
+} from '../../../shared/subagent-providers';
 import type { CapaDatabase } from '../../../db/database';
 import type { Plugin } from '../../../types/capabilities';
 
@@ -132,8 +136,14 @@ export async function passthroughInstallPlugin(opts: {
 
   const pluginSubagents = (merged.subagents ?? []).filter((a) => a.sourcePlugin);
   for (const agent of pluginSubagents) {
-    installSubAgentInstructions(projectPath, agent, merged, unpackProviders);
-    written.push(`subagent:${agent.id}`);
+    const targets = resolveSubAgentProviders(
+      agent,
+      unpackProviders,
+    );
+    const { supported } = targets;
+    warnings.push(...getSubAgentProviderWarnings(agent, targets));
+    installSubAgentInstructions(projectPath, agent, merged, supported);
+    if (supported.length > 0) written.push(`subagent:${agent.id}`);
   }
 
   console.log(`✓ Passthrough: installed plugin "${plugin.id}"`);

--- a/src/cli/utils/passthrough/install.ts
+++ b/src/cli/utils/passthrough/install.ts
@@ -15,6 +15,10 @@ import { expandSecretRecord, loadEnvFileOptional, openAuthDb } from './env';
 import type { MCPServer } from '../../../types/capabilities';
 import type { GetSnapshotResult } from '../../../shared/cache';
 import { getInstallErrorMode } from '../../commands/install-tasks/install-error-policy';
+import {
+  getSubAgentProviderWarnings,
+  resolveSubAgentProviders,
+} from '../../../shared/subagent-providers';
 
 export async function passthroughInstall(opts: {
   envFile?: string | boolean;
@@ -204,8 +208,15 @@ export async function passthroughInstall(opts: {
     const subagents = capabilities.subagents ?? [];
     if (subagents.length > 0) {
       for (const agent of subagents) {
-        installSubAgentInstructions(projectPath, agent, capabilities, providers);
-        added++;
+        const targets = resolveSubAgentProviders(
+          agent,
+          providers,
+        );
+        const { supported } = targets;
+        warnings.push(...getSubAgentProviderWarnings(agent, targets));
+        installSubAgentInstructions(projectPath, agent, capabilities, supported);
+        if (supported.length > 0) added++;
+        else skipped++;
       }
     }
 

--- a/src/db/__tests__/sub-agents.test.ts
+++ b/src/db/__tests__/sub-agents.test.ts
@@ -3,6 +3,8 @@ import { CapaDatabase } from '../database';
 import { mkdtempSync, rmSync } from 'fs';
 import { join } from 'path';
 import { tmpdir } from 'os';
+import { canonicalizePath } from '../../shared/paths';
+import { Database } from 'bun:sqlite';
 
 describe('CapaDatabase — sub-agent operations', () => {
   let db: CapaDatabase;
@@ -32,6 +34,88 @@ describe('CapaDatabase — sub-agent operations', () => {
     const agents = db.getSubAgents('proj-1');
     expect(agents).toHaveLength(1);
     expect(agents[0].agent_id).toBe('infra-agent');
+    expect(agents[0].legacy_unscoped).toBe(true);
+    expect(agents[0].installations).toEqual([]);
+  });
+
+  it('records provider ownership separately for each install path', () => {
+    const rootPath = join(tempDir, 'root');
+    const shadowPath = join(tempDir, 'shadow');
+    db.upsertSubAgent(
+      'proj-1',
+      'infra-agent',
+      {
+        installPath: rootPath,
+        providerIds: ['claude-code', 'codex'],
+        migrateLegacy: true,
+      },
+    );
+    db.upsertSubAgent(
+      'proj-1',
+      'infra-agent',
+      {
+        installPath: shadowPath,
+        providerIds: ['cursor'],
+        migrateLegacy: false,
+      },
+    );
+
+    let agent = db.getSubAgents('proj-1')[0];
+    expect(agent.legacy_unscoped).toBe(false);
+    expect(agent.installations).toEqual([
+      {
+        install_path: canonicalizePath(rootPath),
+        provider_ids: ['claude-code', 'codex'],
+      },
+      {
+        install_path: canonicalizePath(shadowPath),
+        provider_ids: ['cursor'],
+      },
+    ]);
+
+    db.upsertSubAgent('proj-1', 'infra-agent', {
+      installPath: rootPath,
+      providerIds: ['gemini-cli'],
+      migrateLegacy: true,
+    });
+    agent = db.getSubAgents('proj-1')[0];
+    expect(agent.installations).toEqual([
+      {
+        install_path: canonicalizePath(rootPath),
+        provider_ids: ['gemini-cli'],
+      },
+      {
+        install_path: canonicalizePath(shadowPath),
+        provider_ids: ['cursor'],
+      },
+    ]);
+  });
+
+  it('keeps an agent until its final scoped installation is removed', () => {
+    const rootPath = join(tempDir, 'root');
+    const shadowPath = join(tempDir, 'shadow');
+    db.upsertSubAgent('proj-1', 'infra-agent', {
+      installPath: rootPath,
+      providerIds: ['claude-code'],
+      migrateLegacy: true,
+    });
+    db.upsertSubAgent('proj-1', 'infra-agent', {
+      installPath: shadowPath,
+      providerIds: ['cursor'],
+      migrateLegacy: false,
+    });
+
+    db.removeSubAgentInstallation('proj-1', 'infra-agent', {
+      installPath: shadowPath,
+      removeLegacy: false,
+    });
+    expect(db.getSubAgents('proj-1')).toHaveLength(1);
+
+    db.removeSubAgentInstallation('proj-1', 'infra-agent', {
+      installPath: rootPath,
+      removeLegacy: true,
+    });
+    expect(db.getSubAgents('proj-1')).toEqual([]);
   });
 
   it('upsert is idempotent — no duplicate rows', () => {
@@ -78,5 +162,34 @@ describe('CapaDatabase — sub-agent operations', () => {
     // After project deletion the project is gone; re-create to check table is empty
     db.upsertProject({ id: 'proj-1', path: '/test/project' });
     expect(db.getSubAgents('proj-1')).toHaveLength(0);
+  });
+
+  it('migrates pre-scoped sub-agent rows as legacy ownership', () => {
+    const legacyPath = join(tempDir, 'legacy.db');
+    const raw = new Database(legacyPath, { create: true });
+    raw.run(`
+      CREATE TABLE sub_agents (
+        id INTEGER PRIMARY KEY AUTOINCREMENT,
+        project_id TEXT NOT NULL,
+        agent_id TEXT NOT NULL,
+        created_at INTEGER NOT NULL,
+        UNIQUE(project_id, agent_id)
+      )
+    `);
+    raw.run(
+      'INSERT INTO sub_agents (project_id, agent_id, created_at) VALUES (?, ?, ?)',
+      ['legacy-project', 'reviewer', Date.now()],
+    );
+    raw.close();
+
+    const migrated = new CapaDatabase(legacyPath);
+    expect(migrated.getSubAgents('legacy-project')).toEqual([
+      {
+        agent_id: 'reviewer',
+        legacy_unscoped: true,
+        installations: [],
+      },
+    ]);
+    migrated.close();
   });
 });

--- a/src/db/database.ts
+++ b/src/db/database.ts
@@ -26,7 +26,12 @@ import { RegistriesRepo, type RegistryUpsertInput } from "./registries";
 import { migrateSecretsAtRest } from "./migrate-secrets";
 import { initSchema } from "./schema";
 import { SessionsRepo } from "./sessions";
-import { SubAgentsRepo } from "./sub-agents";
+import {
+	type InstalledSubAgent,
+	type SubAgentInstallationInput,
+	type SubAgentInstallationRemoval,
+	SubAgentsRepo,
+} from "./sub-agents";
 import {
 	type ActivityCorrelationLookup,
 	type ToolCallFinish,
@@ -110,16 +115,28 @@ export class CapaDatabase {
 	}
 
 	// Sub-agent operations
-	upsertSubAgent(projectId: string, agentId: string): void {
-		return this.subAgents.upsert(projectId, agentId);
+	upsertSubAgent(
+		projectId: string,
+		agentId: string,
+		installation?: SubAgentInstallationInput,
+	): void {
+		return this.subAgents.upsert(projectId, agentId, installation);
 	}
 
-	getSubAgents(projectId: string): Array<{ agent_id: string }> {
+	getSubAgents(projectId: string): InstalledSubAgent[] {
 		return this.subAgents.getAll(projectId);
 	}
 
 	removeSubAgent(projectId: string, agentId: string): void {
 		return this.subAgents.remove(projectId, agentId);
+	}
+
+	removeSubAgentInstallation(
+		projectId: string,
+		agentId: string,
+		removal: SubAgentInstallationRemoval,
+	): void {
+		return this.subAgents.removeInstallation(projectId, agentId, removal);
 	}
 
 	setProjectCapabilities(projectId: string, capabilitiesJson: string): void {

--- a/src/db/projects.ts
+++ b/src/db/projects.ts
@@ -53,6 +53,9 @@ export class ProjectsRepo {
 			this.db.run("DELETE FROM project_capabilities WHERE project_id = ?", [
 				id,
 			]);
+			this.db.run("DELETE FROM sub_agent_installations WHERE project_id = ?", [
+				id,
+			]);
 			this.db.run("DELETE FROM sub_agents WHERE project_id = ?", [id]);
 			this.db.run("DELETE FROM project_providers WHERE project_id = ?", [id]);
 			this.db.run("DELETE FROM tool_calls WHERE project_id = ?", [id]);

--- a/src/db/schema.ts
+++ b/src/db/schema.ts
@@ -127,9 +127,28 @@ export function initSchema(db: Database): void {
         id INTEGER PRIMARY KEY AUTOINCREMENT,
         project_id TEXT NOT NULL,
         agent_id TEXT NOT NULL,
+        ownership_scoped INTEGER NOT NULL DEFAULT 0,
         created_at INTEGER NOT NULL,
         FOREIGN KEY (project_id) REFERENCES projects(id),
         UNIQUE(project_id, agent_id)
+      )
+    `);
+	ensureColumn(
+		db,
+		"sub_agents",
+		"ownership_scoped",
+		"INTEGER NOT NULL DEFAULT 0",
+	);
+
+	db.run(`
+      CREATE TABLE IF NOT EXISTS sub_agent_installations (
+        project_id TEXT NOT NULL,
+        agent_id TEXT NOT NULL,
+        install_path TEXT NOT NULL,
+        provider_ids TEXT NOT NULL,
+        created_at INTEGER NOT NULL,
+        PRIMARY KEY (project_id, agent_id, install_path),
+        FOREIGN KEY (project_id) REFERENCES projects(id) ON DELETE CASCADE
       )
     `);
 

--- a/src/db/sub-agents.ts
+++ b/src/db/sub-agents.ts
@@ -1,28 +1,158 @@
 import type { Database } from "bun:sqlite";
+import { canonicalizePath } from "../shared/paths";
+
+export interface InstalledSubAgent {
+	agent_id: string;
+	legacy_unscoped: boolean;
+	installations: SubAgentInstallation[];
+}
+
+export interface SubAgentInstallation {
+	install_path: string;
+	provider_ids: string[];
+}
+
+export interface SubAgentInstallationInput {
+	installPath: string;
+	providerIds: string[];
+	/** Real-checkout installs retire pre-migration unscoped ownership; shadows do not. */
+	migrateLegacy: boolean;
+}
+
+export interface SubAgentInstallationRemoval {
+	installPath: string;
+	/** Remove a pre-migration unscoped row when no scoped installations remain. */
+	removeLegacy: boolean;
+}
 
 export class SubAgentsRepo {
 	constructor(private db: Database) {}
 
-	upsert(projectId: string, agentId: string): void {
+	upsert(
+		projectId: string,
+		agentId: string,
+		installation?: SubAgentInstallationInput,
+	): void {
 		const now = Date.now();
-		this.db.run(
-			`INSERT INTO sub_agents (project_id, agent_id, created_at)
-       VALUES (?, ?, ?)
-       ON CONFLICT(project_id, agent_id) DO NOTHING`,
-			[projectId, agentId, now],
-		);
+		const tx = this.db.transaction(() => {
+			this.db.run(
+				`INSERT INTO sub_agents
+			   (project_id, agent_id, ownership_scoped, created_at)
+			 VALUES (?, ?, ?, ?)
+			 ON CONFLICT(project_id, agent_id) DO UPDATE SET
+			   ownership_scoped = CASE
+			     WHEN ? THEN 1
+			     ELSE sub_agents.ownership_scoped
+			   END`,
+				[
+					projectId,
+					agentId,
+					installation ? 1 : 0,
+					now,
+					installation?.migrateLegacy ? 1 : 0,
+				],
+			);
+			if (!installation) return;
+
+			this.db.run(
+				`INSERT INTO sub_agent_installations
+			   (project_id, agent_id, install_path, provider_ids, created_at)
+			 VALUES (?, ?, ?, ?, ?)
+			 ON CONFLICT(project_id, agent_id, install_path) DO UPDATE SET
+			   provider_ids = excluded.provider_ids`,
+				[
+					projectId,
+					agentId,
+					canonicalizePath(installation.installPath),
+					JSON.stringify([...new Set(installation.providerIds)]),
+					now,
+				],
+			);
+		});
+		tx();
 	}
 
-	getAll(projectId: string): Array<{ agent_id: string }> {
-		return this.db
-			.query("SELECT agent_id FROM sub_agents WHERE project_id = ?")
-			.all(projectId) as Array<{ agent_id: string }>;
+	getAll(projectId: string): InstalledSubAgent[] {
+		const agents = this.db
+			.query(
+				"SELECT agent_id, ownership_scoped FROM sub_agents WHERE project_id = ?",
+			)
+			.all(projectId) as Array<{
+			agent_id: string;
+			ownership_scoped: number;
+		}>;
+		const installations = this.db
+			.query(
+				`SELECT agent_id, install_path, provider_ids
+			 FROM sub_agent_installations
+			 WHERE project_id = ?
+			 ORDER BY agent_id, install_path`,
+			)
+			.all(projectId) as Array<{
+			agent_id: string;
+			install_path: string;
+			provider_ids: string;
+		}>;
+
+		return agents.map((agent) => ({
+			agent_id: agent.agent_id,
+			legacy_unscoped: agent.ownership_scoped === 0,
+			installations: installations
+				.filter((installation) => installation.agent_id === agent.agent_id)
+				.map((installation) => ({
+					install_path: installation.install_path,
+					provider_ids: JSON.parse(installation.provider_ids) as string[],
+				})),
+		}));
+	}
+
+	removeInstallation(
+		projectId: string,
+		agentId: string,
+		removal: SubAgentInstallationRemoval,
+	): void {
+		const tx = this.db.transaction(() => {
+			this.db.run(
+				`DELETE FROM sub_agent_installations
+			   WHERE project_id = ? AND agent_id = ? AND install_path = ?`,
+				[projectId, agentId, canonicalizePath(removal.installPath)],
+			);
+			const row = this.db
+				.query(
+					`SELECT ownership_scoped,
+					        (SELECT COUNT(*) FROM sub_agent_installations
+					         WHERE project_id = ? AND agent_id = ?) AS target_count
+					 FROM sub_agents
+					 WHERE project_id = ? AND agent_id = ?`,
+				)
+				.get(projectId, agentId, projectId, agentId) as {
+				ownership_scoped: number;
+				target_count: number;
+			} | null;
+			if (
+				row?.target_count === 0 &&
+				(row.ownership_scoped === 1 || removal.removeLegacy)
+			) {
+				this.db.run(
+					"DELETE FROM sub_agents WHERE project_id = ? AND agent_id = ?",
+					[projectId, agentId],
+				);
+			}
+		});
+		tx();
 	}
 
 	remove(projectId: string, agentId: string): void {
-		this.db.run(
-			"DELETE FROM sub_agents WHERE project_id = ? AND agent_id = ?",
-			[projectId, agentId],
-		);
+		const tx = this.db.transaction(() => {
+			this.db.run(
+				"DELETE FROM sub_agent_installations WHERE project_id = ? AND agent_id = ?",
+				[projectId, agentId],
+			);
+			this.db.run(
+				"DELETE FROM sub_agents WHERE project_id = ? AND agent_id = ?",
+				[projectId, agentId],
+			);
+		});
+		tx();
 	}
 }

--- a/src/server/__tests__/mcp-handler.integration.test.ts
+++ b/src/server/__tests__/mcp-handler.integration.test.ts
@@ -693,7 +693,7 @@ describe('handleMessage > initialize (server icons)', () => {
     expect(resp.result.serverInfo.description).toBe(
       'An agentic skills and tools package manager',
     );
-    expect(resp.result.serverInfo.websiteUrl).toBe('https://capa.infragate.ai');
+    expect(resp.result.serverInfo.websiteUrl).toBe('https://capa.sh');
 
     const icons = resp.result.serverInfo.icons;
     expect(icons).toHaveLength(1);

--- a/src/server/__tests__/registries-routes.test.ts
+++ b/src/server/__tests__/registries-routes.test.ts
@@ -2,6 +2,7 @@ import { describe, it, expect, beforeEach, afterEach, spyOn } from 'bun:test';
 import { mkdtempSync, rmSync, writeFileSync, mkdirSync, existsSync, readFileSync } from 'fs';
 import { join } from 'path';
 import { tmpdir } from 'os';
+import * as cache from '../../shared/cache';
 import * as config from '../../shared/config';
 import * as safeRemoteUrl from '../../shared/safe-remote-url';
 import { CapaDatabase } from '../../db/database';
@@ -539,50 +540,60 @@ describe('registries-routes', () => {
 
     it('installs a git-backed marketplace when materializing from a local snapshot fixture', async () => {
       // Simulate install by writing managed files directly then loading —
-      // full git clone is covered by unit source-mapping tests.
-      const { writeFileSync: write } = await import('fs');
-      const slug = 'dk-local';
-      const dir = join(managedDir, slug);
-      mkdirSync(dir, { recursive: true });
-      write(join(dir, 'marketplace.json'), MARKETPLACE_JSON);
-      write(
-        join(dir, 'marketplace.meta.json'),
-        JSON.stringify({
+      // full git clone is covered by unit source-mapping tests. Stub the
+      // snapshot helper because manager.view() otherwise clones the plugin
+      // repo via inspectPlugin and can exceed bun's 5s default timeout.
+      const snapshotSpy = spyOn(cache, 'getOrCreateSnapshot').mockRejectedValue(
+        new Error('git clone must not run during local marketplace fixture test'),
+      );
+      try {
+        const { writeFileSync: write } = await import('fs');
+        const slug = 'dk-local';
+        const dir = join(managedDir, slug);
+        mkdirSync(dir, { recursive: true });
+        write(join(dir, 'marketplace.json'), MARKETPLACE_JSON);
+        write(
+          join(dir, 'marketplace.meta.json'),
+          JSON.stringify({
+            source: 'giuseppe-trisciuoglio/developer-kit',
+            host: 'github',
+            ownerRepo: 'giuseppe-trisciuoglio/developer-kit',
+            marketplaceName: 'developer-kit',
+            pluginCount: 2,
+            fetchedAt: Date.now(),
+          }),
+        );
+        db.upsertRegistry({
+          slug,
+          type: 'claude-marketplace',
           source: 'giuseppe-trisciuoglio/developer-kit',
-          host: 'github',
-          ownerRepo: 'giuseppe-trisciuoglio/developer-kit',
-          marketplaceName: 'developer-kit',
-          pluginCount: 2,
-          fetchedAt: Date.now(),
-        }),
-      );
-      db.upsertRegistry({
-        slug,
-        type: 'claude-marketplace',
-        source: 'giuseppe-trisciuoglio/developer-kit',
-        status: 'installed',
-        enabled: true,
-      });
-      await manager.reload();
-      const detail = await manager.view(slug, {
-        capability: 'plugins',
-        id: 'developer-kit-typescript',
-      });
-      expect(detail.installSnippet).toMatchObject({
-        id: 'developer-kit-typescript',
-        type: 'github',
-        def: {
-          repo: 'giuseppe-trisciuoglio/developer-kit::plugins/developer-kit-typescript',
-        },
-      });
+          status: 'installed',
+          enabled: true,
+        });
+        await manager.reload();
+        const detail = await manager.view(slug, {
+          capability: 'plugins',
+          id: 'developer-kit-typescript',
+        });
+        expect(detail.installSnippet).toMatchObject({
+          id: 'developer-kit-typescript',
+          type: 'github',
+          def: {
+            repo: 'giuseppe-trisciuoglio/developer-kit::plugins/developer-kit-typescript',
+          },
+        });
 
-      const core = await manager.view(slug, {
-        capability: 'plugins',
-        id: 'developer-kit',
-      });
-      expect((core.installSnippet as any).def.repo).toBe(
-        'giuseppe-trisciuoglio/developer-kit::plugins/developer-kit-core',
-      );
+        const core = await manager.view(slug, {
+          capability: 'plugins',
+          id: 'developer-kit',
+        });
+        expect((core.installSnippet as any).def.repo).toBe(
+          'giuseppe-trisciuoglio/developer-kit::plugins/developer-kit-core',
+        );
+        expect(snapshotSpy).toHaveBeenCalled();
+      } finally {
+        snapshotSpy.mockRestore();
+      }
     });
   });
 });

--- a/src/server/__tests__/registries-routes.test.ts
+++ b/src/server/__tests__/registries-routes.test.ts
@@ -2,10 +2,10 @@ import { describe, it, expect, beforeEach, afterEach, spyOn } from 'bun:test';
 import { mkdtempSync, rmSync, writeFileSync, mkdirSync, existsSync, readFileSync } from 'fs';
 import { join } from 'path';
 import { tmpdir } from 'os';
-import * as cache from '../../shared/cache';
 import * as config from '../../shared/config';
 import * as safeRemoteUrl from '../../shared/safe-remote-url';
 import { CapaDatabase } from '../../db/database';
+import { loadClaudeMarketplaceAdapter } from '../../shared/registries/claude-marketplace';
 import { RegistryManager } from '../../shared/registries/manager';
 import {
   listRegistriesHandler,
@@ -540,60 +540,55 @@ describe('registries-routes', () => {
 
     it('installs a git-backed marketplace when materializing from a local snapshot fixture', async () => {
       // Simulate install by writing managed files directly then loading —
-      // full git clone is covered by unit source-mapping tests. Stub the
-      // snapshot helper because manager.view() otherwise clones the plugin
-      // repo via inspectPlugin and can exceed bun's 5s default timeout.
-      const snapshotSpy = spyOn(cache, 'getOrCreateSnapshot').mockRejectedValue(
-        new Error('git clone must not run during local marketplace fixture test'),
-      );
-      try {
-        const { writeFileSync: write } = await import('fs');
-        const slug = 'dk-local';
-        const dir = join(managedDir, slug);
-        mkdirSync(dir, { recursive: true });
-        write(join(dir, 'marketplace.json'), MARKETPLACE_JSON);
-        write(
-          join(dir, 'marketplace.meta.json'),
-          JSON.stringify({
-            source: 'giuseppe-trisciuoglio/developer-kit',
-            host: 'github',
-            ownerRepo: 'giuseppe-trisciuoglio/developer-kit',
-            marketplaceName: 'developer-kit',
-            pluginCount: 2,
-            fetchedAt: Date.now(),
-          }),
-        );
-        db.upsertRegistry({
-          slug,
-          type: 'claude-marketplace',
+      // full git clone is covered by unit source-mapping tests. View through
+      // loadClaudeMarketplaceAdapter without a db so inspectPlugin is not
+      // attached (manager.view() would clone the plugin repo).
+      const { writeFileSync: write } = await import('fs');
+      const slug = 'dk-local';
+      const dir = join(managedDir, slug);
+      mkdirSync(dir, { recursive: true });
+      write(join(dir, 'marketplace.json'), MARKETPLACE_JSON);
+      write(
+        join(dir, 'marketplace.meta.json'),
+        JSON.stringify({
           source: 'giuseppe-trisciuoglio/developer-kit',
-          status: 'installed',
-          enabled: true,
-        });
-        await manager.reload();
-        const detail = await manager.view(slug, {
-          capability: 'plugins',
-          id: 'developer-kit-typescript',
-        });
-        expect(detail.installSnippet).toMatchObject({
-          id: 'developer-kit-typescript',
-          type: 'github',
-          def: {
-            repo: 'giuseppe-trisciuoglio/developer-kit::plugins/developer-kit-typescript',
-          },
-        });
+          host: 'github',
+          ownerRepo: 'giuseppe-trisciuoglio/developer-kit',
+          marketplaceName: 'developer-kit',
+          pluginCount: 2,
+          fetchedAt: Date.now(),
+        }),
+      );
+      db.upsertRegistry({
+        slug,
+        type: 'claude-marketplace',
+        source: 'giuseppe-trisciuoglio/developer-kit',
+        status: 'installed',
+        enabled: true,
+      });
+      await manager.reload();
+      expect((await manager.list()).some((m) => m.id === slug)).toBe(true);
 
-        const core = await manager.view(slug, {
-          capability: 'plugins',
-          id: 'developer-kit',
-        });
-        expect((core.installSnippet as any).def.repo).toBe(
-          'giuseppe-trisciuoglio/developer-kit::plugins/developer-kit-core',
-        );
-        expect(snapshotSpy).toHaveBeenCalled();
-      } finally {
-        snapshotSpy.mockRestore();
-      }
+      const adapter = loadClaudeMarketplaceAdapter(slug);
+      const detail = await adapter.view({
+        capability: 'plugins',
+        id: 'developer-kit-typescript',
+      });
+      expect(detail.installSnippet).toMatchObject({
+        id: 'developer-kit-typescript',
+        type: 'github',
+        def: {
+          repo: 'giuseppe-trisciuoglio/developer-kit::plugins/developer-kit-typescript',
+        },
+      });
+
+      const core = await adapter.view({
+        capability: 'plugins',
+        id: 'developer-kit',
+      });
+      expect((core.installSnippet as any).def.repo).toBe(
+        'giuseppe-trisciuoglio/developer-kit::plugins/developer-kit-core',
+      );
     });
   });
 });

--- a/src/server/mcp-handler.ts
+++ b/src/server/mcp-handler.ts
@@ -171,7 +171,7 @@ export class CapaMCPServer {
 				version: VERSION,
 				title: "capa",
 				description: "An agentic skills and tools package manager",
-				websiteUrl: "https://capa.infragate.ai",
+				websiteUrl: "https://capa.sh",
 				icons: CAPA_SERVER_ICONS,
 			},
 			{
@@ -1045,7 +1045,7 @@ export class CapaMCPServer {
 						title: "capa",
 						version: VERSION,
 						description: "An agentic skills and tools package manager",
-						websiteUrl: "https://capa.infragate.ai",
+						websiteUrl: "https://capa.sh",
 						icons: CAPA_SERVER_ICONS,
 					},
 				},

--- a/src/server/project-routes.ts
+++ b/src/server/project-routes.ts
@@ -236,6 +236,7 @@ export async function handleGetProject(
 						subagents: (capabilities.subagents || []).map((sa) => ({
 							id: sa.id,
 							description: sa.description || null,
+							providers: sa.providers || [],
 							skills: sa.skills,
 							tools: sa.tools,
 							instructions: sa.instructions || null,

--- a/src/server/sync-project-artifacts.ts
+++ b/src/server/sync-project-artifacts.ts
@@ -106,6 +106,7 @@ export async function syncProjectManagedArtifacts(opts: {
 		providers,
 		db: opts.db,
 		serverOrigin: opts.serverOrigin,
+		materializeShadow: opts.materializeShadow,
 	});
 
 	return { hooks, rules, agents, subagents, skipped: false };

--- a/src/shared/__tests__/capabilities.test.ts
+++ b/src/shared/__tests__/capabilities.test.ts
@@ -129,6 +129,42 @@ describe('capabilities', () => {
       const result = normalizeCapabilities(capabilities);
       expect(result).toEqual(capabilities);
     });
+
+    it('validates and preserves sub-agent provider allow-lists', () => {
+      const result = normalizeCapabilities({
+        subagents: [
+          {
+            id: 'reviewer',
+            providers: ['claude-code', 'codex'],
+            skills: [],
+            tools: [],
+          },
+        ],
+      });
+
+      expect(result.subagents?.[0].providers).toEqual(['claude-code', 'codex']);
+      expect(
+        normalizeCapabilities({
+          subagents: [{ id: 'reviewer', providers: ['CLAUDE-CODE'] }],
+        }).subagents?.[0].providers,
+      ).toEqual(['claude-code']);
+      expect(() =>
+        normalizeCapabilities({
+          subagents: [{ id: 'reviewer', providers: 'claude-code' }],
+        }),
+      ).toThrow(/subagents\.0\.providers/);
+      expect(() =>
+        normalizeCapabilities({
+          subagents: [{ id: 'reviewer', providers: [''] }],
+        }),
+      ).toThrow(/subagents\.0\.providers\.0/);
+      expect(() =>
+        normalizeCapabilities({
+          subagents: [{ id: 'reviewer', providers: ['not-a-provider'] }],
+        }),
+      ).toThrow(/subagents\.0\.providers\.0: Unknown provider: not-a-provider/);
+    });
+
     it('normalizes legacy oauth2 aliases on servers at load', () => {
       const result = normalizeCapabilities({
         skills: [],

--- a/src/shared/__tests__/subagent-providers.test.ts
+++ b/src/shared/__tests__/subagent-providers.test.ts
@@ -1,0 +1,76 @@
+import { describe, expect, it } from "bun:test";
+import type { SubAgent } from "../../types/capabilities";
+import {
+	resolvePreviousSubAgentProviders,
+	resolveSubAgentProviders,
+} from "../subagent-providers";
+
+const subAgent = (providers?: string[]): SubAgent => ({
+	id: "reviewer",
+	providers,
+	skills: [],
+	tools: [],
+});
+
+describe("resolvePreviousSubAgentProviders", () => {
+	it("uses the historical project providers for a legacy real checkout", () => {
+		expect(
+			resolvePreviousSubAgentProviders({
+				installedAgent: {
+					agent_id: "reviewer",
+					legacy_unscoped: true,
+					installations: [],
+				},
+				installPath: "/repo",
+				activeProviders: ["codex"],
+				previousProjectProviders: ["claude-code", "cursor"],
+				isWrapInstall: false,
+			}),
+		).toEqual(["claude-code", "cursor"]);
+	});
+
+	it("prefers path-scoped ownership over project history", () => {
+		expect(
+			resolvePreviousSubAgentProviders({
+				installedAgent: {
+					agent_id: "reviewer",
+					legacy_unscoped: false,
+					installations: [
+						{ install_path: "/repo", provider_ids: ["gemini-cli"] },
+					],
+				},
+				installPath: "/repo",
+				activeProviders: ["codex"],
+				previousProjectProviders: ["claude-code", "cursor"],
+				isWrapInstall: false,
+			}),
+		).toEqual(["gemini-cli"]);
+	});
+});
+
+describe("resolveSubAgentProviders", () => {
+	it("targets every active provider when the allow-list is omitted or empty", () => {
+		const active = ["claude-code", "codex"];
+
+		expect(resolveSubAgentProviders(subAgent(), active).supported).toEqual(active);
+		expect(resolveSubAgentProviders(subAgent([]), active).supported).toEqual(active);
+	});
+
+	it("preserves active-provider order while applying the allow-list", () => {
+		const result = resolveSubAgentProviders(
+			subAgent(["gemini-cli", "claude-code"]),
+			["claude-code", "codex", "cursor", "gemini-cli"],
+		);
+
+		expect(result.supported).toEqual(["claude-code", "gemini-cli"]);
+		expect(result.unsupported).toEqual([]);
+	});
+
+	it("reports active providers without a sub-agent adapter", () => {
+		const result = resolveSubAgentProviders(subAgent(["crush"]), ["crush"]);
+
+		expect(result.targeted).toEqual(["crush"]);
+		expect(result.supported).toEqual([]);
+		expect(result.unsupported).toEqual(["crush"]);
+	});
+});

--- a/src/shared/__tests__/sync-project-subagents.test.ts
+++ b/src/shared/__tests__/sync-project-subagents.test.ts
@@ -1,0 +1,268 @@
+import { afterEach, beforeEach, describe, expect, it } from "bun:test";
+import {
+	existsSync,
+	mkdtempSync,
+	mkdirSync,
+	readFileSync,
+	rmSync,
+	writeFileSync,
+} from "fs";
+import { tmpdir } from "os";
+import { join } from "path";
+import { CapaDatabase } from "../../db/database";
+import { canonicalizePath } from "../paths";
+import type { Capabilities } from "../../types/capabilities";
+import { syncProjectSubagents } from "../sync-project-subagents";
+
+const projectId = "subagent-targeting-project";
+const activeProviders = ["claude-code", "codex", "cursor", "gemini-cli"];
+
+function capabilities(targets: string[]): Capabilities {
+	return {
+		providers: activeProviders,
+		options: { toolExposure: "none" },
+		skills: [],
+		servers: [],
+		tools: [],
+		subagents: [
+			{
+				id: "reviewer",
+				description: "Reviews changes",
+				providers: targets,
+				skills: [],
+				tools: [],
+			},
+		],
+	};
+}
+
+describe("syncProjectSubagents provider targeting", () => {
+	let projectPath: string;
+	let db: CapaDatabase;
+
+	beforeEach(() => {
+		projectPath = mkdtempSync(join(tmpdir(), "capa-subagent-targeting-"));
+		db = new CapaDatabase(join(projectPath, "capa.db"));
+		db.upsertProject({ id: projectId, path: projectPath });
+	});
+
+	afterEach(() => {
+		db.close();
+		rmSync(projectPath, { recursive: true, force: true });
+	});
+
+	it("writes only allow-listed adapters and preserves excluded manual files", async () => {
+		const manualCodexPath = join(projectPath, ".codex", "agents", "reviewer.toml");
+		mkdirSync(join(projectPath, ".codex", "agents"), { recursive: true });
+		writeFileSync(manualCodexPath, "manual = true\n", "utf-8");
+
+		const result = await syncProjectSubagents({
+			projectPath,
+			projectId,
+			capabilities: capabilities(["claude-code"]),
+			providers: activeProviders,
+			db,
+			serverOrigin: "http://127.0.0.1:5912",
+		});
+
+		expect(result).toEqual({ installed: 1, removed: 0, warnings: [] });
+		expect(existsSync(join(projectPath, ".claude", "agents", "reviewer.md"))).toBe(
+			true,
+		);
+		expect(readFileSync(manualCodexPath, "utf-8")).toBe("manual = true\n");
+		expect(existsSync(join(projectPath, ".cursor", "agents", "reviewer.md"))).toBe(
+			false,
+		);
+		expect(existsSync(join(projectPath, ".gemini", "agents", "reviewer.md"))).toBe(
+			false,
+		);
+		expect(db.getSubAgents(projectId)[0].installations).toEqual([
+			{
+				install_path: canonicalizePath(projectPath),
+				provider_ids: ["claude-code"],
+			},
+		]);
+	});
+
+	it("removes the old Capa adapter when the allow-list changes", async () => {
+		await syncProjectSubagents({
+			projectPath,
+			projectId,
+			capabilities: capabilities(["cursor"]),
+			providers: activeProviders,
+			db,
+			serverOrigin: "http://127.0.0.1:5912",
+		});
+		expect(existsSync(join(projectPath, ".cursor", "agents", "reviewer.md"))).toBe(
+			true,
+		);
+
+		await syncProjectSubagents({
+			projectPath,
+			projectId,
+			capabilities: capabilities(["gemini-cli"]),
+			providers: activeProviders,
+			db,
+			serverOrigin: "http://127.0.0.1:5912",
+		});
+
+		expect(existsSync(join(projectPath, ".cursor", "agents", "reviewer.md"))).toBe(
+			false,
+		);
+		expect(existsSync(join(projectPath, ".gemini", "agents", "reviewer.md"))).toBe(
+			true,
+		);
+		expect(db.getSubAgents(projectId)[0].installations[0].provider_ids).toEqual([
+			"gemini-cli",
+		]);
+	});
+
+	it("preserves a stale adapter that was replaced manually", async () => {
+		const cursorPath = join(projectPath, ".cursor", "agents", "reviewer.md");
+		await syncProjectSubagents({
+			projectPath,
+			projectId,
+			capabilities: capabilities(["cursor"]),
+			providers: activeProviders,
+			db,
+			serverOrigin: "http://127.0.0.1:5912",
+		});
+		writeFileSync(cursorPath, "manual replacement\n", "utf-8");
+
+		await syncProjectSubagents({
+			projectPath,
+			projectId,
+			capabilities: capabilities(["gemini-cli"]),
+			providers: activeProviders,
+			db,
+			serverOrigin: "http://127.0.0.1:5912",
+		});
+
+		expect(readFileSync(cursorPath, "utf-8")).toBe("manual replacement\n");
+		expect(
+			existsSync(join(projectPath, ".gemini", "agents", "reviewer.md")),
+		).toBe(true);
+	});
+
+	it("cleans historical providers before scoping legacy ownership", async () => {
+		const claudePath = join(projectPath, ".claude", "agents", "reviewer.md");
+		const cursorPath = join(projectPath, ".cursor", "agents", "reviewer.md");
+		mkdirSync(join(projectPath, ".claude", "agents"), { recursive: true });
+		mkdirSync(join(projectPath, ".cursor", "agents"), { recursive: true });
+		for (const filePath of [claudePath, cursorPath]) {
+			writeFileSync(
+				filePath,
+				'**MCP server key:** `capa-reviewer`\n',
+				"utf-8",
+			);
+		}
+		db.setProjectProviders(projectId, ["claude-code", "cursor"]);
+		db.upsertSubAgent(projectId, "reviewer");
+
+		await syncProjectSubagents({
+			projectPath,
+			projectId,
+			capabilities: capabilities(["gemini-cli"]),
+			providers: ["gemini-cli"],
+			previousProviders: ["claude-code", "cursor"],
+			db,
+			serverOrigin: "http://127.0.0.1:5912",
+		});
+
+		expect(existsSync(claudePath)).toBe(false);
+		expect(existsSync(cursorPath)).toBe(false);
+		expect(
+			existsSync(join(projectPath, ".gemini", "agents", "reviewer.md")),
+		).toBe(true);
+		expect(db.getSubAgents(projectId)[0]).toMatchObject({
+			legacy_unscoped: false,
+			installations: [
+				{
+					provider_ids: ["gemini-cli"],
+				},
+			],
+		});
+	});
+
+	it("warns and skips an active provider without sub-agent support", async () => {
+		const result = await syncProjectSubagents({
+			projectPath,
+			projectId,
+			capabilities: capabilities(["crush"]),
+			providers: ["crush"],
+			db,
+			serverOrigin: "http://127.0.0.1:5912",
+		});
+
+		expect(result.installed).toBe(0);
+		expect(result.warnings).toEqual([
+			'Sub-agent "reviewer": provider "crush" cannot generate a sub-agent adapter (skipping)',
+		]);
+		expect(db.getSubAgents(projectId)[0].installations[0].provider_ids).toEqual(
+			[],
+		);
+	});
+
+	it("keeps real-checkout and wrap-shadow ownership independent", async () => {
+		const shadowPath = mkdtempSync(join(tmpdir(), "capa-subagent-shadow-"));
+		try {
+			await syncProjectSubagents({
+				projectPath,
+				projectId,
+				capabilities: capabilities(["claude-code"]),
+				providers: activeProviders,
+				db,
+				serverOrigin: "http://127.0.0.1:5912",
+			});
+			await syncProjectSubagents({
+				projectPath: shadowPath,
+				projectId,
+				capabilities: capabilities([]),
+				providers: ["cursor"],
+				db,
+				serverOrigin: "http://127.0.0.1:5912",
+				materializeShadow: true,
+			});
+
+			const agent = db.getSubAgents(projectId)[0];
+			expect(
+				Object.fromEntries(
+					agent.installations.map((installation) => [
+						installation.install_path,
+						installation.provider_ids,
+					]),
+				),
+			).toEqual({
+				[canonicalizePath(projectPath)]: ["claude-code"],
+				[canonicalizePath(shadowPath)]: ["cursor"],
+			});
+
+			await syncProjectSubagents({
+				projectPath: shadowPath,
+				projectId,
+				capabilities: capabilities(["claude-code"]),
+				providers: ["cursor"],
+				db,
+				serverOrigin: "http://127.0.0.1:5912",
+				materializeShadow: true,
+			});
+
+			expect(
+				existsSync(join(projectPath, ".claude", "agents", "reviewer.md")),
+			).toBe(true);
+			expect(
+				existsSync(join(shadowPath, ".cursor", "agents", "reviewer.md")),
+			).toBe(false);
+			expect(
+				db
+					.getSubAgents(projectId)[0]
+					.installations.find(
+						(installation) =>
+							installation.install_path === canonicalizePath(projectPath),
+					)?.provider_ids,
+			).toEqual(["claude-code"]);
+		} finally {
+			rmSync(shadowPath, { recursive: true, force: true });
+		}
+	});
+});

--- a/src/shared/__tests__/ui-urls.test.ts
+++ b/src/shared/__tests__/ui-urls.test.ts
@@ -3,7 +3,7 @@ import { CAPA_CLOUD_OAUTH_URL, CAPA_DOCS_URL, cloudOAuthDisclosure, projectUiPat
 
 describe('ui-urls', () => {
   it('CAPA_DOCS_URL points to capa docs site', () => {
-    expect(CAPA_DOCS_URL).toBe('https://capa.infragate.ai/getting-started/introduction/');
+    expect(CAPA_DOCS_URL).toBe('https://capa.sh/getting-started/introduction/');
   });
 
   it('CAPA_CLOUD_OAUTH_URL points to cloud OAuth endpoint', () => {

--- a/src/shared/capabilities.ts
+++ b/src/shared/capabilities.ts
@@ -17,6 +17,7 @@ import type {
 } from "../types/capabilities";
 import { logger } from "./logger";
 import { normalizeOAuth2Block } from "./plugin-manifest/mcp-parser";
+import { getProvider } from "./providers";
 import { secretValueRecordSchema } from "./secret-value";
 
 const KNOWN_CAPABILITY_KEYS = new Set([
@@ -231,6 +232,22 @@ const optionsSchema = z
 
 /** Loose entries for sections Wave 2d will tighten (hooks) or lower priority. */
 const looseEntrySchema = z.record(z.string(), z.unknown());
+const providerIdSchema = z.string().min(1).transform((id, ctx) => {
+	const provider = getProvider(id);
+	if (!provider) {
+		ctx.addIssue({
+			code: "custom",
+			message: `Unknown provider: ${id}`,
+		});
+		return z.NEVER;
+	}
+	return provider.id;
+});
+const subAgentSchema = z
+	.object({
+		providers: z.array(providerIdSchema).optional(),
+	})
+	.passthrough();
 
 export const capabilitiesSchema = z
 	.object({
@@ -241,7 +258,7 @@ export const capabilitiesSchema = z
 		plugins: z.preprocess((val) => val ?? [], z.array(pluginSchema)),
 		options: z.preprocess((val) => val ?? {}, optionsSchema),
 		agents: z.record(z.string(), z.unknown()).optional(),
-		subagents: z.preprocess((val) => val ?? [], z.array(looseEntrySchema)),
+		subagents: z.preprocess((val) => val ?? [], z.array(subAgentSchema)),
 		rules: z.preprocess((val) => val ?? [], z.array(looseEntrySchema)),
 		hooks: z.preprocess((val) => val ?? [], z.array(looseEntrySchema)),
 	})

--- a/src/shared/providers/__tests__/registry.test.ts
+++ b/src/shared/providers/__tests__/registry.test.ts
@@ -345,6 +345,30 @@ describe('Codex pilot integration', () => {
     );
   });
 
+  it('omits Codex MCP declarations when tool exposure is disabled', () => {
+    const codex = getProvider('codex')!;
+    const result = buildSubAgentFile(
+      codex,
+      {
+        id: 'reviewer',
+        description: 'Reviews changes',
+        skills: [],
+        tools: [],
+      },
+      {
+        providers: ['codex'],
+        options: { toolExposure: 'none' },
+        skills: [],
+        servers: [],
+        tools: [],
+      },
+    );
+    const parsed = TOML.parse(result) as any;
+
+    expect(parsed.mcp_servers).toBeUndefined();
+    expect(result).not.toContain('url = ""');
+  });
+
   it('buildSubAgentFile kebab-cases snake_case tool ids in the capa sh form', () => {
     const codex = getProvider('codex')!;
     const subAgent = {

--- a/src/shared/providers/handlers.ts
+++ b/src/shared/providers/handlers.ts
@@ -292,12 +292,15 @@ function buildTomlSubAgent(
 		description: subAgent.description || subAgent.id,
 		...fields,
 		[bodyField]: body,
-		mcp_servers: {
+	};
+
+	if (capabilities.options?.toolExposure !== "none") {
+		data.mcp_servers = {
 			[mcpServerKey]: {
 				url: "",
 			},
-		},
-	};
+		};
+	}
 
 	return TOML.stringify(data as any);
 }

--- a/src/shared/registries/bundled.ts
+++ b/src/shared/registries/bundled.ts
@@ -19,7 +19,7 @@ export const BUNDLED_ADAPTER_PINS: Record<BundledAdapterSlug, string> = {
 	"skills-sh":
 		"4f6b1c7ad0f0ab5a13edb673397602faf073736b86030a9755ab1a0fc87b7a08",
 	"claude-plugins":
-		"075345f00a90ca325032dc9c6910f0d758cf4936e7abe40e160aae9190dbfc49",
+		"e963bb725eb6dfe6ea161d28ae7edbc29802e5c1bcade3ee80db1e0e9c9231f6",
 	"cursor-marketplace":
 		"93fb72fc4c66381f28e7893e9af6b54f270d1fdfdab318838121e802967c0dfd",
 };

--- a/src/shared/subagent-providers.ts
+++ b/src/shared/subagent-providers.ts
@@ -1,0 +1,80 @@
+import type { InstalledSubAgent } from "../db/sub-agents";
+import type { SubAgent } from "../types/capabilities";
+import { getProvider } from "./providers";
+
+export interface SubAgentProviderTargets {
+	targeted: string[];
+	supported: string[];
+	unsupported: string[];
+}
+
+/** Resolve provider ownership recorded before path-scoped installations existed. */
+export function resolvePreviousSubAgentProviders(opts: {
+	installedAgent: InstalledSubAgent;
+	installPath: string;
+	activeProviders: string[];
+	previousProjectProviders: string[];
+	isWrapInstall: boolean;
+}): string[] {
+	const scoped = opts.installedAgent.installations.find(
+		(installation) => installation.install_path === opts.installPath,
+	);
+	if (scoped) return scoped.provider_ids;
+	if (!opts.installedAgent.legacy_unscoped) return [];
+
+	// Legacy wrap files were materialized for the wrap provider. A real checkout
+	// used the project's provider set from before this install rewrote it.
+	if (opts.isWrapInstall) return opts.activeProviders;
+	return opts.previousProjectProviders.length > 0
+		? opts.previousProjectProviders
+		: opts.activeProviders;
+}
+
+/** Resolve a sub-agent allow-list against the providers active for this install. */
+export function resolveSubAgentProviders(
+	subAgent: SubAgent,
+	activeProviders: string[],
+): SubAgentProviderTargets {
+	const allowList = subAgent.providers;
+	const targeted =
+		!allowList || allowList.length === 0
+			? [...activeProviders]
+			: activeProviders.filter((providerId) => allowList.includes(providerId));
+	const supported: string[] = [];
+	const unsupported: string[] = [];
+
+	for (const providerId of targeted) {
+		const provider = getProvider(providerId);
+		if (
+			provider?.subagents ||
+			(provider?.instructions &&
+				provider.foldSubAgentsIntoInstructions === true)
+		) {
+			supported.push(providerId);
+		} else {
+			unsupported.push(providerId);
+		}
+	}
+
+	return { targeted, supported, unsupported };
+}
+
+export function getSubAgentProviderWarnings(
+	subAgent: SubAgent,
+	targets: SubAgentProviderTargets,
+): string[] {
+	const warnings = targets.unsupported.map(
+		(providerId) =>
+			`Sub-agent "${subAgent.id}": provider "${providerId}" cannot generate a sub-agent adapter (skipping)`,
+	);
+	if (
+		subAgent.providers &&
+		subAgent.providers.length > 0 &&
+		targets.targeted.length === 0
+	) {
+		warnings.push(
+			`Sub-agent "${subAgent.id}" targets no active providers (skipping)`,
+		);
+	}
+	return warnings;
+}

--- a/src/shared/sync-project-subagents.ts
+++ b/src/shared/sync-project-subagents.ts
@@ -9,13 +9,29 @@ import {
 	unregisterSubAgentMCPServer,
 } from "../cli/utils/mcp-client-manager";
 import type { CapaDatabase } from "../db/database";
-import { getProvider } from "./providers";
+import type { InstalledSubAgent } from "../db/sub-agents";
 import type { Capabilities } from "../types/capabilities";
+import { canonicalizePath } from "./paths";
+import { getProvider } from "./providers";
+import {
+	getSubAgentProviderWarnings,
+	resolvePreviousSubAgentProviders,
+	resolveSubAgentProviders,
+} from "./subagent-providers";
 
 export interface SyncSectionResult {
 	installed: number;
 	removed: number;
 	warnings: string[];
+}
+
+function providersInstalledAt(
+	agent: InstalledSubAgent,
+	installPath: string,
+): string[] | undefined {
+	return agent.installations.find(
+		(installation) => installation.install_path === installPath,
+	)?.provider_ids;
 }
 
 /**
@@ -29,22 +45,43 @@ export async function syncProjectSubagents(opts: {
 	providers: string[];
 	db: CapaDatabase;
 	serverOrigin: string;
+	materializeShadow?: boolean;
+	previousProviders?: string[];
 }): Promise<SyncSectionResult> {
 	const warnings: string[] = [];
 	const toolExposure = opts.capabilities.options?.toolExposure;
 	const skipMcpWrites = toolExposure === "none";
+	const installPath = canonicalizePath(opts.projectPath);
 	const installedAgents = opts.db.getSubAgents(opts.projectId);
 	const currentSubagents = opts.capabilities.subagents ?? [];
 	const currentAgentIds = new Set(currentSubagents.map((a) => a.id));
 	const removedAgents = installedAgents.filter(
-		({ agent_id }) => !currentAgentIds.has(agent_id),
+		(agent) =>
+			!currentAgentIds.has(agent.agent_id) &&
+			(agent.legacy_unscoped || providersInstalledAt(agent, installPath)),
 	);
+	const installedById = new Map(
+		installedAgents.map((agent) => [agent.agent_id, agent]),
+	);
+	const lifecycleProviders = [
+		...new Set([
+			...opts.providers,
+			...installedAgents.flatMap(
+				(installedAgent) =>
+					resolvePreviousSubAgentProviders({
+						installedAgent,
+						installPath,
+						activeProviders: opts.providers,
+						previousProjectProviders:
+							opts.previousProviders ??
+							opts.db.getProjectProviders(opts.projectId),
+						isWrapInstall: opts.materializeShadow === true,
+					}),
+			),
+		]),
+	];
 
-	const agentsNeedingMcpCleanup = skipMcpWrites
-		? installedAgents.map(({ agent_id }) => agent_id)
-		: removedAgents.map(({ agent_id }) => agent_id);
-
-	const needsPurge = opts.providers.some((id) => {
+	const needsPurge = lifecycleProviders.some((id) => {
 		const provider = getProvider(id);
 		return (
 			provider &&
@@ -64,7 +101,7 @@ export async function syncProjectSubagents(opts: {
 
 	if (needsPurge) {
 		try {
-			await purgeCursorSubAgentMCPEntries(opts.projectPath);
+			await purgeCursorSubAgentMCPEntries(opts.projectPath, opts.projectId);
 		} catch (err: unknown) {
 			warnings.push(
 				`Failed to purge stale sub-agent MCP entries: ${err instanceof Error ? err.message : String(err)}`,
@@ -72,58 +109,110 @@ export async function syncProjectSubagents(opts: {
 		}
 	}
 
-	const cleanupSet = new Set(agentsNeedingMcpCleanup);
-	for (const { agent_id } of removedAgents) {
+	for (const installedAgent of removedAgents) {
+		const { agent_id } = installedAgent;
+		const previousProviders = resolvePreviousSubAgentProviders({
+			installedAgent,
+			installPath,
+			activeProviders: opts.providers,
+			previousProjectProviders:
+				opts.previousProviders ?? opts.db.getProjectProviders(opts.projectId),
+			isWrapInstall: opts.materializeShadow === true,
+		});
 		try {
 			await unregisterSubAgentMCPServer(
 				opts.projectPath,
 				agent_id,
-				opts.providers,
+				previousProviders,
+				opts.projectId,
 			);
-			removeSubAgentInstructions(opts.projectPath, agent_id, opts.providers);
-			opts.db.removeSubAgent(opts.projectId, agent_id);
+			removeSubAgentInstructions(opts.projectPath, agent_id, previousProviders);
+			opts.db.removeSubAgentInstallation(
+				opts.projectId,
+				agent_id,
+				{
+					installPath,
+					removeLegacy: opts.materializeShadow !== true,
+				},
+			);
 			removed++;
-			cleanupSet.delete(agent_id);
 		} catch (err: unknown) {
 			warnings.push(
 				`Failed to remove sub-agent "${agent_id}": ${err instanceof Error ? err.message : String(err)}`,
 			);
 		}
 	}
-	for (const agent_id of cleanupSet) {
-		try {
-			await unregisterSubAgentMCPServer(
-				opts.projectPath,
-				agent_id,
-				opts.providers,
-			);
-		} catch (err: unknown) {
-			warnings.push(
-				`Failed to unregister MCP for sub-agent "${agent_id}": ${err instanceof Error ? err.message : String(err)}`,
-			);
-		}
-	}
-
 	for (const subAgent of currentSubagents) {
 		try {
-			if (!skipMcpWrites) {
+			const targets = resolveSubAgentProviders(
+				subAgent,
+				opts.providers,
+			);
+			const { supported } = targets;
+			warnings.push(...getSubAgentProviderWarnings(subAgent, targets));
+
+			const previous = installedById.get(subAgent.id);
+			const previousProviders = previous
+				? resolvePreviousSubAgentProviders({
+						installedAgent: previous,
+						installPath,
+						activeProviders: opts.providers,
+						previousProjectProviders:
+							opts.previousProviders ??
+							opts.db.getProjectProviders(opts.projectId),
+						isWrapInstall: opts.materializeShadow === true,
+					})
+				: [];
+			const staleProviders = previousProviders.filter(
+				(providerId) => !supported.includes(providerId),
+			);
+			if (staleProviders.length > 0) {
+				await unregisterSubAgentMCPServer(
+					opts.projectPath,
+					subAgent.id,
+					staleProviders,
+					opts.projectId,
+				);
+				removeSubAgentInstructions(
+					opts.projectPath,
+					subAgent.id,
+					staleProviders,
+				);
+			}
+
+			if (skipMcpWrites) {
+				await unregisterSubAgentMCPServer(
+					opts.projectPath,
+					subAgent.id,
+					supported,
+					opts.projectId,
+				);
+			} else {
 				const agentMcpUrl = `${opts.serverOrigin}/${opts.projectId}/agents/${subAgent.id}/mcp`;
 				await registerSubAgentMCPServer(
 					opts.projectPath,
 					subAgent.id,
 					agentMcpUrl,
-					opts.providers,
+					supported,
 				);
 			}
 			installSubAgentInstructions(
 				opts.projectPath,
 				subAgent,
 				opts.capabilities,
-				opts.providers,
+				supported,
 				skillDescriptions,
 			);
-			opts.db.upsertSubAgent(opts.projectId, subAgent.id);
-			installed++;
+			opts.db.upsertSubAgent(
+				opts.projectId,
+				subAgent.id,
+				{
+					installPath,
+					providerIds: supported,
+					migrateLegacy: opts.materializeShadow !== true,
+				},
+			);
+			if (supported.length > 0) installed++;
 		} catch (err: unknown) {
 			warnings.push(
 				`Failed to install sub-agent "${subAgent.id}": ${err instanceof Error ? err.message : String(err)}`,

--- a/src/shared/ui-urls.ts
+++ b/src/shared/ui-urls.ts
@@ -2,7 +2,7 @@
  * Web UI route helpers for the capa server SPA.
  */
 
-export const CAPA_DOCS_URL = "https://capa.infragate.ai/getting-started/introduction/";
+export const CAPA_DOCS_URL = "https://capa.sh/getting-started/introduction/";
 export const CAPA_CLOUD_OAUTH_URL = "https://capa.infragate.ai/auth";
 
 /** Shown before browser OAuth. Cloud host is pinned; not request-controlled. */

--- a/src/types/capabilities.ts
+++ b/src/types/capabilities.ts
@@ -234,6 +234,8 @@ export interface RequiredCommand {
 export interface SubAgent {
   /** Unique identifier. Used as the MCP server key (`capa-{id}`) and agent file name. */
   id: string;
+  /** Restrict this sub-agent to active provider ids. Empty/omitted installs for all. */
+  providers?: string[];
   /**
    * Human-readable description of this agent's role.
    * For Cursor: written into the `description` frontmatter field which drives

--- a/web-ui/src/components/layout/NavLinks.tsx
+++ b/web-ui/src/components/layout/NavLinks.tsx
@@ -25,7 +25,7 @@ export function NavLinks() {
         <span>{t('nav.integrations')}</span>
       </Link>
       <a
-        href="https://capa.infragate.ai/getting-started/introduction/"
+        href="https://capa.sh/getting-started/introduction/"
         target="_blank"
         rel="noopener noreferrer"
         className="flex items-center gap-2 rounded-sm px-3 py-2 text-[13px] text-text-secondary no-underline transition-colors hover:bg-hover-bg"

--- a/web-ui/src/features/projects/components/CapabilitiesSection.tsx
+++ b/web-ui/src/features/projects/components/CapabilitiesSection.tsx
@@ -103,6 +103,7 @@ interface CapabilitiesSectionProps {
   rules: Rule[];
   hooks: Hook[];
   agents: AgentFileConfig | null;
+  providers: string[];
   plugins: AuthoredPlugin[];
   resolvedPlugins: ResolvedPlugin[];
   projectId: string;
@@ -116,6 +117,7 @@ export function CapabilitiesSection({
   rules,
   hooks,
   agents,
+  providers,
   plugins,
   resolvedPlugins,
   projectId,
@@ -332,6 +334,7 @@ export function CapabilitiesSection({
           subagents={subagents}
           skills={skills}
           tools={tools}
+          providers={providers}
           search={search}
           projectId={projectId}
           addOpen={addSubagentOpen}

--- a/web-ui/src/features/projects/components/SubagentsList.tsx
+++ b/web-ui/src/features/projects/components/SubagentsList.tsx
@@ -17,6 +17,7 @@ interface SubagentsListProps {
   subagents: SubAgent[];
   skills: Skill[];
   tools: Tool[];
+  providers: string[];
   search: string;
   projectId: string;
   addOpen: boolean;
@@ -27,6 +28,7 @@ export function SubagentsList({
   subagents,
   skills,
   tools,
+  providers,
   search,
   projectId,
   addOpen,
@@ -40,7 +42,10 @@ export function SubagentsList({
   const [viewing, setViewing] = useState<SubAgent | null>(null);
   const searching = !!search.trim();
   const visible = subagents.filter((s) =>
-    matchesSearch([s.id, s.description, s.instructions, ...s.skills, ...s.tools], search),
+    matchesSearch(
+      [s.id, s.description, s.instructions, ...s.providers, ...s.skills, ...s.tools],
+      search,
+    ),
   );
 
   return (
@@ -135,6 +140,7 @@ export function SubagentsList({
         initial={editing?.sourcePlugin ? null : editing}
         skills={skills}
         tools={tools}
+        providers={providers}
         projectId={projectId}
         busy={updateMutation.isPending}
         onOpenChange={(open) => {
@@ -214,6 +220,27 @@ function SubagentViewDialog({
               <p className="text-sm text-text-secondary">{agent.description}</p>
             )}
 
+            {agent && (
+              <div>
+                <div className="mb-1.5 text-xs font-medium text-text-tertiary">
+                  {t('subagents.providers')}
+                </div>
+                <div className="flex flex-wrap gap-1">
+                  {(agent.providers.length > 0
+                    ? agent.providers
+                    : [t('subagents.allProviders')]
+                  ).map((provider) => (
+                    <span
+                      key={provider}
+                      className="rounded-sm bg-bg-secondary px-1.5 py-0.5 font-mono text-[10px] text-text-tertiary"
+                    >
+                      {provider}
+                    </span>
+                  ))}
+                </div>
+              </div>
+            )}
+
             {(agent?.skills.length ?? 0) > 0 && (
               <div>
                 <div className="mb-1.5 text-xs font-medium text-text-tertiary">
@@ -275,6 +302,7 @@ function SubagentDialog({
   initial,
   skills,
   tools,
+  providers,
   projectId,
   onOpenChange,
   onUpdate,
@@ -284,6 +312,7 @@ function SubagentDialog({
   initial: SubAgent | null;
   skills: Skill[];
   tools: Tool[];
+  providers: string[];
   projectId: string;
   onOpenChange: (open: boolean) => void;
   onUpdate: (entryId: string, patch: Record<string, unknown>) => Promise<void>;
@@ -295,6 +324,7 @@ function SubagentDialog({
   const [id, setId] = useState('');
   const [description, setDescription] = useState('');
   const [instructions, setInstructions] = useState('');
+  const [selectedProviders, setSelectedProviders] = useState<string[]>([]);
   const [selectedSkills, setSelectedSkills] = useState<string[]>([]);
   const [selectedTools, setSelectedTools] = useState<string[]>([]);
   const [error, setError] = useState<string | null>(null);
@@ -304,6 +334,7 @@ function SubagentDialog({
     setId(initial?.id || '');
     setDescription(initial?.description || '');
     setInstructions(initial?.instructions || '');
+    setSelectedProviders(initial?.providers || []);
     setSelectedSkills(initial?.skills || []);
     setSelectedTools(initial?.tools || []);
     setError(null);
@@ -324,6 +355,14 @@ function SubagentDialog({
     );
   }
 
+  function toggleProvider(providerId: string) {
+    setSelectedProviders((list) =>
+      list.includes(providerId)
+        ? list.filter((value) => value !== providerId)
+        : [...list, providerId],
+    );
+  }
+
   async function handleSubmit(e: FormEvent) {
     e.preventDefault();
     setError(null);
@@ -336,6 +375,7 @@ function SubagentDialog({
       id: id.trim(),
       description: description.trim() || undefined,
       instructions: instructions.trim() || undefined,
+      providers: selectedProviders,
       skills: selectedSkills,
       tools: selectedTools,
     };
@@ -396,6 +436,32 @@ function SubagentDialog({
                 className="mt-1 w-full rounded-sm border border-border-tertiary bg-bg-tertiary px-2.5 py-2 text-xs text-text-primary"
               />
             </label>
+            <div>
+              <div className="mb-1 text-xs text-text-secondary">
+                {t('subagents.providers')}
+              </div>
+              <div className="flex flex-wrap gap-1">
+                {providers.map((provider) => (
+                  <button
+                    key={provider}
+                    type="button"
+                    onClick={() => toggleProvider(provider)}
+                    className={`rounded-sm px-1.5 py-0.5 font-mono text-[10px] cursor-pointer ${
+                      selectedProviders.includes(provider)
+                        ? 'bg-accent-primary/15 text-accent-primary'
+                        : 'bg-bg-tertiary text-text-tertiary'
+                    }`}
+                  >
+                    {provider}
+                  </button>
+                ))}
+                {selectedProviders.length === 0 && (
+                  <span className="text-[11px] text-text-tertiary">
+                    {t('subagents.allProviders')}
+                  </span>
+                )}
+              </div>
+            </div>
             <div>
               <div className="mb-1 text-xs text-text-secondary">{t('detail.skills')}</div>
               <div className="flex flex-wrap gap-1">

--- a/web-ui/src/locales/en/projects.json
+++ b/web-ui/src/locales/en/projects.json
@@ -433,6 +433,8 @@
   "subagents": {
     "title": "Sub-Agents",
     "subtitle": "Named agent configurations with scoped skills and tools",
+    "providers": "Providers",
+    "allProviders": "All active providers",
     "skills": "Skills",
     "tools": "Tools",
     "instructions": "Instructions",

--- a/web-ui/src/pages/ProjectDetailPage.tsx
+++ b/web-ui/src/pages/ProjectDetailPage.tsx
@@ -145,6 +145,7 @@ export function ProjectDetailPage() {
                 rules={caps?.rules ?? []}
                 hooks={caps?.hooks ?? []}
                 agents={caps?.agents ?? null}
+                providers={caps?.providers ?? []}
                 plugins={caps?.plugins ?? []}
                 resolvedPlugins={caps?.resolvedPlugins ?? []}
                 projectId={projectId}

--- a/web-ui/src/types/api.ts
+++ b/web-ui/src/types/api.ts
@@ -127,6 +127,7 @@ export interface ResolvedPlugin {
 export interface SubAgent {
   id: string;
   description: string | null;
+  providers: string[];
   skills: string[];
   tools: string[];
   instructions: string | null;


### PR DESCRIPTION
## Why

Multi-provider repositories need to adopt a neutral subagent without Capa generating adapters for every enabled provider. Codex also emitted an invalid empty MCP URL for subagents when tool exposure was disabled.

Fixes #201.

## What

- Support `subagents[].providers` across the schema, managed installs, passthrough installs, plugins, API responses, and Web UI.
- Treat a missing or empty provider allow-list as all active providers.
- Validate provider IDs against the registry and canonicalize their casing.
- Warn and skip active providers that cannot generate a subagent adapter.
- Remove stale Capa-owned adapters when targeting changes while preserving excluded or manually replaced files and MCP entries.
- Track adapter ownership per checkout path so a real checkout and Capa wrap shadows do not overwrite each other's state.
- Omit Codex `mcp_servers` under `toolExposure: none`.
- Migrate and clean legacy unscoped subagent records using their historical provider ownership.

## Validation

- Full test suite: 1,859 passed, 0 failed.
- Review regression suite: 109 passed.
- Root and Web UI TypeScript checks passed.
- Web UI and standalone CLI builds passed.
- Isolated live lifecycle passed: targeted install, retarget cleanup, manual adapter preservation, Codex no-MCP output, project clean, and server shutdown.
