### PR TITLE
Treat missing MCP API-key servers as pending credentials during install

### DIFF
--- a/src/cli/commands/install-tasks/configure-tools.ts
+++ b/src/cli/commands/install-tasks/configure-tools.ts
@@ -106,7 +106,7 @@ export function configureToolsTask(): Task<InstallCtx> {
           }
           const suffix =
             pendingServers.size > 0 ? ` (${[...pendingServers].sort().join(', ')})` : '';
-          breakdown.push(`⏳ ${pendingAuth.length} pending OAuth2${suffix}`);
+          breakdown.push(`⏳ ${pendingAuth.length} pending credentials${suffix}`);
         }
         if (failed.length > 0) {
           breakdown.push(`✗ ${failed.length} failed`);
@@ -136,7 +136,7 @@ export function configureToolsTask(): Task<InstallCtx> {
           }
           task.title = `Configuring tools — ${failed.length} of ${result.toolValidation.length} tool(s) failed validation`;
         } else if (pendingAuth.length > 0 && pendingAuth.length < result.toolValidation.length) {
-          task.title = `Configuring tools — ${successful.length} validated, ${pendingAuth.length} pending OAuth2`;
+          task.title = `Configuring tools — ${successful.length} validated, ${pendingAuth.length} pending credentials`;
         } else if (pendingAuth.length === 0) {
           task.title = `Configuring tools — ${result.toolValidation.length} validated`;
         }

--- a/src/server/configure-routes.ts
+++ b/src/server/configure-routes.ts
@@ -7,6 +7,7 @@ import { logger } from "../shared/logger";
 import { detectCapabilitiesFile } from "../shared/paths";
 import { trustStdioServers } from "../shared/stdio-allowlist";
 import { projectUiUrl } from "../shared/ui-urls";
+import { mcpServerIdsPendingCredentials } from "../shared/secret-value";
 import { extractAllVariables } from "../shared/variable-resolver";
 import type { Capabilities } from "../types/capabilities";
 import type { OAuth2Config } from "../types/oauth";
@@ -347,36 +348,42 @@ export async function runProjectConfigure(
 			);
 		}
 
-		const oauth2ServerIds = new Set(
+		const pendingServerIds = new Set(
 			oauth2Servers.filter((s) => !s.isConnected).map((s) => s.serverId),
 		);
-		const nonOAuth2ValidationResults = toolValidationResults.filter(
-			(r) => !oauth2ServerIds.has(r.serverId),
+		for (const id of mcpServerIdsPendingCredentials(
+			capabilitiesToUse.servers ?? [],
+			missingVars,
+		)) {
+			pendingServerIds.add(id);
+		}
+		const nonPendingValidationResults = toolValidationResults.filter(
+			(r) => !pendingServerIds.has(r.serverId),
 		);
-		const oauth2PendingResults = toolValidationResults.filter((r) =>
-			oauth2ServerIds.has(r.serverId),
+		const pendingResults = toolValidationResults.filter((r) =>
+			pendingServerIds.has(r.serverId),
 		);
 
-		if (oauth2PendingResults.length > 0) {
+		if (pendingResults.length > 0) {
 			apiLogger.info(
-				`${oauth2PendingResults.length} tool(s) skipped validation (OAuth2 authentication required)`,
+				`${pendingResults.length} tool(s) skipped validation (credentials pending)`,
 			);
-			for (const pending of oauth2PendingResults) {
+			for (const pending of pendingResults) {
 				pending.success = true;
 				pending.pendingAuth = true;
 				pending.error = undefined;
 			}
 		}
 
-		const failedTools = nonOAuth2ValidationResults.filter((r) => !r.success);
+		const failedTools = nonPendingValidationResults.filter((r) => !r.success);
 		if (failedTools.length > 0) {
 			apiLogger.warn(`${failedTools.length} tool(s) failed validation`);
 			for (const failed of failedTools) {
 				apiLogger.debug(`  ${failed.toolId}: ${failed.error}`);
 			}
-		} else if (nonOAuth2ValidationResults.length > 0) {
+		} else if (nonPendingValidationResults.length > 0) {
 			apiLogger.success(
-				`All ${nonOAuth2ValidationResults.length} non-OAuth2 tool(s) validated successfully`,
+				`All ${nonPendingValidationResults.length} non-pending tool(s) validated successfully`,
 			);
 		}
 	} catch (error: any) {

--- a/src/server/configure-routes.ts
+++ b/src/server/configure-routes.ts
@@ -351,11 +351,25 @@ export async function runProjectConfigure(
 		const pendingServerIds = new Set(
 			oauth2Servers.filter((s) => !s.isConnected).map((s) => s.serverId),
 		);
-		for (const id of mcpServerIdsPendingCredentials(
-			capabilitiesToUse.servers ?? [],
-			missingVars,
-		)) {
-			pendingServerIds.add(id);
+		// Only servers that actually failed need excusing, and resolving a def
+		// can re-run a `fromCommand` secret — so don't touch the ones that
+		// validated fine.
+		const failedServerIds = new Set(
+			toolValidationResults
+				.filter((r) => !r.success && r.serverId)
+				.map((r) => r.serverId),
+		);
+		const pendingCandidates = (capabilitiesToUse.servers ?? []).filter(
+			(s) => failedServerIds.has(s.id) && !pendingServerIds.has(s.id),
+		);
+		if (project && pendingCandidates.length > 0) {
+			for (const id of await mcpServerIdsPendingCredentials(pendingCandidates, {
+				projectId,
+				projectPath: project.path,
+				db: deps.db,
+			})) {
+				pendingServerIds.add(id);
+			}
 		}
 		const nonPendingValidationResults = toolValidationResults.filter(
 			(r) => !pendingServerIds.has(r.serverId),

--- a/src/server/mcp-validate-tools.ts
+++ b/src/server/mcp-validate-tools.ts
@@ -8,7 +8,7 @@ export interface ToolValidationResult {
 	error?: string;
 	serverId?: string;
 	remoteTool?: string;
-	pendingAuth?: boolean; // True if validation was skipped due to pending OAuth2 authentication
+	pendingAuth?: boolean; // True if validation was skipped due to pending credentials (OAuth2 or API key)
 }
 
 /**

--- a/src/shared/__tests__/secret-value.test.ts
+++ b/src/shared/__tests__/secret-value.test.ts
@@ -2,6 +2,8 @@ import { afterEach, beforeEach, describe, expect, it } from "bun:test";
 import { mkdtempSync, rmSync, writeFileSync } from "fs";
 import { tmpdir } from "os";
 import { join } from "path";
+import type { CapaDatabase } from "../../db/database";
+import type { MCPServer } from "../../types/capabilities";
 import {
 	hasUnresolvedSecretSources,
 	isSecretValueObject,
@@ -10,6 +12,7 @@ import {
 	resolveSecretValueRecord,
 	SecretValueResolveError,
 	secretValueSchema,
+	type SecretValue,
 } from "../secret-value";
 
 describe("secretValueSchema", () => {
@@ -117,58 +120,82 @@ describe("isSecretValueObject / hasUnresolvedSecretSources", () => {
 });
 
 describe("mcpServerIdsPendingCredentials", () => {
-	it("includes servers whose headers still reference a missing ${var}", () => {
+	let dir: string;
+
+	beforeEach(() => {
+		dir = mkdtempSync(join(tmpdir(), "capa-pending-creds-"));
+	});
+
+	afterEach(() => {
+		rmSync(dir, { recursive: true, force: true });
+	});
+
+	const ctx = (vars: Record<string, string> = {}) => ({
+		projectId: "p1",
+		projectPath: dir,
+		db: {
+			getVariable: (_projectId: string, key: string) => vars[key] ?? null,
+		} as unknown as CapaDatabase,
+	});
+
+	const server = (id: string, headers: Record<string, SecretValue>) => ({
+		id,
+		def: { url: "https://example.test/mcp", headers },
+	});
+
+	it("includes servers whose headers still reference a missing ${var}", async () => {
 		expect(
-			mcpServerIdsPendingCredentials(
+			await mcpServerIdsPendingCredentials(
 				[
-					{
-						id: "sharecube",
-						def: {
-							url: "https://example.test/mcp",
-							headers: { Authorization: "Bearer ${ShareCubeApiKey}" },
-						},
-					},
-					{
-						id: "aws-knowledge",
-						def: { url: "https://knowledge-mcp.global.api.aws" },
-					},
+					server("sharecube", {
+						Authorization: "Bearer ${ShareCubeApiKey}",
+					}),
+					{ id: "aws-knowledge", def: { url: "https://knowledge.test" } },
 				],
-				["ShareCubeApiKey"],
+				ctx(),
 			),
 		).toEqual(["sharecube"]);
 	});
 
-	it("does not include a ${var} server once the variable is present", () => {
+	it("does not include a ${var} server once the variable is present", async () => {
 		expect(
-			mcpServerIdsPendingCredentials(
-				[
-					{
-						id: "sharecube",
-						def: {
-							url: "https://example.test/mcp",
-							headers: { Authorization: "Bearer ${ShareCubeApiKey}" },
-						},
-					},
-				],
-				[],
+			await mcpServerIdsPendingCredentials(
+				[server("sharecube", { Authorization: "Bearer ${ShareCubeApiKey}" })],
+				ctx({ ShareCubeApiKey: "sk-live" }),
 			),
 		).toEqual([]);
 	});
 
-	it("includes servers with unresolved secret-source objects", () => {
+	it("includes a secret source that fails to resolve", async () => {
 		expect(
-			mcpServerIdsPendingCredentials(
-				[
-					{
-						id: "vaulted",
-						def: {
-							url: "https://example.test/mcp",
-							headers: { Authorization: { fromEnv: "TOKEN" } },
-						},
-					},
-				],
-				[],
+			await mcpServerIdsPendingCredentials(
+				[server("vaulted", { Authorization: { fromEnv: "CAPA_TEST_UNSET" } })],
+				{ ...ctx(), env: {} },
 			),
 		).toEqual(["vaulted"]);
+	});
+
+	it("does not include a secret source that resolves", async () => {
+		expect(
+			await mcpServerIdsPendingCredentials(
+				[server("vaulted", { Authorization: { fromEnv: "CAPA_TEST_TOKEN" } })],
+				{ ...ctx(), env: { CAPA_TEST_TOKEN: "tok" } },
+			),
+		).toEqual([]);
+	});
+
+	it("includes a plugin-contributed server with an unset ${var}", async () => {
+		const pluginServer: MCPServer = {
+			...server("plugin-server", { Authorization: "Bearer ${PluginToken}" }),
+			type: "mcp",
+			sourcePlugin: {
+				id: "some-plugin@abc123",
+				name: "some-plugin",
+				provider: "claude",
+			},
+		};
+		expect(
+			await mcpServerIdsPendingCredentials([pluginServer], ctx()),
+		).toEqual(["plugin-server"]);
 	});
 });

--- a/src/shared/__tests__/secret-value.test.ts
+++ b/src/shared/__tests__/secret-value.test.ts
@@ -5,6 +5,7 @@ import { join } from "path";
 import {
 	hasUnresolvedSecretSources,
 	isSecretValueObject,
+	mcpServerIdsPendingCredentials,
 	resolveSecretValue,
 	resolveSecretValueRecord,
 	SecretValueResolveError,
@@ -112,5 +113,62 @@ describe("isSecretValueObject / hasUnresolvedSecretSources", () => {
 			}),
 		).toBe(true);
 		expect(hasUnresolvedSecretSources({ env: { K: "done" } })).toBe(false);
+	});
+});
+
+describe("mcpServerIdsPendingCredentials", () => {
+	it("includes servers whose headers still reference a missing ${var}", () => {
+		expect(
+			mcpServerIdsPendingCredentials(
+				[
+					{
+						id: "sharecube",
+						def: {
+							url: "https://example.test/mcp",
+							headers: { Authorization: "Bearer ${ShareCubeApiKey}" },
+						},
+					},
+					{
+						id: "aws-knowledge",
+						def: { url: "https://knowledge-mcp.global.api.aws" },
+					},
+				],
+				["ShareCubeApiKey"],
+			),
+		).toEqual(["sharecube"]);
+	});
+
+	it("does not include a ${var} server once the variable is present", () => {
+		expect(
+			mcpServerIdsPendingCredentials(
+				[
+					{
+						id: "sharecube",
+						def: {
+							url: "https://example.test/mcp",
+							headers: { Authorization: "Bearer ${ShareCubeApiKey}" },
+						},
+					},
+				],
+				[],
+			),
+		).toEqual([]);
+	});
+
+	it("includes servers with unresolved secret-source objects", () => {
+		expect(
+			mcpServerIdsPendingCredentials(
+				[
+					{
+						id: "vaulted",
+						def: {
+							url: "https://example.test/mcp",
+							headers: { Authorization: { fromEnv: "TOKEN" } },
+						},
+					},
+				],
+				[],
+			),
+		).toEqual(["vaulted"]);
 	});
 });

--- a/src/shared/secret-value.ts
+++ b/src/shared/secret-value.ts
@@ -6,7 +6,6 @@ import type { CapaDatabase } from "../db/database";
 import type { MCPServerDefinition } from "../types/capabilities";
 import { isPlainObject } from "./plugin-manifest/types-helpers";
 import {
-	extractAllVariables,
 	hasUnresolvedVariables,
 	resolveVariablesInObject,
 } from "./variable-resolver";
@@ -230,25 +229,24 @@ export function hasUnresolvedMcpSecrets(def: MCPServerDefinition): boolean {
 }
 
 /**
- * Server ids whose MCP def still needs credentials: a ${placeholder} whose
- * value is missing, or an unresolved secret-source object in env/headers.
+ * Server ids that cannot be credentialed right now: a secret source that fails
+ * to resolve, or a `${placeholder}` with no value for this project. Judged on
+ * the *resolved* def — a working `fromEnv`/`fromFile`/`fromCommand` source is
+ * not pending, so genuine validation failures still surface. Each def is
+ * inspected on its own, so plugin-contributed servers are covered too.
  * Used at install time so those tools are pending rather than failed.
  */
-export function mcpServerIdsPendingCredentials(
+export async function mcpServerIdsPendingCredentials(
 	servers: Array<{ id: string; def: MCPServerDefinition }>,
-	missingVars: string[],
-): string[] {
-	const missing = new Set(missingVars);
+	ctx: ResolveMcpServerDefContext,
+): Promise<string[]> {
 	const ids: string[] = [];
 	for (const server of servers) {
-		const needsPlaceholder = extractAllVariables(server.def).some((v) =>
-			missing.has(v),
-		);
-		if (
-			needsPlaceholder ||
-			hasUnresolvedSecretSources(server.def.env) ||
-			hasUnresolvedSecretSources(server.def.headers)
-		) {
+		try {
+			const resolved = await resolveMcpServerDef(server.def, ctx);
+			if (hasUnresolvedMcpSecrets(resolved)) ids.push(server.id);
+		} catch (error) {
+			if (!(error instanceof SecretValueResolveError)) throw error;
 			ids.push(server.id);
 		}
 	}

--- a/src/shared/secret-value.ts
+++ b/src/shared/secret-value.ts
@@ -6,6 +6,7 @@ import type { CapaDatabase } from "../db/database";
 import type { MCPServerDefinition } from "../types/capabilities";
 import { isPlainObject } from "./plugin-manifest/types-helpers";
 import {
+	extractAllVariables,
 	hasUnresolvedVariables,
 	resolveVariablesInObject,
 } from "./variable-resolver";
@@ -226,6 +227,32 @@ export function hasUnresolvedMcpSecrets(def: MCPServerDefinition): boolean {
 		hasUnresolvedSecretSources(def.headers) ||
 		hasUnresolvedVariables(def)
 	);
+}
+
+/**
+ * Server ids whose MCP def still needs credentials: a ${placeholder} whose
+ * value is missing, or an unresolved secret-source object in env/headers.
+ * Used at install time so those tools are pending rather than failed.
+ */
+export function mcpServerIdsPendingCredentials(
+	servers: Array<{ id: string; def: MCPServerDefinition }>,
+	missingVars: string[],
+): string[] {
+	const missing = new Set(missingVars);
+	const ids: string[] = [];
+	for (const server of servers) {
+		const needsPlaceholder = extractAllVariables(server.def).some((v) =>
+			missing.has(v),
+		);
+		if (
+			needsPlaceholder ||
+			hasUnresolvedSecretSources(server.def.env) ||
+			hasUnresolvedSecretSources(server.def.headers)
+		) {
+			ids.push(server.id);
+		}
+	}
+	return ids;
 }
 
 /** Normalize fingerprint maps that may still contain SecretValue objects. */


### PR DESCRIPTION
## Summary
Unattended `capa install` (including Cursor Cloud Agent environment builds) was exiting 1 because ShareCube MCP tools failed validation when `${ShareCubeApiKey}` was not set. OAuth2 servers were already treated as pending; API-key servers were not.

## What changed
- Classify MCP servers whose defs still reference missing `${vars}` or unresolved secret sources as pending credentials
- Remap those tools to `pendingAuth` the same way disconnected OAuth2 servers already are
- CLI copy now says "pending credentials" instead of "pending OAuth2"

## Screenshots / logs
Environment build `bld-20260907-5fbb6124-f160-432c-a739-b0ac8a5e782a` failed with:
```
15 of 32 tool(s) failed validation:
  • sharecube.list_projects
  …
  Available tools: (none)
✗ Install completed with 15 failure(s).
[INSTALL] Exit code: 1
```
Slack/Atlassian on the same run were pending OAuth2 and did not fail the install.

Published capa 2.1.2 already treats install validation errors as warnings (exit 0). This PR is the remaining UX fix so missing API-key MCP servers show as pending credentials instead of 15 failed tools.

## Test plan
- [x] Unit tests for `mcpServerIdsPendingCredentials` (missing var, present var, secret-source object)
- [x] `bun test` — 1837 pass
- [x] `bunx tsc --noEmit`
- [x] CI: tests (Linux/macOS/Windows), lint, CodeQL, dependency review, Code Smells — all green
- [x] Draft Cloud Agent environment build `bld-20260907-277b47e2-5485-4492-824e-fd50cdf66050` succeeded with capa 2.1.2 (`capa --headless install --yes`, exit 0). Recurring builds still need the dashboard install command saved until this ships in a release.

## Checklist
- [x] Tests added or updated
- [x] `bunx tsc --noEmit` passes
- [x] `bun run smells` clean vs base (or CI Qlty Smells job green)
- [x] Docs updated (if user-facing) — CLI status string only; no schema change
