### PR TITLE
Fix null capability fields and silent MCP connect failures

### DIFF
--- a/src/server/__tests__/mcp-proxy.test.ts
+++ b/src/server/__tests__/mcp-proxy.test.ts
@@ -242,6 +242,29 @@ describe('mcp-proxy', () => {
       ).rejects.toThrow(/Could not connect to MCP server "sharecube": .*HTTP 401/);
     });
 
+    it("scrubs the server's own header credential when the body echoes it", async () => {
+      const proxy = new MCPProxy(makeMockDb(), 'proj-1', '/tmp/project');
+      (proxy as any).connectWithTimeout = async () => {
+        throw new Error(
+          'Error POSTing to endpoint (HTTP 401): {"received":"key-abc123456"}',
+        );
+      };
+
+      const message = await proxy
+        .listTools(
+          'sharecube',
+          {
+            url: 'https://mcp.example.com',
+            headers: { 'X-Api-Key': 'key-abc123456' },
+          },
+          { throwOnError: true },
+        )
+        .then(() => 'no error thrown', (err: Error) => err.message);
+
+      expect(message).toContain('HTTP 401');
+      expect(message).not.toContain('key-abc123456');
+    });
+
     it('keeps a bearer token out of the surfaced message', async () => {
       const proxy = new MCPProxy(makeMockDb(), 'proj-1', '/tmp/project');
       (proxy as any).connectWithTimeout = async () => {

--- a/src/server/__tests__/mcp-proxy.test.ts
+++ b/src/server/__tests__/mcp-proxy.test.ts
@@ -230,6 +230,30 @@ describe('mcp-proxy', () => {
     });
   });
 
+  describe('connect failure detail', () => {
+    it('listTools reports why the transport failed, not a bare "could not connect"', async () => {
+      const proxy = new MCPProxy(makeMockDb(), 'proj-1', '/tmp/project');
+      (proxy as any).connectWithTimeout = async () => {
+        throw new Error('Error POSTing to endpoint (HTTP 401): Unauthorized');
+      };
+
+      await expect(
+        proxy.listTools('sharecube', { url: 'https://mcp.example.com' }, { throwOnError: true }),
+      ).rejects.toThrow(/Could not connect to MCP server "sharecube": .*HTTP 401/);
+    });
+
+    it('keeps a bearer token out of the surfaced message', async () => {
+      const proxy = new MCPProxy(makeMockDb(), 'proj-1', '/tmp/project');
+      (proxy as any).connectWithTimeout = async () => {
+        throw new Error('rejected request with Bearer sk-live-supersecret');
+      };
+
+      await expect(
+        proxy.listTools('sharecube', { url: 'https://mcp.example.com' }, { throwOnError: true }),
+      ).rejects.toThrow(/Bearer \*\*\*/);
+    });
+  });
+
   describe('stdio crash fail-fast', () => {
     let capaDir: string;
     let dirSpy: ReturnType<typeof spyOn>;

--- a/src/server/__tests__/secret-redaction.test.ts
+++ b/src/server/__tests__/secret-redaction.test.ts
@@ -1,5 +1,11 @@
 import { describe, expect, it } from "bun:test";
-import { mergeServerDef, redactOAuth2ConfigForApi, redactServerForApi } from "../secret-redaction";
+import {
+	mergeServerDef,
+	redactErrorDetail,
+	redactOAuth2ConfigForApi,
+	redactServerForApi,
+	resolvedSecretValues,
+} from "../secret-redaction";
 
 const ENV_SECRET = "mcp-env-secret-ABCDEFGH";
 const HEADER_SECRET = "Bearer mcp-header-secret-1234";
@@ -141,5 +147,53 @@ describe("redactServerForApi secret sources", () => {
 			Accept: "application/json",
 		});
 		expect(JSON.stringify(redacted)).not.toContain("secret-literal");
+	});
+});
+
+describe("redactErrorDetail", () => {
+	it("removes a credential capa knows about, wherever it appears", () => {
+		const detail = redactErrorDetail(
+			'Error POSTing to endpoint (HTTP 401): {"sent":"sk-live-9f3a2b7c41"}',
+			["sk-live-9f3a2b7c41"],
+		);
+		expect(detail).not.toContain("sk-live-9f3a2b7c41");
+		expect(detail).toContain("HTTP 401");
+	});
+
+	it("masks credential-shaped values that are not Bearer tokens", () => {
+		const detail = redactErrorDetail(
+			'rejected: {"api_key": "abcd1234efgh", "password": "hunter2000"}',
+		);
+		expect(detail).not.toContain("abcd1234efgh");
+		expect(detail).not.toContain("hunter2000");
+	});
+
+	it("collapses control characters and caps the length", () => {
+		const detail = redactErrorDetail(
+			"line1\n\tline2\u0000 " + "x".repeat(400),
+		);
+		expect(detail).not.toMatch(/[\u0000-\u001F]/);
+		expect(detail.length).toBeLessThanOrEqual(300);
+	});
+
+	it("leaves an ordinary transport failure readable", () => {
+		expect(redactErrorDetail("getaddrinfo ENOTFOUND mcp.example.com")).toBe(
+			"getaddrinfo ENOTFOUND mcp.example.com",
+		);
+	});
+});
+
+describe("resolvedSecretValues", () => {
+	it("collects sensitive header values and every env value", () => {
+		const values = resolvedSecretValues({
+			headers: {
+				Authorization: "Bearer tok-123456",
+				Accept: "application/json",
+			},
+			env: { API_KEY: "env-secret-1", NODE_ENV: "production" },
+		});
+		expect(values.sort()).toEqual(
+			["Bearer tok-123456", "env-secret-1", "production"].sort(),
+		);
 	});
 });

--- a/src/server/capabilities-mutations.ts
+++ b/src/server/capabilities-mutations.ts
@@ -20,6 +20,17 @@ import {
 import { mergeServerDef } from "./secret-redaction";
 import { clientErrorMessage } from "./http-error";
 
+/**
+ * A `null` field means "clear it" (same convention `mergeServerDef` uses inside
+ * `def`) — write the key out as absent rather than an explicit null, which no
+ * capability schema accepts.
+ */
+function withoutNulls(entry: Record<string, unknown>): Record<string, unknown> {
+	return Object.fromEntries(
+		Object.entries(entry).filter(([, value]) => value !== null),
+	);
+}
+
 export async function handleAppend(
 	deps: CapabilitiesRouteDeps,
 	projectId: string,
@@ -32,6 +43,8 @@ export async function handleAppend(
 	} catch {
 		return jsonError("Invalid JSON body", 400);
 	}
+
+	body = withoutNulls(body);
 
 	const id = entryId(body);
 	if (!id) {
@@ -147,10 +160,11 @@ export async function handleUpdate(
 			section,
 			(e) => e.id === id,
 			(e) => {
-				const merged = { ...e, ...body, id: nextId } as Record<
-					string,
-					unknown
-				> & {
+				const merged = withoutNulls({
+					...e,
+					...body,
+					id: nextId,
+				}) as Record<string, unknown> & {
 					id: string;
 				};
 				if (asObj(body.def)) {

--- a/src/server/mcp-meta-routes.ts
+++ b/src/server/mcp-meta-routes.ts
@@ -8,6 +8,7 @@ import type {
 } from "../types/capabilities";
 import { clientErrorMessage } from "./http-error";
 import { matchRoute } from "./match-route";
+import { redactErrorDetail } from "./secret-redaction";
 import type { CapaMCPServer, ShellToolInfo } from "./mcp-handler";
 import type { McpServerStateManager } from "./mcp-server-state";
 import type { SessionManager } from "./session-manager";
@@ -77,10 +78,12 @@ export async function handleGetServerTools(
 			{ headers: JSON_HEADERS },
 		);
 	} catch (error: any) {
-		const detail = error?.message ?? String(error);
-		const needsAuth = /authentication failed|reconnect oauth2/i.test(detail);
 		// The proxy's message already names the server and the transport reason
 		// (e.g. HTTP 401) — keep it, a flat "unreachable" hides a bad API key.
+		// Redact first: a listTools failure carries the remote body verbatim,
+		// which can echo the request's own credentials back.
+		const detail = redactErrorDetail(error?.message ?? String(error));
+		const needsAuth = /authentication failed|reconnect oauth2/i.test(detail);
 		const message = needsAuth
 			? `Authentication required for "${serverId}". Please reconnect this server's OAuth2 connection.`
 			: detail || `Server unreachable: "${serverId}" could not be contacted.`;
@@ -335,10 +338,13 @@ export async function handleGetShellToolSchema(
 			headers: JSON_HEADERS,
 		});
 	} catch (error: any) {
-		return new Response(JSON.stringify({ error: error.message }), {
-			status: 502,
-			headers: JSON_HEADERS,
-		});
+		return new Response(
+			JSON.stringify({ error: redactErrorDetail(error?.message ?? String(error)) }),
+			{
+				status: 502,
+				headers: JSON_HEADERS,
+			},
+		);
 	}
 }
 

--- a/src/server/mcp-meta-routes.ts
+++ b/src/server/mcp-meta-routes.ts
@@ -79,9 +79,11 @@ export async function handleGetServerTools(
 	} catch (error: any) {
 		const detail = error?.message ?? String(error);
 		const needsAuth = /authentication failed|reconnect oauth2/i.test(detail);
+		// The proxy's message already names the server and the transport reason
+		// (e.g. HTTP 401) — keep it, a flat "unreachable" hides a bad API key.
 		const message = needsAuth
 			? `Authentication required for "${serverId}". Please reconnect this server's OAuth2 connection.`
-			: `Server unreachable: "${serverId}" could not be contacted.`;
+			: detail || `Server unreachable: "${serverId}" could not be contacted.`;
 		return new Response(JSON.stringify({ error: message }), {
 			status: 502,
 			headers: JSON_HEADERS,

--- a/src/server/mcp-proxy.ts
+++ b/src/server/mcp-proxy.ts
@@ -42,6 +42,19 @@ export interface MCPToolResult {
 	error?: string;
 }
 
+/**
+ * One-line reason a connect attempt failed, safe to show a user. Bearer values
+ * are stripped in case a server echoes the request back in its error body.
+ */
+function connectFailureDetail(error: unknown): string {
+	const raw = error instanceof Error ? error.message : String(error);
+	return raw
+		.replace(/Bearer\s+\S+/gi, "Bearer ***")
+		.replace(/\s+/g, " ")
+		.trim()
+		.slice(0, 300);
+}
+
 export class MCPProxy {
 	private db: CapaDatabase;
 	private projectId: string;
@@ -55,6 +68,9 @@ export class MCPProxy {
 	private listToolsInFlight = new Map<string, Promise<any[]>>();
 	/** Last unexpected stdio exit reason per server (from transport onerror). */
 	private stdioExitReasons = new Map<string, string>();
+	/** Why the last connect attempt failed, per server. Kept so callers can
+	 * report "401 Unauthorized" instead of a bare "Could not connect". */
+	private connectFailures = new Map<string, string>();
 	private logger = logger.child("MCPProxy");
 	private isServerEnabled: McpEnabledCheck;
 
@@ -359,7 +375,7 @@ export class MCPProxy {
 		}
 		if (!client) {
 			if (throwOnError) {
-				throw new Error(`Could not connect to MCP server "${cleanServerId}"`);
+				throw new Error(this.connectFailureMessage(cleanServerId));
 			}
 			return [];
 		}
@@ -393,7 +409,7 @@ export class MCPProxy {
 				if (!freshClient) {
 					if (throwOnError) {
 						throw new Error(
-							`Could not reconnect to MCP server "${cleanServerId}"`,
+							this.connectFailureMessage(cleanServerId, "reconnect"),
 						);
 					}
 					return [];
@@ -544,6 +560,7 @@ export class MCPProxy {
 
 			this.clients.set(serverId, client);
 			this.clientFingerprints.set(serverId, fingerprint);
+			this.connectFailures.delete(serverId);
 			this.logger.success("Client connected");
 			return client;
 		} catch (error: any) {
@@ -551,6 +568,7 @@ export class MCPProxy {
 				`Failed to create HTTP client for ${serverId}:`,
 				error,
 			);
+			this.connectFailures.set(serverId, connectFailureDetail(error));
 			return null;
 		}
 	}
@@ -613,6 +631,7 @@ export class MCPProxy {
 
 			this.clients.set(serverId, client);
 			this.clientFingerprints.set(serverId, fingerprint);
+			this.connectFailures.delete(serverId);
 			this.logger.success("Client connected");
 			return client;
 		} catch (error) {
@@ -620,8 +639,22 @@ export class MCPProxy {
 				`Failed to create MCP client for ${serverId}:`,
 				error,
 			);
+			this.connectFailures.set(
+				serverId,
+				this.stdioExitReasons.get(serverId) ?? connectFailureDetail(error),
+			);
 			return null;
 		}
+	}
+
+	/**
+	 * "Could not connect" plus why, when the transport told us. A bad API key
+	 * reads as 401 rather than looking like the server is down.
+	 */
+	private connectFailureMessage(serverId: string, verb = "connect"): string {
+		const base = `Could not ${verb} to MCP server "${serverId}"`;
+		const detail = this.connectFailures.get(serverId);
+		return detail ? `${base}: ${detail}` : base;
 	}
 
 	/**

--- a/src/server/mcp-proxy.ts
+++ b/src/server/mcp-proxy.ts
@@ -2,6 +2,10 @@ import { Client } from "@modelcontextprotocol/sdk/client/index.js";
 import type { Transport } from "@modelcontextprotocol/sdk/shared/transport.js";
 import type { CapaDatabase } from "../db/database";
 import { logger } from "../shared/logger";
+import {
+	redactErrorDetail,
+	resolvedSecretValues,
+} from "./secret-redaction";
 import { isStdioTrusted } from "../shared/stdio-allowlist";
 import {
 	hasUnresolvedMcpSecrets,
@@ -43,16 +47,16 @@ export interface MCPToolResult {
 }
 
 /**
- * One-line reason a connect attempt failed, safe to show a user. Bearer values
- * are stripped in case a server echoes the request back in its error body.
+ * One-line reason a connect attempt failed, safe to show a user. The def's own
+ * resolved credentials are scrubbed, plus anything else that reads like one —
+ * a non-2xx body can echo the request headers straight back.
  */
-function connectFailureDetail(error: unknown): string {
+function connectFailureDetail(
+	error: unknown,
+	def?: MCPServerDefinition,
+): string {
 	const raw = error instanceof Error ? error.message : String(error);
-	return raw
-		.replace(/Bearer\s+\S+/gi, "Bearer ***")
-		.replace(/\s+/g, " ")
-		.trim()
-		.slice(0, 300);
+	return redactErrorDetail(raw, def ? resolvedSecretValues(def) : []);
 }
 
 export class MCPProxy {
@@ -568,7 +572,10 @@ export class MCPProxy {
 				`Failed to create HTTP client for ${serverId}:`,
 				error,
 			);
-			this.connectFailures.set(serverId, connectFailureDetail(error));
+			this.connectFailures.set(
+				serverId,
+				connectFailureDetail(error, serverDefinition),
+			);
 			return null;
 		}
 	}
@@ -639,9 +646,13 @@ export class MCPProxy {
 				`Failed to create MCP client for ${serverId}:`,
 				error,
 			);
+			// The stdio exit reason is raw stderr — scrub it like any other detail.
 			this.connectFailures.set(
 				serverId,
-				this.stdioExitReasons.get(serverId) ?? connectFailureDetail(error),
+				connectFailureDetail(
+					this.stdioExitReasons.get(serverId) ?? error,
+					serverDefinition,
+				),
 			);
 			return null;
 		}

--- a/src/server/secret-redaction.ts
+++ b/src/server/secret-redaction.ts
@@ -165,3 +165,56 @@ export function mergeServerDef(
 
 	return merged;
 }
+
+/**
+ * Credential-looking `key: value` pairs a server might echo back in an error
+ * body. Only the value is masked, so the message still says what went wrong.
+ */
+const CREDENTIAL_PAIR =
+	/\b(authorization|proxy-authorization|api[-_]?key|apikey|access[-_]?token|refresh[-_]?token|token|secret|password|passwd|pwd)\b["']?\s*[:=]\s*["']?([^\s"',;}\]]{4,})/gi;
+
+/** `Bearer <token>` / `Basic <token>` carry the value with no separator. */
+const AUTH_SCHEME_VALUE = /\b(bearer|basic)\s+([^\s"',;}\]]+)/gi;
+
+/**
+ * Client-safe one-liner for a transport error. Values capa knows are secret
+ * are removed outright; anything else that reads like a credential is masked,
+ * because a non-2xx body can echo the request headers straight back.
+ */
+export function redactErrorDetail(
+	message: string,
+	knownSecrets: Iterable<string> = [],
+): string {
+	let out = message;
+	for (const secret of knownSecrets) {
+		// Short values produce noisy false positives and are not worth hiding.
+		if (secret.length >= 6) out = out.split(secret).join("***");
+	}
+	return out
+		.replace(CREDENTIAL_PAIR, (_match, label: string) => `${label}: ***`)
+		.replace(AUTH_SCHEME_VALUE, (_match, scheme: string) => `${scheme} ***`)
+		.replace(/[\u0000-\u001F\u007F]+/g, " ")
+		.replace(/\s+/g, " ")
+		.trim()
+		.slice(0, 300);
+}
+
+/**
+ * Resolved secret values carried by a server def — sensitive headers and every
+ * env value. Used to scrub them out of error text before it reaches a client.
+ */
+export function resolvedSecretValues(def: {
+	headers?: Record<string, unknown>;
+	env?: Record<string, unknown>;
+}): string[] {
+	const values: string[] = [];
+	for (const [name, value] of Object.entries(def.headers ?? {})) {
+		if (typeof value === "string" && isSensitiveHeaderName(name)) {
+			values.push(value);
+		}
+	}
+	for (const value of Object.values(def.env ?? {})) {
+		if (typeof value === "string") values.push(value);
+	}
+	return values;
+}

--- a/src/shared/__tests__/capabilities.test.ts
+++ b/src/shared/__tests__/capabilities.test.ts
@@ -220,6 +220,33 @@ describe('capabilities', () => {
       expect(caps.servers[0].description).toBeUndefined();
     });
 
+    it('keeps a null that is a tool default, not an absent field', () => {
+      const caps = normalizeCapabilities({
+        providers: ['claude-code'],
+        servers: [{ id: 's', type: 'mcp', def: { url: 'https://example.test/mcp' } }],
+        tools: [
+          {
+            id: 'search',
+            type: 'mcp',
+            def: { server: '@s', tool: 'search', defaults: { filter: null } },
+          },
+          {
+            id: 'run',
+            type: 'command',
+            def: {
+              run: {
+                cmd: 'echo',
+                args: [{ name: 'mode', type: 'string', default: null }],
+              },
+            },
+          },
+        ],
+      });
+
+      expect((caps.tools[0].def as any).defaults).toEqual({ filter: null });
+      expect((caps.tools[1].def as any).run.args[0].default).toBeNull();
+    });
+
     it('accepts a bare "description:" key in YAML (parses as null)', async () => {
       const file = join(tempDir, 'capabilities.yaml');
       await writeFile(

--- a/src/shared/__tests__/capabilities.test.ts
+++ b/src/shared/__tests__/capabilities.test.ts
@@ -202,6 +202,46 @@ describe('capabilities', () => {
     });
   });
 
+  describe('null fields read as absent', () => {
+    it('accepts a server whose description is an explicit null', () => {
+      const caps = normalizeCapabilities({
+        providers: ['claude-code'],
+        servers: [
+          {
+            id: 'sharecube',
+            type: 'mcp',
+            def: { url: 'https://example.test/mcp' },
+            description: null,
+          },
+        ],
+      });
+
+      expect(caps.servers[0].id).toBe('sharecube');
+      expect(caps.servers[0].description).toBeUndefined();
+    });
+
+    it('accepts a bare "description:" key in YAML (parses as null)', async () => {
+      const file = join(tempDir, 'capabilities.yaml');
+      await writeFile(
+        file,
+        [
+          'providers:',
+          '  - claude-code',
+          'servers:',
+          '  - id: sharecube',
+          '    type: mcp',
+          '    description:',
+          '    def:',
+          '      url: https://example.test/mcp',
+          '',
+        ].join('\n'),
+      );
+
+      const caps = await parseCapabilitiesFile(file, 'yaml');
+      expect(caps.servers[0].description).toBeUndefined();
+    });
+  });
+
   describe('createDefaultCapabilities', () => {
     it('should create default capabilities structure', () => {
       const capabilities = createDefaultCapabilities();

--- a/src/shared/capabilities.ts
+++ b/src/shared/capabilities.ts
@@ -265,6 +265,14 @@ export const capabilitiesSchema = z
 	.passthrough();
 
 /**
+ * Fields whose value is arbitrary user data (`z.unknown()` in the schema): a
+ * tool's `defaults` map and an argument's `default`. A null in there is a value
+ * the tool is meant to receive, not an absent field, so the subtree is left
+ * exactly as authored.
+ */
+const ARBITRARY_VALUE_KEYS = new Set(["defaults", "default"]);
+
+/**
  * Drop null-valued object keys so an explicit `null` reads as "not set".
  * A bare `description:` in YAML and a `"description": null` written by an API
  * client both land here; the schema only allows a string or absence, so without
@@ -275,6 +283,10 @@ function stripNulls(value: unknown): unknown {
 	if (value === null || typeof value !== "object") return value;
 	const out: Record<string, unknown> = {};
 	for (const [key, val] of Object.entries(value as Record<string, unknown>)) {
+		if (ARBITRARY_VALUE_KEYS.has(key)) {
+			out[key] = val;
+			continue;
+		}
 		if (val !== null) out[key] = stripNulls(val);
 	}
 	return out;

--- a/src/shared/capabilities.ts
+++ b/src/shared/capabilities.ts
@@ -264,6 +264,22 @@ export const capabilitiesSchema = z
 	})
 	.passthrough();
 
+/**
+ * Drop null-valued object keys so an explicit `null` reads as "not set".
+ * A bare `description:` in YAML and a `"description": null` written by an API
+ * client both land here; the schema only allows a string or absence, so without
+ * this either one fails the whole file.
+ */
+function stripNulls(value: unknown): unknown {
+	if (Array.isArray(value)) return value.map(stripNulls);
+	if (value === null || typeof value !== "object") return value;
+	const out: Record<string, unknown> = {};
+	for (const [key, val] of Object.entries(value as Record<string, unknown>)) {
+		if (val !== null) out[key] = stripNulls(val);
+	}
+	return out;
+}
+
 export function normalizeCapabilities(parsed: unknown): Capabilities {
 	if (
 		parsed === null ||
@@ -274,7 +290,7 @@ export function normalizeCapabilities(parsed: unknown): Capabilities {
 		throw new Error("capabilities file is empty or not a YAML/JSON object");
 	}
 
-	const result = capabilitiesSchema.safeParse(parsed);
+	const result = capabilitiesSchema.safeParse(stripNulls(parsed));
 	if (!result.success) {
 		const detail = result.error.issues
 			.slice(0, 5)


### PR DESCRIPTION
## Summary
Adding a server from the web UI wrote `description: null` into `capabilities.yaml`, which no capability schema accepts — the file stopped parsing and `capa install` broke. Separately, a rejected credential was reported as "Could not connect" / "Server unreachable", which looks identical to the server being down.

## What changed
- `handleAppend` / `handleUpdate`: a `null` field means "clear it" — write the key as absent instead of an explicit null (same convention `mergeServerDef` already uses inside `def`)
- `normalizeCapabilities`: read an explicit `null` as an absent field, so files already written with one — and a hand-written bare `description:` in YAML, which parses as null — load instead of failing
- `mcp-proxy`: remember why a connect attempt failed and include it in the error (`Could not connect to MCP server "x": … HTTP 401 …`); bearer values are stripped in case a server echoes the request back
- `mcp-meta-routes`: pass that detail through instead of the flat "Server unreachable"

## Screenshots / logs
Before, with a valid-looking but rejected API key:
```
$ capa sh sharecube list-projects
Could not load "list-projects": Could not connect to MCP server "sharecube"
```
The transport had the answer all along — HTTP 401 from the server — and it was dropped in `createHttpClient`'s catch.

## Test plan
- [x] `bun test src/shared/__tests__/capabilities.test.ts` — 42 pass, incl. new null-description and bare-YAML-key cases
- [x] `bun test src/server/__tests__/mcp-proxy.test.ts` — 22 pass, incl. new detail-surfacing and bearer-redaction cases
- [x] `bunx tsc --noEmit`
- [x] `bun test src/server/__tests__ src/shared/__tests__` — 795 pass / 30 fail, identical 30 failures on `develop` (Windows symlink + EBUSY, pre-existing)

## Checklist
- [x] Tests added or updated
- [x] `bunx tsc --noEmit` passes
- [ ] `bun run smells` clean vs base (CI Qlty Smells job)
- [x] Docs updated (if user-facing) — error strings only, no schema change

🤖 Generated with [Claude Code](https://claude.com/claude-code)