### PR TITLE
Add the search tool exposure mode

### DIFF
--- a/skills/capabilities-manager/SKILL.md
+++ b/skills/capabilities-manager/SKILL.md
@@ -56,10 +56,11 @@ When binding tools to skills via `requires:`, mismatching the `@` prefix is the 
 
 ### Tool exposure mode shapes everything downstream
 
-`options.toolExposure` has three values and they change what `capa install` writes:
+`options.toolExposure` has four values and they change what `capa install` writes:
 
 - `expose-all`: every tool any active skill requires shows up in the MCP `tools/list`. Simplest.
 - `on-demand` (what `capa init` writes by default): only `setup_tools` and `call_tool` are exposed at startup; the agent activates skills on demand. Keeps the active toolset small for long contexts.
+- `search`: only `search` and `call_tool` are exposed. The agent finds tools by keyword — `search('open a pull request')` — and calls what comes back. Discovery is by task rather than by skill id, which suits servers exposing many tools (`expose: all`).
 - `none`: capa writes **no** project-local MCP config files at all. The agent is expected to invoke tools via `capa sh <group> <tool>` instead. Useful when policy forbids per-project `.mcp.json` edits.
 
 Pick deliberately — switching modes later cleans up old entries on the next install but the choice colours the install output.

--- a/skills/capabilities-manager/references/capabilities-schema.md
+++ b/skills/capabilities-manager/references/capabilities-schema.md
@@ -190,13 +190,22 @@ tools:
 
 ## Tool Exposure (`options.toolExposure`)
 
-Controls how capa exposes skill tools to the MCP client. Three modes:
+Controls how capa exposes skill tools to the MCP client. Four modes:
 
 | Mode | `tools/list` returns | Per-install MCP file writes | Agent invocation path |
 |------|----------------------|------------------------------|------------------------|
 | `'expose-all'` | Every tool required by any active skill, with full input schemas | Yes — main `capa` entry + sub-agent `capa-<id>` entries | Direct MCP `tools/call` |
 | `'on-demand'` (what `capa init` writes) | Only the meta-tools `setup_tools` and `call_tool` | Yes — same as expose-all | Agent calls `setup_tools(['<skill>'])` (returns compact `name(required, optional?)` signature list), then `call_tool(name, data)`. If the call is invalid the full schema is returned in the error so the agent can self-correct without re-running setup. |
+| `'search'` | Only the meta-tools `search` and `call_tool` | Yes — same as expose-all | Agent calls `search('<what it needs to do>')`, gets back the best-matching tools as compact signatures with descriptions, then `call_tool(name, data)`. Same error-returns-the-schema behavior. |
 | `'none'` | Empty list | **No** — capa skips all project-local MCP config files (`.mcp.json`, `.cursor/mcp.json`, `.codex/config.toml` `mcp_servers.capa`, sub-agent `capa-<id>` entries). Any previously-written entries are removed on install. | The agent must use `capa sh <group> <tool> [--args]` (see [`commands.md`](./commands.md)). Sub-agent instruction files are still installed for documentation but their tools are not reachable over MCP. |
+
+Notes on `'search'`:
+- Discovery is by task, not by skill id: `search('open a pull request')` returns the tools whose names and descriptions match those words. Plain term matching — no embeddings, no index — scored over every tool in the project, which is fast at the scale a capabilities file reaches.
+- Matches are **activated** for the session, exactly like `setup_tools` does, so a tool goes straight from a search result into `call_tool`. Searches accumulate: tools found earlier stay callable.
+- `search` takes an optional `limit` (default 10, max 50). An empty query lists tools alphabetically, which is the "what is there?" case.
+- `setup_tools` is not available in this mode — calling it returns a pointer to `search`.
+- Pairs well with a server-wide `expose: all` (see [Server tool exposure](#server-tool-exposure-serversexpose)): the whole server is reachable, and the agent pulls in only the handful of tools each task needs.
+- Tool descriptions are what searches match against, so a server with terse remote descriptions is harder to search. Explicit `tools:` entries with a `description` help.
 
 Notes on `'none'`:
 - The capa HTTP server still runs and the project endpoints stay live; `tools/list` returns empty so MCP-aware agents don't try to discover tools through capa's MCP endpoint. `tools/call` is **not** gated — that's the path `capa sh` uses to execute tools, and gating it would mean rejecting `capa sh` itself.

--- a/skills/capabilities-manager/references/capabilities-schema.md
+++ b/skills/capabilities-manager/references/capabilities-schema.md
@@ -205,7 +205,7 @@ Notes on `'search'`:
 - `search` takes an optional `limit` (default 10, max 50). An empty query lists tools alphabetically, which is the "what is there?" case.
 - `setup_tools` is not available in this mode — calling it returns a pointer to `search`.
 - Pairs well with a server-wide `expose: all` (see [Server tool exposure](#server-tool-exposure-serversexpose)): the whole server is reachable, and the agent pulls in only the handful of tools each task needs.
-- Tool descriptions are what searches match against, so a server with terse remote descriptions is harder to search. Explicit `tools:` entries with a `description` help.
+- Searches match a tool's id, remote name, server/group, and description. Tools capa synthesized from a server's `expose` policy carry the server's own descriptions; a tool you declare by hand in `tools:` only has the `description` you write there, so write one — the id alone is thin search text.
 
 Notes on `'none'`:
 - The capa HTTP server still runs and the project endpoints stay live; `tools/list` returns empty so MCP-aware agents don't try to discover tools through capa's MCP endpoint. `tools/call` is **not** gated — that's the path `capa sh` uses to execute tools, and gating it would mean rejecting `capa sh` itself.

--- a/skills/capabilities-manager/references/workflows-and-examples.md
+++ b/skills/capabilities-manager/references/workflows-and-examples.md
@@ -434,7 +434,11 @@ With `on-demand` mode, the agent starts with only `setup_tools()` and `call_tool
 - `setup_tools(["data-analyst"])` → Adds `pandas_query(file, query)` to the active set.
 - `call_tool({ name: "brave.search", data: { query: "MCP spec" } })` → Invokes the tool. If `data` is missing required args or fails validation, the error response includes the full input schema so the agent can retry without re-running `setup_tools`.
 
-For a third option that bypasses MCP entirely, see `toolExposure: 'none'` in [`capabilities-schema.md`](./capabilities-schema.md#tool-exposure-optionstoolexposure) — capa skips writing any `.mcp.json` / `.cursor/mcp.json` / `.codex/config.toml` entries and the agent is expected to invoke tools via `capa sh <group> <tool> [--args]` instead.
+With `search` mode the same project starts with only `search()` and `call_tool()`:
+- `search("web search for a paper")` → returns `{ tool: "brave.search", signature: "brave.search(query, count?, …)", description: … }` and makes it callable.
+- `call_tool({ name: "brave.search", data: { query: "MCP spec" } })` → same call path as on-demand. No skill ids involved; search again when the task changes.
+
+For an option that bypasses MCP entirely, see `toolExposure: 'none'` in [`capabilities-schema.md`](./capabilities-schema.md#tool-exposure-optionstoolexposure) — capa skips writing any `.mcp.json` / `.cursor/mcp.json` / `.codex/config.toml` entries and the agent is expected to invoke tools via `capa sh <group> <tool> [--args]` instead.
 
 ### Example 5: CLI Prerequisites
 

--- a/src/cli/commands/install-tasks/configure-tools.ts
+++ b/src/cli/commands/install-tasks/configure-tools.ts
@@ -151,11 +151,12 @@ export function configureToolsTask(): Task<InstallCtx> {
 
       // The "tool is not required by any skill" check is meaningless under
       // `toolExposure: 'none'` — capa never exposes any tools to MCP clients
-      // in that mode by design (the agent invokes them via `capa sh`), so
-      // `requires` lists don't gate anything. Suppress the warning to avoid
-      // noise that would push users to "fix" a non-issue.
+      // in that mode by design (the agent invokes them via `capa sh`) — and
+      // under `'search'`, where the agent finds tools by keyword and `requires`
+      // gates nothing either. Suppress the warning to avoid noise that would
+      // push users to "fix" a non-issue.
       const toolExposure = ctx.capabilitiesToUse.options?.toolExposure;
-      if (toolExposure !== 'none') {
+      if (toolExposure !== 'none' && toolExposure !== 'search') {
         const unexposed = getUnexposedToolIds(ctx.capabilitiesToUse);
         if (unexposed.length > 0) {
           ctx.warnings.push(

--- a/src/server/__tests__/mcp-handler.integration.test.ts
+++ b/src/server/__tests__/mcp-handler.integration.test.ts
@@ -880,6 +880,64 @@ describe('handleMessage > search mode', () => {
     expect(payload.message).toMatch(/No tools matched/);
   });
 
+  it('rejects a search call with no query instead of listing everything', async () => {
+    const resp = await call('search', {});
+    const payload = parseToolText(resp.result);
+    expect(payload.error).toMatch(/requires a string "query"/);
+
+    // Nothing was activated by the malformed call.
+    const denied = await h.mcp.handleMessage({
+      jsonrpc: '2.0',
+      id: 3,
+      method: 'tools/call',
+      params: {
+        name: 'call_tool',
+        arguments: { name: 'github.create_issue', data: { title: 't' } },
+      },
+    });
+    expect(parseToolText(denied.result).error).toMatch(/not activated/);
+  });
+
+  it('tells an unactivated call to search, not to call setup_tools', async () => {
+    await h.mcp.handleMessage({ jsonrpc: '2.0', id: 1, method: 'initialize' });
+    const denied = await h.mcp.handleMessage({
+      jsonrpc: '2.0',
+      id: 2,
+      method: 'tools/call',
+      params: {
+        name: 'call_tool',
+        arguments: { name: 'github.create_issue', data: { title: 't' } },
+      },
+    });
+    const error = parseToolText(denied.result).error;
+    expect(error).toMatch(/search/);
+    expect(error).not.toMatch(/setup_tools/);
+  });
+
+  it('still lists everything for an explicitly empty query', async () => {
+    const payload = parseToolText((await call('search', { query: '' })).result);
+    expect(payload.matches.map((m: any) => m.tool)).toEqual([
+      'github.create_issue',
+      'slack.post_message',
+    ]);
+  });
+
+  it('leaves a direct tools/call ungated, like every other mode', async () => {
+    // `capa sh` executes tools by POSTing tools/call with the real tool name,
+    // in every exposure mode — gating that on activation would reject the
+    // shell itself. The activation gate is a discovery convention for the
+    // `call_tool` wrapper; the sub-agent allow-list is the real boundary and
+    // is enforced separately on this path.
+    await h.mcp.handleMessage({ jsonrpc: '2.0', id: 1, method: 'initialize' });
+    const resp = await h.mcp.handleMessage({
+      jsonrpc: '2.0',
+      id: 2,
+      method: 'tools/call',
+      params: { name: 'github.create_issue', arguments: { title: 't' } },
+    });
+    expect(JSON.stringify(resp)).not.toMatch(/not activated/);
+  });
+
   it('points setup_tools at search', async () => {
     const resp = await call('setup_tools', { skills: ['whatever'] });
     expect(JSON.stringify(resp)).toMatch(/search/);

--- a/src/server/__tests__/mcp-handler.integration.test.ts
+++ b/src/server/__tests__/mcp-handler.integration.test.ts
@@ -734,3 +734,181 @@ describe('handleMessage > ping', () => {
     });
   });
 });
+
+// ─── search mode: discover tools by keyword, then call them ──────────────────
+
+describe('handleMessage > search mode', () => {
+  let h: Harness;
+
+  const capabilities: Capabilities = {
+    providers: ['claude-code'],
+    options: { toolExposure: 'search' },
+    skills: [],
+    servers: [],
+    tools: [
+      {
+        id: 'create_issue',
+        type: 'command',
+        group: 'github',
+        description: 'Open a new issue on a repository.',
+        def: {
+          run: {
+            cmd: 'gh issue create',
+            args: [
+              { name: 'title', type: 'string', required: true },
+              { name: 'labels', type: 'string', required: false },
+            ],
+          },
+        },
+      },
+      {
+        id: 'post_message',
+        type: 'command',
+        group: 'slack',
+        description: 'Send a message to a Slack channel.',
+        def: {
+          run: {
+            cmd: 'slack post',
+            args: [{ name: 'text', type: 'string', required: true }],
+          },
+        },
+      },
+    ],
+  } as Capabilities;
+
+  beforeEach(() => {
+    h = makeHarness(capabilities);
+  });
+
+  afterEach(() => destroyHarness(h));
+
+  async function call(name: string, args: Record<string, unknown>) {
+    await h.mcp.handleMessage({ jsonrpc: '2.0', id: 1, method: 'initialize' });
+    return await h.mcp.handleMessage({
+      jsonrpc: '2.0',
+      id: 2,
+      method: 'tools/call',
+      params: { name, arguments: args },
+    });
+  }
+
+  it('lists only the search and call_tool meta-tools', async () => {
+    await h.mcp.handleMessage({ jsonrpc: '2.0', id: 1, method: 'initialize' });
+    const resp = await h.mcp.handleMessage({
+      jsonrpc: '2.0',
+      id: 2,
+      method: 'tools/list',
+    });
+
+    expect(resp.result.tools.map((t: any) => t.name)).toEqual([
+      'search',
+      'call_tool',
+    ]);
+  });
+
+  it('returns matching tools as signatures with descriptions', async () => {
+    const resp = await call('search', { query: 'open an issue' });
+    const payload = parseToolText(resp.result);
+
+    expect(payload.success).toBe(true);
+    expect(payload.query).toBe('open an issue');
+    expect(payload.matches).toEqual([
+      {
+        tool: 'github.create_issue',
+        signature: 'github.create_issue(title, labels?)',
+        description: 'Open a new issue on a repository.',
+      },
+    ]);
+    expect(payload.hint).toMatch(/call_tool/);
+  });
+
+  it('makes a searched tool callable, and leaves an unsearched one inert', async () => {
+    await call('search', { query: 'issue' });
+
+    const denied = await h.mcp.handleMessage({
+      jsonrpc: '2.0',
+      id: 3,
+      method: 'tools/call',
+      params: {
+        name: 'call_tool',
+        arguments: { name: 'slack.post_message', data: { text: 'hi' } },
+      },
+    });
+    expect(parseToolText(denied.result).error).toMatch(/not activated/);
+
+    // The searched one resolves to the tool itself (execution failure here is
+    // the command not existing, not the activation gate).
+    const allowed = await h.mcp.handleMessage({
+      jsonrpc: '2.0',
+      id: 4,
+      method: 'tools/call',
+      params: {
+        name: 'call_tool',
+        arguments: { name: 'github.create_issue', data: { title: 't' } },
+      },
+    });
+    const payload = parseToolText(allowed.result);
+    if (payload.error) expect(payload.error).not.toMatch(/not activated/);
+  });
+
+  it('accumulates matches across searches', async () => {
+    await call('search', { query: 'issue' });
+    const second = await call('search', { query: 'slack message' });
+
+    expect(parseToolText(second.result).matches[0].tool).toBe(
+      'slack.post_message',
+    );
+
+    // The tool found by the earlier search is still callable — matches
+    // accumulate rather than replacing each other.
+    const earlier = await h.mcp.handleMessage({
+      jsonrpc: '2.0',
+      id: 5,
+      method: 'tools/call',
+      params: {
+        name: 'call_tool',
+        arguments: { name: 'github.create_issue', data: { title: 't' } },
+      },
+    });
+    const payload = parseToolText(earlier.result);
+    if (payload.error) expect(payload.error).not.toMatch(/not activated/);
+  });
+
+  it('says so plainly when nothing matches', async () => {
+    const payload = parseToolText((await call('search', { query: 'kubernetes' })).result);
+    expect(payload.matches).toEqual([]);
+    expect(payload.message).toMatch(/No tools matched/);
+  });
+
+  it('points setup_tools at search', async () => {
+    const resp = await call('setup_tools', { skills: ['whatever'] });
+    expect(JSON.stringify(resp)).toMatch(/search/);
+  });
+});
+
+describe('handleMessage > search meta-tool outside search mode', () => {
+  let h: Harness;
+
+  beforeEach(() => {
+    h = makeHarness({
+      providers: ['claude-code'],
+      options: { toolExposure: 'on-demand' },
+      skills: [],
+      servers: [],
+      tools: [],
+    } as Capabilities);
+  });
+
+  afterEach(() => destroyHarness(h));
+
+  it('is unavailable in on-demand mode', async () => {
+    await h.mcp.handleMessage({ jsonrpc: '2.0', id: 1, method: 'initialize' });
+    const resp = await h.mcp.handleMessage({
+      jsonrpc: '2.0',
+      id: 2,
+      method: 'tools/call',
+      params: { name: 'search', arguments: { query: 'anything' } },
+    });
+    expect(JSON.stringify(resp)).toMatch(/only available in search mode/);
+  });
+});

--- a/src/server/mcp-handler.ts
+++ b/src/server/mcp-handler.ts
@@ -650,7 +650,15 @@ export class CapaMCPServer {
 		limit?: number;
 	}): Promise<any> {
 		const session = this.ensureSession();
-		const query = typeof args?.query === "string" ? args.query : "";
+		if (typeof args?.query !== "string") {
+			// An explicit "" is the documented list-everything request; a missing
+			// or non-string query is a malformed call, and coercing it would
+			// activate ten unrelated tools.
+			return toolTextError(
+				'search requires a string "query" — the words describing what you need to do.',
+			);
+		}
+		const query = args.query;
 		const traceId = this.beginTrace({
 			kind: "search",
 			toolName: "search",
@@ -673,19 +681,26 @@ export class CapaMCPServer {
 			);
 			const hits = searchTools(candidates, query, args?.limit ?? undefined);
 
-			const matches: SearchMatch[] = [];
-			for (const hit of hits) {
-				const tool = capabilities.tools.find(
-					(t) => getQualifiedToolName(t) === hit.tool.qualifiedName,
-				);
-				if (!tool) continue;
-				const mcpTool = await this.convertToolToMCP(tool, capabilities);
-				matches.push({
-					tool: hit.tool.qualifiedName,
-					signature: buildToolSignature(mcpTool),
-					description: mcpTool.description ?? hit.tool.description,
-				});
-			}
+			// Schema conversion lists the remote server's tools. Run the hits
+			// together so several matches on one server coalesce into a single
+			// round-trip instead of paying that server's timeout once each.
+			const converted: Array<SearchMatch | null> = await Promise.all(
+				hits.map(async (hit): Promise<SearchMatch | null> => {
+					const tool = capabilities.tools.find(
+						(t) => getQualifiedToolName(t) === hit.tool.qualifiedName,
+					);
+					if (!tool) return null;
+					const mcpTool = await this.convertToolToMCP(tool, capabilities);
+					return {
+						tool: hit.tool.qualifiedName,
+						signature: buildToolSignature(mcpTool),
+						description: mcpTool.description ?? hit.tool.description,
+					};
+				}),
+			);
+			const matches: SearchMatch[] = converted.filter(
+				(m): m is SearchMatch => m !== null,
+			);
 
 			if (matches.length > 0) {
 				this.sessionManager.activateTools(
@@ -951,11 +966,17 @@ export class CapaMCPServer {
 				)
 			) {
 				this.logger.warn(`Tool not activated: ${toolName}`);
-				// The tool exists but isn't activated — `setup_tools` is the next
-				// step, so don't pre-emptively dump the schema and confuse the agent.
+				// The tool exists but isn't activated — the next step is whichever
+				// discovery meta-tool this mode exposes, so don't pre-emptively dump
+				// the schema and confuse the agent.
+				const discoveryStep =
+					this.sessionManager.getProjectCapabilities(this.projectId)?.options
+						?.toolExposure === "search"
+						? `Call search("<what you need to do>") first.`
+						: "Call setup_tools with the appropriate skills first.";
 				const result = await this.buildCallToolErrorResult(
 					toolName,
-					`Tool "${toolName}" is not activated. Call setup_tools with the appropriate skills first.`,
+					`Tool "${toolName}" is not activated. ${discoveryStep}`,
 					{ includeSchema: false },
 				);
 				this.finishTraceError(

--- a/src/server/mcp-handler.ts
+++ b/src/server/mcp-handler.ts
@@ -11,6 +11,7 @@ import type { CapaDatabase } from "../db/database";
 import { logger } from "../shared/logger";
 import { CAPA_SERVER_ICONS } from "../shared/mcp-icons";
 import { projectNameFromId } from "../shared/paths";
+import { searchableTools, searchTools } from "../shared/tool-search";
 import type {
 	Capabilities,
 	MCPServerDefinition,
@@ -31,9 +32,11 @@ import {
 } from "./mcp-shell-tools";
 import {
 	buildCallToolErrorPayload,
+	buildSearchPayload,
 	buildSetupToolsPayload,
 	buildToolSignature,
 	mergeDefaults,
+	type SearchMatch,
 } from "./mcp-tool-defaults";
 import { convertToolToMCP as convertToolToMCPImpl } from "./mcp-tool-schema";
 import {
@@ -92,6 +95,49 @@ const ON_DEMAND_META_TOOLS: MCPTool[] = [
 		name: "call_tool",
 		description:
 			"Call any activated tool by name. Use `setup_tools` first to discover available tools (returned as compact signatures). If you pass invalid or missing args the full input schema is returned in the error so you can retry.",
+		inputSchema: {
+			type: "object",
+			properties: {
+				name: {
+					type: "string",
+					description: "The name of the tool to call",
+				},
+				data: {
+					type: "object",
+					description: "The input data for the tool",
+				},
+			},
+			required: ["name", "data"],
+		},
+	},
+];
+
+/** Meta-tools exposed only when `toolExposure` is `search`. */
+const SEARCH_META_TOOLS: MCPTool[] = [
+	{
+		name: "search",
+		description:
+			"Find tools for the task at hand by keyword — e.g. search('open a pull request'). Returns the best matches as compact signatures (`tool_name(required, optional?)`) with their descriptions, and makes them callable with `call_tool`. Search again with different words whenever the task changes; matches accumulate.",
+		inputSchema: {
+			type: "object",
+			properties: {
+				query: {
+					type: "string",
+					description:
+						"Words describing what you need to do (tool names, verbs, the system you want to touch).",
+				},
+				limit: {
+					type: "number",
+					description: "Maximum number of tools to return (default 10).",
+				},
+			},
+			required: ["query"],
+		},
+	},
+	{
+		name: "call_tool",
+		description:
+			"Call any tool that `search` returned, by name. If you pass invalid or missing args the full input schema is returned in the error so you can retry.",
 		inputSchema: {
 			type: "object",
 			properties: {
@@ -205,7 +251,7 @@ export class CapaMCPServer {
 	}
 
 	private beginTrace(input: {
-		kind: "setup_tools" | "call_tool" | "tool";
+		kind: "setup_tools" | "search" | "call_tool" | "tool";
 		toolName: string;
 		metaTool?: string | null;
 		args?: unknown;
@@ -324,6 +370,11 @@ export class CapaMCPServer {
 			return { tools };
 		}
 
+		if (toolExposureMode === "search") {
+			// Discovery is by keyword: the agent searches, then calls.
+			return { tools: SEARCH_META_TOOLS };
+		}
+
 		// On-demand: only meta-tools
 		return { tools: ON_DEMAND_META_TOOLS };
 	}
@@ -348,6 +399,14 @@ export class CapaMCPServer {
 			capabilities?.options?.toolExposure || "expose-all";
 
 		if (name === "setup_tools") {
+			if (toolExposureMode === "search") {
+				this.logger.warn("setup_tools called in search mode");
+				return {
+					type: "unavailable",
+					message:
+						'This project discovers tools with "search". Call search("<what you need to do>") and then call_tool with a name it returns.',
+				};
+			}
 			// HTTP historically accepts setup_tools in any mode; SDK only in on-demand.
 			if (toolExposureMode === "on-demand" || style === "http") {
 				if (style === "http") {
@@ -372,8 +431,24 @@ export class CapaMCPServer {
 			// mode === 'none': fall through to direct tool lookup (SDK quirk)
 		}
 
+		if (name === "search") {
+			if (toolExposureMode === "search") {
+				return {
+					type: "ok",
+					result: await this.handleSearch(
+						cleanArgs as { query: string; limit?: number },
+					),
+				};
+			}
+			this.logger.warn(`Meta-tool search called in ${toolExposureMode} mode`);
+			return {
+				type: "unavailable",
+				message: `The meta-tool "search" is only available in search mode. Your project is configured for ${toolExposureMode} mode.`,
+			};
+		}
+
 		if (name === "call_tool") {
-			if (toolExposureMode === "on-demand") {
+			if (toolExposureMode === "on-demand" || toolExposureMode === "search") {
 				return {
 					type: "ok",
 					result: await this.handleCallTool(
@@ -382,10 +457,12 @@ export class CapaMCPServer {
 				};
 			}
 			if (style === "http") {
-				this.logger.warn("call_tool is only available in on-demand mode");
+				this.logger.warn(
+					"call_tool is only available in on-demand and search modes",
+				);
 				return {
 					type: "unavailable",
-					message: "call_tool is only available in on-demand mode",
+					message: "call_tool is only available in on-demand and search modes",
 				};
 			}
 			if (toolExposureMode === "expose-all") {
@@ -398,7 +475,7 @@ export class CapaMCPServer {
 			// mode === 'none': fall through (SDK quirk)
 		}
 
-		if (toolExposureMode === "on-demand") {
+		if (toolExposureMode === "on-demand" || toolExposureMode === "search") {
 			this.ensureSession();
 		}
 
@@ -559,6 +636,76 @@ export class CapaMCPServer {
 				}
 			}
 		});
+	}
+
+	/**
+	 * `search` meta-tool: find tools by keyword and make them callable.
+	 *
+	 * Matches are activated for the session, so the agent can go straight from
+	 * a search result to `call_tool` — the same accumulate-as-you-go contract
+	 * `setup_tools` has, keyed on the task instead of on a skill id.
+	 */
+	private async handleSearch(args: {
+		query: string;
+		limit?: number;
+	}): Promise<any> {
+		const session = this.ensureSession();
+		const query = typeof args?.query === "string" ? args.query : "";
+		const traceId = this.beginTrace({
+			kind: "search",
+			toolName: "search",
+			metaTool: "search",
+			args,
+		});
+		try {
+			const capabilities = this.sessionManager.getProjectCapabilities(
+				this.projectId,
+			);
+			if (!capabilities) {
+				throw new Error(
+					`No capabilities configured for project: ${this.projectId}`,
+				);
+			}
+
+			const allowedToolIds = this.getAgentAllowedToolIds(capabilities);
+			const candidates = searchableTools(capabilities).filter(
+				(t) => !allowedToolIds || allowedToolIds.has(t.qualifiedName),
+			);
+			const hits = searchTools(candidates, query, args?.limit ?? undefined);
+
+			const matches: SearchMatch[] = [];
+			for (const hit of hits) {
+				const tool = capabilities.tools.find(
+					(t) => getQualifiedToolName(t) === hit.tool.qualifiedName,
+				);
+				if (!tool) continue;
+				const mcpTool = await this.convertToolToMCP(tool, capabilities);
+				matches.push({
+					tool: hit.tool.qualifiedName,
+					signature: buildToolSignature(mcpTool),
+					description: mcpTool.description ?? hit.tool.description,
+				});
+			}
+
+			if (matches.length > 0) {
+				this.sessionManager.activateTools(
+					session.sessionId,
+					matches.map((m) => m.tool),
+				);
+			}
+
+			const payload = buildSearchPayload(query, matches);
+			const result = {
+				content: [{ type: "text", text: JSON.stringify(payload) }],
+			};
+			this.finishTraceOk(traceId, result);
+			return result;
+		} catch (error: any) {
+			const message = error?.message || "Search failed";
+			const result = toolTextError(message);
+			this.finishTraceError(traceId, message, result);
+			return result;
+		}
 	}
 
 	private async handleSetupTools(args: { skills: string[] }): Promise<any> {

--- a/src/server/mcp-tool-defaults.ts
+++ b/src/server/mcp-tool-defaults.ts
@@ -111,6 +111,47 @@ export function buildSetupToolsPayload(
 	};
 }
 
+export interface SearchMatch {
+	/** Name to pass to `call_tool`. */
+	tool: string;
+	/** `tool_name(required, optional?)` — see `buildToolSignature`. */
+	signature: string;
+	description?: string;
+}
+
+export interface SearchPayload {
+	success: true;
+	query: string;
+	message: string;
+	matches: SearchMatch[];
+	hint: string;
+}
+
+/**
+ * Build the JSON payload returned by `search`. Signatures rather than full
+ * schemas, for the same reason `setup_tools` returns them: a schema per tool
+ * fills the context window, and the full schema comes back in the `call_tool`
+ * error when a call is actually wrong.
+ */
+export function buildSearchPayload(
+	query: string,
+	matches: SearchMatch[],
+): SearchPayload {
+	return {
+		success: true,
+		query,
+		message:
+			matches.length > 0
+				? `${matches.length} tool(s) matched and are now callable with call_tool.`
+				: "No tools matched. Try different words, or fewer of them.",
+		matches,
+		hint:
+			"Tools are listed as `name(required, optional?)`. " +
+			"Invoke with `call_tool`; if you pass wrong/missing args, the full input schema is returned in the error. " +
+			"Search again with different words to find more tools.",
+	};
+}
+
 /**
  * Build the error payload returned by `call_tool` when a tool invocation
  * fails. When the failure is plausibly an arg/schema problem (tool exists and

--- a/src/server/session-manager.ts
+++ b/src/server/session-manager.ts
@@ -124,6 +124,22 @@ export class SessionManager {
 	/**
 	 * Setup tools for a session (activate skills)
 	 */
+	/**
+	 * Make specific tools callable for a session without going through a skill.
+	 * This is how `search` mode activates what it just handed the agent.
+	 */
+	activateTools(sessionId: string, qualifiedNames: string[]): string[] {
+		const session = this.sessions.get(sessionId);
+		if (!session) {
+			throw new Error(`Session not found: ${sessionId}`);
+		}
+		session.availableTools = [
+			...new Set([...session.availableTools, ...qualifiedNames]),
+		];
+		session.lastActivity = Date.now();
+		return session.availableTools;
+	}
+
 	setupTools(
 		sessionId: string,
 		skillIds: string[],

--- a/src/shared/__tests__/tool-search.test.ts
+++ b/src/shared/__tests__/tool-search.test.ts
@@ -142,3 +142,68 @@ describe("searchableTools", () => {
 		]);
 	});
 });
+
+describe("ranking and tokenizing details", () => {
+	it("prefers wider query coverage over one strong match", () => {
+		const tools: SearchableTool[] = [
+			{
+				qualifiedName: "deploy",
+				id: "deploy",
+				description: "Ship the service.",
+			},
+			{
+				qualifiedName: "ops.rollout",
+				id: "rollout",
+				description: "Deploy the staging environment.",
+			},
+		];
+
+		// "deploy" alone is an exact id match on the first tool; adding
+		// "staging" makes the second one the better answer.
+		expect(names(searchTools(tools, "deploy"))[0]).toBe("deploy");
+		expect(names(searchTools(tools, "deploy staging"))[0]).toBe("ops.rollout");
+	});
+
+	it("ignores filler words when counting coverage", () => {
+		const tools: SearchableTool[] = [
+			{
+				qualifiedName: "github.create_pr",
+				id: "create_pr",
+				description: "Open a pull request.",
+			},
+			{
+				qualifiedName: "notes.append",
+				id: "append",
+				description: "Add a line to a note in the project.",
+			},
+		];
+
+		expect(names(searchTools(tools, "open a pull request"))[0]).toBe(
+			"github.create_pr",
+		);
+	});
+
+	it("tokenizes non-ASCII words instead of dropping them", () => {
+		expect(tokenize("déployer l'environnement")).toEqual([
+			"déployer",
+			"l",
+			"environnement",
+		]);
+	});
+
+	it("does not fall back to listing everything for a non-ASCII query", () => {
+		const tools: SearchableTool[] = [
+			{ qualifiedName: "a.one", id: "one", description: "first" },
+			{ qualifiedName: "b.two", id: "two", description: "second" },
+		];
+		expect(searchTools(tools, "デプロイ")).toEqual([]);
+	});
+
+	it("still searches when the query is nothing but filler", () => {
+		const tools: SearchableTool[] = [
+			{ qualifiedName: "how_to", id: "how_to", description: "A how-to." },
+			{ qualifiedName: "other", id: "other", description: "Unrelated." },
+		];
+		expect(names(searchTools(tools, "how do I"))).toEqual(["how_to"]);
+	});
+});

--- a/src/shared/__tests__/tool-search.test.ts
+++ b/src/shared/__tests__/tool-search.test.ts
@@ -1,0 +1,144 @@
+import { describe, expect, it } from "bun:test";
+import type { Capabilities } from "../../types/capabilities";
+import {
+	type SearchableTool,
+	searchableTools,
+	searchTools,
+	tokenize,
+} from "../tool-search";
+
+const TOOLS: SearchableTool[] = [
+	{
+		qualifiedName: "github.create_issue",
+		id: "create_issue",
+		remoteName: "create_issue",
+		context: "github",
+		description: "Open a new issue on a repository.",
+	},
+	{
+		qualifiedName: "github.search_code",
+		id: "search_code",
+		remoteName: "search_code",
+		context: "github",
+		description: "Search code across repositories.",
+	},
+	{
+		qualifiedName: "slack.post_message",
+		id: "post_message",
+		remoteName: "chat_postMessage",
+		context: "slack",
+		description: "Send a message to a Slack channel.",
+	},
+	{
+		qualifiedName: "lint",
+		id: "lint",
+		description: "Run eslint over the workspace.",
+	},
+];
+
+const names = (hits: ReturnType<typeof searchTools>) =>
+	hits.map((h) => h.tool.qualifiedName);
+
+describe("tokenize", () => {
+	it("splits on anything that is not a letter or digit", () => {
+		expect(tokenize("create_issue on GitHub!")).toEqual([
+			"create",
+			"issue",
+			"on",
+			"github",
+		]);
+	});
+});
+
+describe("searchTools", () => {
+	it("finds a tool by a word in its name", () => {
+		expect(names(searchTools(TOOLS, "issue"))).toEqual(["github.create_issue"]);
+	});
+
+	it("finds a tool by a word in its description", () => {
+		expect(names(searchTools(TOOLS, "eslint"))).toEqual(["lint"]);
+	});
+
+	it("matches the remote name when the local id differs", () => {
+		expect(names(searchTools(TOOLS, "postMessage"))).toContain(
+			"slack.post_message",
+		);
+	});
+
+	it("ranks a tool matching both terms above one matching either", () => {
+		expect(names(searchTools(TOOLS, "search code"))[0]).toBe(
+			"github.search_code",
+		);
+	});
+
+	it("ranks an exact name match first", () => {
+		expect(names(searchTools(TOOLS, "lint"))[0]).toBe("lint");
+	});
+
+	it("matches across a plural", () => {
+		expect(names(searchTools(TOOLS, "repositories"))).toContain(
+			"github.create_issue",
+		);
+	});
+
+	it("returns nothing when no term matches", () => {
+		expect(searchTools(TOOLS, "kubernetes helm")).toEqual([]);
+	});
+
+	it("lists tools alphabetically for an empty query", () => {
+		expect(names(searchTools(TOOLS, "   "))).toEqual([
+			"github.create_issue",
+			"github.search_code",
+			"lint",
+			"slack.post_message",
+		]);
+	});
+
+	it("respects the limit, and clamps a silly one", () => {
+		expect(searchTools(TOOLS, "", 2)).toHaveLength(2);
+		expect(searchTools(TOOLS, "", 0)).toHaveLength(4);
+		expect(searchTools(TOOLS, "", 9999)).toHaveLength(4);
+	});
+});
+
+describe("searchableTools", () => {
+	it("carries the qualified name, remote name, and server for each tool", () => {
+		const capabilities = {
+			providers: [],
+			options: {},
+			skills: [],
+			servers: [],
+			tools: [
+				{
+					id: "search",
+					type: "mcp",
+					description: "Web search",
+					def: { server: "@brave", tool: "brave_web_search" },
+				},
+				{
+					id: "commit",
+					type: "command",
+					group: "git",
+					def: { run: { cmd: "git", args: [] } },
+				},
+			],
+		} as unknown as Capabilities;
+
+		expect(searchableTools(capabilities)).toEqual([
+			{
+				qualifiedName: "brave.search",
+				id: "search",
+				remoteName: "brave_web_search",
+				context: "brave",
+				description: "Web search",
+			},
+			{
+				qualifiedName: "git.commit",
+				id: "commit",
+				remoteName: undefined,
+				context: "git",
+				description: undefined,
+			},
+		]);
+	});
+});

--- a/src/shared/__tests__/tool-search.test.ts
+++ b/src/shared/__tests__/tool-search.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it } from "bun:test";
 import type { Capabilities } from "../../types/capabilities";
 import {
 	type SearchableTool,
+	queryTerms,
 	searchableTools,
 	searchTools,
 	tokenize,
@@ -181,6 +182,35 @@ describe("ranking and tokenizing details", () => {
 		expect(names(searchTools(tools, "open a pull request"))[0]).toBe(
 			"github.create_pr",
 		);
+	});
+
+	it("does not match a tool on filler words alone", () => {
+		const tools: SearchableTool[] = [
+			{
+				qualifiedName: "vault.rotate_credentials",
+				id: "rotate_credentials",
+				description: "Rotate the stored database password.",
+			},
+			{
+				qualifiedName: "ops.deploy",
+				id: "deploy",
+				// Shares only "the" and "to" with the query below.
+				description: "Deploy the service to production.",
+			},
+		];
+
+		expect(names(searchTools(tools, "rotate the database password"))).toEqual([
+			"vault.rotate_credentials",
+		]);
+	});
+
+	it("exposes the same term filtering searchTools uses", () => {
+		expect(queryTerms("rotate the database password")).toEqual([
+			"rotate",
+			"database",
+			"password",
+		]);
+		expect(queryTerms("how do I")).toEqual(["how", "do", "i"]);
 	});
 
 	it("tokenizes non-ASCII words instead of dropping them", () => {

--- a/src/shared/capabilities.ts
+++ b/src/shared/capabilities.ts
@@ -246,7 +246,9 @@ const pluginSchema = z
 
 const optionsSchema = z
 	.object({
-		toolExposure: z.enum(["expose-all", "on-demand", "none"]).optional(),
+		toolExposure: z
+			.enum(["expose-all", "on-demand", "search", "none"])
+			.optional(),
 		agentActivity: z.boolean().optional(),
 		security: z
 			.object({

--- a/src/shared/tool-search.ts
+++ b/src/shared/tool-search.ts
@@ -1,0 +1,154 @@
+import type { Capabilities } from "../types/capabilities";
+import { getQualifiedToolName } from "../types/capabilities";
+
+/**
+ * Term-based tool search. No embeddings, no index — a project has tens to low
+ * hundreds of tools, so scoring every one against the query is cheaper than
+ * anything it could be replaced with.
+ */
+
+/** The text of one tool that a query can match against. */
+export interface SearchableTool {
+	/** Name the agent calls: `server.tool` / `group.tool` / `tool`. */
+	qualifiedName: string;
+	/** Local id. */
+	id: string;
+	/** Remote MCP tool name, when it differs from the id. */
+	remoteName?: string;
+	/** Server id for MCP tools, group for grouped command tools. */
+	context?: string;
+	description?: string;
+}
+
+export interface ToolSearchHit {
+	tool: SearchableTool;
+	score: number;
+	/** How many distinct query terms this tool matched. */
+	matchedTerms: number;
+}
+
+const DEFAULT_LIMIT = 10;
+const MAX_LIMIT = 50;
+
+/** Lowercase words, splitting on anything that is not a letter or digit. */
+export function tokenize(text: string): string[] {
+	return text
+		.toLowerCase()
+		.split(/[^a-z0-9]+/)
+		.filter(Boolean);
+}
+
+/** Shared-prefix length needed to treat two different words as the same one. */
+const STEM_PREFIX = 5;
+
+/**
+ * True when a token and a query term are close enough to count as a match:
+ * equal, one contains the other ("issue" vs "issues", "repo" vs "repository"),
+ * or they share a long prefix ("repository" vs "repositories").
+ *
+ * ponytail: prefix length stands in for a stemmer — it also matches
+ * "container"/"contains", which is tolerable in a ranked list. Swap in a real
+ * stemmer if the noise ever shows up in results people complain about.
+ */
+function tokenMatches(token: string, term: string): boolean {
+	if (token === term) return true;
+	if (term.length >= 3 && token.includes(term)) return true;
+	if (token.length >= 3 && term.includes(token)) return true;
+	if (token.length >= STEM_PREFIX && term.length >= STEM_PREFIX) {
+		let shared = 0;
+		while (
+			shared < token.length &&
+			shared < term.length &&
+			token[shared] === term[shared]
+		) {
+			shared++;
+		}
+		if (shared >= STEM_PREFIX) return true;
+	}
+	return false;
+}
+
+/** Score one tool against one query term. 0 means the term did not match. */
+function scoreTerm(tool: SearchableTool, term: string): number {
+	const id = tool.id.toLowerCase();
+	const qualified = tool.qualifiedName.toLowerCase();
+	if (id === term || qualified === term) return 12;
+
+	const nameTokens = tokenize(
+		`${tool.id} ${tool.remoteName ?? ""} ${tool.qualifiedName}`,
+	);
+	if (nameTokens.some((t) => t === term)) return 6;
+	if (nameTokens.some((t) => tokenMatches(t, term))) return 4;
+
+	const descriptionTokens = tokenize(tool.description ?? "");
+	if (descriptionTokens.some((t) => t === term)) return 2;
+	if (descriptionTokens.some((t) => tokenMatches(t, term))) return 1;
+
+	const contextTokens = tokenize(tool.context ?? "");
+	if (contextTokens.some((t) => tokenMatches(t, term))) return 1;
+
+	return 0;
+}
+
+/**
+ * Tools matching `query`, best first. A tool that matches more of the query's
+ * terms outranks one that matches a single term repeatedly, which is what
+ * makes a two-word query behave like the AND a person expects.
+ *
+ * An empty query lists the first `limit` tools alphabetically — "what is
+ * there?" is a reasonable thing to ask a search tool.
+ */
+export function searchTools(
+	tools: SearchableTool[],
+	query: string,
+	limit: number = DEFAULT_LIMIT,
+): ToolSearchHit[] {
+	const capped = Math.min(
+		Math.max(Math.trunc(limit) || DEFAULT_LIMIT, 1),
+		MAX_LIMIT,
+	);
+	const terms = [...new Set(tokenize(query))];
+
+	if (terms.length === 0) {
+		return [...tools]
+			.sort((a, b) => a.qualifiedName.localeCompare(b.qualifiedName))
+			.slice(0, capped)
+			.map((tool) => ({ tool, score: 0, matchedTerms: 0 }));
+	}
+
+	const hits: ToolSearchHit[] = [];
+	for (const tool of tools) {
+		let score = 0;
+		let matchedTerms = 0;
+		for (const term of terms) {
+			const termScore = scoreTerm(tool, term);
+			if (termScore > 0) {
+				score += termScore;
+				matchedTerms++;
+			}
+		}
+		if (matchedTerms === 0) continue;
+		hits.push({ tool, score: score + matchedTerms * 3, matchedTerms });
+	}
+
+	hits.sort(
+		(a, b) =>
+			b.score - a.score ||
+			a.tool.qualifiedName.localeCompare(b.tool.qualifiedName),
+	);
+	return hits.slice(0, capped);
+}
+
+/** The project's tools in the shape `searchTools` scores. */
+export function searchableTools(capabilities: Capabilities): SearchableTool[] {
+	return (capabilities.tools ?? []).map((tool) => ({
+		qualifiedName: getQualifiedToolName(tool),
+		id: tool.id,
+		remoteName: tool.type === "mcp" ? tool.def.tool : undefined,
+		context:
+			tool.type === "mcp"
+				? tool.def.server.replace(/^@/, "")
+				: (tool.group ?? undefined),
+		description: tool.description,
+	}));
+}

--- a/src/shared/tool-search.ts
+++ b/src/shared/tool-search.ts
@@ -30,12 +30,69 @@ export interface ToolSearchHit {
 const DEFAULT_LIMIT = 10;
 const MAX_LIMIT = 50;
 
-/** Lowercase words, splitting on anything that is not a letter or digit. */
+/**
+ * Words a query contributes nothing by matching. Ranking counts how many of
+ * the query's terms a tool matched, so "open a pull request" must not reward a
+ * tool whose description happens to contain "a".
+ */
+const STOPWORDS = new Set([
+	"a",
+	"an",
+	"the",
+	"and",
+	"or",
+	"of",
+	"for",
+	"to",
+	"in",
+	"on",
+	"at",
+	"by",
+	"with",
+	"from",
+	"into",
+	"is",
+	"are",
+	"be",
+	"do",
+	"does",
+	"it",
+	"its",
+	"this",
+	"that",
+	"my",
+	"me",
+	"i",
+	"we",
+	"you",
+	"how",
+	"what",
+	"can",
+	"should",
+	"want",
+	"need",
+	"using",
+	"use",
+	"please",
+]);
+
+/**
+ * Lowercase words, splitting on anything that is not a letter or digit in any
+ * script — an all-non-ASCII query must produce terms, not look empty.
+ */
 export function tokenize(text: string): string[] {
 	return text
 		.toLowerCase()
-		.split(/[^a-z0-9]+/)
+		.split(/[^\p{L}\p{N}]+/u)
 		.filter(Boolean);
+}
+
+/** Query terms worth scoring: tokenized, de-duplicated, stopwords removed. */
+export function queryTerms(query: string): string[] {
+	const terms = queryTerms(query);
+	const meaningful = terms.filter((t) => !STOPWORDS.has(t));
+	// An all-stopword query ("how do I") still beats listing everything.
+	return meaningful.length > 0 ? meaningful : terms;
 }
 
 /** Shared-prefix length needed to treat two different words as the same one. */
@@ -92,8 +149,8 @@ function scoreTerm(tool: SearchableTool, term: string): number {
 
 /**
  * Tools matching `query`, best first. A tool that matches more of the query's
- * terms outranks one that matches a single term repeatedly, which is what
- * makes a two-word query behave like the AND a person expects.
+ * terms outranks one matching fewer of them however strongly, which is what
+ * makes a multi-word query behave like the AND a person expects.
  *
  * An empty query lists the first `limit` tools alphabetically — "what is
  * there?" is a reasonable thing to ask a search tool.
@@ -128,11 +185,15 @@ export function searchTools(
 			}
 		}
 		if (matchedTerms === 0) continue;
-		hits.push({ tool, score: score + matchedTerms * 3, matchedTerms });
+		hits.push({ tool, score, matchedTerms });
 	}
 
+	// Coverage first: a tool matching two of the query's words beats one that
+	// matches a single word strongly, however heavy that single match scores.
+	// Field weights only break ties within the same coverage.
 	hits.sort(
 		(a, b) =>
+			b.matchedTerms - a.matchedTerms ||
 			b.score - a.score ||
 			a.tool.qualifiedName.localeCompare(b.tool.qualifiedName),
 	);

--- a/src/shared/tool-search.ts
+++ b/src/shared/tool-search.ts
@@ -89,7 +89,7 @@ export function tokenize(text: string): string[] {
 
 /** Query terms worth scoring: tokenized, de-duplicated, stopwords removed. */
 export function queryTerms(query: string): string[] {
-	const terms = queryTerms(query);
+	const terms = [...new Set(tokenize(query))];
 	const meaningful = terms.filter((t) => !STOPWORDS.has(t));
 	// An all-stopword query ("how do I") still beats listing everything.
 	return meaningful.length > 0 ? meaningful : terms;
@@ -164,7 +164,7 @@ export function searchTools(
 		Math.max(Math.trunc(limit) || DEFAULT_LIMIT, 1),
 		MAX_LIMIT,
 	);
-	const terms = [...new Set(tokenize(query))];
+	const terms = queryTerms(query);
 
 	if (terms.length === 0) {
 		return [...tools]

--- a/src/types/capabilities.ts
+++ b/src/types/capabilities.ts
@@ -45,13 +45,17 @@ export type {
  *   `setup_tools(['<skill>'])`. `setup_tools` returns a compact signature
  *   list (`tool_name(required, optional?)`); the full input schema is only
  *   returned in `call_tool` error responses when the agent calls incorrectly.
+ * - `'search'`: Only the meta-tools `search` and `call_tool` are listed; the
+ *   agent finds tools by keyword — `search('open a pull request')` — and calls
+ *   what it finds. Same compact signatures as `on-demand`, but discovery is by
+ *   the task at hand rather than by knowing which skill to activate.
  * - `'none'`: capa does **not** write any project-local MCP config files
  *   (`.mcp.json`, `.cursor/mcp.json`, `.codex/config.toml` `mcp_servers.capa`,
  *   sub-agent `capa-<id>` entries, etc.) at install time, and the MCP
  *   endpoints return an empty `tools/list`. The agent is expected to
  *   discover and execute tools through the `capa sh` CLI fallback instead.
  */
-export type ToolExposureMode = 'expose-all' | 'on-demand' | 'none';
+export type ToolExposureMode = 'expose-all' | 'on-demand' | 'search' | 'none';
 
 /**
  * Security options for skill installation.

--- a/src/types/database.ts
+++ b/src/types/database.ts
@@ -53,6 +53,7 @@ export type ToolCallStatus = 'running' | 'ok' | 'error';
 /** Activity row kind — capa MCP tools plus provider-hook agent events. */
 export const TOOL_CALL_KINDS = [
   'setup_tools',
+  'search',
   'call_tool',
   'tool',
   'prompt',

--- a/web-ui/src/features/projects/components/OptionsSection.tsx
+++ b/web-ui/src/features/projects/components/OptionsSection.tsx
@@ -11,7 +11,7 @@ interface OptionsSectionProps {
   options: CapabilitiesOptions | null;
 }
 
-const EXPOSURE_MODES = ['on-demand', 'expose-all', 'none'] as const;
+const EXPOSURE_MODES = ['on-demand', 'search', 'expose-all', 'none'] as const;
 
 export function OptionsSection({ projectId, options }: OptionsSectionProps) {
   const { t } = useTranslation('projects');

--- a/web-ui/src/features/projects/components/activity/ActivityShared.tsx
+++ b/web-ui/src/features/projects/components/activity/ActivityShared.tsx
@@ -4,6 +4,7 @@ import {
   FileText,
   MessageSquare,
   Minimize2,
+  Search,
   Server,
   Sparkles,
   Square,
@@ -58,6 +59,8 @@ export function kindIcon(kind: string): LucideIcon {
       return Square;
     case 'agent_mcp':
       return Server;
+    case 'search':
+      return Search;
     case 'setup_tools':
     case 'call_tool':
     case 'tool':

--- a/web-ui/src/features/projects/components/activity/buildProcessGraph.test.ts
+++ b/web-ui/src/features/projects/components/activity/buildProcessGraph.test.ts
@@ -122,6 +122,57 @@ describe('buildProcessGraph', () => {
     ).toMatchObject({ id: 'Read', label: 'Read' });
   });
 
+  it('treats MCP:search as a capa meta-tool wrapper', () => {
+    expect(
+      isCapaMetaToolWrapperSpan(
+        call({ id: 's1', kind: 'agent_tool', tool_name: 'MCP:search', started_at: 1 }),
+      ),
+    ).toBe(true);
+    expect(
+      isCapaMetaToolWrapperSpan(
+        call({ id: 's2', kind: 'agent_mcp', tool_name: 'search', started_at: 2 }),
+      ),
+    ).toBe(true);
+    // A provider's own tool that happens to be called "search" is not ours.
+    expect(
+      isCapaMetaToolWrapperSpan(
+        call({ id: 's3', kind: 'agent_tool', tool_name: 'search', started_at: 3 }),
+      ),
+    ).toBe(false);
+  });
+
+  it('keeps a real tool named "search" on the map', () => {
+    const prompt = call({ id: 'p', kind: 'prompt', tool_name: 'find it', started_at: 0 });
+    const graph = buildProcessGraph([
+      run(
+        [
+          call({
+            id: '1',
+            kind: 'search',
+            tool_name: 'search',
+            meta_tool: 'search',
+            started_at: 1,
+          }),
+          call({
+            id: '2',
+            kind: 'call_tool',
+            tool_name: 'brave.search',
+            meta_tool: 'call_tool',
+            started_at: 2,
+          }),
+          call({ id: '3', kind: 'tool', tool_name: 'search', started_at: 3 }),
+        ],
+        prompt,
+      ),
+    ]);
+
+    const ids = graph.activities.map((a) => a.id);
+    // capa's own search span is dropped; both real tools survive.
+    expect(ids).toContain('capa:brave.search');
+    expect(ids).toContain('capa:search');
+    expect(ids).not.toContain('search');
+  });
+
   it('dedupes capa MCP meta-tool wrappers (MCP:call_tool, agent_mcp, setup_tools)', () => {
     expect(
       isCapaMetaToolWrapperSpan(

--- a/web-ui/src/features/projects/components/activity/buildProcessGraph.ts
+++ b/web-ui/src/features/projects/components/activity/buildProcessGraph.ts
@@ -9,10 +9,11 @@ const SKIP_KINDS = new Set([
   'session',
   'compact',
   'setup_tools',
+  'search',
 ]);
 
-/** Capa on-demand MCP meta-tools — traced again as the real tool via `call_tool` / `tool`. */
-const CAPA_META_TOOL_NAMES = new Set(['call_tool', 'setup_tools']);
+/** Capa meta-tools (on-demand / search) — traced again as the real tool via `call_tool` / `tool`. */
+const CAPA_META_TOOL_NAMES = new Set(['call_tool', 'setup_tools', 'search']);
 
 /** Canonical labels for well-known agent tools. */
 const TOOL_ALIASES: Record<string, string> = {

--- a/web-ui/src/features/projects/components/activity/buildProcessGraph.ts
+++ b/web-ui/src/features/projects/components/activity/buildProcessGraph.ts
@@ -112,8 +112,8 @@ export function isCapaMetaToolWrapperSpan(ev: ToolCallRecord): boolean {
   if (ev.kind === 'agent_mcp' && CAPA_META_TOOL_NAMES.has(name)) {
     return true;
   }
-  if (ev.kind === 'agent_tool' && /^MCP:(call_tool|setup_tools)$/i.test(name)) {
-    return true;
+  if (ev.kind === 'agent_tool' && /^MCP:/i.test(name)) {
+    return CAPA_META_TOOL_NAMES.has(name.slice(4).trim());
   }
   return false;
 }
@@ -161,7 +161,13 @@ export function processActivityForSpan(ev: ToolCallRecord): ProcessActivity | nu
 
   if (ev.kind === 'call_tool' || ev.kind === 'tool') {
     const toolName = ev.tool_name?.trim();
-    if (!toolName || CAPA_META_TOOL_NAMES.has(toolName)) return null;
+    if (!toolName) return null;
+    // Capa's own meta-tool span, recognised by the trace's `meta_tool` rather
+    // than by name: a project can perfectly well have a real tool called
+    // `search`, and the real tool is what belongs on the map.
+    if (ev.meta_tool === toolName && CAPA_META_TOOL_NAMES.has(toolName)) {
+      return null;
+    }
     return capaToolActivity(toolName);
   }
 

--- a/web-ui/src/types/api.ts
+++ b/web-ui/src/types/api.ts
@@ -364,6 +364,7 @@ export interface OAuthStartResponse {
 export type ToolCallStatus = 'running' | 'ok' | 'error';
 export type ToolCallKind =
   | 'setup_tools'
+  | 'search'
   | 'call_tool'
   | 'tool'
   | 'prompt'


### PR DESCRIPTION
## Summary
`on-demand` makes the agent name a skill before it can see any tool, which assumes it already knows how the project is organised. `search` asks it what it is trying to do instead:

```
search("open a pull request")
  → { tool: "github.create_pr", signature: "github.create_pr(title, draft?)",
      description: "Open a pull request for the current branch." }
call_tool({ name: "github.create_pr", data: { title: "…" } })
```

`tools/list` returns exactly two meta-tools — `search` and `call_tool`. Same compact-signature contract as `on-demand`: signatures only, with the full input schema returned in the `call_tool` error when a call is actually wrong.

## How matching works
Plain term scoring, no embeddings and no index — a capabilities file holds tens to low hundreds of tools, so scoring every one per query is cheaper than maintaining anything cleverer.

- The query is lowercased and split into terms; each tool is scored against each term over its id, qualified name, remote MCP name, description, and server/group.
- Field weights descend from an exact name match to a description substring, and a tool matching **more of the query's distinct terms** outranks one matching a single term repeatedly — that is what makes a two-word query behave like the AND a person expects.
- `issue`/`issues` and `repository`/`repositories` match; the latter is a shared-prefix rule standing in for a stemmer, flagged in a `ponytail:` comment with its known false positives (`container`/`contains`).
- `limit` defaults to 10, clamps to 50. An empty query lists tools alphabetically — "what is there?" is a fair thing to ask a search tool.

## Behavior
- **Matches are activated** for the session, the same way `setup_tools` activates a skill's tools, so a result goes straight into `call_tool`. Searches accumulate: tools found earlier stay callable.
- **`setup_tools` is not available** in this mode — calling it returns a pointer to `search`.
- Sub-agent endpoints search only within their allow-list.
- Install writes MCP config exactly as `on-demand` does; only `'none'` skips those writes.
- The "N tool(s) are not exposed to MCP clients (not required by any skill)" warning is suppressed in this mode — `requires:` gates nothing when discovery is by keyword.
- Traced as its own activity kind (`search`), and treated as a capa meta-tool wrapper in the process graph like `setup_tools`.

Pairs naturally with a server-wide `expose: all`: the whole server is reachable and the agent pulls in only the handful of tools each task needs.

## What changed
- `src/shared/tool-search.ts` (new) — tokenizer, scoring, `searchTools`, and `searchableTools` to project a `Capabilities` into searchable rows.
- `src/server/mcp-handler.ts` — `SEARCH_META_TOOLS`, the `tools/list` branch, routing for `search` / `call_tool` / `setup_tools`, and `handleSearch`.
- `src/server/session-manager.ts` — `activateTools`, the skill-free activation search needs.
- `src/server/mcp-tool-defaults.ts` — `buildSearchPayload`.
- Types / schema — `'search'` added to `ToolExposureMode`, the zod enum, and `TOOL_CALL_KINDS`.
- Web UI — mode selector, activity icon, process-graph meta-tool handling.
- Docs — `capabilities-schema.md` table + notes, `capabilities-manager` skill, workflows example.

## Screenshots / logs
Against a three-tool project in `search` mode:
```
tools/list -> search, call_tool

search("open a pull request") ->
{
  "matches": [
    { "tool": "github.create_pr",   "signature": "github.create_pr(title, draft?)", … },
    { "tool": "github.list_issues", "signature": "github.list_issues()",            … }
  ],
  "message": "2 tool(s) matched and are now callable with call_tool."
}
```
(`list_issues` ranks second on the word "open" in its description — term matching, ranked, not filtered.)

## Test plan
- [x] `bun test src/shared/__tests__/tool-search.test.ts` — 11 pass (tokenizing, name/description/remote-name matches, multi-term ranking, plurals, no-match, empty query, limit clamping)
- [x] `bun test src/server/__tests__/mcp-handler.integration.test.ts` — 27 pass, incl. new search-mode cases: `tools/list` shape, payload shape, a searched tool callable while an unsearched one is not, accumulation across searches, empty result message, `setup_tools` pointing at `search`, and `search` rejected outside search mode
- [x] Manual smoke test through `handleMessage` (output above)
- [x] `bunx tsc --noEmit`, and `bunx tsc -p web-ui/tsconfig.json` (only the pre-existing `mermaid` errors)
- [x] `bun test` — 98 failures on this branch and 98 on `develop`, identical sets (Windows symlink + EBUSY, pre-existing); no new failures

## Checklist
- [x] Tests added or updated
- [x] `bunx tsc --noEmit` passes
- [ ] `bun run smells` clean vs base (CI Qlty Smells job)
- [x] Docs updated (if user-facing)

🤖 Generated with [Claude Code](https://claude.com/claude-code)