### PR TITLE
Stop warning about sub-agent refs to server-exposed tools

### DIFF
--- a/src/cli/commands/install-tasks/helpers/__tests__/tool-warnings.test.ts
+++ b/src/cli/commands/install-tasks/helpers/__tests__/tool-warnings.test.ts
@@ -126,25 +126,73 @@ describe('collectSubagentRefWarnings with server-exposed tools', () => {
     subagents: [{ id: 'oncall', skills: [], tools: subagentTools }],
   });
 
-  const exposing = { id: 'devtools', type: 'mcp', def: { url: 'https://x.test/mcp' } };
+  const server = (extra: Record<string, unknown> = {}): any => ({
+    id: 'devtools',
+    type: 'mcp',
+    def: { url: 'https://x.test/mcp' },
+    ...extra,
+  });
 
   it('does not warn for a tool the server exposes at configure time', () => {
     // `devtools.list_alerts` is never in the file — it comes from the server's
     // own tools/list — so it must not be reported as a typo.
-    expect(collectSubagentRefWarnings(caps([exposing], [], ['@devtools.list_alerts']))).toEqual([]);
-    expect(collectSubagentRefWarnings(caps([exposing], [], ['@devtools']))).toEqual([]);
-    expect(collectSubagentRefWarnings(caps([exposing], [], ['devtools.*']))).toEqual([]);
+    expect(collectSubagentRefWarnings(caps([server()], [], ['@devtools.list_alerts']))).toEqual([]);
+    expect(collectSubagentRefWarnings(caps([server()], [], ['@devtools']))).toEqual([]);
+    expect(collectSubagentRefWarnings(caps([server()], [], ['devtools.*']))).toEqual([]);
   });
 
   it('still warns for a server that exposes nothing', () => {
-    const optedOut = { ...exposing, expose: 'none' };
     expect(
-      collectSubagentRefWarnings(caps([optedOut], [], ['@devtools.list_alerts'])),
+      collectSubagentRefWarnings(caps([server({ expose: 'none' })], [], ['@devtools.list_alerts'])),
     ).toHaveLength(1);
   });
 
+  it('still warns once the server has a declared tool (policy off)', () => {
+    // One `tools:` entry turns the whole policy off, so nothing else on that
+    // server can appear — an undeclared ref is a typo again.
+    const declared = {
+      id: 'alerts',
+      type: 'mcp',
+      def: { server: '@devtools', tool: 'list_alerts' },
+    };
+    expect(
+      collectSubagentRefWarnings(caps([server()], [declared], ['@devtools.rotate_credentials'])),
+    ).toHaveLength(1);
+    // The declared one still resolves normally.
+    expect(collectSubagentRefWarnings(caps([server()], [declared], ['@devtools.alerts']))).toEqual([]);
+  });
+
+  it('applies except / exactly before suppressing', () => {
+    const except = server({ expose: 'except', tools: ['rotate_credentials'] });
+    expect(
+      collectSubagentRefWarnings(caps([except], [], ['@devtools.rotate_credentials'])),
+    ).toHaveLength(1);
+    expect(collectSubagentRefWarnings(caps([except], [], ['@devtools.list_alerts']))).toEqual([]);
+
+    const exactly = server({ expose: 'exactly', tools: ['list_alerts'] });
+    expect(collectSubagentRefWarnings(caps([exactly], [], ['@devtools.list_alerts']))).toEqual([]);
+    expect(
+      collectSubagentRefWarnings(caps([exactly], [], ['@devtools.rotate_credentials'])),
+    ).toHaveLength(1);
+  });
+
+  it('handles a server id that contains dots', () => {
+    const dotted = server({ id: 'foo.bar' });
+    expect(collectSubagentRefWarnings(caps([dotted], [], ['@foo.bar']))).toEqual([]);
+    expect(collectSubagentRefWarnings(caps([dotted], [], ['foo.bar.*']))).toEqual([]);
+    expect(collectSubagentRefWarnings(caps([dotted], [], ['@foo.bar.list_alerts']))).toEqual([]);
+    expect(collectSubagentRefWarnings(caps([dotted], [], ['@foo.list_alerts']))).toHaveLength(1);
+  });
+
+  it('matches the sanitized id of a remote name under exactly', () => {
+    // A remote tool called `a.b` is synthesized as `a_b`, which is the name a
+    // sub-agent would reference.
+    const exactly = server({ expose: 'exactly', tools: ['a.b'] });
+    expect(collectSubagentRefWarnings(caps([exactly], [], ['@devtools.a_b']))).toEqual([]);
+  });
+
   it('still warns for an unknown server or a plain typo', () => {
-    expect(collectSubagentRefWarnings(caps([exposing], [], ['@nope.thing']))).toHaveLength(1);
-    expect(collectSubagentRefWarnings(caps([exposing], [], ['typo_tool']))).toHaveLength(1);
+    expect(collectSubagentRefWarnings(caps([server()], [], ['@nope.thing']))).toHaveLength(1);
+    expect(collectSubagentRefWarnings(caps([server()], [], ['typo_tool']))).toHaveLength(1);
   });
 });

--- a/src/cli/commands/install-tasks/helpers/__tests__/tool-warnings.test.ts
+++ b/src/cli/commands/install-tasks/helpers/__tests__/tool-warnings.test.ts
@@ -115,3 +115,36 @@ describe('collectSubagentRefWarnings', () => {
     expect(collectSubagentRefWarnings(cap)).toEqual([]);
   });
 });
+
+describe('collectSubagentRefWarnings with server-exposed tools', () => {
+  const caps = (servers: any[], tools: any[], subagentTools: string[]): any => ({
+    providers: [],
+    options: {},
+    skills: [],
+    servers,
+    tools,
+    subagents: [{ id: 'oncall', skills: [], tools: subagentTools }],
+  });
+
+  const exposing = { id: 'devtools', type: 'mcp', def: { url: 'https://x.test/mcp' } };
+
+  it('does not warn for a tool the server exposes at configure time', () => {
+    // `devtools.list_alerts` is never in the file — it comes from the server's
+    // own tools/list — so it must not be reported as a typo.
+    expect(collectSubagentRefWarnings(caps([exposing], [], ['@devtools.list_alerts']))).toEqual([]);
+    expect(collectSubagentRefWarnings(caps([exposing], [], ['@devtools']))).toEqual([]);
+    expect(collectSubagentRefWarnings(caps([exposing], [], ['devtools.*']))).toEqual([]);
+  });
+
+  it('still warns for a server that exposes nothing', () => {
+    const optedOut = { ...exposing, expose: 'none' };
+    expect(
+      collectSubagentRefWarnings(caps([optedOut], [], ['@devtools.list_alerts'])),
+    ).toHaveLength(1);
+  });
+
+  it('still warns for an unknown server or a plain typo', () => {
+    expect(collectSubagentRefWarnings(caps([exposing], [], ['@nope.thing']))).toHaveLength(1);
+    expect(collectSubagentRefWarnings(caps([exposing], [], ['typo_tool']))).toHaveLength(1);
+  });
+});

--- a/src/cli/commands/install-tasks/helpers/tool-warnings.ts
+++ b/src/cli/commands/install-tasks/helpers/tool-warnings.ts
@@ -61,6 +61,20 @@ export function collectPluginSkillWarnings(capabilities: Capabilities): string[]
 // Tool refs accept three equivalent forms (handled by resolveSubagentToolRef):
 // `@server.tool`, `server.tool`, or the bare local tool id. The warning fires
 // only when none of those resolve.
+/**
+ * True when a sub-agent tool ref points at a server whose tools capa resolves
+ * from the server itself (`@github`, `@github.*`, `@github.create_issue`).
+ */
+function referencesExposingServer(
+  toolRef: string,
+  capabilities: Capabilities,
+): boolean {
+  const stripped = toolRef.startsWith('@') ? toolRef.slice(1) : toolRef;
+  const serverId = stripped.replace(/\.(\*|[^.]+)$/, '');
+  const server = (capabilities.servers ?? []).find((s) => s.id === serverId);
+  return !!server && server.expose !== 'none';
+}
+
 export function collectSubagentRefWarnings(capabilities: Capabilities): string[] {
   const subagents = capabilities.subagents ?? [];
   if (subagents.length === 0) return [];
@@ -78,12 +92,15 @@ export function collectSubagentRefWarnings(capabilities: Capabilities): string[]
       }
     }
     for (const toolRef of sa.tools ?? []) {
-      if (resolveSubagentToolRefs(toolRef, capabilities.tools).length === 0) {
-        warnings.push(
-          `Subagent "${sa.id}" references unknown tool "${toolRef}". ` +
-          `Add it under top-level \`tools\` (accepts \`tool_id\`, \`server.tool\`, or \`@server.tool\`) or remove it from the subagent.`,
-        );
-      }
+      if (resolveSubagentToolRefs(toolRef, capabilities.tools).length > 0) continue;
+      // A server that exposes its own tools contributes them at configure time
+      // from its live `tools/list` — they are not in the file, so a ref to one
+      // cannot be resolved here and is not a typo.
+      if (referencesExposingServer(toolRef, capabilities)) continue;
+      warnings.push(
+        `Subagent "${sa.id}" references unknown tool "${toolRef}". ` +
+        `Add it under top-level \`tools\` (accepts \`tool_id\`, \`server.tool\`, or \`@server.tool\`) or remove it from the subagent.`,
+      );
     }
   }
   return warnings;

--- a/src/cli/commands/install-tasks/helpers/tool-warnings.ts
+++ b/src/cli/commands/install-tasks/helpers/tool-warnings.ts
@@ -1,4 +1,9 @@
-import type { Capabilities } from '../../../../types/capabilities';
+import {
+  effectiveExpose,
+  serversWithExposePolicy,
+  synthesizedToolId,
+} from '../../../../shared/server-tool-exposure';
+import type { Capabilities, MCPServer } from '../../../../types/capabilities';
 import {
   getQualifiedToolName,
   normalizeToolReference,
@@ -52,6 +57,53 @@ export function collectPluginSkillWarnings(capabilities: Capabilities): string[]
   return warnings;
 }
 
+/** True when a server's policy can still produce a tool by this remote name. */
+function policyCanExpose(server: MCPServer, name: string): boolean {
+  const named = server.tools ?? [];
+  const listed =
+    named.includes(name) || named.some((n) => synthesizedToolId(n) === name);
+  switch (effectiveExpose(server)) {
+    case 'exactly':
+      return listed;
+    case 'except':
+      return !listed;
+    default:
+      // `all`: only the server's live tool list can say, and install has no
+      // business asking it here.
+      return true;
+  }
+}
+
+/**
+ * True when a sub-agent tool ref points at a tool capa resolves from a server
+ * rather than from the file (`@github`, `@github.*`, `@github.create_issue`),
+ * so its absence from `tools:` is expected rather than a typo.
+ *
+ * Only servers that actually expose their own tools count — declaring any
+ * `tools:` entry for a server turns its policy off, as does `expose: none` —
+ * and a name the policy definitively excludes still warns.
+ */
+function referencesExposingServer(
+  toolRef: string,
+  capabilities: Capabilities,
+): boolean {
+  const stripped = (toolRef.startsWith('@') ? toolRef.slice(1) : toolRef)
+    .replace(/\.\*$/, '');
+  const eligible = serversWithExposePolicy(capabilities);
+
+  if (eligible.some((s) => s.id === stripped)) return true;
+
+  // `<serverId>.<remoteName>`. Server ids may contain dots, so match the
+  // longest configured id that prefixes the ref instead of splitting on the
+  // last dot.
+  const server = eligible
+    .filter((s) => stripped.startsWith(`${s.id}.`))
+    .sort((a, b) => b.id.length - a.id.length)[0];
+  if (!server) return false;
+
+  return policyCanExpose(server, stripped.slice(server.id.length + 1));
+}
+
 // Warn for each subagent that references a skill or tool id that is not
 // declared in the top-level `skills` / `tools` arrays. Today these typos
 // pass silently: rendered files include junk bullets and the subagent loses
@@ -61,20 +113,6 @@ export function collectPluginSkillWarnings(capabilities: Capabilities): string[]
 // Tool refs accept three equivalent forms (handled by resolveSubagentToolRef):
 // `@server.tool`, `server.tool`, or the bare local tool id. The warning fires
 // only when none of those resolve.
-/**
- * True when a sub-agent tool ref points at a server whose tools capa resolves
- * from the server itself (`@github`, `@github.*`, `@github.create_issue`).
- */
-function referencesExposingServer(
-  toolRef: string,
-  capabilities: Capabilities,
-): boolean {
-  const stripped = toolRef.startsWith('@') ? toolRef.slice(1) : toolRef;
-  const serverId = stripped.replace(/\.(\*|[^.]+)$/, '');
-  const server = (capabilities.servers ?? []).find((s) => s.id === serverId);
-  return !!server && server.expose !== 'none';
-}
-
 export function collectSubagentRefWarnings(capabilities: Capabilities): string[] {
   const subagents = capabilities.subagents ?? [];
   if (subagents.length === 0) return [];


### PR DESCRIPTION
## Summary
A sub-agent that references a tool from a server with an `expose` policy is reported at install as a typo:

```
▲  Subagent "oncall" references unknown tool "@devtools.list_alerts". Add it under
   top-level `tools` (accepts `tool_id`, `server.tool`, or `@server.tool`) or remove
   it from the subagent.
```

The reference is correct. Those tools are deliberately absent from the capabilities file — capa resolves them from the server's own `tools/list` at configure time — and the runtime resolves the ref fine. Only the install-time check, which runs against the authored file, disagrees.

## What changed
`collectSubagentRefWarnings` skips a ref whose server contributes its own tools (`@devtools`, `devtools.*`, `@devtools.list_alerts`). A ref to a server with `expose: none`, an unknown server, or a bare typo still warns.

## Screenshots / logs
Same project, same sub-agent, on `develop` and on this branch:

```
develop:      unknown-tool warnings: 1
this branch:  unknown-tool warnings: 0
```

And the endpoint behaved correctly the whole time — the sub-agent's search returned only its allow-listed tool, and a call outside the list was denied:
```
sub-agent search -> devtools.list_alerts
sub-agent calling a tool outside its list -> Tool "devtools.create_pull_request" is not
  available on this sub-agent endpoint (oncall).
```

Found while driving a real capa server end to end against a live stdio MCP server, not from reading the diff.

## Test plan
- [x] `bun test src/cli/commands/install-tasks/helpers/__tests__/tool-warnings.test.ts` — 11 pass, incl. new cases: no warning for `@server.tool` / `@server` / `server.*` on an exposing server; still warns for `expose: none`, an unknown server, and a plain typo
- [x] End-to-end: `capa install` against a project with a stdio MCP server and a sub-agent referencing one of its tools — warning present on `develop`, gone here
- [x] `bunx tsc --noEmit`
- [x] `bun test` — 98 failures on this branch and 98 on `develop`, identical sets (Windows symlink + EBUSY, pre-existing); no new failures

## Checklist
- [x] Tests added or updated
- [x] `bunx tsc --noEmit` passes
- [ ] `bun run smells` clean vs base (CI Qlty Smells job)
- [x] Docs updated (if user-facing) — warning text only

🤖 Generated with [Claude Code](https://claude.com/claude-code)